### PR TITLE
Rotating an image by negative amount results in the wrong rotation

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -79,7 +79,7 @@ namespace ImageSharp.Processing.Processors
                 return;
             }
 
-            this.processMatrix = Matrix3x2Extensions.CreateRotation(-this.Angle, new Point(0, 0));
+            this.processMatrix = Matrix3x2Extensions.CreateRotationDegrees(-this.Angle, new Point(0, 0));
             if (this.Expand)
             {
                 this.CreateNewCanvas(sourceRectangle, this.processMatrix);

--- a/tests/ImageSharp.Tests/Image/ImageRotationTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageRotationTests.cs
@@ -1,0 +1,54 @@
+﻿using SixLabors.Primitives;
+using Xunit;
+
+namespace ImageSharp.Tests
+{
+    public class ImageRotationTests
+    {
+        [Fact]
+        public void RotateImageByMinus90Degrees()
+        {
+            (Size original, Size rotated) = Rotate(-90);
+            Assert.Equal(new Size(original.Height, original.Width), rotated);
+        }
+
+        [Fact]
+        public void RotateImageBy90Degrees()
+        {
+            (Size original, Size rotated) = Rotate(90);
+            Assert.Equal(new Size(original.Height, original.Width), rotated);
+        }
+
+        [Fact]
+        public void RotateImageBy180Degrees()
+        {
+            (Size original, Size rotated) = Rotate(180);
+            Assert.Equal(original, rotated);
+        }
+
+        [Fact]
+        public void RotateImageBy270Degrees()
+        {
+            (Size original, Size rotated) = Rotate(270);
+            Assert.Equal(new Size(original.Height, original.Width), rotated);
+        }
+
+        [Fact]
+        public void RotateImageBy360Degrees()
+        {
+            (Size original, Size rotated) = Rotate(360);
+            Assert.Equal(original, rotated);
+        }
+
+        private static (Size original, Size rotated) Rotate(int angle)
+        {
+            TestFile file = TestFile.Create(TestImages.Bmp.Car);
+            using (Image<Rgba32> image = Image.Load<Rgba32>(file.FilePath))
+            {
+                Size expected = image.Bounds.Size;
+                image.Rotate(angle);
+                return (expected, image.Bounds.Size);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x ] I have written a descriptive pull-request title
- [x ] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x ] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x ] I have provided test coverage for my change (where applicable)

### Description
Fixed bug: Rotating an image by negative amount results in the wrong rotation. Switched to correct roation service. 

Fixes #269
