### PR TITLE
Handle CultureNotFoundException when reading MultilocalizedUnicodeTagDataEntry

### DIFF
--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.TagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.TagDataEntry.cs
@@ -476,19 +476,7 @@ namespace ImageSharp
                 string languageCode = this.ReadAsciiString(2);
                 string countryCode = this.ReadAsciiString(2);
 
-                if (string.IsNullOrWhiteSpace(languageCode))
-                {
-                    culture[i] = CultureInfo.InvariantCulture;
-                }
-                else if (string.IsNullOrWhiteSpace(countryCode))
-                {
-                    culture[i] = new CultureInfo(languageCode);
-                }
-                else
-                {
-                    culture[i] = new CultureInfo($"{languageCode}-{countryCode}");
-                }
-
+                culture[i] = ReadCulture(languageCode, countryCode);
                 length[i] = this.ReadUInt32();
                 offset[i] = this.ReadUInt32();
             }
@@ -500,6 +488,36 @@ namespace ImageSharp
             }
 
             return new IccMultiLocalizedUnicodeTagDataEntry(text);
+
+            CultureInfo ReadCulture(string language, string country)
+            {
+                if (string.IsNullOrWhiteSpace(language))
+                {
+                    return CultureInfo.InvariantCulture;
+                }
+                else if (string.IsNullOrWhiteSpace(country))
+                {
+                    try
+                    {
+                        return new CultureInfo(language);
+                    }
+                    catch (CultureNotFoundException)
+                    {
+                        return CultureInfo.InvariantCulture;
+                    }
+                }
+                else
+                {
+                    try
+                    {
+                        return new CultureInfo($"{language}-{country}");
+                    }
+                    catch (CultureNotFoundException)
+                    {
+                        return ReadCulture(language, null);
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/TestDataIcc/IccTestDataTagDataEntry.cs
+++ b/tests/ImageSharp.Tests/TestDataIcc/IccTestDataTagDataEntry.cs
@@ -455,15 +455,46 @@ namespace ImageSharp.Tests
 
         #region MultiLocalizedUnicodeTagDataEntry
 
-        private static readonly IccLocalizedString LocalizedString_Rand_enUs = new IccLocalizedString(new CultureInfo("en-US"), IccTestDataPrimitives.Unicode_ValRand2);
-        private static readonly IccLocalizedString LocalizedString_Rand_deDE = new IccLocalizedString(new CultureInfo("de-DE"), IccTestDataPrimitives.Unicode_ValRand3);
-        private static readonly IccLocalizedString LocalizedString_Rand2_deDE = new IccLocalizedString(new CultureInfo("de-DE"), IccTestDataPrimitives.Unicode_ValRand2);
-        private static readonly IccLocalizedString LocalizedString_Rand_en = new IccLocalizedString(new CultureInfo("en"), IccTestDataPrimitives.Unicode_ValRand2);
+        private static readonly IccLocalizedString LocalizedString_Rand_enUS = CreateLocalizedString("en", "US", IccTestDataPrimitives.Unicode_ValRand2);
+        private static readonly IccLocalizedString LocalizedString_Rand_deDE = CreateLocalizedString("de", "DE", IccTestDataPrimitives.Unicode_ValRand3);
+        private static readonly IccLocalizedString LocalizedString_Rand2_deDE = CreateLocalizedString("de", "DE", IccTestDataPrimitives.Unicode_ValRand2);
+        private static readonly IccLocalizedString LocalizedString_Rand2_esXL = CreateLocalizedString("es", "XL", IccTestDataPrimitives.Unicode_ValRand2);
+        private static readonly IccLocalizedString LocalizedString_Rand2_xyXL = CreateLocalizedString("xy", "XL", IccTestDataPrimitives.Unicode_ValRand2);
+        private static readonly IccLocalizedString LocalizedString_Rand_en = CreateLocalizedString("en", null, IccTestDataPrimitives.Unicode_ValRand2);
         private static readonly IccLocalizedString LocalizedString_Rand_Invariant = new IccLocalizedString(CultureInfo.InvariantCulture, IccTestDataPrimitives.Unicode_ValRand3);
 
-        private static readonly IccLocalizedString[] LocalizedString_RandArr_enUs_deDE = new IccLocalizedString[]
+        private static IccLocalizedString CreateLocalizedString(string language, string country, string text)
         {
-            LocalizedString_Rand_enUs,
+            CultureInfo culture;
+            if (country == null)
+            {
+                try
+                {
+                    culture = new CultureInfo(language);
+                }
+                catch (CultureNotFoundException)
+                {
+                    culture = CultureInfo.InvariantCulture;
+                }
+            }
+            else
+            {
+                try
+                {
+                    culture = new CultureInfo($"{language}-{country}");
+                }
+                catch (CultureNotFoundException)
+                {
+                    return CreateLocalizedString(language, null, text);
+                }
+            }
+
+            return new IccLocalizedString(culture, text);
+        }
+
+        private static readonly IccLocalizedString[] LocalizedString_RandArr_enUS_deDE = new IccLocalizedString[]
+        {
+            LocalizedString_Rand_enUS,
             LocalizedString_Rand_deDE,
         };
         private static readonly IccLocalizedString[] LocalizedString_RandArr_en_Invariant = new IccLocalizedString[]
@@ -471,13 +502,15 @@ namespace ImageSharp.Tests
             LocalizedString_Rand_en,
             LocalizedString_Rand_Invariant,
         };
-        private static readonly IccLocalizedString[] LocalizedString_SameArr_enUs_deDE = new IccLocalizedString[]
+        private static readonly IccLocalizedString[] LocalizedString_SameArr_enUS_deDE_esXL_xyXL = new IccLocalizedString[]
         {
-            LocalizedString_Rand_enUs,
-            LocalizedString_Rand2_deDE
+            LocalizedString_Rand_enUS,
+            LocalizedString_Rand2_deDE,
+            LocalizedString_Rand2_esXL,
+            LocalizedString_Rand2_xyXL,
         };
 
-        public static readonly IccMultiLocalizedUnicodeTagDataEntry MultiLocalizedUnicode_Val = new IccMultiLocalizedUnicodeTagDataEntry(LocalizedString_RandArr_enUs_deDE);
+        public static readonly IccMultiLocalizedUnicodeTagDataEntry MultiLocalizedUnicode_Val = new IccMultiLocalizedUnicodeTagDataEntry(LocalizedString_RandArr_enUS_deDE);
         public static readonly byte[] MultiLocalizedUnicode_Arr = ArrayHelper.Concat
         (
             IccTestDataPrimitives.UInt32_2,
@@ -530,19 +563,27 @@ namespace ImageSharp.Tests
             IccTestDataPrimitives.Unicode_Rand3
         );
 
-        public static readonly IccMultiLocalizedUnicodeTagDataEntry MultiLocalizedUnicode_Val3 = new IccMultiLocalizedUnicodeTagDataEntry(LocalizedString_SameArr_enUs_deDE);
+        public static readonly IccMultiLocalizedUnicodeTagDataEntry MultiLocalizedUnicode_Val3 = new IccMultiLocalizedUnicodeTagDataEntry(LocalizedString_SameArr_enUS_deDE_esXL_xyXL);
         public static readonly byte[] MultiLocalizedUnicode_Arr3 = ArrayHelper.Concat
         (
-            IccTestDataPrimitives.UInt32_2,
+            IccTestDataPrimitives.UInt32_4,
             new byte[] { 0x00, 0x00, 0x00, 0x0C },  // 12
 
             new byte[] { (byte)'e', (byte)'n', (byte)'U', (byte)'S' },
             new byte[] { 0x00, 0x00, 0x00, 0x0C },  // 12
-            new byte[] { 0x00, 0x00, 0x00, 0x28 },  // 40
+            new byte[] { 0x00, 0x00, 0x00, 0x40 },  // 64
 
             new byte[] { (byte)'d', (byte)'e', (byte)'D', (byte)'E' },
             new byte[] { 0x00, 0x00, 0x00, 0x0C },  // 12
-            new byte[] { 0x00, 0x00, 0x00, 0x28 },  // 40
+            new byte[] { 0x00, 0x00, 0x00, 0x40 },  // 64
+
+            new byte[] { (byte)'e', (byte)'s', (byte)'X', (byte)'L' },
+            new byte[] { 0x00, 0x00, 0x00, 0x0C },  // 12
+            new byte[] { 0x00, 0x00, 0x00, 0x40 },  // 64
+
+            new byte[] { (byte)'x', (byte)'y', (byte)'X', (byte)'L' },
+            new byte[] { 0x00, 0x00, 0x00, 0x0C },  // 12
+            new byte[] { 0x00, 0x00, 0x00, 0x40 },  // 64
 
             IccTestDataPrimitives.Unicode_Rand2
         );
@@ -670,8 +711,8 @@ namespace ImageSharp.Tests
         (
             new IccProfileSequenceIdentifier[]
             {
-                new IccProfileSequenceIdentifier(IccTestDataNonPrimitives.ProfileId_ValRand, LocalizedString_RandArr_enUs_deDE),
-                new IccProfileSequenceIdentifier(IccTestDataNonPrimitives.ProfileId_ValRand, LocalizedString_RandArr_enUs_deDE),
+                new IccProfileSequenceIdentifier(IccTestDataNonPrimitives.ProfileId_ValRand, LocalizedString_RandArr_enUS_deDE),
+                new IccProfileSequenceIdentifier(IccTestDataNonPrimitives.ProfileId_ValRand, LocalizedString_RandArr_enUS_deDE),
             }
         );
         public static readonly byte[] ProfileSequenceIdentifier_Arr = ArrayHelper.Concat


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
On some OS versions creating a `CultureInfo` from an invalid culture throws a `CultureNotFoundException` while on others it accepts it.
This PR handles the exception by trying to create the full culture (languge and country), then trying language only and after that falling back to `CultureInfo.Invariant`
This fixes #304