### PR TITLE
Several fixes in the PNG decoder.

### DIFF
--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -31,22 +31,21 @@ namespace ImageSharp.Formats
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
 
             // Paeth(x) + PaethPredictor(Raw(x-bpp), Prior(x), Prior(x-bpp))
-            for (int x = 1; x < scanline.Length; x++)
+            int offset = bytesPerPixel + 1;
+            for (int x = 1; x < offset; x++)
             {
-                if (x - bytesPerPixel < 1)
-                {
-                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
-                    byte above = Unsafe.Add(ref prevBaseRef, x);
-                    scan = (byte)((scan + PaethPredicator(0, above, 0)) % 256);
-                }
-                else
-                {
-                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
-                    byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
-                    byte above = Unsafe.Add(ref prevBaseRef, x);
-                    byte upperLeft = Unsafe.Add(ref prevBaseRef, x - bytesPerPixel);
-                    scan = (byte)((scan + PaethPredicator(left, above, upperLeft)) % 256);
-                }
+                ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                byte above = Unsafe.Add(ref prevBaseRef, x);
+                scan = (byte)(scan + above);
+            }
+
+            for (int x = offset; x < scanline.Length; x++)
+            {
+                ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
+                byte above = Unsafe.Add(ref prevBaseRef, x);
+                byte upperLeft = Unsafe.Add(ref prevBaseRef, x - bytesPerPixel);
+                scan = (byte)(scan + PaethPredicator(left, above, upperLeft));
             }
         }
 

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -515,7 +515,7 @@ namespace ImageSharp.Formats
                     this.currentRowBytesRead = 0;
 
                     Span<byte> scanSpan = this.scanline.Slice(0, bytesPerInterlaceScanline);
-                    Span<byte> prevSpan = this.previousScanline.Span.Slice(0, bytesPerInterlaceScanline);
+                    Span<byte> prevSpan = this.previousScanline.Slice(0, bytesPerInterlaceScanline);
                     var filterType = (FilterType)scanSpan[0];
 
                     switch (filterType)
@@ -556,6 +556,8 @@ namespace ImageSharp.Formats
                 }
 
                 this.pass++;
+                this.previousScanline.Clear();
+
                 if (this.pass < 7)
                 {
                     this.currentRow = Adam7FirstRow[this.pass];

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -564,6 +564,7 @@ namespace ImageSharp.Formats
                 }
                 else
                 {
+                    this.pass = 0;
                     break;
                 }
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request fixes a couple of issue that occur when decoding a PNG file. With these patches the images from #313 and #314 can be read. 

I have not tested if the images from #301 can be read on the beta-1 branch. Could you check if these patches also fix the tests in the beta-1 branch @JimBobSquarePants?

It is probably also wise to investigate if we don't have the same issues in the PNG encoder. Anyone?

<!-- Thanks for contributing to ImageSharp! -->
