### PR TITLE
Update cache key to handle multi-tenancy

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -140,7 +140,9 @@ namespace ImageSharp.Web.Middleware
                 return;
             }
 
-            string uri = context.Request.Path + QueryString.Create(commands);
+            // Create a cache key based on all the components of the requested url
+            string uri = context.Request.Host.ToString().ToLowerInvariant() + "/" + context.Request.PathBase.ToString().ToLowerInvariant() + "/" + context.Request.Path + QueryString.Create(commands);
+
             string key = CacheHash.Create(uri, this.options.Configuration);
 
             CachedInfo info = await this.cache.IsExpiredAsync(key, DateTime.UtcNow.AddDays(-this.options.MaxCacheDays));


### PR DESCRIPTION
The current cache key computation doesn't use the `Request.PathBase` (which is like virtual path in IIS) or the domain. This creates collisions when two files with the same name are used in a multi-tenant system (see Orchard) and could leak voluntarily or involuntarily some images from other tenants.
