### PR TITLE
Making FormatHelpers public

### DIFF
--- a/src/ImageSharp.Web/Helpers/FormatHelpers.cs
+++ b/src/ImageSharp.Web/Helpers/FormatHelpers.cs
@@ -14,7 +14,7 @@ namespace ImageSharp.Web.Helpers
     /// <summary>
     /// Helper utilities for image formats
     /// </summary>
-    internal class FormatHelpers
+    public class FormatHelpers
     {
         /// <summary>
         /// Returns the correct content type (mimetype) for the given cached image key.


### PR DESCRIPTION
Or you end up having to duplicate its code when implementing custom `IImageResolver`.
See https://github.com/OrchardCMS/Orchard2/blob/30c9b53b013861f2742c191e18f18c1bf09b93b6/src/OrchardCore.Modules/Orchard.Media/Processing/MediaFileSystemResolver.cs#L75
