### PR TITLE
update dependencies to prevent stylecop.json being included in package

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -37,9 +37,9 @@
     <ProjectReference Include="..\ImageSharp\ImageSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0002" />
-    <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-beta0001" />
-    <PackageReference Include="SixLabors.Shapes" Version="1.0.0-beta0001" />
+    <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0003" />
+    <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-beta0002" />
+    <PackageReference Include="SixLabors.Shapes" Version="1.0.0-beta0002" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -34,7 +34,7 @@
     <Compile Include="..\Shared\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0002" />
+    <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0003" />
     <AdditionalFiles Include="..\..\stylecop.json" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>


### PR DESCRIPTION
updates package dependencies 

Current beta1 of ImageSharp.Drawing includes a copy of stylecop.json which is an artefact from an issue inside sixlabors.core. All dependent project are fixed to prevent it from being included here.