### PR TITLE
Fix #345

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -301,7 +301,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             int mask = 0xFF >> (8 - bits);
             int resultOffset = 0;
 
-            for (int i = 0; i < bytesPerScanline; i++)
+            for (int i = 0; i < bytesPerScanline - 1; i++)
             {
                 byte b = source[i];
                 for (int shift = 0; shift < 8; shift += bits)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I forgot to take into account we were slicing the first byte. 

<!-- Thanks for contributing to ImageSharp! -->
