### PR TITLE
Js/fix imageframe allocation

### DIFF
--- a/src/ImageSharp/Image/ImageFrameCollection.cs
+++ b/src/ImageSharp/Image/ImageFrameCollection.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp
             Guard.NotNull(parent, nameof(parent));
 
             this.parent = parent;
-            this.AddFrame(new ImageFrame<TPixel>(width, height));
+            this.frames.Add(new ImageFrame<TPixel>(width, height));
         }
 
         internal ImageFrameCollection(Image<TPixel> parent, IEnumerable<ImageFrame<TPixel>> frames)

--- a/src/ImageSharp/Image/ImageFrameCollection.cs
+++ b/src/ImageSharp/Image/ImageFrameCollection.cs
@@ -24,6 +24,8 @@ namespace SixLabors.ImageSharp
             Guard.NotNull(parent, nameof(parent));
 
             this.parent = parent;
+
+            // Frames are already cloned within the caller
             this.frames.Add(new ImageFrame<TPixel>(width, height));
         }
 
@@ -33,9 +35,11 @@ namespace SixLabors.ImageSharp
             Guard.NotNullOrEmpty(frames, nameof(frames));
 
             this.parent = parent;
+
+            // Frames are already cloned by the caller
             foreach (ImageFrame<TPixel> f in frames)
             {
-                this.AddFrame(f);
+                this.frames.Add(f);
             }
         }
 

--- a/src/ImageSharp/Image/ImageFrameCollection.cs
+++ b/src/ImageSharp/Image/ImageFrameCollection.cs
@@ -39,6 +39,7 @@ namespace SixLabors.ImageSharp
             // Frames are already cloned by the caller
             foreach (ImageFrame<TPixel> f in frames)
             {
+                this.ValidateFrame(f);
                 this.frames.Add(f);
             }
         }

--- a/src/ImageSharp/Image/Image{TPixel}.cs
+++ b/src/ImageSharp/Image/Image{TPixel}.cs
@@ -143,9 +143,8 @@ namespace SixLabors.ImageSharp
         /// <returns>Returns a new image with all the same metadata as the original.</returns>
         public Image<TPixel> Clone()
         {
-            IEnumerable<ImageFrame<TPixel>> frames = this.frames.Select(x => x.Clone()).ToArray();
-
-            return new Image<TPixel>(this.configuration, this.MetaData.Clone(), frames);
+            IEnumerable<ImageFrame<TPixel>> clonedFrames = this.frames.Select(x => x.Clone());
+            return new Image<TPixel>(this.configuration, this.MetaData.Clone(), clonedFrames);
         }
 
         /// <inheritdoc/>
@@ -162,8 +161,8 @@ namespace SixLabors.ImageSharp
         public Image<TPixel2> CloneAs<TPixel2>()
             where TPixel2 : struct, IPixel<TPixel2>
         {
-            IEnumerable<ImageFrame<TPixel2>> frames = this.frames.Select(x => x.CloneAs<TPixel2>()).ToArray();
-            var target = new Image<TPixel2>(this.configuration, this.MetaData, frames);
+            IEnumerable<ImageFrame<TPixel2>> clonedFrames = this.frames.Select(x => x.CloneAs<TPixel2>());
+            var target = new Image<TPixel2>(this.configuration, this.MetaData.Clone(), clonedFrames);
 
             return target;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This fixes the allocations we discovered in #348

Turns out we were double cloning and not disposing of frames when initializing the `ImageFrameCollection`.

<!-- Thanks for contributing to ImageSharp! -->
