### PR TITLE
Js/fix 262

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -98,9 +98,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
             this.hasFrames = image.Frames.Count > 1;
 
-            // Dithering when animating gifs is a bad idea as we introduce pixel tearing across frames.
             var ditheredQuantizer = (IQuantizer<TPixel>)this.quantizer;
-            ditheredQuantizer.Dither = !this.hasFrames;
 
             // Quantize the image returning a palette.
             QuantizedImage<TPixel> quantized = ditheredQuantizer.Quantize(image.Frames.RootFrame, size);

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -98,10 +98,10 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
             this.hasFrames = image.Frames.Count > 1;
 
-            var ditheredQuantizer = (IQuantizer<TPixel>)this.quantizer;
+            var pixelQuantizer = (IQuantizer<TPixel>)this.quantizer;
 
             // Quantize the image returning a palette.
-            QuantizedImage<TPixel> quantized = ditheredQuantizer.Quantize(image.Frames.RootFrame, size);
+            QuantizedImage<TPixel> quantized = pixelQuantizer.Quantize(image.Frames.RootFrame, size);
 
             int index = this.GetTransparentIndex(quantized);
 
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             {
                 if (quantized == null)
                 {
-                    quantized = ditheredQuantizer.Quantize(frame, size);
+                    quantized = pixelQuantizer.Quantize(frame, size);
                 }
 
                 this.WriteGraphicalControlExtension(frame.MetaData, writer, this.GetTransparentIndex(quantized));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Dither is a property of the `IQuantizer<TPixel>` interface so that can be used to turn off dithering now. It's on by default. 

<!-- Thanks for contributing to ImageSharp! -->
