### PR TITLE
Add missing test for #359

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -24,6 +24,7 @@ namespace SixLabors.ImageSharp.Tests
                 TestImages.Png.Splash, TestImages.Png.Indexed,
                 TestImages.Png.FilterVar,
                 TestImages.Png.Bad.ChunkLength1,
+                TestImages.Png.Bad.CorruptedChunk,
 
                 TestImages.Png.VimImage1,
                 TestImages.Png.VersioningImage1,

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -20,7 +20,6 @@ namespace SixLabors.ImageSharp.Tests
             public const string Blur = "Png/blur.png";
             public const string Indexed = "Png/indexed.png";
             public const string Splash = "Png/splash.png";
-            public const string CorruptedChunk = "Png/big-corrupted-chunk.png";
             public const string Cross = "Png/cross.png";
             public const string Powerpoint = "Png/pp.png";
             public const string SplashInterlaced = "Png/splash-interlaced.png";
@@ -57,6 +56,7 @@ namespace SixLabors.ImageSharp.Tests
                 // Odd chunk lengths
                 public const string ChunkLength1 = "Png/chunklength1.png";
                 public const string ChunkLength2 = "Png/chunklength2.png";
+                public const string CorruptedChunk = "Png/big-corrupted-chunk.png";
             }
 
             public static readonly string[] All =


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Missing tests for PR #359

<!-- Thanks for contributing to ImageSharp! -->
