### PR TITLE
Js/fix diffused animations

### DIFF
--- a/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
@@ -61,6 +61,7 @@ namespace SixLabors.ImageSharp.Quantizers
             this.colors = (byte)maxColors.Clamp(1, 255);
             this.octree = new Octree(this.GetBitsNeededForColorDepth(this.colors));
             this.palette = null;
+            this.colorMap.Clear();
 
             return base.Quantize(image, this.colors);
         }

--- a/src/ImageSharp/Quantizers/PaletteQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/PaletteQuantizer{TPixel}.cs
@@ -58,6 +58,7 @@ namespace SixLabors.ImageSharp.Quantizers
         public override QuantizedImage<TPixel> Quantize(ImageFrame<TPixel> image, int maxColors)
         {
             Array.Resize(ref this.colors, maxColors.Clamp(1, 255));
+            this.colorMap.Clear();
             return base.Quantize(image, maxColors);
         }
 

--- a/src/ImageSharp/Quantizers/QuantizerBase{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/QuantizerBase{TPixel}.cs
@@ -43,7 +43,7 @@ namespace SixLabors.ImageSharp.Quantizers.Base
         public bool Dither { get; set; } = true;
 
         /// <inheritdoc />
-        public IErrorDiffuser DitherType { get; set; } = new SierraLiteDiffuser();
+        public IErrorDiffuser DitherType { get; set; } = new FloydSteinbergDiffuser();
 
         /// <inheritdoc/>
         public virtual QuantizedImage<TPixel> Quantize(ImageFrame<TPixel> image, int maxColors)

--- a/src/ImageSharp/Quantizers/WuQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/WuQuantizer{TPixel}.cs
@@ -139,6 +139,7 @@ namespace SixLabors.ImageSharp.Quantizers
 
             this.colors = maxColors.Clamp(1, 255);
             this.palette = null;
+            this.colorMap.Clear();
 
             try
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
When encoding animated gifs we weren't resetting the colormap cache between frames. This caused banding for the Octree Quantizer and out of range exceptions in the Wu Quantizer. 

I've also switched out the default SierraLite Diffuser in QuantizerBase for the Floyd-Steinburg one despite it being slower as it yields much reduced file sizes. 30kb against one test image.

<!-- Thanks for contributing to ImageSharp! -->
