### PR TITLE
Jpeg Quality 0 and 1 should be equal

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegEncoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoder.cs
@@ -21,13 +21,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// Gets or sets the quality, that will be used to encode the image. Quality
         /// index must be between 0 and 100 (compression from max to min).
         /// </summary>
-        /// <value>The quality of the jpg image from 0 to 100.</value>
         public int Quality { get; set; }
 
         /// <summary>
         /// Gets or sets the subsample ration, that will be used to encode the image.
         /// </summary>
-        /// <value>The subsample ratio of the jpg image.</value>
         public JpegSubsample? Subsample { get; set; }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/JpegEncoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoder.cs
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// Gets or sets the quality, that will be used to encode the image. Quality
         /// index must be between 0 and 100 (compression from max to min).
         /// </summary>
-        public int Quality { get; set; }
+        public int Quality { get; set; } = 75;
 
         /// <summary>
         /// Gets or sets the subsample ration, that will be used to encode the image.

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         public void LoadResizeSave<TPixel>(TestImageProvider<TPixel> provider, int quality, JpegSubsample subsample)
             where TPixel : struct, IPixel<TPixel>
         {
-            using (Image<TPixel> image = provider.GetImage(x=>x.Resize(new ResizeOptions { Size = new Size(150, 100), Mode = ResizeMode.Max })))
+            using (Image<TPixel> image = provider.GetImage(x => x.Resize(new ResizeOptions { Size = new Size(150, 100), Mode = ResizeMode.Max })))
             {
 
                 image.MetaData.ExifProfile = null; // Reduce the size of the file
@@ -62,8 +62,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 {
                     image.Save(outputStream, new JpegEncoder()
                     {
-                      Subsample = subSample,
-                      Quality = quality
+                        Subsample = subSample,
+                        Quality = quality
                     });
                 }
             }
@@ -83,7 +83,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             {
                 using (MemoryStream memStream = new MemoryStream())
                 {
-                    input.Save(memStream,  options);
+                    input.Save(memStream, options);
 
                     memStream.Position = 0;
                     using (Image<Rgba32> output = Image.Load<Rgba32>(memStream))
@@ -116,6 +116,52 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                         Assert.Null(output.MetaData.ExifProfile);
                     }
                 }
+            }
+        }
+
+        [Fact]
+        public void Encode_Quality_0_And_1_Are_Identical()
+        {
+            var options = new JpegEncoder
+            {
+                Quality = 0
+            };
+
+            var testFile = TestFile.Create(TestImages.Jpeg.Baseline.Calliphora);
+
+            using (Image<Rgba32> input = testFile.CreateImage())
+            using (var memStream0 = new MemoryStream())
+            using (var memStream1 = new MemoryStream())
+            {
+                input.SaveAsJpeg(memStream0, options);
+
+                options.Quality = 1;
+                input.SaveAsJpeg(memStream1, options);
+
+                Assert.Equal(memStream0.ToArray(), memStream1.ToArray());
+            }
+        }
+
+        [Fact]
+        public void Encode_Quality_0_And_100_Are_Not_Identical()
+        {
+            var options = new JpegEncoder
+            {
+                Quality = 0
+            };
+
+            var testFile = TestFile.Create(TestImages.Jpeg.Baseline.Calliphora);
+
+            using (Image<Rgba32> input = testFile.CreateImage())
+            using (var memStream0 = new MemoryStream())
+            using (var memStream1 = new MemoryStream())
+            {
+                input.SaveAsJpeg(memStream0, options);
+
+                options.Quality = 100;
+                input.SaveAsJpeg(memStream1, options);
+
+                Assert.NotEqual(memStream0.ToArray(), memStream1.ToArray());
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This fixes #260 so that the behaviour matches `System.Drawing` which produces identical output for quality of 0 and 1.

<!-- Thanks for contributing to ImageSharp! -->
