### PR TITLE
Handle negative x offset for DrawImage

### DIFF
--- a/src/ImageSharp.Drawing/Processors/DrawImageProcessor.cs
+++ b/src/ImageSharp.Drawing/Processors/DrawImageProcessor.cs
@@ -72,10 +72,11 @@ namespace SixLabors.ImageSharp.Drawing.Processors
                 }
 
                 // Align start/end positions.
-                Rectangle bounds = this.Image.Bounds();
+                Rectangle bounds = targetImage.Bounds();
                 int minX = Math.Max(this.Location.X, sourceRectangle.X);
                 int maxX = Math.Min(this.Location.X + bounds.Width, sourceRectangle.Width);
                 maxX = Math.Min(this.Location.X + this.Size.Width, maxX);
+                int targetX = minX - this.Location.X;
 
                 int minY = Math.Max(this.Location.Y, sourceRectangle.Y);
                 int maxY = Math.Min(this.Location.Y + bounds.Height, sourceRectangle.Bottom);
@@ -97,7 +98,7 @@ namespace SixLabors.ImageSharp.Drawing.Processors
                         y =>
                             {
                                 Span<TPixel> background = source.GetPixelRowSpan(y).Slice(minX, width);
-                                Span<TPixel> foreground = targetImage.GetPixelRowSpan(y - this.Location.Y).Slice(0, width);
+                                Span<TPixel> foreground = targetImage.GetPixelRowSpan(y - this.Location.Y).Slice(targetX, width);
                                 this.blender.Blend(background, background, foreground, amount);
                             });
                 }

--- a/src/ImageSharp.Drawing/Processors/DrawImageProcessor.cs
+++ b/src/ImageSharp.Drawing/Processors/DrawImageProcessor.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Numerics;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Helpers;
@@ -42,7 +41,7 @@ namespace SixLabors.ImageSharp.Drawing.Processors
         /// <summary>
         /// Gets the image to blend.
         /// </summary>
-        public Image<TPixel> Image { get; private set; }
+        public Image<TPixel> Image { get; }
 
         /// <summary>
         /// Gets the alpha percentage value.
@@ -84,9 +83,7 @@ namespace SixLabors.ImageSharp.Drawing.Processors
                 maxY = Math.Min(this.Location.Y + this.Size.Height, maxY);
 
                 int width = maxX - minX;
-                using (Buffer<float> amount = new Buffer<float>(width))
-                using (PixelAccessor<TPixel> toBlendPixels = targetImage.Lock())
-                using (PixelAccessor<TPixel> sourcePixels = source.Lock())
+                using (var amount = new Buffer<float>(width))
                 {
                     for (int i = 0; i < width; i++)
                     {
@@ -99,8 +96,8 @@ namespace SixLabors.ImageSharp.Drawing.Processors
                         configuration.ParallelOptions,
                         y =>
                             {
-                                Span<TPixel> background = sourcePixels.GetRowSpan(y).Slice(minX, width);
-                                Span<TPixel> foreground = toBlendPixels.GetRowSpan(y - this.Location.Y).Slice(0, width);
+                                Span<TPixel> background = source.GetPixelRowSpan(y).Slice(minX, width);
+                                Span<TPixel> foreground = targetImage.GetPixelRowSpan(y - this.Location.Y).Slice(0, width);
                                 this.blender.Blend(background, background, foreground, amount);
                             });
                 }

--- a/tests/ImageSharp.Tests/Drawing/DrawImageTest.cs
+++ b/tests/ImageSharp.Tests/Drawing/DrawImageTest.cs
@@ -9,6 +9,8 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests
 {
+    using System;
+
     public class DrawImageTest : FileTestBase
     {
         private const PixelTypes PixelTypes = Tests.PixelTypes.Rgba32;
@@ -40,6 +42,46 @@ namespace SixLabors.ImageSharp.Tests
             {
                 image.Mutate(x => x.DrawImage(blend, mode, .75f, new Size(image.Width / 2, image.Height / 2), new Point(image.Width / 4, image.Height / 4)));
                 image.DebugSave(provider, new { mode });
+            }
+        }
+
+        [Theory]
+        [WithFile(TestImages.Bmp.Car, PixelTypes.Rgba32, TestImages.Png.Splash)]
+        public void ImageShouldHandleNegativeLocation(TestImageProvider<Rgba32> provider, string backgroundPath)
+        {
+            using (Image<Rgba32> background = TestFile.Create(backgroundPath).CreateImage())
+            using (Image<Rgba32> overlay = provider.GetImage())
+            {
+                int xy = -25;
+                Rgba32 backgroundPixel = background[0, 0];
+                Rgba32 overlayPixel = overlay[Math.Abs(xy) + 1, Math.Abs(xy) + 1];
+
+                background.Mutate(x => x.DrawImage(overlay, PixelBlenderMode.Normal, 1F, new Size(overlay.Width, overlay.Height), new Point(xy, xy)));
+
+                Assert.Equal(default(Rgba32), backgroundPixel);
+                Assert.Equal(overlayPixel, background[0, 0]);
+
+                background.DebugSave(provider, new[] { "Negative" });
+            }
+        }
+
+        [Theory]
+        [WithFile(TestImages.Bmp.Car, PixelTypes.Rgba32, TestImages.Png.Splash)]
+        public void ImageShouldHandlePositiveLocation(TestImageProvider<Rgba32> provider, string backgroundPath)
+        {
+            using (Image<Rgba32> background = TestFile.Create(backgroundPath).CreateImage())
+            using (Image<Rgba32> overlay = provider.GetImage())
+            {
+                int xy = 25;
+                Rgba32 backgroundPixel = background[xy - 1, xy - 1];
+                Rgba32 overlayPixel = overlay[0, 0];
+
+                background.Mutate(x => x.DrawImage(overlay, PixelBlenderMode.Normal, 1F, new Size(overlay.Width, overlay.Height), new Point(xy, xy)));
+
+                Assert.Equal(default(Rgba32), backgroundPixel);
+                Assert.Equal(overlayPixel, background[xy, xy]);
+
+                background.DebugSave(provider, new[] { "Positive" });
             }
         }
     }

--- a/tests/ImageSharp.Tests/Drawing/DrawImageTest.cs
+++ b/tests/ImageSharp.Tests/Drawing/DrawImageTest.cs
@@ -46,19 +46,21 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         [Theory]
-        [WithFile(TestImages.Bmp.Car, PixelTypes.Rgba32, TestImages.Png.Splash)]
-        public void ImageShouldHandleNegativeLocation(TestImageProvider<Rgba32> provider, string backgroundPath)
+        [WithSolidFilledImages(100, 100, 255, 255, 255, PixelTypes.Rgba32)]
+        public void ImageShouldHandleNegativeLocation(TestImageProvider<Rgba32> provider)
         {
-            using (Image<Rgba32> background = TestFile.Create(backgroundPath).CreateImage())
-            using (Image<Rgba32> overlay = provider.GetImage())
+            using (Image<Rgba32> background = provider.GetImage())
+            using (var overlay = new Image<Rgba32>(50, 50))
             {
+                overlay.Mutate(x => x.Fill(Rgba32.Black));
+
                 int xy = -25;
                 Rgba32 backgroundPixel = background[0, 0];
                 Rgba32 overlayPixel = overlay[Math.Abs(xy) + 1, Math.Abs(xy) + 1];
 
                 background.Mutate(x => x.DrawImage(overlay, PixelBlenderMode.Normal, 1F, new Size(overlay.Width, overlay.Height), new Point(xy, xy)));
 
-                Assert.Equal(default(Rgba32), backgroundPixel);
+                Assert.Equal(Rgba32.White, backgroundPixel);
                 Assert.Equal(overlayPixel, background[0, 0]);
 
                 background.DebugSave(provider, new[] { "Negative" });
@@ -66,19 +68,21 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         [Theory]
-        [WithFile(TestImages.Bmp.Car, PixelTypes.Rgba32, TestImages.Png.Splash)]
-        public void ImageShouldHandlePositiveLocation(TestImageProvider<Rgba32> provider, string backgroundPath)
+        [WithSolidFilledImages(100, 100, 255, 255, 255, PixelTypes.Rgba32)]
+        public void ImageShouldHandlePositiveLocation(TestImageProvider<Rgba32> provider)
         {
-            using (Image<Rgba32> background = TestFile.Create(backgroundPath).CreateImage())
-            using (Image<Rgba32> overlay = provider.GetImage())
+            using (Image<Rgba32> background = provider.GetImage())
+            using (var overlay = new Image<Rgba32>(50, 50))
             {
+                overlay.Mutate(x => x.Fill(Rgba32.Black));
+
                 int xy = 25;
                 Rgba32 backgroundPixel = background[xy - 1, xy - 1];
                 Rgba32 overlayPixel = overlay[0, 0];
 
                 background.Mutate(x => x.DrawImage(overlay, PixelBlenderMode.Normal, 1F, new Size(overlay.Width, overlay.Height), new Point(xy, xy)));
 
-                Assert.Equal(default(Rgba32), backgroundPixel);
+                Assert.Equal(Rgba32.White, backgroundPixel);
                 Assert.Equal(overlayPixel, background[xy, xy]);
 
                 background.DebugSave(provider, new[] { "Positive" });


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR fixes #252 where we weren't correctly handling negative x-offset values when drawing images.

<!-- Thanks for contributing to ImageSharp! -->
