### PR TITLE
Enable decoding  only single frame from animated gif + fix quantization issue

### DIFF
--- a/src/ImageSharp/Formats/Gif/FrameDecodingMode.cs
+++ b/src/ImageSharp/Formats/Gif/FrameDecodingMode.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Formats.Gif
+{
+    /// <summary>
+    /// Enumerated frame process modes to apply to multi-frame images.
+    /// </summary>
+    public enum FrameDecodingMode
+    {
+        /// <summary>
+        /// Decodes all the frames of a multi-frame image.
+        /// </summary>
+        All,
+
+        /// <summary>
+        /// Decodes only the first frame of a multi-frame image.
+        /// </summary>
+        First
+    }
+}

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -24,6 +24,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         public Encoding TextEncoding { get; set; } = GifConstants.DefaultEncoding;
 
+        /// <summary>
+        /// Gets or sets the decoding mode for multi-frame images
+        /// </summary>
+        public FrameDecodingMode DecodingMode { get; set; } = FrameDecodingMode.All;
+
         /// <inheritdoc/>
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
             where TPixel : struct, IPixel<TPixel>

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -84,6 +84,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         {
             this.TextEncoding = options.TextEncoding ?? GifConstants.DefaultEncoding;
             this.IgnoreMetadata = options.IgnoreMetadata;
+            this.DecodingMode = options.DecodingMode;
             this.configuration = configuration ?? Configuration.Default;
         }
 
@@ -96,6 +97,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// Gets the text encoding
         /// </summary>
         public Encoding TextEncoding { get; }
+
+        /// <summary>
+        /// Gets the decoding mode for multi-frame images
+        /// </summary>
+        public FrameDecodingMode DecodingMode { get; }
 
         /// <summary>
         /// Decodes the stream to the image.
@@ -129,6 +135,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 {
                     if (nextFlag == GifConstants.ImageLabel)
                     {
+                        if (this.previousFrame != null && this.DecodingMode == FrameDecodingMode.First)
+                        {
+                            break;
+                        }
+
                         this.ReadFrame();
                     }
                     else if (nextFlag == GifConstants.ExtensionIntroducer)
@@ -238,14 +249,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
             {
                 throw new ImageFormatException($"Invalid gif colormap size '{this.logicalScreenDescriptor.GlobalColorTableSize}'");
             }
-
-            /* // No point doing this as the max width/height is always int.Max and that always bigger than the max size of a gif which is stored in a short.
-            if (this.logicalScreenDescriptor.Width > Image<TPixel>.MaxWidth || this.logicalScreenDescriptor.Height > Image<TPixel>.MaxHeight)
-            {
-                throw new ArgumentOutOfRangeException(
-                    $"The input gif '{this.logicalScreenDescriptor.Width}x{this.logicalScreenDescriptor.Height}' is bigger then the max allowed size '{Image<TPixel>.MaxWidth}x{Image<TPixel>.MaxHeight}'");
-            }
-            */
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -154,18 +154,14 @@ namespace SixLabors.ImageSharp.Formats.Gif
         {
             // Transparent pixels are much more likely to be found at the end of a palette
             int index = -1;
+            var trans = default(Rgba32);
             for (int i = quantized.Palette.Length - 1; i >= 0; i--)
             {
-                quantized.Palette[i].ToXyzwBytes(this.buffer, 0);
+                quantized.Palette[i].ToRgba32(ref trans);
 
-                if (this.buffer[3] > 0)
-                {
-                    continue;
-                }
-                else
+                if (trans.Equals(default(Rgba32)))
                 {
                     index = i;
-                    break;
                 }
             }
 

--- a/src/ImageSharp/Formats/Gif/IGifDecoderOptions.cs
+++ b/src/ImageSharp/Formats/Gif/IGifDecoderOptions.cs
@@ -19,5 +19,10 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// Gets the encoding that should be used when reading comments.
         /// </summary>
         Encoding TextEncoding { get; }
+
+        /// <summary>
+        /// Gets the decoding mode for multi-frame images
+        /// </summary>
+        FrameDecodingMode DecodingMode { get; }
     }
 }

--- a/src/ImageSharp/Formats/Gif/IGifDecoderOptions.cs
+++ b/src/ImageSharp/Formats/Gif/IGifDecoderOptions.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Text;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Formats.Gif
 {

--- a/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
@@ -24,11 +24,6 @@ namespace SixLabors.ImageSharp.Quantizers
         private readonly Dictionary<TPixel, byte> colorMap = new Dictionary<TPixel, byte>();
 
         /// <summary>
-        /// The pixel buffer, used to reduce allocations.
-        /// </summary>
-        private readonly byte[] pixelBuffer = new byte[4];
-
-        /// <summary>
         /// Stores the tree
         /// </summary>
         private Octree octree;
@@ -42,6 +37,11 @@ namespace SixLabors.ImageSharp.Quantizers
         /// The reduced image palette
         /// </summary>
         private TPixel[] palette;
+
+        /// <summary>
+        /// The transparent index
+        /// </summary>
+        private byte transparentIndex;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OctreeQuantizer{TPixel}"/> class.
@@ -73,7 +73,8 @@ namespace SixLabors.ImageSharp.Quantizers
             // pass of the algorithm by avoiding transforming rows of identical color.
             TPixel sourcePixel = source[0, 0];
             TPixel previousPixel = sourcePixel;
-            byte pixelValue = this.QuantizePixel(sourcePixel);
+            var rgba = default(Rgba32);
+            byte pixelValue = this.QuantizePixel(sourcePixel, ref rgba);
             TPixel[] colorPalette = this.GetPalette();
             TPixel transformedPixel = colorPalette[pixelValue];
 
@@ -92,7 +93,7 @@ namespace SixLabors.ImageSharp.Quantizers
                     if (!previousPixel.Equals(sourcePixel))
                     {
                         // Quantize the pixel
-                        pixelValue = this.QuantizePixel(sourcePixel);
+                        pixelValue = this.QuantizePixel(sourcePixel, ref rgba);
 
                         // And setup the previous pointer
                         previousPixel = sourcePixel;
@@ -118,24 +119,57 @@ namespace SixLabors.ImageSharp.Quantizers
         protected override void InitialQuantizePixel(TPixel pixel)
         {
             // Add the color to the Octree
-            this.octree.AddColor(pixel, this.pixelBuffer);
+            var rgba = default(Rgba32);
+            this.octree.AddColor(pixel, ref rgba);
         }
 
         /// <inheritdoc/>
         protected override TPixel[] GetPalette()
         {
-            return this.palette ?? (this.palette = this.octree.Palletize(Math.Max(this.colors, (byte)1)));
+            if (this.palette == null)
+            {
+                this.palette = this.octree.Palletize(Math.Max(this.colors, (byte)1));
+                this.transparentIndex = this.GetTransparentIndex();
+            }
+
+            return this.palette;
+        }
+
+        /// <summary>
+        /// Returns the index of the first instance of the transparent color in the palette.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="int"/>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private byte GetTransparentIndex()
+        {
+            // Transparent pixels are much more likely to be found at the end of a palette
+            int index = this.colors;
+            var trans = default(Rgba32);
+            for (int i = this.palette.Length - 1; i >= 0; i--)
+            {
+                this.palette[i].ToRgba32(ref trans);
+
+                if (trans.Equals(default(Rgba32)))
+                {
+                    index = i;
+                }
+            }
+
+            return (byte)index;
         }
 
         /// <summary>
         /// Process the pixel in the second pass of the algorithm
         /// </summary>
         /// <param name="pixel">The pixel to quantize</param>
+        /// <param name="rgba">The color to compare against</param>
         /// <returns>
         /// The quantized value
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private byte QuantizePixel(TPixel pixel)
+        private byte QuantizePixel(TPixel pixel, ref Rgba32 rgba)
         {
             if (this.Dither)
             {
@@ -144,13 +178,13 @@ namespace SixLabors.ImageSharp.Quantizers
                 return this.GetClosestPixel(pixel, this.palette, this.colorMap);
             }
 
-            pixel.ToXyzwBytes(this.pixelBuffer, 0);
-            if (this.pixelBuffer[3] == 0)
+            pixel.ToRgba32(ref rgba);
+            if (rgba.Equals(default(Rgba32)))
             {
-                return this.colors;
+                return this.transparentIndex;
             }
 
-            return (byte)this.octree.GetPaletteIndex(pixel, this.pixelBuffer);
+            return (byte)this.octree.GetPaletteIndex(pixel, ref rgba);
         }
 
         /// <summary>
@@ -233,8 +267,8 @@ namespace SixLabors.ImageSharp.Quantizers
             /// Add a given color value to the Octree
             /// </summary>
             /// <param name="pixel">The pixel data.</param>
-            /// <param name="buffer">The buffer array.</param>
-            public void AddColor(TPixel pixel, byte[] buffer)
+            /// <param name="rgba">The color.</param>
+            public void AddColor(TPixel pixel, ref Rgba32 rgba)
             {
                 // Check if this request is for the same color as the last
                 if (this.previousColor.Equals(pixel))
@@ -244,18 +278,18 @@ namespace SixLabors.ImageSharp.Quantizers
                     if (this.previousNode == null)
                     {
                         this.previousColor = pixel;
-                        this.root.AddColor(pixel, this.maxColorBits, 0, this, buffer);
+                        this.root.AddColor(pixel, this.maxColorBits, 0, this, ref rgba);
                     }
                     else
                     {
                         // Just update the previous node
-                        this.previousNode.Increment(pixel, buffer);
+                        this.previousNode.Increment(pixel, ref rgba);
                     }
                 }
                 else
                 {
                     this.previousColor = pixel;
-                    this.root.AddColor(pixel, this.maxColorBits, 0, this, buffer);
+                    this.root.AddColor(pixel, this.maxColorBits, 0, this, ref rgba);
                 }
             }
 
@@ -287,13 +321,13 @@ namespace SixLabors.ImageSharp.Quantizers
             /// Get the palette index for the passed color
             /// </summary>
             /// <param name="pixel">The pixel data.</param>
-            /// <param name="buffer">The buffer array.</param>
+            /// <param name="rgba">The color to map to.</param>
             /// <returns>
             /// The <see cref="int"/>.
             /// </returns>
-            public int GetPaletteIndex(TPixel pixel, byte[] buffer)
+            public int GetPaletteIndex(TPixel pixel, ref Rgba32 rgba)
             {
-                return this.root.GetPaletteIndex(pixel, 0, buffer);
+                return this.root.GetPaletteIndex(pixel, 0, ref rgba);
             }
 
             /// <summary>
@@ -415,17 +449,17 @@ namespace SixLabors.ImageSharp.Quantizers
                 /// <summary>
                 /// Add a color into the tree
                 /// </summary>
-                /// <param name="pixel">The color</param>
+                /// <param name="pixel">The pixel color</param>
                 /// <param name="colorBits">The number of significant color bits</param>
                 /// <param name="level">The level in the tree</param>
                 /// <param name="octree">The tree to which this node belongs</param>
-                /// <param name="buffer">The buffer array.</param>
-                public void AddColor(TPixel pixel, int colorBits, int level, Octree octree, byte[] buffer)
+                /// <param name="rgba">The color to map to.</param>
+                public void AddColor(TPixel pixel, int colorBits, int level, Octree octree, ref Rgba32 rgba)
                 {
                     // Update the color information if this is a leaf
                     if (this.leaf)
                     {
-                        this.Increment(pixel, buffer);
+                        this.Increment(pixel, ref rgba);
 
                         // Setup the previous node
                         octree.TrackPrevious(this);
@@ -434,11 +468,11 @@ namespace SixLabors.ImageSharp.Quantizers
                     {
                         // Go to the next level down in the tree
                         int shift = 7 - level;
-                        pixel.ToXyzwBytes(buffer, 0);
+                        pixel.ToRgba32(ref rgba);
 
-                        int index = ((buffer[2] & Mask[level]) >> (shift - 2)) |
-                                    ((buffer[1] & Mask[level]) >> (shift - 1)) |
-                                    ((buffer[0] & Mask[level]) >> shift);
+                        int index = ((rgba.B & Mask[level]) >> (shift - 2)) |
+                                    ((rgba.G & Mask[level]) >> (shift - 1)) |
+                                    ((rgba.R & Mask[level]) >> shift);
 
                         OctreeNode child = this.children[index];
 
@@ -450,7 +484,7 @@ namespace SixLabors.ImageSharp.Quantizers
                         }
 
                         // Add the color to the child node
-                        child.AddColor(pixel, colorBits, level + 1, octree, buffer);
+                        child.AddColor(pixel, colorBits, level + 1, octree, ref rgba);
                     }
                 }
 
@@ -524,26 +558,26 @@ namespace SixLabors.ImageSharp.Quantizers
                 /// </summary>
                 /// <param name="pixel">The pixel data.</param>
                 /// <param name="level">The level.</param>
-                /// <param name="buffer">The buffer array.</param>
+                /// <param name="rgba">The color to map to.</param>
                 /// <returns>
                 /// The <see cref="int"/> representing the index of the pixel in the palette.
                 /// </returns>
-                public int GetPaletteIndex(TPixel pixel, int level, byte[] buffer)
+                public int GetPaletteIndex(TPixel pixel, int level, ref Rgba32 rgba)
                 {
                     int index = this.paletteIndex;
 
                     if (!this.leaf)
                     {
                         int shift = 7 - level;
-                        pixel.ToXyzwBytes(buffer, 0);
+                        pixel.ToRgba32(ref rgba);
 
-                        int pixelIndex = ((buffer[2] & Mask[level]) >> (shift - 2)) |
-                                         ((buffer[1] & Mask[level]) >> (shift - 1)) |
-                                         ((buffer[0] & Mask[level]) >> shift);
+                        int pixelIndex = ((rgba.B & Mask[level]) >> (shift - 2)) |
+                                         ((rgba.G & Mask[level]) >> (shift - 1)) |
+                                         ((rgba.R & Mask[level]) >> shift);
 
                         if (this.children[pixelIndex] != null)
                         {
-                            index = this.children[pixelIndex].GetPaletteIndex(pixel, level + 1, buffer);
+                            index = this.children[pixelIndex].GetPaletteIndex(pixel, level + 1, ref rgba);
                         }
                         else
                         {
@@ -558,14 +592,14 @@ namespace SixLabors.ImageSharp.Quantizers
                 /// Increment the pixel count and add to the color information
                 /// </summary>
                 /// <param name="pixel">The pixel to add.</param>
-                /// <param name="buffer">The buffer array.</param>
-                public void Increment(TPixel pixel, byte[] buffer)
+                /// <param name="rgba">The color to map to.</param>
+                public void Increment(TPixel pixel, ref Rgba32 rgba)
                 {
-                    pixel.ToXyzwBytes(buffer, 0);
+                    pixel.ToRgba32(ref rgba);
                     this.pixelCount++;
-                    this.red += buffer[0];
-                    this.green += buffer[1];
-                    this.blue += buffer[2];
+                    this.red += rgba.R;
+                    this.green += rgba.G;
+                    this.blue += rgba.B;
                 }
             }
         }

--- a/src/ImageSharp/Quantizers/QuantizerBase{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/QuantizerBase{TPixel}.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Quantizers.Base
         }
 
         /// <inheritdoc />
-        public bool Dither { get; set; } = true;
+        public bool Dither { get; set; } = false;
 
         /// <inheritdoc />
         public IErrorDiffuser DitherType { get; set; } = new FloydSteinbergDiffuser();

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Text;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
@@ -45,12 +44,12 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void Decode_IgnoreMetadataIsFalse_CommentsAreRead()
         {
-            GifDecoder options = new GifDecoder()
+            var options = new GifDecoder
             {
                 IgnoreMetadata = false
             };
 
-            TestFile testFile = TestFile.Create(TestImages.Gif.Rings);
+            var testFile = TestFile.Create(TestImages.Gif.Rings);
 
             using (Image<Rgba32> image = testFile.CreateImage(options))
             {
@@ -63,12 +62,12 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void Decode_IgnoreMetadataIsTrue_CommentsAreIgnored()
         {
-            GifDecoder options = new GifDecoder()
+            var options = new GifDecoder
             {
                 IgnoreMetadata = true
             };
 
-            TestFile testFile = TestFile.Create(TestImages.Gif.Rings);
+            var testFile = TestFile.Create(TestImages.Gif.Rings);
 
             using (Image<Rgba32> image = testFile.CreateImage(options))
             {
@@ -79,17 +78,39 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void Decode_TextEncodingSetToUnicode_TextIsReadWithCorrectEncoding()
         {
-            GifDecoder options = new GifDecoder()
+            var options = new GifDecoder
             {
                 TextEncoding = Encoding.Unicode
             };
 
-            TestFile testFile = TestFile.Create(TestImages.Gif.Rings);
+            var testFile = TestFile.Create(TestImages.Gif.Rings);
 
             using (Image<Rgba32> image = testFile.CreateImage(options))
             {
                 Assert.Equal(1, image.MetaData.Properties.Count);
                 Assert.Equal("浉条卥慨灲", image.MetaData.Properties[0].Value);
+            }
+        }
+
+        [Theory]
+        [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
+        public void CanDecodeJustOneFrame<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage(new GifDecoder { DecodingMode = FrameDecodingMode.First }))
+            {
+                Assert.Equal(1, image.Frames.Count);
+            }
+        }
+
+        [Theory]
+        [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
+        public void CanDecodeAllFrames<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage(new GifDecoder { DecodingMode = FrameDecodingMode.All }))
+            {
+                Assert.True(image.Frames.Count > 1);
             }
         }
     }

--- a/tests/ImageSharp.Tests/Quantization/QuantizedImageTests.cs
+++ b/tests/ImageSharp.Tests/Quantization/QuantizedImageTests.cs
@@ -1,0 +1,95 @@
+﻿namespace SixLabors.ImageSharp.Tests
+{
+    using SixLabors.ImageSharp.PixelFormats;
+    using SixLabors.ImageSharp.Quantizers;
+
+    using Xunit;
+
+    public class QuantizedImageTests
+    {
+        [Theory]
+        [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32, true)]
+        [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32, false)]
+        public void PaletteQuantizerYieldsCorrectTransparentPixel<TPixel>(TestImageProvider<TPixel> provider, bool dither)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                Assert.True(image[0, 0].Equals(default(TPixel)));
+
+                IQuantizer<TPixel> quantizer = new PaletteQuantizer<TPixel> { Dither = dither };
+
+                foreach (ImageFrame<TPixel> frame in image.Frames)
+                {
+                    QuantizedImage<TPixel> quantized = quantizer.Quantize(frame, 256);
+
+                    int index = this.GetTransparentIndex(quantized);
+                    Assert.Equal(index, quantized.Pixels[0]);
+                }
+            }
+        }
+
+        [Theory]
+        [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32, true)]
+        [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32, false)]
+        public void OctreeQuantizerYieldsCorrectTransparentPixel<TPixel>(TestImageProvider<TPixel> provider, bool dither)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                Assert.True(image[0, 0].Equals(default(TPixel)));
+
+                IQuantizer<TPixel> quantizer = new OctreeQuantizer<TPixel> { Dither = dither };
+
+                foreach (ImageFrame<TPixel> frame in image.Frames)
+                {
+                    QuantizedImage<TPixel> quantized = quantizer.Quantize(frame, 256);
+
+                    int index = this.GetTransparentIndex(quantized);
+                    Assert.Equal(index, quantized.Pixels[0]);
+                }
+            }
+        }
+
+        [Theory]
+        [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32, true)]
+        [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32, false)]
+        public void WuQuantizerYieldsCorrectTransparentPixel<TPixel>(TestImageProvider<TPixel> provider, bool dither)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                Assert.True(image[0, 0].Equals(default(TPixel)));
+
+                IQuantizer<TPixel> quantizer = new WuQuantizer<TPixel> { Dither = dither };
+
+                foreach (ImageFrame<TPixel> frame in image.Frames)
+                {
+                    QuantizedImage<TPixel> quantized = quantizer.Quantize(frame, 256);
+
+                    int index = this.GetTransparentIndex(quantized);
+                    Assert.Equal(index, quantized.Pixels[0]);
+                }
+            }
+        }
+
+        private int GetTransparentIndex<TPixel>(QuantizedImage<TPixel> quantized)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            // Transparent pixels are much more likely to be found at the end of a palette
+            int index = -1;
+            var trans = default(Rgba32);
+            for (int i = quantized.Palette.Length - 1; i >= 0; i--)
+            {
+                quantized.Palette[i].ToRgba32(ref trans);
+
+                if (trans.Equals(default(Rgba32)))
+                {
+                    index = i;
+                }
+            }
+
+            return index;
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR was originally designed to simply add a `FrameDecodingMode` enumeration for decoding animated gifs but I discovered an inconsistency in quantization while I was cleaning up the codebase. 

As such I've combined the fix + tests to this PR.

<!-- Thanks for contributing to ImageSharp! -->
