### PR TITLE
Rotation by bi-linear interpolation

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/RotateInterpolationProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateInterpolationProcessor.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Helpers;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.Primitives;
+
+namespace SixLabors.ImageSharp.Processing.Processors
+{
+    internal class RotateInterpolationProcessor<TPixel> : RotateProcessor<TPixel>
+        where TPixel : struct, IPixel<TPixel>
+    {
+        /// <inheritdoc/>
+        protected override void OnApply(ImageFrame<TPixel> source, Rectangle sourceRectangle, Configuration configuration)
+        {
+            if (this.OptimizedApply(source, configuration))
+            {
+                return;
+            }
+
+            int height = this.CanvasRectangle.Height;
+            int width = this.CanvasRectangle.Width;
+            Matrix3x2 matrix = this.GetCenteredMatrix(source, this.ProcessMatrix);
+            Rectangle sourceBounds = source.Bounds();
+
+            using (var targetPixels = new PixelAccessor<TPixel>(width, height))
+            {
+                Parallel.For(
+                    0,
+                    height,
+                    new ParallelOptions { MaxDegreeOfParallelism = 1 }, //configuration.ParallelOptions,
+                    y =>
+                    {
+                        Span<TPixel> targetRow = targetPixels.GetRowSpan(y);
+
+                        for (int x = 0; x < width; x++)
+                        {
+                            var transformedPoint = PointF.Rotate(new Point(x, y), matrix);
+                            var rounded = Point.Round(transformedPoint);
+                            if (sourceBounds.Contains(rounded.X, rounded.Y))
+                            {
+                                int ceilX = unchecked((int)MathF.Ceiling(transformedPoint.X));
+                                int ceilY = unchecked((int)MathF.Ceiling(transformedPoint.Y));
+                                int floorX = unchecked((int)MathF.Floor(transformedPoint.X));
+                                int floorY = unchecked((int)MathF.Floor(transformedPoint.Y));
+
+                                // Clamp sampling pixels to the source image edge
+                                ceilX = Math.Min(ceilX, sourceBounds.Width - 1);
+                                floorX = Math.Max(0, floorX);
+                                ceilY = Math.Min(ceilY, sourceBounds.Height - 1);
+                                floorY = Math.Max(0, floorY);
+
+                                // At the image edge, take the whole value of source
+                                float wx1, wx2, wy1, wy2;
+                                if (ceilX == floorX)
+                                {
+                                    wx1 = 1;
+                                    wx2 = 0;
+                                }
+                                else
+                                {
+                                    wx1 = ceilX - transformedPoint.X;
+                                    wx2 = transformedPoint.X - floorX;
+                                }
+                                if (ceilY == floorY)
+                                {
+                                    wy1 = 1;
+                                    wy2 = 0;
+                                }
+                                else
+                                {
+                                    wy1 = ceilY - transformedPoint.Y;
+                                    wy2 = transformedPoint.Y - floorY;
+                                }
+
+                                var topLeft = source[floorX, ceilY].ToVector4();
+                                var topRight = source[ceilX, ceilY].ToVector4();
+                                var bottomLeft = source[floorX, floorY].ToVector4();
+                                var bottomRight = source[ceilX, floorY].ToVector4();
+
+                                Vector4 interpolated = (wy2 * ((topLeft * wx1) + (topRight * wx2))) +
+                                                       (wy1 * ((bottomLeft * wx1) + (bottomRight * wx2)));
+
+                                targetRow[x].PackFromVector4(interpolated);
+                            }
+                        }
+                    });
+
+                source.SwapPixelsBuffers(targetPixels);
+            }
+        }
+
+    }
+}

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -21,9 +21,9 @@ namespace SixLabors.ImageSharp.Processing.Processors
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>
-        /// The transform matrix to apply.
+        /// Gets or sets the transform matrix to apply.
         /// </summary>
-        private Matrix3x2 processMatrix;
+        protected Matrix3x2 ProcessMatrix { get; set; }
 
         /// <summary>
         /// Gets or sets the angle of processMatrix in degrees.
@@ -45,7 +45,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
 
             int height = this.CanvasRectangle.Height;
             int width = this.CanvasRectangle.Width;
-            Matrix3x2 matrix = this.GetCenteredMatrix(source, this.processMatrix);
+            Matrix3x2 matrix = this.GetCenteredMatrix(source, this.ProcessMatrix);
             Rectangle sourceBounds = source.Bounds();
 
             using (var targetPixels = new PixelAccessor<TPixel>(width, height))
@@ -81,10 +81,10 @@ namespace SixLabors.ImageSharp.Processing.Processors
                 return;
             }
 
-            this.processMatrix = Matrix3x2Extensions.CreateRotationDegrees(-this.Angle, new Point(0, 0));
+            this.ProcessMatrix = Matrix3x2Extensions.CreateRotationDegrees(-this.Angle, new Point(0, 0));
             if (this.Expand)
             {
-                this.CreateNewCanvas(sourceRectangle, this.processMatrix);
+                this.CreateNewCanvas(sourceRectangle, this.ProcessMatrix);
             }
         }
 
@@ -120,7 +120,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// <returns>
         /// The <see cref="bool" />
         /// </returns>
-        private bool OptimizedApply(ImageFrame<TPixel> source, Configuration configuration)
+        protected bool OptimizedApply(ImageFrame<TPixel> source, Configuration configuration)
         {
             if (MathF.Abs(this.Angle) < Constants.Epsilon)
             {

--- a/src/ImageSharp/Processing/Transforms/Rotate.cs
+++ b/src/ImageSharp/Processing/Transforms/Rotate.cs
@@ -47,6 +47,6 @@ namespace SixLabors.ImageSharp
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         public static IImageProcessingContext<TPixel> Rotate<TPixel>(this IImageProcessingContext<TPixel> source, float degrees, bool expand)
             where TPixel : struct, IPixel<TPixel>
-        => source.ApplyProcessor(new RotateProcessor<TPixel> { Angle = degrees, Expand = expand });
+        => source.ApplyProcessor(new RotateInterpolationProcessor<TPixel> { Angle = degrees, Expand = expand });
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
This is a first-draft attempt at bilinear interpolation following the algorithm as described here:
http://supercomputingblog.com/graphics/coding-bilinear-interpolation/

Before I go any further, could this be useful? There are various things that I know still need to be done and probably several that I don't know about yet.

This branch currently replaces the original RotateProcessor with the new interpolating version when the Rotate extension method is called, so the extension methods will need a way for the user to specify a resampling algo. There are likely optimisation to be made. I noticed in the resize processor there is a fork in the code based on 'Compand', I'm guessing this is probably applicable here, but not sure.

<!-- Thanks for contributing to ImageSharp! -->
