### PR TITLE
Minor png hashing optimizations

### DIFF
--- a/src/ImageSharp/Formats/Png/Zlib/Adler32.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/Adler32.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.Formats.Png.Zlib
 {
@@ -74,9 +75,17 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         }
 
         /// <inheritdoc/>
-        public long Value => this.checksum;
+        public long Value
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return this.checksum;
+            }
+        }
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Reset()
         {
             this.checksum = 1;
@@ -88,6 +97,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         /// <param name="value">
         /// The data value to add. The high byte of the int is ignored.
         /// </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Update(int value)
         {
             // We could make a length 1 byte array and call update again, but I
@@ -102,6 +112,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         }
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Update(byte[] buffer)
         {
             if (buffer == null)
@@ -113,32 +124,14 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         }
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Update(byte[] buffer, int offset, int count)
         {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-
-            if (offset < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset), "cannot be negative");
-            }
-
-            if (count < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count), "cannot be negative");
-            }
-
-            if (offset >= buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset), "not a valid index into buffer");
-            }
-
-            if (offset + count > buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count), "exceeds buffer size");
-            }
+            DebugGuard.NotNull(buffer, nameof(buffer));
+            DebugGuard.MustBeGreaterThanOrEqualTo(offset, 0, nameof(offset));
+            DebugGuard.MustBeGreaterThanOrEqualTo(count, 0, nameof(count));
+            DebugGuard.MustBeLessThan(offset, buffer.Length, nameof(offset));
+            DebugGuard.MustBeLessThanOrEqualTo(offset + count, buffer.Length, nameof(count));
 
             // (By Per Bothner)
             uint s1 = this.checksum & 0xFFFF;

--- a/src/ImageSharp/Formats/Png/Zlib/Crc32.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/Crc32.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.Formats.Png.Zlib
 {
@@ -108,18 +109,15 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         /// <inheritdoc/>
         public long Value
         {
-            get
-            {
-                return this.crc;
-            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this.crc;
 
-            set
-            {
-                this.crc = (uint)value;
-            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => this.crc = (uint)value;
         }
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Reset()
         {
             this.crc = 0;
@@ -129,6 +127,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         /// Updates the checksum with the given value.
         /// </summary>
         /// <param name="value">The byte is taken as the lower 8 bits of value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Update(int value)
         {
             this.crc ^= CrcSeed;
@@ -137,6 +136,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         }
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Update(byte[] buffer)
         {
             if (buffer == null)
@@ -148,22 +148,13 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         }
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Update(byte[] buffer, int offset, int count)
         {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-
-            if (count < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count), "Count cannot be less than zero");
-            }
-
-            if (offset < 0 || offset + count > buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            }
+            DebugGuard.NotNull(buffer, nameof(buffer));
+            DebugGuard.MustBeGreaterThanOrEqualTo(count, 0, nameof(count));
+            DebugGuard.MustBeGreaterThanOrEqualTo(offset, 0, nameof(offset));
+            DebugGuard.MustBeLessThanOrEqualTo(offset + count, buffer.Length, nameof(count));
 
             this.crc ^= CrcSeed;
 

--- a/tests/ImageSharp.Benchmarks/Image/DecodePng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodePng.cs
@@ -10,29 +10,39 @@ namespace SixLabors.ImageSharp.Benchmarks.Image
 
     using BenchmarkDotNet.Attributes;
 
+    using SixLabors.ImageSharp.Tests;
+
     using CoreImage = ImageSharp.Image;
 
     using CoreSize = SixLabors.Primitives.Size;
 
+    [Config(typeof(Config.ShortClr))]
     public class DecodePng : BenchmarkBase
     {
         private byte[] pngBytes;
+
+        private string TestImageFullPath => Path.Combine(
+            TestEnvironment.InputImagesDirectoryFullPath,
+            this.TestImage);
+
+        [Params(TestImages.Png.Splash)]
+        public string TestImage { get; set; }
 
         [GlobalSetup]
         public void ReadImages()
         {
             if (this.pngBytes == null)
             {
-                this.pngBytes = File.ReadAllBytes("../ImageSharp.Tests/TestImages/Formats/Png/splash.png");
+                this.pngBytes = File.ReadAllBytes(this.TestImageFullPath);
             }
         }
 
         [Benchmark(Baseline = true, Description = "System.Drawing Png")]
         public Size PngSystemDrawing()
         {
-            using (MemoryStream memoryStream = new MemoryStream(this.pngBytes))
+            using (var memoryStream = new MemoryStream(this.pngBytes))
             {
-                using (Image image = Image.FromStream(memoryStream))
+                using (var image = Image.FromStream(memoryStream))
                 {
                     return image.Size;
                 }
@@ -42,9 +52,9 @@ namespace SixLabors.ImageSharp.Benchmarks.Image
         [Benchmark(Description = "ImageSharp Png")]
         public CoreSize PngCore()
         {
-            using (MemoryStream memoryStream = new MemoryStream(this.pngBytes))
+            using (var memoryStream = new MemoryStream(this.pngBytes))
             {
-                using (Image<Rgba32> image = CoreImage.Load<Rgba32>(memoryStream))
+                using (var image = CoreImage.Load<Rgba32>(memoryStream))
                 {
                     return new CoreSize(image.Width, image.Height);
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Minor optimization of png hashing methods changes scaled performance from `2.48` to `2.40` relative to System.Drawing

Method |      TestImage |     Mean |    Error |    StdDev | Scaled | ScaledSD |   Gen 0 |   Gen 1 |   Gen 2 | Allocated |
--------------------- |--------------- |---------:|---------:|----------:|-------:|---------:|--------:|--------:|--------:|----------:|
'System.Drawing Png' | Png/splash.png | 3.949 ms | 3.165 ms | 0.1788 ms |   1.00 |     0.00 | 70.3125 | 70.3125 | 70.3125 | 240.51 KB |
'ImageSharp Png' | Png/splash.png | 9.765 ms | 4.235 ms | 0.2393 ms |   2.48 |     0.11 | 46.8750 |       - |       - |  96.94 KB |

Method |      TestImage |     Mean |     Error |    StdDev | Scaled | ScaledSD |   Gen 0 |   Gen 1 |   Gen 2 | Allocated |
--------------------- |--------------- |---------:|----------:|----------:|-------:|---------:|--------:|--------:|--------:|----------:|
'System.Drawing Png' | Png/splash.png | 3.559 ms | 2.3499 ms | 0.1328 ms |   1.00 |     0.00 | 74.2188 | 74.2188 | 74.2188 | 240.54 KB |
'ImageSharp Png' | Png/splash.png | 8.549 ms | 0.5069 ms | 0.0286 ms |   2.40 |     0.08 | 46.8750 |       - |       - |  96.94 KB |

<!-- Thanks for contributing to ImageSharp! -->
