### PR TITLE
#423. "Value should be an unsigned short" exception on image rotate

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -105,10 +105,10 @@ namespace SixLabors.ImageSharp.Processing.Processors
 
             profile.RemoveValue(ExifTag.Orientation);
 
-            if (this.Expand && profile.GetValue(ExifTag.PixelXDimension) != null)
+            if (this.Expand && profile.GetValue(ExifTag.PixelXDimension) != null && source.Width <= ushort.MaxValue && source.Height <= ushort.MaxValue)
             {
-                profile.SetValue(ExifTag.PixelXDimension, source.Width);
-                profile.SetValue(ExifTag.PixelYDimension, source.Height);
+                profile.SetValue(ExifTag.PixelXDimension, (ushort)source.Width);
+                profile.SetValue(ExifTag.PixelYDimension, (ushort)source.Height);
             }
         }
 


### PR DESCRIPTION
Added safe Int Width and Height values cast to ushort. ExifTag.PixelXDimension and  ExifTag.PixelYDimension will not be updated if it is impossible to cast int to ushort without truncation.