### PR TITLE
Add missing pixel formats

### DIFF
--- a/src/ImageSharp/PixelFormats/PackedPixelConverterHelper.cs
+++ b/src/ImageSharp/PixelFormats/PackedPixelConverterHelper.cs
@@ -290,9 +290,11 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <returns>The <see cref="bool"/></returns>
         private static bool IsStandardNormalizedType(Type type)
         {
-            return type == typeof(Rgba32)
+            return
+                type == typeof(Alpha8)
                 || type == typeof(Argb32)
-                || type == typeof(Alpha8)
+                || type == typeof(Bgr24)
+                || type == typeof(Bgra32)
                 || type == typeof(Bgr565)
                 || type == typeof(Bgra4444)
                 || type == typeof(Bgra5551)
@@ -300,8 +302,10 @@ namespace SixLabors.ImageSharp.PixelFormats
                 || type == typeof(HalfVector2)
                 || type == typeof(HalfVector4)
                 || type == typeof(Rg32)
-                || type == typeof(Rgba1010102)
-                || type == typeof(Rgba64);
+                || type == typeof(Rgb24)
+                || type == typeof(Rgba32)
+                || type == typeof(Rgba64)
+                || type == typeof(Rgba1010102);
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/Image/ImageCloneTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageCloneTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests
+{
+    public class ImageCloneTests
+    {
+        [Theory]
+        [WithTestPatternImages(9, 9, PixelTypes.Rgba32)]
+        public void CloneAs_ToBgra32(TestImageProvider<Rgba32> provider)
+        {
+            using (Image<Rgba32> image = provider.GetImage())
+            using (Image<Bgra32> clone = image.CloneAs<Bgra32>())
+            {
+                for (int y = 0; y < image.Height; y++)
+                {
+                    Span<Rgba32> row = image.GetPixelRowSpan(y);
+                    Span<Bgra32> rowClone = clone.GetPixelRowSpan(y);
+
+                    for (int x = 0; x < image.Width; x++)
+                    {
+                        Rgba32 rgba = row[x];
+                        Bgra32 bgra = rowClone[x];
+
+                        Assert.Equal(rgba.R, bgra.R);
+                        Assert.Equal(rgba.G, bgra.G);
+                        Assert.Equal(rgba.B, bgra.B);
+                        Assert.Equal(rgba.A, bgra.A);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
A few of the newer pixel formats were missing from our conversion functions. This adds them.

<!-- Thanks for contributing to ImageSharp! -->
