### PR TITLE
Move swap to classes to avoid odd issues on Mono.

### DIFF
--- a/src/ImageSharp/Common/Extensions/ComparableExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/ComparableExtensions.cs
@@ -169,19 +169,5 @@ namespace SixLabors.ImageSharp
         {
             return (byte)value.Clamp(0, 255);
         }
-
-        /// <summary>
-        /// Swaps the references to two objects in memory.
-        /// </summary>
-        /// <param name="first">The first reference.</param>
-        /// <param name="second">The second reference.</param>
-        /// <typeparam name="T">The type of object.</typeparam>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Swap<T>(ref T first, ref T second)
-        {
-            T temp = second;
-            second = first;
-            first = temp;
-        }
     }
 }

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -14,7 +14,6 @@ using SixLabors.ImageSharp.Formats.Png.Zlib;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.MetaData;
 using SixLabors.ImageSharp.PixelFormats;
-using static SixLabors.ImageSharp.ComparableExtensions;
 
 namespace SixLabors.ImageSharp.Formats.Png
 {
@@ -589,7 +588,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
                 this.ProcessDefilteredScanline(this.scanline.Array, image);
 
-                Swap(ref this.scanline, ref this.previousScanline);
+                this.SwapBuffers();
                 this.currentRow++;
             }
         }
@@ -665,7 +664,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                     Span<TPixel> rowSpan = image.GetPixelRowSpan(this.currentRow);
                     this.ProcessInterlacedDefilteredScanline(this.scanline.Array, rowSpan, Adam7FirstColumn[this.pass], Adam7ColumnIncrement[this.pass]);
 
-                    Swap(ref this.scanline, ref this.previousScanline);
+                    this.SwapBuffers();
 
                     this.currentRow += Adam7RowIncrement[this.pass];
                 }
@@ -1347,6 +1346,13 @@ namespace SixLabors.ImageSharp.Formats.Png
                 case 6: return width;
                 default: throw new ArgumentException($"Not a valid pass index: {passIndex}");
             }
+        }
+
+        private void SwapBuffers()
+        {
+            Buffer<byte> temp = this.previousScanline;
+            this.previousScanline = this.scanline;
+            this.scanline = temp;
         }
     }
 }

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -11,7 +11,6 @@ using SixLabors.ImageSharp.Formats.Png.Zlib;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Quantizers;
-using static SixLabors.ImageSharp.ComparableExtensions;
 
 namespace SixLabors.ImageSharp.Formats.Png
 {
@@ -645,7 +644,9 @@ namespace SixLabors.ImageSharp.Formats.Png
                         Buffer<byte> r = this.EncodePixelRow(pixels.GetPixelRowSpan(y), y);
                         deflateStream.Write(r.Array, 0, resultLength);
 
-                        Swap(ref this.rawScanline, ref this.previousScanline);
+                        Buffer<byte> temp = this.rawScanline;
+                        this.rawScanline = this.previousScanline;
+                        this.previousScanline = temp;
                     }
                 }
 

--- a/src/ImageSharp/Image/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/Image/ImageFrame{TPixel}.cs
@@ -168,7 +168,9 @@ namespace SixLabors.ImageSharp
         {
             Guard.NotNull(pixelSource, nameof(pixelSource));
 
-            ComparableExtensions.Swap(ref this.pixelBuffer, ref pixelSource.pixelBuffer);
+            Buffer2D<TPixel> temp = this.pixelBuffer;
+            this.pixelBuffer = pixelSource.pixelBuffer;
+            pixelSource.pixelBuffer = temp;
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

It appears that the issue reported in #439 is happening due to some odd bug in Mono. The problem is this line in `PngDecoderCore.cs`:

```C#
Swap(ref this.scanline, ref this.previousScanline);
```

Swapping these two buffers corrupts the value of `this.bytesPerScanline` and makes it `0`. I am guessing that some pointer magic is happening in the swap method that corrupts the value. I tried to reproduce the issue but I could only make it happen with our code and not a simple sample program. Maybe @akoeplinger from the Mono team could take a look at this and try to figure out why this corruption is happening. It can be reproduced  (at e4293f95b3876e51e9e82b8c47555ec91fec1694) with the first image of #439 and the code below. I used the `ImageSharp.Sandbox46` project to build and test it on Mono.

```C#
var img = Image.Load("35096374-3b93aba8-fc4c-11e7-96f2-da35deafe8d0.png");
img.Save("out.png");
```

Moving the swap inside the class and removing the `ref` seems to resolve the issue.

<!-- Thanks for contributing to ImageSharp! -->
