### PR TITLE
Fix #453

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
@@ -191,25 +191,5 @@ namespace SixLabors.ImageSharp.Processing.Processors
                     });
             }
         }
-
-        /// <inheritdoc/>
-        protected override void AfterImageApply(Image<TPixel> source, Image<TPixel> destination, Rectangle sourceRectangle)
-        {
-            ExifProfile profile = destination.MetaData.ExifProfile;
-            if (profile == null)
-            {
-                return;
-            }
-
-            if (profile.GetValue(ExifTag.PixelXDimension) != null)
-            {
-                profile.SetValue(ExifTag.PixelXDimension, destination.Width);
-            }
-
-            if (profile.GetValue(ExifTag.PixelYDimension) != null)
-            {
-                profile.SetValue(ExifTag.PixelYDimension, destination.Height);
-            }
-        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Remove that bogus overload in `ResizeProcessor` is should have deleted before.

<!-- Thanks for contributing to ImageSharp! -->
