### PR TITLE
Added actionable error message if image is saved after being disposed.

### DIFF
--- a/src/ImageSharp/Common/Helpers/Guard.cs
+++ b/src/ImageSharp/Common/Helpers/Guard.cs
@@ -85,6 +85,24 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
+        /// Verifies that the provided reference is not yet disposed
+        /// and throws an exception if it is.
+        /// </summary>
+        /// <param name="t">The target value, which should be validated.</param>
+        /// <param name="disposed">A boolean value indicating whether the T has been disposed. </param>
+        /// <typeparam name="T">The type of the value.</typeparam>
+        /// <exception cref="ObjectDisposedException">
+        /// <paramref name="t"/> is disposed.
+        /// </exception>
+        public static void NotDisposed<T>(this T t, bool disposed)
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(t.GetType().Name);
+            }
+        }
+
+        /// <summary>
         /// Verifies that the specified value is less than a maximum value
         /// and throws an exception if it is not.
         /// </summary>

--- a/src/ImageSharp/Image/Image{TPixel}.cs
+++ b/src/ImageSharp/Image/Image{TPixel}.cs
@@ -105,6 +105,11 @@ namespace SixLabors.ImageSharp
         public IImageFrameCollection<TPixel> Frames => this.frames;
 
         /// <summary>
+        /// Gets a value indicating whether this object has yet been disposed.
+        /// </summary>
+        public bool Disposed { get; private set; }
+
+        /// <summary>
         /// Gets the root frame.
         /// </summary>
         private IPixelSource<TPixel> PixelSource => this.frames?.RootFrame ?? throw new ObjectDisposedException(nameof(Image<TPixel>));
@@ -132,6 +137,7 @@ namespace SixLabors.ImageSharp
         {
             Guard.NotNull(stream, nameof(stream));
             Guard.NotNull(encoder, nameof(encoder));
+            Guard.NotDisposed(this, this.Disposed);
 
             encoder.Encode(this, stream);
         }
@@ -172,6 +178,7 @@ namespace SixLabors.ImageSharp
         public void Dispose()
         {
             this.frames.Dispose();
+            this.Disposed = true;
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/ImageOperationTests.cs
+++ b/tests/ImageSharp.Tests/ImageOperationTests.cs
@@ -37,6 +37,15 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         [Fact]
+        public void Save_ShouldThrowExceptionIfImageHasBeenDisposed()
+        {
+            image.Dispose();
+            Action saveAction = () => image.Save(new MemoryStream(), Configuration.FindEncoder(ImageFormats.Png));
+
+            Assert.Throws<ObjectDisposedException>(saveAction);
+        }
+
+        [Fact]
         public void MutateCallsImageOperationsProvider_Func_OriginalImage()
         {
             this.image.Mutate(x => x.ApplyProcessor(this.processor));


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
Added an ObjectDisposedException if image is saved after being disposed.  

Previously, I did this on accident, and got null reference exceptions from deep within the png/jpg/etc encoders which made it difficult to translate those exceptions into the simple fix that was needed on my end.  Perhaps future users will figure out what they did wrong more quickly with this ObjectDisposedException.

I added a test but cannot run it, as the test suite blows up with a GDI+ related error.  I guess I would need a Windows machine to run the tests myself?  I don't have one handy.