### PR TITLE
Improved test coverage for Encoders/Decoders

### DIFF
--- a/src/ImageSharp/Image/IImage.cs
+++ b/src/ImageSharp/Image/IImage.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
+
 namespace SixLabors.ImageSharp
 {
     /// <summary>
     /// Encapsulates the properties and methods that describe an image.
     /// </summary>
-    public interface IImage : IImageInfo
+    public interface IImage : IImageInfo, IDisposable
     {
     }
 }

--- a/src/ImageSharp/Image/Image{TPixel}.cs
+++ b/src/ImageSharp/Image/Image{TPixel}.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp
     /// Encapsulates an image, which consists of the pixel data for a graphics image and its attributes.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    public sealed partial class Image<TPixel> : IImage, IDisposable, IConfigurable
+    public sealed partial class Image<TPixel> : IImage, IConfigurable
         where TPixel : struct, IPixel<TPixel>
     {
         private Configuration configuration;

--- a/tests/ImageSharp.Tests/ComplexIntegrationTests.cs
+++ b/tests/ImageSharp.Tests/ComplexIntegrationTests.cs
@@ -1,0 +1,35 @@
+﻿namespace SixLabors.ImageSharp.Tests
+{
+    using SixLabors.ImageSharp.Formats.Jpeg;
+    using SixLabors.ImageSharp.PixelFormats;
+    using SixLabors.ImageSharp.Processing;
+    using SixLabors.Primitives;
+
+    using Xunit;
+
+    /// <summary>
+    /// Might be useful to catch complex bugs
+    /// </summary>
+    public class ComplexIntegrationTests
+    {
+        [Theory]
+        [WithFile(TestImages.Jpeg.Baseline.Snake, PixelTypes.Rgba32, 75, JpegSubsample.Ratio420)]
+        [WithFile(TestImages.Jpeg.Baseline.Lake, PixelTypes.Rgba32, 75, JpegSubsample.Ratio420)]
+        [WithFile(TestImages.Jpeg.Baseline.Snake, PixelTypes.Rgba32, 75, JpegSubsample.Ratio444)]
+        [WithFile(TestImages.Jpeg.Baseline.Lake, PixelTypes.Rgba32, 75, JpegSubsample.Ratio444)]
+        public void LoadResizeSave<TPixel>(TestImageProvider<TPixel> provider, int quality, JpegSubsample subsample)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage(x => x.Resize(new ResizeOptions { Size = new Size(150, 100), Mode = ResizeMode.Max })))
+            {
+
+                image.MetaData.ExifProfile = null; // Reduce the size of the file
+                JpegEncoder options = new JpegEncoder { Subsample = subsample, Quality = quality };
+
+                provider.Utility.TestName += $"{subsample}_Q{quality}";
+                provider.Utility.SaveTestOutputFile(image, "png");
+                provider.Utility.SaveTestOutputFile(image, "jpg", options);
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -1,19 +1,28 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.Formats;
+using System.IO;
+using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
+
 // ReSharper disable InconsistentNaming
 
 namespace SixLabors.ImageSharp.Tests
 {
-    using System.IO;
+    
+    using static TestImages.Bmp;
 
-    using SixLabors.ImageSharp.Formats.Bmp;
-
-    public class BmpDecoderTests : FileTestBase
+    public class BmpDecoderTests
     {
+        public const PixelTypes CommonNonDefaultPixelTypes =
+            PixelTypes.Rgba32 | PixelTypes.Bgra32 | PixelTypes.RgbaVector;
+
+        public static readonly string[] AllBmpFiles =
+            {
+                Car, F, NegHeight, CoreHeader, V5Header, RLE, RLEInverted, Bit8, Bit8Inverted, Bit16, Bit16Inverted
+            };
+
         [Theory]
         [WithFileCollection(nameof(AllBmpFiles), PixelTypes.Rgba32)]
         public void DecodeBmp<TPixel>(TestImageProvider<TPixel> provider)
@@ -27,7 +36,7 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         [Theory]
-        [WithFile(TestImages.Bmp.F, CommonNonDefaultPixelTypes)]
+        [WithFile(F, CommonNonDefaultPixelTypes)]
         public void BmpDecoder_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : struct, IPixel<TPixel>
         {
@@ -39,14 +48,14 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         [Theory]
-        [InlineData(TestImages.Bmp.Car, 24)]
-        [InlineData(TestImages.Bmp.F, 24)]
-        [InlineData(TestImages.Bmp.NegHeight, 24)]
-        [InlineData(TestImages.Bmp.Bit8, 8)]
-        [InlineData(TestImages.Bmp.Bit8Inverted, 8)]
+        [InlineData(Car, 24)]
+        [InlineData(F, 24)]
+        [InlineData(NegHeight, 24)]
+        [InlineData(Bit8, 8)]
+        [InlineData(Bit8Inverted, 8)]
         public void DetectPixelSize(string imagePath, int expectedPixelSize)
         {
-            TestFile testFile = TestFile.Create(imagePath);
+            var testFile = TestFile.Create(imagePath);
             using (var stream = new MemoryStream(testFile.Bytes, false))
             {
                 Assert.Equal(expectedPixelSize, Image.Identify(stream)?.PixelType?.BitsPerPixel);

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests
 {
-    
     using static TestImages.Bmp;
 
     public class BmpDecoderTests

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -8,28 +8,59 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests
 {
+    using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
+
+    using Xunit.Abstractions;
+
     public class BmpEncoderTests : FileTestBase
     {
-        public static readonly TheoryData<BmpBitsPerPixel> BitsPerPixel
-        = new TheoryData<BmpBitsPerPixel>
+        private const PixelTypes PixelTypesToTest = PixelTypes.Rgba32 | PixelTypes.Bgra32 | PixelTypes.Rgb24;
+
+        public static readonly TheoryData<BmpBitsPerPixel> BitsPerPixel =
+            new TheoryData<BmpBitsPerPixel>
+                {
+                    BmpBitsPerPixel.Pixel24,
+                    BmpBitsPerPixel.Pixel32
+                };
+
+        public BmpEncoderTests(ITestOutputHelper output)
         {
-            BmpBitsPerPixel.Pixel24,
-            BmpBitsPerPixel.Pixel32
-        };
+            this.Output = output;
+        }
+
+        private ITestOutputHelper Output { get; }
 
         [Theory]
-        [MemberData(nameof(BitsPerPixel))]
-        public void BitmapCanEncodeDifferentBitRates(BmpBitsPerPixel bitsPerPixel)
+        [WithTestPatternImages(nameof(BitsPerPixel), 48, 24, PixelTypesToTest)]
+        [WithTestPatternImages(nameof(BitsPerPixel), 47, 8, PixelTypesToTest)]
+        [WithTestPatternImages(nameof(BitsPerPixel), 49, 7, PixelTypesToTest)]
+        [WithSolidFilledImages(nameof(BitsPerPixel), 1, 1, 255, 100, 50, 255, PixelTypesToTest)]
+        [WithTestPatternImages(nameof(BitsPerPixel), 7, 5, PixelTypesToTest)]
+        public void Encode<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
+            where TPixel : struct, IPixel<TPixel>
         {
-            string path = TestEnvironment.CreateOutputDirectory("Bmp");
-
-            foreach (TestFile file in Files)
+            
+            using (Image<TPixel> image = provider.GetImage())
             {
-                string filename = file.GetFileNameWithoutExtension(bitsPerPixel);
-                using (Image<Rgba32> image = file.CreateImage())
-                {
-                    image.Save($"{path}/{filename}.bmp", new BmpEncoder { BitsPerPixel = bitsPerPixel });
-                }
+                // there is no alpha in bmp!
+                image.Mutate(
+                    c => c.Opacity(1)
+                    );
+                
+                var encoder = new BmpEncoder { BitsPerPixel = bitsPerPixel };
+                string path = provider.Utility.SaveTestOutputFile(image, "bmp", encoder, testOutputDetails:bitsPerPixel);
+
+                this.Output.WriteLine(path);
+
+                IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(path);
+                string referenceOutputFile = provider.Utility.GetReferenceOutputFileName("bmp", bitsPerPixel, true);
+
+                this.Output.WriteLine(referenceOutputFile);
+
+                //using (var encodedImage = Image.Load<TPixel>(referenceOutputFile, referenceDecoder))
+                //{
+                //    ImageComparer.Exact.CompareImagesOrFrames(image, encodedImage);
+                //}
             }
         }
     }

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -20,11 +20,6 @@ namespace SixLabors.ImageSharp.Tests
     {
         private const PixelTypes TestPixelTypes = PixelTypes.Rgba32 | PixelTypes.RgbaVector | PixelTypes.Argb32;
 
-        public static readonly string[] TestFiles =
-            {
-                TestImages.Gif.Giphy, TestImages.Gif.Rings, TestImages.Gif.Trans, TestImages.Gif.Kumin
-            };
-
         public static readonly string[] MultiFrameTestFiles =
             {
                 TestImages.Gif.Giphy, TestImages.Gif.Kumin

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -6,23 +6,52 @@ using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 using Xunit;
+using System.IO;
+using SixLabors.ImageSharp.Advanced;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests
 {
-    using System.IO;
-    using SixLabors.ImageSharp.Advanced;
-
     public class GifDecoderTests
     {
-        private const PixelTypes PixelTypes = Tests.PixelTypes.Rgba32 | Tests.PixelTypes.RgbaVector | Tests.PixelTypes.Argb32;
+        private const PixelTypes TestPixelTypes = PixelTypes.Rgba32 | PixelTypes.RgbaVector | PixelTypes.Argb32;
 
-        public static readonly string[] TestFiles = { TestImages.Gif.Giphy, TestImages.Gif.Rings, TestImages.Gif.Trans };
+        public static readonly string[] TestFiles =
+            {
+                TestImages.Gif.Giphy, TestImages.Gif.Rings, TestImages.Gif.Trans, TestImages.Gif.Kumin
+            };
+
+        public static readonly string[] MultiFrameTestFiles =
+            {
+                TestImages.Gif.Giphy, TestImages.Gif.Kumin
+            };
 
         public static readonly string[] BadAppExtFiles = { TestImages.Gif.Issues.BadAppExtLength, TestImages.Gif.Issues.BadAppExtLength_2 };
 
         [Theory]
-        [WithFileCollection(nameof(TestFiles), PixelTypes)]
+        [WithFileCollection(nameof(MultiFrameTestFiles), PixelTypes.Rgba32)]
+        public void AllFramesDecoded<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                image.DebugSaveMultiFrame(provider);
+            }
+        }
+
+        [Theory]
+        [WithFile(TestImages.Gif.Trans, TestPixelTypes)]
+        public void IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                image.DebugSave(provider);
+            }
+        }
+
+        [Theory]
+        [WithFileCollection(nameof(TestFiles), TestPixelTypes)]
         public void DecodeAndReSave<TPixel>(TestImageProvider<TPixel> imageProvider)
             where TPixel : struct, IPixel<TPixel>
         {
@@ -34,7 +63,7 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         [Theory]
-        [WithFileCollection(nameof(TestFiles), PixelTypes)]
+        [WithFileCollection(nameof(TestFiles), TestPixelTypes)]
         public void DecodeResizeAndSave<TPixel>(TestImageProvider<TPixel> imageProvider)
             where TPixel : struct, IPixel<TPixel>
         {

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -7,15 +7,16 @@ using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.MetaData;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
+// ReSharper disable InconsistentNaming
 
 namespace SixLabors.ImageSharp.Tests
 {
     public class GifEncoderTests
     {
-        private const PixelTypes PixelTypes = Tests.PixelTypes.Rgba32 | Tests.PixelTypes.RgbaVector | Tests.PixelTypes.Argb32;
+        private const PixelTypes TestPixelTypes = PixelTypes.Rgba32 | PixelTypes.RgbaVector | PixelTypes.Argb32;
 
         [Theory]
-        [WithTestPatternImages(100, 100, PixelTypes)]
+        [WithTestPatternImages(100, 100, TestPixelTypes)]
         public void EncodeGeneratedPatterns<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : struct, IPixel<TPixel>
         {
@@ -78,7 +79,7 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         [Fact]
-        public void Encode_CommentIsToLong_CommentIsTrimmed()
+        public void Encode_WhenCommentIsTooLong_CommentIsTrimmed()
         {
             using (Image<Rgba32> input = new Image<Rgba32>(1, 1))
             {

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -10,36 +10,127 @@ using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.IO;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
+// ReSharper disable InconsistentNaming
 
 namespace SixLabors.ImageSharp.Tests
 {
+    using SixLabors.ImageSharp.Quantizers;
+    using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
+
     public class PngEncoderTests : FileTestBase
     {
-        private const PixelTypes PixelTypes = Tests.PixelTypes.Rgba32 | Tests.PixelTypes.RgbaVector | Tests.PixelTypes.Argb32;
+        /// <summary>
+        /// All types except Palette
+        /// </summary>
+        public static readonly TheoryData<PngColorType> PngColorTypes = new TheoryData<PngColorType>()
+                                                                           {
+                                                                               PngColorType.RgbWithAlpha,
+                                                                               PngColorType.Rgb,
+                                                                               PngColorType.Grayscale,
+                                                                               PngColorType.GrayscaleWithAlpha,
+                                                                           };
+
+        /// <summary>
+        /// All types except Palette
+        /// </summary>
+        public static readonly TheoryData<int> CompressionLevels = new TheoryData<int>()
+                                                                            {
+                                                                                1, 2, 3, 4, 5, 6, 7, 8, 9
+                                                                            };
+
+        public static readonly TheoryData<int> PaletteSizes = new TheoryData<int>()
+                                                                  {
+                                                                      30, 55, 100, 201, 255
+                                                                  };
 
         [Theory]
-        [WithTestPatternImages(100, 100, PixelTypes, PngColorType.RgbWithAlpha)]
-        [WithTestPatternImages(100, 100, PixelTypes, PngColorType.Rgb)]
-        [WithTestPatternImages(100, 100, PixelTypes, PngColorType.Palette)]
-        [WithTestPatternImages(100, 100, PixelTypes, PngColorType.Grayscale)]
-        [WithTestPatternImages(100, 100, PixelTypes, PngColorType.GrayscaleWithAlpha)]
-        public void EncodeGeneratedPatterns<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType)
+        [WithTestPatternImages(nameof(PngColorTypes), 48, 24, PixelTypes.Rgba32)]
+        [WithTestPatternImages(nameof(PngColorTypes), 47, 8, PixelTypes.Rgba32)]
+        [WithTestPatternImages(nameof(PngColorTypes), 49, 7, PixelTypes.Rgba32)]
+        [WithSolidFilledImages(nameof(PngColorTypes), 1, 1, 255, 100, 50, 255, PixelTypes.Rgba32)]
+        [WithTestPatternImages(nameof(PngColorTypes), 7, 5, PixelTypes.Rgba32)]
+        public void WorksWithDifferentSizes<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TestPngEncoderCore(provider, pngColorType, appendPngColorType: true);
+        }
+
+        [Theory]
+        [WithTestPatternImages(nameof(PngColorTypes), 24, 24, PixelTypes.Rgba32 | PixelTypes.Bgra32 | PixelTypes.Rgb24)]
+        public void IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TestPngEncoderCore(provider, pngColorType, appendPixelType: true);
+        }
+
+        [Theory]
+        [WithTestPatternImages(nameof(CompressionLevels), 24, 24, PixelTypes.Rgba32)]
+        public void WorksWithAllCompressionLevels<TPixel>(TestImageProvider<TPixel> provider, int compressionLevel)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TestPngEncoderCore(provider, PngColorType.RgbWithAlpha, compressionLevel, appendCompressionLevel: true);
+        }
+
+        [Theory]
+        [WithTestPatternImages(nameof(PaletteSizes), 72, 72, PixelTypes.Rgba32)]
+        public void PaletteColorType_WuQuantizer<TPixel>(TestImageProvider<TPixel> provider, int paletteSize)
             where TPixel : struct, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
-                var options = new PngEncoder()
-                {
-                    PngColorType = pngColorType
-                };
-                provider.Utility.TestName += "_" + pngColorType;
+                var encoder = new PngEncoder
+                                  {
+                                      PngColorType = PngColorType.Palette,
+                                      PaletteSize = paletteSize,
+                                      Quantizer = new WuQuantizer<TPixel>()
+                                  };
 
-                provider.Utility.SaveTestOutputFile(image, "png", options);
+                image.VerifyEncoder(provider, "png", $"PaletteSize-{paletteSize}", encoder, appendPixelTypeToFileName: false);
             }
         }
 
+        private static bool HasAlpha(PngColorType pngColorType) =>
+            pngColorType == PngColorType.GrayscaleWithAlpha || pngColorType == PngColorType.RgbWithAlpha;
+
+        private static void TestPngEncoderCore<TPixel>(
+            TestImageProvider<TPixel> provider,
+            PngColorType pngColorType,
+            int compressionLevel = 6,
+            bool appendPngColorType = false,
+            bool appendPixelType = false,
+            bool appendCompressionLevel = false)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                if (!HasAlpha(pngColorType))
+                {
+                    image.Mutate(c => c.Opacity(1));
+                }
+
+                var encoder = new PngEncoder { PngColorType = pngColorType, CompressionLevel = compressionLevel};
+
+                string pngColorTypeInfo = appendPixelType ? pngColorType.ToString() : "";
+                string compressionLevelInfo = appendCompressionLevel ? $"_C{compressionLevel}" : "";
+                string debugInfo = $"{pngColorTypeInfo}{compressionLevelInfo}";
+                string referenceInfo = $"{pngColorTypeInfo}";
+
+                // Does DebugSave & load reference CompareToReferenceInput():
+                string path = ((ITestImageProvider)provider).Utility.SaveTestOutputFile(image, "png", encoder, debugInfo, appendPixelType);
+            
+                IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(path);
+                string referenceOutputFile = ((ITestImageProvider)provider).Utility.GetReferenceOutputFileName("png", referenceInfo, appendPixelType);
+            
+                using (var encodedImage = Image.Load<TPixel>(referenceOutputFile, referenceDecoder))
+                {
+                    ImageComparer comparer = null ?? ImageComparer.Exact;
+                    comparer.CompareImagesOrFrames(image, encodedImage);
+                }
+            }
+        }
+        
         [Theory]
-        [WithBlankImages(1, 1, PixelTypes.All)]
+        [WithBlankImages(1, 1, PixelTypes.Rgba32)]
         public void WritesFileMarker<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : struct, IPixel<TPixel>
         {

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Tests
     using SixLabors.ImageSharp.Quantizers;
     using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 
-    public class PngEncoderTests : FileTestBase
+    public class PngEncoderTests
     {
         private const float ToleranceThresholdForPaletteEncoder = 0.01f / 100;
 

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -19,6 +19,8 @@ namespace SixLabors.ImageSharp.Tests
 
     public class PngEncoderTests : FileTestBase
     {
+        private const float ToleranceThresholdForPaletteEncoder = 0.01f / 100;
+
         /// <summary>
         /// All types except Palette
         /// </summary>
@@ -123,7 +125,7 @@ namespace SixLabors.ImageSharp.Tests
             
                 using (var encodedImage = Image.Load<TPixel>(referenceOutputFile, referenceDecoder))
                 {
-                    ImageComparer comparer = null ?? ImageComparer.Exact;
+                    ImageComparer comparer = pngColorType== PngColorType.Palette ? ImageComparer.Tolerant(ToleranceThresholdForPaletteEncoder) : ImageComparer.Exact;
                     comparer.CompareImagesOrFrames(image, encodedImage);
                 }
             }

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -45,7 +45,13 @@ namespace SixLabors.ImageSharp.Tests
                                                                       30, 55, 100, 201, 255
                                                                   };
 
+        public static readonly TheoryData<int> PaletteLargeOnly = new TheoryData<int>()
+                                                                  {
+                                                                      80, 100, 120, 230
+                                                                  };
+
         [Theory]
+        [WithFile(TestImages.Png.Palette8Bpp, nameof(PngColorTypes), PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(PngColorTypes), 48, 24, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(PngColorTypes), 47, 8, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(PngColorTypes), 49, 7, PixelTypes.Rgba32)]
@@ -56,7 +62,7 @@ namespace SixLabors.ImageSharp.Tests
         {
             TestPngEncoderCore(provider, pngColorType, appendPngColorType: true);
         }
-
+        
         [Theory]
         [WithTestPatternImages(nameof(PngColorTypes), 24, 24, PixelTypes.Rgba32 | PixelTypes.Bgra32 | PixelTypes.Rgb24)]
         public void IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType)
@@ -71,6 +77,16 @@ namespace SixLabors.ImageSharp.Tests
             where TPixel : struct, IPixel<TPixel>
         {
             TestPngEncoderCore(provider, PngColorType.RgbWithAlpha, compressionLevel, appendCompressionLevel: true);
+        }
+
+        [Theory]
+        [WithFile(TestImages.Png.Palette8Bpp, nameof(PaletteLargeOnly), PixelTypes.Rgba32)]
+        public void PaletteColorType_WuQuantizer_File<TPixel>(
+            TestImageProvider<TPixel> provider,
+            int paletteSize)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            this.PaletteColorType_WuQuantizer(provider, paletteSize);
         }
 
         [Theory]

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
@@ -86,9 +86,10 @@ namespace SixLabors.ImageSharp.Tests
                                      NamedColors<TPixel>.HotPink,
                                      NamedColors<TPixel>.Blue
                                  };
-                int p = 0;
+                
                 for (int y = top; y < bottom; y++)
                 {
+                    int p = 0;
                     for (int x = left; x < right; x++)
                     {
                         if (x % stride == 0)

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -227,6 +227,33 @@ namespace SixLabors.ImageSharp.Tests
             return image;
         }
 
+        /// <summary>
+        /// Loads the expected image with a reference decoder + compares it to <paramref name="image"/>.
+        /// Also performs a debug save using <see cref="ImagingTestCaseUtility.SaveTestOutputFile{TPixel}"/>.
+        /// </summary>
+        internal static void VerifyEncoder<TPixel>(this Image<TPixel> image,
+                                                   ITestImageProvider provider,
+                                                   string extension,
+                                                   object testOutputDetails,
+                                                   IImageEncoder encoder,
+                                                   ImageComparer customComparer = null,
+                                                   bool appendPixelTypeToFileName = true
+                                                   )
+            where TPixel : struct, IPixel<TPixel>
+        {
+
+            string path = provider.Utility.SaveTestOutputFile(image, extension, encoder, testOutputDetails, appendPixelTypeToFileName);
+            
+            IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(path);
+            string referenceOutputFile = provider.Utility.GetReferenceOutputFileName(extension, testOutputDetails, appendPixelTypeToFileName);
+            
+            using (var encodedImage = Image.Load<TPixel>(referenceOutputFile, referenceDecoder))
+            {
+                ImageComparer comparer = customComparer ?? ImageComparer.Exact;
+                comparer.CompareImagesOrFrames(image, encodedImage);
+            }
+        }
+
         internal static Image<Rgba32> ToGrayscaleImage(this Buffer2D<float> buffer, float scale)
         {
             var image = new Image<Rgba32>(buffer.Width, buffer.Height);
@@ -242,5 +269,6 @@ namespace SixLabors.ImageSharp.Tests
 
             return image;
         }
+
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -352,16 +352,19 @@ namespace SixLabors.ImageSharp.Tests
                                                    object testOutputDetails,
                                                    IImageEncoder encoder,
                                                    ImageComparer customComparer = null,
-                                                   bool appendPixelTypeToFileName = true
+                                                   bool appendPixelTypeToFileName = true,
+                                                   string referenceImageExtension = null
                                                    )
             where TPixel : struct, IPixel<TPixel>
         {
 
-            string path = provider.Utility.SaveTestOutputFile(image, extension, encoder, testOutputDetails, appendPixelTypeToFileName);
+            provider.Utility.SaveTestOutputFile(image, extension, encoder, testOutputDetails, appendPixelTypeToFileName);
             
-            IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(path);
-            string referenceOutputFile = provider.Utility.GetReferenceOutputFileName(extension, testOutputDetails, appendPixelTypeToFileName);
-            
+            referenceImageExtension = referenceImageExtension ?? extension;
+            string referenceOutputFile = provider.Utility.GetReferenceOutputFileName(referenceImageExtension, testOutputDetails, appendPixelTypeToFileName);
+
+            IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(referenceOutputFile);
+
             using (var encodedImage = Image.Load<TPixel>(referenceOutputFile, referenceDecoder))
             {
                 ImageComparer comparer = customComparer ?? ImageComparer.Exact;

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageProviderTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageProviderTests.cs
@@ -239,8 +239,28 @@ namespace SixLabors.ImageSharp.Tests
             where TPixel : struct, IPixel<TPixel>
         {
             Assert.NotNull(provider.Utility.SourceFileOrDescription);
-            Image<TPixel> image = provider.GetImage();
-            provider.Utility.SaveTestOutputFile(image, "png");
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                provider.Utility.SaveTestOutputFile(image, "png");
+            }
+        }
+
+        [Theory]
+        [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
+        public void SaveTestOutputFileMultiFrame<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                string[] files = provider.Utility.SaveTestOutputFileMultiFrame(image);
+
+                Assert.True(files.Length > 2);
+                foreach (string path in files)
+                {
+                    this.Output.WriteLine(path);
+                    Assert.True(File.Exists(path));
+                }
+            }
         }
 
         [Theory]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I really need better regression testing for codecs to unblock my work on #225. The following tests have been restructured to use reference images:
- BmpEncoderTests
- PngEncoderTests
- GifDecoderTests: 
Single frame tests + 2 multiframe tests using [one reference image per frame](https://github.com/SixLabors/Imagesharp.Tests.Images/tree/master/ReferenceOutput/GifDecoderTests/Decode_VerifyAllFrames_Rgba32_kumin.gif)
- JpegEncoderTests

`GifEncoderTests` are still missing proper coverage, but they are less critical than others, and also the hardest ones to implement. 

@JimBobSquarePants I did my best to cover `PngEncoder` properly. Can you check if my coverage is correct and robust enough? There are some tests utilizing error diffusers with [reference image based assertions](https://github.com/SixLabors/Imagesharp.Tests.Images/blob/master/ReferenceOutput/PngEncoderTests/PaletteColorType_WuQuantizer_File_palette-8bpp_PaletteSize-100.png).

