### PR TITLE
Fixing Encoder Tests

### DIFF
--- a/src/ImageSharp/Processing/ColorMatrix/Opacity.cs
+++ b/src/ImageSharp/Processing/ColorMatrix/Opacity.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp
     public static partial class ImageExtensions
     {
         /// <summary>
-        /// Alters the alpha component of the image.
+        /// Multiplies the alpha component of the image.
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="source">The image this method extends.</param>
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp
         => source.ApplyProcessor(new OpacityProcessor<TPixel>(amount));
 
         /// <summary>
-        /// Alters the alpha component of the image.
+        /// Multiplies the alpha component of the image.
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="source">The image this method extends.</param>

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -51,13 +51,15 @@ namespace SixLabors.ImageSharp.Tests
             TestBmpEncoderCore(provider, bitsPerPixel);
         }
 
+        
+
         private static void TestBmpEncoderCore<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
             where TPixel : struct, IPixel<TPixel>
-        {
+        {   
             using (Image<TPixel> image = provider.GetImage())
             {
                 // there is no alpha in bmp!
-                image.Mutate(c => c.Opacity(1));
+                image.Mutate(c => c.MakeOpaque());
 
                 var encoder = new BmpEncoder { BitsPerPixel = bitsPerPixel };
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
@@ -80,7 +80,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             using (Image<TPixel> image = provider.GetImage())
             {
                 // There is no alpha in Jpeg!
-                image.Mutate(c => c.Opacity(1));
+                image.Mutate(c => c.MakeOpaque());
 
                 var encoder = new JpegEncoder()
                                   {

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -68,7 +68,7 @@ namespace SixLabors.ImageSharp.Tests
         public void IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType)
             where TPixel : struct, IPixel<TPixel>
         {
-            TestPngEncoderCore(provider, pngColorType, appendPixelType: true);
+            TestPngEncoderCore(provider, pngColorType, appendPixelType: true, appendPngColorType: true);
         }
 
         [Theory]
@@ -78,33 +78,13 @@ namespace SixLabors.ImageSharp.Tests
         {
             TestPngEncoderCore(provider, PngColorType.RgbWithAlpha, compressionLevel, appendCompressionLevel: true);
         }
-
+        
         [Theory]
         [WithFile(TestImages.Png.Palette8Bpp, nameof(PaletteLargeOnly), PixelTypes.Rgba32)]
-        public void PaletteColorType_WuQuantizer_File<TPixel>(
-            TestImageProvider<TPixel> provider,
-            int paletteSize)
-            where TPixel : struct, IPixel<TPixel>
-        {
-            this.PaletteColorType_WuQuantizer(provider, paletteSize);
-        }
-
-        [Theory]
-        [WithTestPatternImages(nameof(PaletteSizes), 72, 72, PixelTypes.Rgba32)]
         public void PaletteColorType_WuQuantizer<TPixel>(TestImageProvider<TPixel> provider, int paletteSize)
             where TPixel : struct, IPixel<TPixel>
         {
-            using (Image<TPixel> image = provider.GetImage())
-            {
-                var encoder = new PngEncoder
-                                  {
-                                      PngColorType = PngColorType.Palette,
-                                      PaletteSize = paletteSize,
-                                      Quantizer = new WuQuantizer<TPixel>()
-                                  };
-
-                image.VerifyEncoder(provider, "png", $"PaletteSize-{paletteSize}", encoder, appendPixelTypeToFileName: false);
-            }
+            TestPngEncoderCore(provider, PngColorType.Palette, paletteSize: paletteSize, appendPaletteSize: true);
         }
 
         private static bool HasAlpha(PngColorType pngColorType) =>
@@ -114,9 +94,11 @@ namespace SixLabors.ImageSharp.Tests
             TestImageProvider<TPixel> provider,
             PngColorType pngColorType,
             int compressionLevel = 6,
+            int paletteSize = 0,
             bool appendPngColorType = false,
             bool appendPixelType = false,
-            bool appendCompressionLevel = false)
+            bool appendCompressionLevel = false,
+            bool appendPaletteSize = false)
             where TPixel : struct, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
@@ -126,24 +108,33 @@ namespace SixLabors.ImageSharp.Tests
                     image.Mutate(c => c.MakeOpaque());
                 }
 
-                var encoder = new PngEncoder { PngColorType = pngColorType, CompressionLevel = compressionLevel};
+                var encoder = new PngEncoder
+                                  {
+                                      PngColorType = pngColorType,
+                                      CompressionLevel = compressionLevel,
+                                      PaletteSize = paletteSize
+                                  };
 
                 string pngColorTypeInfo = appendPngColorType ? pngColorType.ToString() : "";
                 string compressionLevelInfo = appendCompressionLevel ? $"_C{compressionLevel}" : "";
-                string debugInfo = $"{pngColorTypeInfo}{compressionLevelInfo}";
-                
+                string paletteSizeInfo = appendPaletteSize ? $"_PaletteSize-{paletteSize}" : "";
+                string debugInfo = $"{pngColorTypeInfo}{compressionLevelInfo}{paletteSizeInfo}";
+                //string referenceInfo = $"{pngColorTypeInfo}";
+
                 // Does DebugSave & load reference CompareToReferenceInput():
                 string actualOutputFile = ((ITestImageProvider)provider).Utility.SaveTestOutputFile(image, "png", encoder, debugInfo, appendPixelType);
             
                 IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(actualOutputFile);
+                string referenceOutputFile = ((ITestImageProvider)provider).Utility.GetReferenceOutputFileName("png", debugInfo, appendPixelType);
             
                 using (var actualImage = Image.Load<TPixel>(actualOutputFile, referenceDecoder))
+                using (var referenceImage = Image.Load<TPixel>(referenceOutputFile, referenceDecoder))
                 {
                     ImageComparer comparer = pngColorType == PngColorType.Palette
                                                  ? ImageComparer.Tolerant(ToleranceThresholdForPaletteEncoder)
                                                  : ImageComparer.Exact;
 
-                    comparer.VerifySimilarity(image, actualImage);
+                    comparer.VerifySimilarity(referenceImage, actualImage);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -123,26 +123,27 @@ namespace SixLabors.ImageSharp.Tests
             {
                 if (!HasAlpha(pngColorType))
                 {
-                    image.Mutate(c => c.Opacity(1));
+                    image.Mutate(c => c.MakeOpaque());
                 }
 
                 var encoder = new PngEncoder { PngColorType = pngColorType, CompressionLevel = compressionLevel};
 
-                string pngColorTypeInfo = appendPixelType ? pngColorType.ToString() : "";
+                string pngColorTypeInfo = appendPngColorType ? pngColorType.ToString() : "";
                 string compressionLevelInfo = appendCompressionLevel ? $"_C{compressionLevel}" : "";
                 string debugInfo = $"{pngColorTypeInfo}{compressionLevelInfo}";
-                string referenceInfo = $"{pngColorTypeInfo}";
-
+                
                 // Does DebugSave & load reference CompareToReferenceInput():
-                string path = ((ITestImageProvider)provider).Utility.SaveTestOutputFile(image, "png", encoder, debugInfo, appendPixelType);
+                string actualOutputFile = ((ITestImageProvider)provider).Utility.SaveTestOutputFile(image, "png", encoder, debugInfo, appendPixelType);
             
-                IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(path);
-                string referenceOutputFile = ((ITestImageProvider)provider).Utility.GetReferenceOutputFileName("png", referenceInfo, appendPixelType);
+                IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(actualOutputFile);
             
-                using (var encodedImage = Image.Load<TPixel>(referenceOutputFile, referenceDecoder))
+                using (var actualImage = Image.Load<TPixel>(actualOutputFile, referenceDecoder))
                 {
-                    ImageComparer comparer = pngColorType== PngColorType.Palette ? ImageComparer.Tolerant(ToleranceThresholdForPaletteEncoder) : ImageComparer.Exact;
-                    comparer.CompareImagesOrFrames(image, encodedImage);
+                    ImageComparer comparer = pngColorType == PngColorType.Palette
+                                                 ? ImageComparer.Tolerant(ToleranceThresholdForPaletteEncoder)
+                                                 : ImageComparer.Exact;
+
+                    comparer.VerifySimilarity(image, actualImage);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/ReferenceCodecTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/ReferenceCodecTests.cs
@@ -56,7 +56,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 if (pngColorType != PngColorType.RgbWithAlpha)
                 {
-                    sourceImage.Mutate(c => c.Opacity(1));
+                    sourceImage.Mutate(c => c.MakeOpaque());
                 }
 
                 var encoder = new PngEncoder() { PngColorType = pngColorType };
@@ -93,12 +93,12 @@ namespace SixLabors.ImageSharp.Tests
 
             using (Image<TPixel> original = provider.GetImage())
             {
-                original.Mutate(c => c.Opacity(1));
+                original.Mutate(c => c.MakeOpaque());
                 using (var sdBitmap = new System.Drawing.Bitmap(path))
                 {
                     using (Image<TPixel> resaved = SystemDrawingBridge.FromFromRgb24SystemDrawingBitmap<TPixel>(sdBitmap))
                     {
-                        resaved.Mutate(c => c.Opacity(1));
+                        resaved.Mutate(c => c.MakeOpaque());
                         ImageComparer comparer = ImageComparer.Exact;
                         comparer.VerifySimilarity(original, resaved);
                     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
There were several bugs in the BMP+PNG+Jpeg encoder tests introduced by #469. In fact, those tests weren't verifying anything. This is fixed now.

BMP and Jpeg encoders are now tested without reference images using the `System.Drawing.Common` decoder implementation of the platform running the tests. In case of Jpeg, the tolerance threshold values are set to high values now, the correct values are TBD. (+ I think the encoder's LUT-based RGB->YCbCr conversion is not accurate enough at the moment, making the encoder inaccurate. Like in the decoder, it has to be implemented with `float` + SIMD instead!)