### PR TITLE
Fix non-nearest-neighbour resize for multi-frame-images

### DIFF
--- a/src/ImageSharp/Processing/Transforms/Processors/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Transforms/Processors/ResizeProcessor.cs
@@ -368,10 +368,9 @@ namespace SixLabors.ImageSharp.Processing.Transforms.Processors
             }
         }
 
-        /// <inheritdoc />
-        protected override void AfterFrameApply(ImageFrame<TPixel> source, ImageFrame<TPixel> destination, Rectangle sourceRectangle, Configuration configuration)
+        protected override void AfterImageApply(Image<TPixel> source, Image<TPixel> destination, Rectangle sourceRectangle)
         {
-            base.AfterFrameApply(source, destination, sourceRectangle, configuration);
+            base.AfterImageApply(source, destination, sourceRectangle);
 
             // TODO: An exception in the processing chain can leave these buffers undisposed. We should consider making image processors IDisposable!
             this.horizontalWeights?.Dispose();

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -102,7 +102,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         {
             using (Image<TPixel> image = provider.GetImage())
             {
-                image.Mutate(x => x.Resize(image.Width / 2, image.Height / 2, KnownResamplers.NearestNeighbor));
+                image.Mutate(x => x.Resize(image.Width / 2, image.Height / 2, KnownResamplers.Bicubic));
 
                 // Comparer fights decoder with gif-s. Could not use CompareToReferenceOutput here :(
                 image.DebugSave(provider, extension: Extensions.Gif);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
We were disposing the private weight fields after the first frame was processed. This was introduced during optimization moving the generation of weights from per-image-frame to per-image.

See. https://gitter.im/ImageSharp/General?at=5ab06675e4d1c636041c1283

<!-- Thanks for contributing to ImageSharp! -->
