### PR TITLE
Rename Blend to DrawImage

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Drawing/DrawImageExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Drawing/DrawImageExtensions.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Processing.Drawing
         /// <param name="image">The image to blend with the currently processing image.</param>
         /// <param name="opacity">The opacity of the image to blend. Must be between 0 and 1.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> Blend<TPixel>(this IImageProcessingContext<TPixel> source, Image<TPixel> image, float opacity)
+        public static IImageProcessingContext<TPixel> DrawImage<TPixel>(this IImageProcessingContext<TPixel> source, Image<TPixel> image, float opacity)
             where TPixel : struct, IPixel<TPixel>
             => source.ApplyProcessor(new DrawImageProcessor<TPixel>(image, opacity));
 
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp.Processing.Drawing
         /// <param name="blender">The blending mode.</param>
         /// <param name="opacity">The opacity of the image to blend. Must be between 0 and 1.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> Blend<TPixel>(this IImageProcessingContext<TPixel> source, Image<TPixel> image, PixelBlenderMode blender, float opacity)
+        public static IImageProcessingContext<TPixel> DrawImage<TPixel>(this IImageProcessingContext<TPixel> source, Image<TPixel> image, PixelBlenderMode blender, float opacity)
             where TPixel : struct, IPixel<TPixel>
             => source.ApplyProcessor(new DrawImageProcessor<TPixel>(image, opacity, blender));
 
@@ -45,11 +45,9 @@ namespace SixLabors.ImageSharp.Processing.Drawing
         /// <param name="options">The options, including the blending type and blending amount.</param>
         /// <param name="image">The image to blend with the currently processing image.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> Blend<TPixel>(this IImageProcessingContext<TPixel> source, GraphicsOptions options, Image<TPixel> image)
+        public static IImageProcessingContext<TPixel> DrawImage<TPixel>(this IImageProcessingContext<TPixel> source, GraphicsOptions options, Image<TPixel> image)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return source.ApplyProcessor(new DrawImageProcessor<TPixel>(image, options));
-        }
+            => source.ApplyProcessor(new DrawImageProcessor<TPixel>(image, options));
 
         /// <summary>
         /// Draws the given image together with the current one by blending their pixels.

--- a/tests/ImageSharp.Tests/PixelFormats/PixelBlenders/PorterDuffCompositorTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelBlenders/PorterDuffCompositorTests.cs
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
             using (Image<Rgba32> src = srcFile.CreateImage())
             using (Image<Rgba32> dest = provider.GetImage())
             {
-                using (Image<Rgba32> res = dest.Clone(x => x.Blend(new GraphicsOptions { BlenderMode = mode }, src)))
+                using (Image<Rgba32> res = dest.Clone(x => x.DrawImage(new GraphicsOptions { BlenderMode = mode }, src)))
                 {
                     res.DebugSave(provider, mode.ToString());
                     res.CompareToReferenceOutput(provider, mode.ToString());


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
We had both method names, both calling the same processor. It's odd and confusing. 

<!-- Thanks for contributing to ImageSharp! -->
