### PR TITLE
update external dependencies + fix RectangularPolygon usages

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -36,9 +36,9 @@
         <ProjectReference Include="..\ImageSharp\ImageSharp.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="SixLabors.Core" Version="1.0.0-ci0005" />
-        <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-ci0005" />
-        <PackageReference Include="SixLabors.Shapes" Version="1.0.0-ci0005" />
+        <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0005" />
+        <PackageReference Include="SixLabors.Shapes" Version="1.0.0-beta0004" />
+        <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-beta0004" />
         <AdditionalFiles Include="..\..\stylecop.json" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
             <PrivateAssets>All</PrivateAssets>

--- a/src/ImageSharp.Drawing/Processing/Drawing/DrawRectangleExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Drawing/DrawRectangleExtensions.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Processing.Drawing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext<TPixel> Draw<TPixel>(this IImageProcessingContext<TPixel> source, GraphicsOptions options, IPen<TPixel> pen, RectangleF shape)
             where TPixel : struct, IPixel<TPixel>
-            => source.Draw(options, pen, new RectangularePolygon(shape.X, shape.Y, shape.Width, shape.Height));
+            => source.Draw(options, pen, new RectangularPolygon(shape.X, shape.Y, shape.Width, shape.Height));
 
         /// <summary>
         /// Draws the outline of the rectangle with the provided pen.

--- a/src/ImageSharp.Drawing/Processing/Drawing/FillRectangleExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Drawing/FillRectangleExtensions.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Processing.Drawing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext<TPixel> Fill<TPixel>(this IImageProcessingContext<TPixel> source, GraphicsOptions options, IBrush<TPixel> brush, RectangleF shape)
             where TPixel : struct, IPixel<TPixel>
-            => source.Fill(options, brush, new RectangularePolygon(shape.X, shape.Y, shape.Width, shape.Height));
+            => source.Fill(options, brush, new RectangularPolygon(shape.X, shape.Y, shape.Width, shape.Height));
 
         /// <summary>
         /// Flood fills the image in the shape of the provided rectangle with the specified brush.
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Processing.Drawing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext<TPixel> Fill<TPixel>(this IImageProcessingContext<TPixel> source, IBrush<TPixel> brush, RectangleF shape)
             where TPixel : struct, IPixel<TPixel>
-            => source.Fill(brush, new RectangularePolygon(shape.X, shape.Y, shape.Width, shape.Height));
+            => source.Fill(brush, new RectangularPolygon(shape.X, shape.Y, shape.Width, shape.Height));
 
         /// <summary>
         /// Flood fills the image in the shape of the provided rectangle with the specified brush.

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -35,7 +35,7 @@
     <Compile Include="..\Shared\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Core" Version="1.0.0-ci0005" />
+    <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0005" />
     <AdditionalFiles Include="..\..\stylecop.json" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006">
       <PrivateAssets>All</PrivateAssets>

--- a/tests/ImageSharp.Tests/Drawing/Paths/FillRectangle.cs
+++ b/tests/ImageSharp.Tests/Drawing/Paths/FillRectangle.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Paths
             Assert.Equal(GraphicsOptions.Default, processor.Options);
 
             ShapeRegion region = Assert.IsType<ShapeRegion>(processor.Region);
-            Shapes.RectangularePolygon rect = Assert.IsType<Shapes.RectangularePolygon>(region.Shape);
+            Shapes.RectangularPolygon rect = Assert.IsType<Shapes.RectangularPolygon>(region.Shape);
             Assert.Equal(rect.Location.X, this.rectangle.X);
             Assert.Equal(rect.Location.Y, this.rectangle.Y);
             Assert.Equal(rect.Size.Width, this.rectangle.Width);
@@ -44,7 +44,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Paths
             Assert.Equal(this.noneDefault, processor.Options);
 
             ShapeRegion region = Assert.IsType<ShapeRegion>(processor.Region);
-            Shapes.RectangularePolygon rect = Assert.IsType<Shapes.RectangularePolygon>(region.Shape);
+            Shapes.RectangularPolygon rect = Assert.IsType<Shapes.RectangularPolygon>(region.Shape);
             Assert.Equal(rect.Location.X, this.rectangle.X);
             Assert.Equal(rect.Location.Y, this.rectangle.Y);
             Assert.Equal(rect.Size.Width, this.rectangle.Width);
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Paths
             Assert.Equal(GraphicsOptions.Default, processor.Options);
 
             ShapeRegion region = Assert.IsType<ShapeRegion>(processor.Region);
-            Shapes.RectangularePolygon rect = Assert.IsType<Shapes.RectangularePolygon>(region.Shape);
+            Shapes.RectangularPolygon rect = Assert.IsType<Shapes.RectangularPolygon>(region.Shape);
             Assert.Equal(rect.Location.X, this.rectangle.X);
             Assert.Equal(rect.Location.Y, this.rectangle.Y);
             Assert.Equal(rect.Size.Width, this.rectangle.Width);
@@ -81,7 +81,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Paths
             Assert.Equal(this.noneDefault, processor.Options);
 
             ShapeRegion region = Assert.IsType<ShapeRegion>(processor.Region);
-            Shapes.RectangularePolygon rect = Assert.IsType<Shapes.RectangularePolygon>(region.Shape);
+            Shapes.RectangularPolygon rect = Assert.IsType<Shapes.RectangularPolygon>(region.Shape);
             Assert.Equal(rect.Location.X, this.rectangle.X);
             Assert.Equal(rect.Location.Y, this.rectangle.Y);
             Assert.Equal(rect.Size.Width, this.rectangle.Width);

--- a/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
@@ -151,7 +151,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             {
                 image.Mutate(x => x
                     .BackgroundColor(Rgba32.Blue)
-                    .Fill(Rgba32.HotPink, new SixLabors.Shapes.RectangularePolygon(10, 10, 190, 140)));
+                    .Fill(Rgba32.HotPink, new SixLabors.Shapes.RectangularPolygon(10, 10, 190, 140)));
                 image.Save($"{path}/Rectangle.png");
 
                 using (PixelAccessor<Rgba32> sourcePixels = image.Lock())


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
- update external dependencies
- Replace Rectangular**e**Polygon with RectangularPolygon