### PR TITLE
Drop NETSTANDARD 1.1

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -5,7 +5,7 @@
         <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
         <VersionPrefix Condition="$(packageversion) == ''">0.0.1</VersionPrefix>
         <Authors>SixLabors and contributors</Authors>
-        <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AssemblyName>SixLabors.ImageSharp.Drawing</AssemblyName>

--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -9,9 +9,7 @@ using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
-#if !NETSTANDARD1_1
 using SixLabors.ImageSharp.IO;
-#endif
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Processing;
 
@@ -84,12 +82,10 @@ namespace SixLabors.ImageSharp
         /// </summary>
         internal int MaxHeaderSize => this.ImageFormatsManager.MaxHeaderSize;
 
-#if !NETSTANDARD1_1
         /// <summary>
         /// Gets or sets the filesystem helper for accessing the local file system.
         /// </summary>
         internal IFileSystem FileSystem { get; set; } = new LocalFileSystem();
-#endif
 
         /// <summary>
         /// Gets or sets the image operations provider factory.
@@ -119,10 +115,7 @@ namespace SixLabors.ImageSharp
                 MemoryManager = this.MemoryManager,
                 ImageOperationsProvider = this.ImageOperationsProvider,
                 ReadOrigin = this.ReadOrigin,
-
-#if !NETSTANDARD1_1
                 FileSystem = this.FileSystem
-#endif
             };
         }
 

--- a/src/ImageSharp/Formats/Gif/GifConstants.cs
+++ b/src/ImageSharp/Formats/Gif/GifConstants.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <summary>
         /// The ASCII encoded bytes used to identify the GIF file.
         /// </summary>
-        internal static readonly byte[] MagicNumber = Encoding.UTF8.GetBytes(FileType + FileVersion);
+        internal static readonly byte[] MagicNumber = Encoding.ASCII.GetBytes(FileType + FileVersion);
 
         /// <summary>
         /// The extension block introducer <value>!</value>.
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <summary>
         /// The ASCII encoded application identification bytes.
         /// </summary>
-        internal static readonly byte[] ApplicationIdentificationBytes = Encoding.UTF8.GetBytes(ApplicationIdentification);
+        internal static readonly byte[] ApplicationIdentificationBytes = Encoding.ASCII.GetBytes(ApplicationIdentification);
 
         /// <summary>
         /// The application block size.
@@ -99,7 +99,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <summary>
         /// Gets the default encoding to use when reading comments.
         /// </summary>
-        public static readonly Encoding DefaultEncoding = Encoding.GetEncoding("ASCII");
+        public static readonly Encoding DefaultEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The list of mimetypes that equate to a gif.

--- a/src/ImageSharp/Formats/Png/PngConstants.cs
+++ b/src/ImageSharp/Formats/Png/PngConstants.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <summary>
         /// The default encoding for text metadata.
         /// </summary>
-        public static readonly Encoding DefaultEncoding = Encoding.GetEncoding("ASCII");
+        public static readonly Encoding DefaultEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The list of mimetypes that equate to a png.

--- a/src/ImageSharp/IO/IFileSystem.cs
+++ b/src/ImageSharp/IO/IFileSystem.cs
@@ -5,7 +5,6 @@ using System.IO;
 
 namespace SixLabors.ImageSharp.IO
 {
- #if !NETSTANDARD1_1
     /// <summary>
     /// A simple interface representing the filesystem.
     /// </summary>
@@ -25,5 +24,4 @@ namespace SixLabors.ImageSharp.IO
         /// <returns>A stream representing the file to open.</returns>
         Stream Create(string path);
     }
-#endif
 }

--- a/src/ImageSharp/IO/LocalFileSystem.cs
+++ b/src/ImageSharp/IO/LocalFileSystem.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace SixLabors.ImageSharp.IO
 {
- #if !NETSTANDARD1_1
     /// <summary>
     /// A wrapper around the local File apis.
     /// </summary>
@@ -26,5 +22,4 @@ namespace SixLabors.ImageSharp.IO
             return File.Create(path);
         }
     }
-#endif
 }

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-#if !NETSTANDARD1_1
 using System;
 using System.IO;
 using SixLabors.ImageSharp.Formats;
@@ -213,4 +212,3 @@ namespace SixLabors.ImageSharp
         }
     }
 }
-#endif

--- a/src/ImageSharp/ImageExtensions.cs
+++ b/src/ImageSharp/ImageExtensions.cs
@@ -18,7 +18,6 @@ namespace SixLabors.ImageSharp
     /// </summary>
     public static partial class ImageExtensions
     {
-#if !NETSTANDARD1_1
         /// <summary>
         /// Saves the image to the given stream using the currently loaded image format.
         /// </summary>
@@ -79,7 +78,6 @@ namespace SixLabors.ImageSharp
                 source.Save(fs, encoder);
             }
         }
-#endif
 
         /// <summary>
         /// Saves the image to the given stream using the currently loaded image format.

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
     <VersionPrefix Condition="$(packageversion) == ''">0.0.1</VersionPrefix>
     <Authors>Six Labors and contributors</Authors>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SixLabors.ImageSharp</AssemblyName>
@@ -44,7 +44,7 @@
     <PackageReference Include="System.Memory" Version="4.5.0-preview1-26216-02" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0-preview1-26216-02" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' OR '$(TargetFramework)' == 'netstandard1.3'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifReader.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifReader.cs
@@ -140,19 +140,13 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
 
         private unsafe string ConvertToString(ReadOnlySpan<byte> buffer)
         {
-#if NETSTANDARD1_1
-            byte[] bytes = buffer.ToArray();
-
-            string result = Encoding.UTF8.GetString(bytes, 0, buffer.Length);
-
-#else
             string result;
 
             fixed (byte* pointer = &MemoryMarshal.GetReference(buffer))
             {
                 result = Encoding.UTF8.GetString(pointer, buffer.Length);
             }
-#endif
+
             int nullCharIndex = result.IndexOf('\0');
             if (nullCharIndex != -1)
             {

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     internal sealed partial class IccDataReader
     {
         private static readonly bool IsLittleEndian = BitConverter.IsLittleEndian;
-        private static readonly Encoding AsciiEncoding = Encoding.GetEncoding("ASCII");
+        private static readonly Encoding AsciiEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The data that is read

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     internal sealed partial class IccDataWriter : IDisposable
     {
         private static readonly bool IsLittleEndian = BitConverter.IsLittleEndian;
-        private static readonly Encoding AsciiEncoding = Encoding.GetEncoding("ASCII");
+        private static readonly Encoding AsciiEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The underlying stream where the data is written to

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-
-#if !NETSTANDARD1_1
 using System.Security.Cryptography;
-#endif
 
 namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
 {
@@ -105,8 +102,6 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
             }
         }
 
-#if !NETSTANDARD1_1
-
         /// <summary>
         /// Calculates the MD5 hash value of an ICC profile header
         /// </summary>
@@ -117,6 +112,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
             Guard.NotNull(data, nameof(data));
             Guard.IsTrue(data.Length >= 128, nameof(data), "Data length must be at least 128 to be a valid profile header");
 
+            // TODO: stackalloc
             byte[] header = new byte[128];
             Buffer.BlockCopy(data, 0, header, 0, 128);
 
@@ -135,8 +131,6 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
                 return reader.ReadProfileId();
             }
         }
-
-#endif
 
         /// <summary>
         /// Extends the profile with additional data.

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccWriter.cs
@@ -51,12 +51,8 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
             writer.WriteXyzNumber(header.PcsIlluminant);
             writer.WriteAsciiString(header.CreatorSignature, 4, false);
 
-#if !NETSTANDARD1_1
             IccProfileId id = IccProfile.CalculateHash(writer.GetData());
             writer.WriteProfileId(id);
-#else
-            writer.WriteProfileId(IccProfileId.Zero);
-#endif
         }
 
         private void WriteTagTable(IccDataWriter writer, IccTagTableEntry[] table)

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDataTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDataTagDataEntry.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     /// </summary>
     internal sealed class IccDataTagDataEntry : IccTagDataEntry, IEquatable<IccDataTagDataEntry>
     {
-        private static readonly Encoding AsciiEncoding = Encoding.GetEncoding("ASCII");
+        private static readonly Encoding AsciiEncoding = Encoding.ASCII;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IccDataTagDataEntry"/> class.

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -292,7 +292,7 @@ namespace SixLabors.ImageSharp.Tests
         private static void WriteChunk(MemoryStream memStream, string chunkName)
         {
             memStream.Write(new byte[] { 0, 0, 0, 1 }, 0, 4);
-            memStream.Write(Encoding.GetEncoding("ASCII").GetBytes(chunkName), 0, 4);
+            memStream.Write(Encoding.ASCII.GetBytes(chunkName), 0, 4);
             memStream.Write(new byte[] { 0, 0, 0, 0, 0 }, 0, 5);
         }
 

--- a/tests/ImageSharp.Tests/TestDataIcc/IccTestDataProfiles.cs
+++ b/tests/ImageSharp.Tests/TestDataIcc/IccTestDataProfiles.cs
@@ -15,20 +15,12 @@ namespace SixLabors.ImageSharp.Tests
             "ijkl");    // should be overwritten to "acsp"
 
         public static readonly IccProfileHeader Header_Random_Read = CreateHeaderRandomValue(132,
-#if !NETSTANDARD1_1
             new IccProfileId(2931428592, 418415738, 3086756963, 2237536530),
-#else
-            IccProfileId.Zero,
-#endif
             "acsp");
 
         public static readonly byte[] Header_Random_Array = CreateHeaderRandomArray(132, 0, new byte[]
         {
-#if !NETSTANDARD1_1
-                0xAE, 0xBA, 0x0C, 0xF0, 0x18, 0xF0, 0x84, 0x7A, 0xB7, 0xFC, 0x2C, 0x63, 0x85, 0x5E, 0x19, 0x12,
-#else
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-#endif
+            0xAE, 0xBA, 0x0C, 0xF0, 0x18, 0xF0, 0x84, 0x7A, 0xB7, 0xFC, 0x2C, 0x63, 0x85, 0x5E, 0x19, 0x12,
         });
 
         public static IccProfileHeader CreateHeaderRandomValue(uint size, IccProfileId id, string fileSignature)
@@ -45,11 +37,7 @@ namespace SixLabors.ImageSharp.Tests
                 DeviceModel = 987654321u,
                 FileSignature = "acsp",
                 Flags = IccProfileFlag.Embedded | IccProfileFlag.Independent,
-#if !NETSTANDARD1_1
                 Id = new IccProfileId(2931428592, 418415738, 3086756963, 2237536530),
-#else
-            Id = IccProfileId.Zero,
-#endif
                 PcsIlluminant = new Vector3(4, 5, 6),
                 PrimaryPlatformSignature = IccPrimaryPlatformType.MicrosoftCorporation,
                 ProfileConnectionSpace = IccColorSpaceType.CieXyz,
@@ -96,11 +84,7 @@ namespace SixLabors.ImageSharp.Tests
 
         public static byte[] Profile_Random_Array = ArrayHelper.Concat(CreateHeaderRandomArray(168, 2, new byte[] 
             {
-#if !NETSTANDARD1_1
                 0xA9, 0x71, 0x8F, 0xC1, 0x1E, 0x2D, 0x64, 0x1B, 0x10, 0xF4, 0x7D, 0x6A, 0x5B, 0xF6, 0xAC, 0xB9
-#else
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-#endif
             }),
             new byte[]
             {
@@ -117,11 +101,7 @@ namespace SixLabors.ImageSharp.Tests
         );
 
         public static IccProfile Profile_Random_Val = new IccProfile(CreateHeaderRandomValue(168,
-#if !NETSTANDARD1_1
             new IccProfileId(0xA9718FC1, 0x1E2D641B, 0x10F47D6A, 0x5BF6ACB9),
-#else
-            IccProfileId.Zero,
-#endif
             "acsp"),
             new IccTagDataEntry[]
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

This PR drops support for .NETStandard 1.1. This eliminates the need to conditionally exclude the file system APIs.

Most importantly, this also helps ensure that we don't take on any legacy users as we build for the future.