### PR TITLE
Faster Gif Decoding

### DIFF
--- a/src/ImageSharp/Common/Helpers/DebugGuard.cs
+++ b/src/ImageSharp/Common/Helpers/DebugGuard.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 
+// TODO: These should just call the guard equivalents
 namespace SixLabors.ImageSharp
 {
     /// <summary>
@@ -111,6 +112,28 @@ namespace SixLabors.ImageSharp
             if (value.CompareTo(min) < 0)
             {
                 throw new ArgumentOutOfRangeException(parameterName, $"Value must be greater than or equal to {min}.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [Conditional("DEBUG")]
+        public static void MustBeBetweenOrEqualTo<TValue>(TValue value, TValue min, TValue max, string parameterName)
+           where TValue : IComparable<TValue>
+        {
+            if (value.CompareTo(min) < 0 || value.CompareTo(max) > 0)
+            {
+                throw new ArgumentOutOfRangeException(parameterName, $"Value {value} must be greater than or equal to {min} and less than or equal to {max}.");
             }
         }
 

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -342,7 +342,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 {
                     ref TPixel entry = ref Unsafe.Add(ref paletteRef, i);
                     entry.ToRgb24(ref rgb);
-                    Unsafe.Add(ref rgb24Ref, i);
+                    Unsafe.Add(ref rgb24Ref, i) = rgb;
                 }
 
                 writer.Write(colorTable.Array, 0, colorTableLength);

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -51,11 +51,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
         private int bitDepth;
 
         /// <summary>
-        /// Whether the current image has multiple frames.
-        /// </summary>
-        private bool hasFrames;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="GifEncoderCore"/> class.
         /// </summary>
         /// <param name="memoryManager">The <see cref="MemoryManager"/> to use for buffer allocations.</param>

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Buffers;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -4,7 +4,8 @@
 using System;
 using System.Buffers;
 using System.IO;
-
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.Memory;
 
 namespace SixLabors.ImageSharp.Formats.Gif
@@ -115,14 +116,14 @@ namespace SixLabors.ImageSharp.Formats.Gif
             int data = 0;
             int first = 0;
 
-            Span<int> prefixSpan = this.prefix.Span;
-            Span<int> suffixSpan = this.suffix.Span;
-            Span<int> pixelStackSpan = this.pixelStack.Span;
+            ref int prefixRef = ref MemoryMarshal.GetReference(this.prefix.Span);
+            ref int suffixRef = ref MemoryMarshal.GetReference(this.suffix.Span);
+            ref int pixelStackRef = ref MemoryMarshal.GetReference(this.pixelStack.Span);
+            ref byte pixelsRef = ref MemoryMarshal.GetReference(pixels);
 
             for (code = 0; code < clearCode; code++)
             {
-                prefixSpan[code] = 0;
-                suffixSpan[code] = (byte)code;
+                Unsafe.Add(ref suffixRef, code) = (byte)code;
             }
 
             byte[] buffer = new byte[255];
@@ -176,7 +177,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
                     if (oldCode == NullCode)
                     {
-                        pixelStackSpan[top++] = suffixSpan[code];
+                        Unsafe.Add(ref pixelStackRef, top++) = Unsafe.Add(ref suffixRef, code);
                         oldCode = code;
                         first = code;
                         continue;
@@ -185,27 +186,27 @@ namespace SixLabors.ImageSharp.Formats.Gif
                     int inCode = code;
                     if (code == availableCode)
                     {
-                        pixelStackSpan[top++] = (byte)first;
+                        Unsafe.Add(ref pixelStackRef, top++) = (byte)first;
 
                         code = oldCode;
                     }
 
                     while (code > clearCode)
                     {
-                        pixelStackSpan[top++] = suffixSpan[code];
-                        code = prefixSpan[code];
+                        Unsafe.Add(ref pixelStackRef, top++) = Unsafe.Add(ref suffixRef, code);
+                        code = Unsafe.Add(ref prefixRef, code);
                     }
 
-                    first = suffixSpan[code];
-
-                    pixelStackSpan[top++] = suffixSpan[code];
+                    int suffixCode = Unsafe.Add(ref suffixRef, code);
+                    first = suffixCode;
+                    Unsafe.Add(ref pixelStackRef, top++) = suffixCode;
 
                     // Fix for Gifs that have "deferred clear code" as per here :
                     // https://bugzilla.mozilla.org/show_bug.cgi?id=55918
                     if (availableCode < MaxStackSize)
                     {
-                        prefixSpan[availableCode] = oldCode;
-                        suffixSpan[availableCode] = first;
+                        Unsafe.Add(ref prefixRef, availableCode) = oldCode;
+                        Unsafe.Add(ref suffixRef, availableCode) = first;
                         availableCode++;
                         if (availableCode == codeMask + 1 && availableCode < MaxStackSize)
                         {
@@ -221,7 +222,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 top--;
 
                 // Clear missing pixels
-                pixels[xyz++] = (byte)pixelStackSpan[top];
+                Unsafe.Add(ref pixelsRef, xyz++) = (byte)Unsafe.Add(ref pixelStackRef, top);
             }
         }
 
@@ -238,8 +239,9 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         /// <param name="buffer">The buffer to store the block in.</param>
         /// <returns>
-        /// The <see cref="T:byte[]"/>.
+        /// The <see cref="int"/>.
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int ReadBlock(byte[] buffer)
         {
             int bufferSize = this.stream.ReadByte();

--- a/src/ImageSharp/Formats/Gif/PackedField.cs
+++ b/src/ImageSharp/Formats/Gif/PackedField.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.Formats.Gif
 {
@@ -21,6 +23,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         public byte Byte
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 int returnValue = 0;
@@ -53,7 +56,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <returns>The <see cref="PackedField"/></returns>
         public static PackedField FromInt(byte value)
         {
-            PackedField packed = default(PackedField);
+            PackedField packed = default;
             packed.SetBits(0, 8, value);
             return packed;
         }
@@ -70,12 +73,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </param>
         public void SetBit(int index, bool valueToSet)
         {
-            if (index < 0 || index > 7)
-            {
-                string message = $"Index must be between 0 and 7. Supplied index: {index}";
-                throw new ArgumentOutOfRangeException(nameof(index), message);
-            }
-
+            DebugGuard.MustBeBetweenOrEqualTo(index, 0, 7, nameof(index));
             Bits[index] = valueToSet;
         }
 
@@ -88,18 +86,8 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="valueToSet">The value to set the bits to.</param>
         public void SetBits(int startIndex, int length, int valueToSet)
         {
-            if (startIndex < 0 || startIndex > 7)
-            {
-                string message = $"Start index must be between 0 and 7. Supplied index: {startIndex}";
-                throw new ArgumentOutOfRangeException(nameof(startIndex), message);
-            }
-
-            if (length < 1 || startIndex + length > 8)
-            {
-                string message = "Length must be greater than zero and the sum of length and start index must be less than 8. "
-                                 + $"Supplied length: {length}. Supplied start index: {startIndex}";
-                throw new ArgumentOutOfRangeException(nameof(length), message);
-            }
+            DebugGuard.MustBeBetweenOrEqualTo(startIndex, 0, 7, nameof(startIndex));
+            DebugCheckLength(startIndex, length);
 
             int bitShift = length - 1;
             for (int i = startIndex; i < startIndex + length; i++)
@@ -121,12 +109,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </returns>
         public bool GetBit(int index)
         {
-            if (index < 0 || index > 7)
-            {
-                string message = $"Index must be between 0 and 7. Supplied index: {index}";
-                throw new ArgumentOutOfRangeException(nameof(index), message);
-            }
-
+            DebugGuard.MustBeBetweenOrEqualTo(index, 0, 7, nameof(index));
             return Bits[index];
         }
 
@@ -140,19 +123,8 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </returns>
         public int GetBits(int startIndex, int length)
         {
-            if (startIndex < 0 || startIndex > 7)
-            {
-                string message = $"Start index must be between 0 and 7. Supplied index: {startIndex}";
-                throw new ArgumentOutOfRangeException(nameof(startIndex), message);
-            }
-
-            if (length < 1 || startIndex + length > 8)
-            {
-                string message = "Length must be greater than zero and the sum of length and start index must be less than 8. "
-                                 + $"Supplied length: {length}. Supplied start index: {startIndex}";
-
-                throw new ArgumentOutOfRangeException(nameof(length), message);
-            }
+            DebugGuard.MustBeBetweenOrEqualTo(startIndex, 1, 8, nameof(startIndex));
+            DebugCheckLength(startIndex, length);
 
             int returnValue = 0;
             int bitShift = length - 1;
@@ -188,6 +160,18 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public override int GetHashCode()
         {
             return this.Byte.GetHashCode();
+        }
+
+        [Conditional("DEBUG")]
+        private static void DebugCheckLength(int startIndex, int length)
+        {
+            if (length < 1 || startIndex + length > 8)
+            {
+                string message = "Length must be greater than zero and the sum of length and start index must be less than 8. "
+                                 + $"Supplied length: {length}. Supplied start index: {startIndex}";
+
+                throw new ArgumentOutOfRangeException(nameof(length), message);
+            }
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Tests
         {
             using (Image<TPixel> image = provider.GetImage())
             {
-                provider.Utility.SaveTestOutputFile(image, "gif", new GifEncoder() { Quantizer = new PaletteQuantizer() });
+                provider.Utility.SaveTestOutputFile(image, "gif", new GifEncoder());
             }
         }
 

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -6,6 +6,7 @@ using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.MetaData;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing.Quantization;
 using Xunit;
 // ReSharper disable InconsistentNaming
 
@@ -22,28 +23,28 @@ namespace SixLabors.ImageSharp.Tests
         {
             using (Image<TPixel> image = provider.GetImage())
             {
-                provider.Utility.SaveTestOutputFile(image, "gif", new GifEncoder());
+                provider.Utility.SaveTestOutputFile(image, "gif", new GifEncoder() { Quantizer = new PaletteQuantizer() });
             }
         }
 
         [Fact]
         public void Encode_IgnoreMetadataIsFalse_CommentsAreWritten()
         {
-            GifEncoder options = new GifEncoder()
+            var options = new GifEncoder()
             {
                 IgnoreMetadata = false
             };
 
-            TestFile testFile = TestFile.Create(TestImages.Gif.Rings);
+            var testFile = TestFile.Create(TestImages.Gif.Rings);
 
             using (Image<Rgba32> input = testFile.CreateImage())
             {
-                using (MemoryStream memStream = new MemoryStream())
+                using (var memStream = new MemoryStream())
                 {
                     input.Save(memStream, options);
 
                     memStream.Position = 0;
-                    using (Image<Rgba32> output = Image.Load<Rgba32>(memStream))
+                    using (var output = Image.Load<Rgba32>(memStream))
                     {
                         Assert.Equal(1, output.MetaData.Properties.Count);
                         Assert.Equal("Comments", output.MetaData.Properties[0].Name);
@@ -56,21 +57,21 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void Encode_IgnoreMetadataIsTrue_CommentsAreNotWritten()
         {
-            GifEncoder options = new GifEncoder()
+            var options = new GifEncoder()
             {
                 IgnoreMetadata = true
             };
 
-            TestFile testFile = TestFile.Create(TestImages.Gif.Rings);
+            var testFile = TestFile.Create(TestImages.Gif.Rings);
 
             using (Image<Rgba32> input = testFile.CreateImage())
             {
-                using (MemoryStream memStream = new MemoryStream())
+                using (var memStream = new MemoryStream())
                 {
                     input.SaveAsGif(memStream, options);
 
                     memStream.Position = 0;
-                    using (Image<Rgba32> output = Image.Load<Rgba32>(memStream))
+                    using (var output = Image.Load<Rgba32>(memStream))
                     {
                         Assert.Equal(0, output.MetaData.Properties.Count);
                     }
@@ -81,17 +82,17 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void Encode_WhenCommentIsTooLong_CommentIsTrimmed()
         {
-            using (Image<Rgba32> input = new Image<Rgba32>(1, 1))
+            using (var input = new Image<Rgba32>(1, 1))
             {
                 string comments = new string('c', 256);
                 input.MetaData.Properties.Add(new ImageProperty("Comments", comments));
 
-                using (MemoryStream memStream = new MemoryStream())
+                using (var memStream = new MemoryStream())
                 {
                     input.Save(memStream, new GifEncoder());
 
                     memStream.Position = 0;
-                    using (Image<Rgba32> output = Image.Load<Rgba32>(memStream))
+                    using (var output = Image.Load<Rgba32>(memStream))
                     {
                         Assert.Equal(1, output.MetaData.Properties.Count);
                         Assert.Equal("Comments", output.MetaData.Properties[0].Name);

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -87,6 +87,37 @@ namespace SixLabors.ImageSharp.Tests
             return image;
         }
 
+        /// <summary>
+        /// Saves the image only when not running in the CI server.
+        /// </summary>
+        /// <typeparam name="TPixel">The pixel format</typeparam>
+        /// <param name="image">The image</param>
+        /// <param name="provider">The image provider</param>
+        /// <param name="encoder">The image encoder</param>
+        /// <param name="testOutputDetails">Details to be concatenated to the test output file, describing the parameters of the test.</param>
+        /// <param name="appendPixelTypeToFileName">A boolean indicating whether to append the pixel type to the  output file name.</param>
+        public static Image<TPixel> DebugSave<TPixel>(
+            this Image<TPixel> image,
+            ITestImageProvider provider,
+            IImageEncoder encoder,
+            object testOutputDetails = null,
+            bool appendPixelTypeToFileName = true)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            if (TestEnvironment.RunsOnCI)
+            {
+                return image;
+            }
+
+            // We are running locally then we want to save it out
+            provider.Utility.SaveTestOutputFile(
+                image,
+                encoder: encoder,
+                testOutputDetails: testOutputDetails,
+                appendPixelTypeToFileName: appendPixelTypeToFileName);
+            return image;
+        }
+
         public static Image<TPixel> DebugSaveMultiFrame<TPixel>(
             this Image<TPixel> image,
             ITestImageProvider provider,
@@ -168,7 +199,7 @@ namespace SixLabors.ImageSharp.Tests
                 provider,
                 testOutputDetails,
                 extension,
-                appendPixelTypeToFileName)) 
+                appendPixelTypeToFileName))
             {
                 comparer.VerifySimilarity(referenceImage, image);
             }
@@ -272,7 +303,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             Image<TPixel> firstTemp = temporaryFrameImages[0];
-            
+
             var result = new Image<TPixel>(firstTemp.Width, firstTemp.Height);
 
             foreach (Image<TPixel> fi in temporaryFrameImages)
@@ -345,7 +376,7 @@ namespace SixLabors.ImageSharp.Tests
         {
             return CompareToOriginal(image, provider, ImageComparer.Tolerant());
         }
-        
+
         public static Image<TPixel> CompareToOriginal<TPixel>(
             this Image<TPixel> image,
             ITestImageProvider provider,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Nothing fancy just a bit of a performance improvement reading and writing gifs. 33% faster decoding but no noticeable change with the encoder. 

We've got 250 GC Generation 2 collects per 1k Operations when encoding that I haven't identified the reason for yet. Possibly caused by multiple short writes to the stream.

**Before**

Method | Runtime |     TestImage |       Mean |      Error |   StdDev | Scaled | ScaledSD |   Gen 0 | Allocated |
--------------------- |-------- |-------------- |-----------:|-----------:|---------:|-------:|---------:|--------:|----------:|
'System.Drawing Gif' |    Core | Gif/rings.gif |   440.1 us |   966.4 us | 54.60 us |   1.00 |     0.00 | 51.2695 |  105.3 KB |
'ImageSharp Gif' |    Core | Gif/rings.gif | 1,231.9 us |   594.7 us | 33.60 us |   2.83 |     0.27 |       - |   2.04 KB |
|         |               |            |            |          |        |          |         |           |
'System.Drawing Gif' |     Clr | Gif/rings.gif |   386.2 us |   198.9 us | 11.24 us |   1.00 |     0.00 | 51.2695 | 105.44 KB |
'ImageSharp Gif' |     Clr | Gif/rings.gif | 1,317.2 us | 1,458.3 us | 82.40 us |   3.41 |     0.19 |       - |   2.09 KB |

**After** 

Method | Runtime |     TestImage |     Mean |    Error |   StdDev | Scaled |   Gen 0 | Allocated |
--------------------- |-------- |-------------- |---------:|---------:|---------:|-------:|--------:|----------:|
'System.Drawing Gif' |    Core | Gif/rings.gif | 391.2 us | 32.14 us | 1.816 us |   1.00 | 51.2695 |  105.3 KB |
'ImageSharp Gif' |    Core | Gif/rings.gif | 909.6 us | 83.44 us | 4.714 us |   2.32 |       - |   2.04 KB |
|         |               |          |          |          |        |         |           |
'System.Drawing Gif' |     Clr | Gif/rings.gif | 392.9 us | 25.92 us | 1.464 us |   1.00 | 51.2695 | 105.44 KB |
'ImageSharp Gif' |     Clr | Gif/rings.gif | 935.4 us | 83.61 us | 4.724 us |   2.38 |  0.9766 |   2.09 KB |



<!-- Thanks for contributing to ImageSharp! -->
