### PR TITLE
Disposing data chunk instead of explicit returning it to ArrayPool in PngDecoderCore.Identify

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -313,11 +313,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                     }
                     finally
                     {
-                        // Data is rented in ReadChunkData()
-                        if (chunk.Data != null)
-                        {
-                            ArrayPool<byte>.Shared.Return(chunk.Data.Array);
-                        }
+                        chunk.Data?.Dispose(); // Data is rented in ReadChunkData()
                     }
                 }
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
The new `Image.Identify` API was introduced in #292. In #475 memory management was significantly improved, but there is still a case for `png` format when `ArrayPool` is used directly when calling `Image.Identify`, not with `IManagedByteBuffer` API.
This leads to the issue when `ArgumentException` is throwing in `ArrayPool.Return` method with this message:

```
The buffer is not associated with this pool and may not be returned to it.
Parameter name: array
```

This PR fixes this problem.

<!-- Thanks for contributing to ImageSharp! -->
