### PR TITLE
fix for unnecessary memory allocation, if Identify is used to retrieve the metadata of an image only

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/GolangPort/Components/Decoder/OrigComponent.cs
+++ b/src/ImageSharp/Formats/Jpeg/GolangPort/Components/Decoder/OrigComponent.cs
@@ -246,7 +246,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort.Components.Decoder
 
         public void Dispose()
         {
-            this.SpectralBlocks.Dispose();
+            this.SpectralBlocks?.Dispose();
         }
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/GolangPort/Components/Decoder/OrigComponent.cs
+++ b/src/ImageSharp/Formats/Jpeg/GolangPort/Components/Decoder/OrigComponent.cs
@@ -57,7 +57,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort.Components.Decoder
         /// </summary>
         /// <param name="memoryManager">The <see cref="MemoryManager"/> to use for buffer allocations.</param>
         /// <param name="decoder">The <see cref="OrigJpegDecoderCore"/> instance</param>
-        public void InitializeDerivedData(MemoryManager memoryManager, OrigJpegDecoderCore decoder)
+        /// <param name="metadataOnly">Whether to decode metadata only. If this is true, memory allocation for SpectralBlocks will not be necessary</param>
+        public void InitializeDerivedData(MemoryManager memoryManager, OrigJpegDecoderCore decoder, bool metadataOnly)
         {
             // For 4-component images (either CMYK or YCbCrK), we only support two
             // hv vectors: [0x11 0x11 0x11 0x11] and [0x22 0x11 0x11 0x22].
@@ -80,7 +81,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort.Components.Decoder
                 this.SubSamplingDivisors = c0.SamplingFactors.DivideBy(this.SamplingFactors);
             }
 
-            this.SpectralBlocks = memoryManager.Allocate2D<Block8x8>(this.SizeInBlocks.Width, this.SizeInBlocks.Height, true);
+            if (!metadataOnly)
+            {
+                this.SpectralBlocks = memoryManager.Allocate2D<Block8x8>(this.SizeInBlocks.Width, this.SizeInBlocks.Height, true);
+            }
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/GolangPort/OrigJpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/GolangPort/OrigJpegDecoderCore.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort
 
         /// <summary>
         /// Encapsulates stream reading and processing data and operations for <see cref="OrigJpegDecoderCore"/>.
-        /// It's a value type for imporved data locality, and reduced number of CALLVIRT-s
+        /// It's a value type for improved data locality, and reduced number of CALLVIRT-s
         /// </summary>
         public InputProcessor InputProcessor;
 #pragma warning restore SA401
@@ -168,7 +168,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort
         public int MCUCountY => this.ImageSizeInMCU.Height;
 
         /// <summary>
-        /// Gets the the total number of MCU-s (Minimum Coded Units) in the image.
+        /// Gets the total number of MCU-s (Minimum Coded Units) in the image.
         /// </summary>
         public int TotalMCUCount => this.MCUCountX * this.MCUCountY;
 
@@ -331,7 +331,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort
                     case OrigJpegConstants.Markers.SOF1:
                     case OrigJpegConstants.Markers.SOF2:
                         this.IsProgressive = marker == OrigJpegConstants.Markers.SOF2;
-                        this.ProcessStartOfFrameMarker(remaining);
+                        this.ProcessStartOfFrameMarker(remaining, metadataOnly);
                         if (metadataOnly && this.isJFif)
                         {
                             return;
@@ -634,7 +634,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort
         /// Processes the Start of Frame marker.  Specified in section B.2.2.
         /// </summary>
         /// <param name="remaining">The remaining bytes in the segment block.</param>
-        private void ProcessStartOfFrameMarker(int remaining)
+        /// <param name="metadataOnly">Whether to decode metadata only.</param>
+        private void ProcessStartOfFrameMarker(int remaining, bool metadataOnly)
         {
             if (this.ComponentCount != 0)
             {
@@ -689,12 +690,15 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort
 
             this.ImageSizeInMCU = this.ImageSizeInPixels.DivideRoundUp(8 * h0, 8 * v0);
 
-            foreach (OrigComponent component in this.Components)
-            {
-                component.InitializeDerivedData(this.configuration.MemoryManager, this);
-            }
-
             this.ColorSpace = this.DeduceJpegColorSpace();
+
+            if (!metadataOnly)
+            {
+                foreach (OrigComponent component in this.Components)
+                {
+                    component.InitializeDerivedData(this.configuration.MemoryManager, this);
+                }
+            }
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/GolangPort/OrigJpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/GolangPort/OrigJpegDecoderCore.cs
@@ -692,12 +692,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort
 
             this.ColorSpace = this.DeduceJpegColorSpace();
 
-            if (!metadataOnly)
+            foreach (OrigComponent component in this.Components)
             {
-                foreach (OrigComponent component in this.Components)
-                {
-                    component.InitializeDerivedData(this.configuration.MemoryManager, this);
-                }
+                component.InitializeDerivedData(this.configuration.MemoryManager, this, metadataOnly);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Image.Identify was allocating unnecessary memory. This PR is supposed to fix this.
