### PR TITLE
Performance improvements in the PNG filtering (roughly 20% gain on my machine).

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Drawing/Processors/FillRegionProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Drawing/Processors/FillRegionProcessor.cs
@@ -100,6 +100,8 @@ namespace SixLabors.ImageSharp.Processing.Drawing.Processors
                 using (BasicArrayBuffer<float> scanline = source.MemoryManager.AllocateFake<float>(scanlineWidth))
                 {
                     bool scanlineDirty = true;
+                    float subpixelFraction = 1f / subpixelCount;
+                    float subpixelFractionPoint = subpixelFraction / subpixelCount;
                     for (int y = minY; y < maxY; y++)
                     {
                         if (scanlineDirty)
@@ -113,9 +115,8 @@ namespace SixLabors.ImageSharp.Processing.Drawing.Processors
                             scanlineDirty = false;
                         }
 
-                        float subpixelFraction = 1f / subpixelCount;
-                        float subpixelFractionPoint = subpixelFraction / subpixelCount;
-                        for (float subPixel = (float)y; subPixel < y + 1; subPixel += subpixelFraction)
+                        float yPlusOne = y + 1;
+                        for (float subPixel = (float)y; subPixel < yPlusOne; subPixel += subpixelFraction)
                         {
                             int pointsFound = region.Scan(subPixel + offset, buffer.Array, 0);
                             if (pointsFound == 0)
@@ -197,8 +198,7 @@ namespace SixLabors.ImageSharp.Processing.Drawing.Processors
 
         private static void QuickSort(Span<float> data)
         {
-            int hi = Math.Min(data.Length - 1, data.Length - 1);
-            QuickSort(data, 0, hi);
+            QuickSort(data, 0, data.Length - 1);
         }
 
         private static void QuickSort(Span<float> data, int lo, int hi)

--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -29,21 +29,19 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
 
             // Average(x) + floor((Raw(x-bpp)+Prior(x))/2)
-            for (int x = 1; x < scanline.Length; x++)
+            int x = 1;
+            for (; x <= bytesPerPixel /* Note the <= because x starts at 1 */; ++x) {
+                ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                byte above = Unsafe.Add(ref prevBaseRef, x);
+                scan = (byte)(scan + (above >> 1));
+            }
+
+            for (; x < scanline.Length; ++x)
             {
-                if (x - bytesPerPixel < 1)
-                {
-                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
-                    byte above = Unsafe.Add(ref prevBaseRef, x);
-                    scan = (byte)((scan + (above >> 1)) % 256);
-                }
-                else
-                {
-                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
-                    byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
-                    byte above = Unsafe.Add(ref prevBaseRef, x);
-                    scan = (byte)((scan + Average(left, above)) % 256);
-                }
+                ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
+                byte above = Unsafe.Add(ref prevBaseRef, x);
+                scan = (byte)(scan + Average(left, above));
             }
         }
 
@@ -69,30 +67,8 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             // Average(x) = Raw(x) - floor((Raw(x-bpp)+Prior(x))/2)
             resultBaseRef = 3;
 
-#if OLD_AND_SLOW
-            for (int x = 0; x < scanline.Length; x++)
-            {
-                if (x - bytesPerPixel < 0)
-                {
-                    byte scan = Unsafe.Add(ref scanBaseRef, x);
-                    byte above = Unsafe.Add(ref prevBaseRef, x);
-                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
-                    res = (byte)((scan - (above >> 1)) % 256);
-                    sum += res < 128 ? res : 256 - res;
-                }
-                else
-                {
-                    byte scan = Unsafe.Add(ref scanBaseRef, x);
-                    byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
-                    byte above = Unsafe.Add(ref prevBaseRef, x);
-                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
-                    res = (byte)((scan - Average(left, above)) % 256);
-                    sum += res < 128 ? res : 256 - res;
-                }
-            }
-#else
             int x = 0;
-            for (; x < bytesPerPixel;) {
+            for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */) {
                 byte scan = Unsafe.Add(ref scanBaseRef, x);
                 byte above = Unsafe.Add(ref prevBaseRef, x);
                 ++x;
@@ -101,7 +77,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
                 sum += ImageMaths.FastAbs(unchecked((sbyte)res));
             }
 
-            for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft) {
+            for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */) {
                 byte scan = Unsafe.Add(ref scanBaseRef, x);
                 byte left = Unsafe.Add(ref scanBaseRef, xLeft);
                 byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -110,7 +86,6 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
                 res = (byte)(scan - Average(left, above));
                 sum += ImageMaths.FastAbs(unchecked((sbyte)res));
             }
-#endif
 
             sum -= 3;
         }

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -25,19 +25,17 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
 
             // Sub(x) + Raw(x-bpp)
-            for (int x = 1; x < scanline.Length; x++)
+            int x = 1;
+            for (; x <= bytesPerPixel /* Note the <= because x starts at 1 */; ++x)
             {
-                if (x - bytesPerPixel < 1)
-                {
-                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
-                    scan = (byte)(scan % 256);
-                }
-                else
-                {
-                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
-                    byte prev = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
-                    scan = (byte)((scan + prev) % 256);
-                }
+                ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+            }
+
+            for (; x < scanline.Length; ++x)
+            {
+                ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                byte prev = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
+                scan = (byte)(scan + prev);
             }
         }
 
@@ -60,28 +58,8 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             // Sub(x) = Raw(x) - Raw(x-bpp)
             resultBaseRef = 1;
 
-#if OLD_AND_SLOW
-            for (int x = 0; x < scanline.Length; x++)
-            {
-                if (x - bytesPerPixel < 0)
-                {
-                    byte scan = Unsafe.Add(ref scanBaseRef, x);
-                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
-                    res = (byte)(scan % 256);
-                    sum += res < 128 ? res : 256 - res;
-                }
-                else
-                {
-                    byte scan = Unsafe.Add(ref scanBaseRef, x);
-                    byte prev = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
-                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
-                    res = (byte)((scan - prev) % 256);
-                    sum += res < 128 ? res : 256 - res;
-                }
-            }
-#else
             int x = 0;
-            for (; x < bytesPerPixel;) {
+            for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */) {
                 byte scan = Unsafe.Add(ref scanBaseRef, x);
                 ++x;
                 ref byte res = ref Unsafe.Add(ref resultBaseRef, x);
@@ -89,7 +67,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
                 sum += ImageMaths.FastAbs(unchecked((sbyte)res));
             }
 
-            for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft) {
+            for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */) {
                 byte scan = Unsafe.Add(ref scanBaseRef, x);
                 byte prev = Unsafe.Add(ref scanBaseRef, xLeft);
                 ++x;
@@ -97,7 +75,6 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
                 res = (byte)(scan - prev);
                 sum += ImageMaths.FastAbs(unchecked((sbyte)res));
             }
-#endif
 
             sum -= 1;
         }

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -57,6 +57,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             // Up(x) = Raw(x) - Prior(x)
             resultBaseRef = 2;
 
+#if OLD_AND_SLOW
             for (int x = 0; x < scanline.Length; x++)
             {
                 byte scan = Unsafe.Add(ref scanBaseRef, x);
@@ -65,6 +66,16 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
                 res = (byte)((scan - above) % 256);
                 sum += res < 128 ? res : 256 - res;
             }
+#else
+            for (int x = 0; x < scanline.Length;) {
+                byte scan = Unsafe.Add(ref scanBaseRef, x);
+                byte above = Unsafe.Add(ref prevBaseRef, x);
+                ++x;
+                ref byte res = ref Unsafe.Add(ref resultBaseRef, x);
+                res = (byte)(scan - above);
+                sum += ImageMaths.FastAbs(unchecked((sbyte)res));
+            }
+#endif
 
             sum -= 2;
         }

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             {
                 ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
                 byte above = Unsafe.Add(ref prevBaseRef, x);
-                scan = (byte)((scan + above) % 256);
+                scan = (byte)(scan + above);
             }
         }
 
@@ -57,17 +57,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             // Up(x) = Raw(x) - Prior(x)
             resultBaseRef = 2;
 
-#if OLD_AND_SLOW
-            for (int x = 0; x < scanline.Length; x++)
-            {
-                byte scan = Unsafe.Add(ref scanBaseRef, x);
-                byte above = Unsafe.Add(ref prevBaseRef, x);
-                ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
-                res = (byte)((scan - above) % 256);
-                sum += res < 128 ? res : 256 - res;
-            }
-#else
-            for (int x = 0; x < scanline.Length;) {
+            for (int x = 0; x < scanline.Length; /* Note: ++x happens in the body to avoid one add operation */) {
                 byte scan = Unsafe.Add(ref scanBaseRef, x);
                 byte above = Unsafe.Add(ref prevBaseRef, x);
                 ++x;
@@ -75,7 +65,6 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
                 res = (byte)(scan - above);
                 sum += ImageMaths.FastAbs(unchecked((sbyte)res));
             }
-#endif
 
             sum -= 2;
         }

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -321,15 +321,15 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <returns>The <see cref="T:byte[]"/></returns>
         private IManagedByteBuffer GetOptimalFilteredScanline()
         {
-            Span<byte> scanSpan = this.rawScanline.Span;
-            Span<byte> prevSpan = this.previousScanline.Span;
-
             // Palette images don't compress well with adaptive filtering.
             if (this.pngColorType == PngColorType.Palette || this.bitDepth < 8)
             {
                 NoneFilter.Encode(this.rawScanline.Span, this.result.Span);
                 return this.result;
             }
+
+            Span<byte> scanSpan = this.rawScanline.Span;
+            Span<byte> prevSpan = this.previousScanline.Span;
 
             // This order, while different to the enumerated order is more likely to produce a smaller sum
             // early on which shaves a couple of milliseconds off the processing time.

--- a/src/ImageSharp/PixelFormats/Bgra32.cs
+++ b/src/ImageSharp/PixelFormats/Bgra32.cs
@@ -39,6 +39,16 @@ namespace SixLabors.ImageSharp.PixelFormats
         public byte A;
 
         /// <summary>
+        /// The maximum byte value.
+        /// </summary>
+        private static readonly Vector4 MaxBytes = new Vector4(255);
+
+        /// <summary>
+        /// The half vector value.
+        /// </summary>
+        private static readonly Vector4 Half = new Vector4(0.5F);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Bgra32"/> struct.
         /// </summary>
         /// <param name="r">The red component.</param>
@@ -141,16 +151,14 @@ namespace SixLabors.ImageSharp.PixelFormats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void PackFromVector4(Vector4 vector)
         {
-            var rgba = default(Rgba32);
-            rgba.PackFromVector4(vector);
-            this.PackFromRgba32(rgba);
+            this.Pack(ref vector);
         }
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector4 ToVector4()
         {
-            return this.ToRgba32().ToVector4();
+            return new Vector4(this.R, this.G, this.B, this.A) / MaxBytes;
         }
 
         /// <inheritdoc/>
@@ -243,5 +251,21 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <returns>The RGBA value</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Bgra32 ToBgra32() => this;
+
+        /// <summary>
+        /// Packs a <see cref="Vector4"/> into a color.
+        /// </summary>
+        /// <param name="vector">The vector containing the values to pack.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Pack(ref Vector4 vector) {
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            this.R = (byte)vector.X;
+            this.G = (byte)vector.Y;
+            this.B = (byte)vector.Z;
+            this.A = (byte)vector.W;
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Image/ImageFramesCollectionTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageFramesCollectionTests.cs
@@ -15,6 +15,9 @@ namespace SixLabors.ImageSharp.Tests
 
         public ImageFramesCollectionTests()
         {
+            // Needed to get English exception messages, which are checked in several tests.
+            System.Threading.Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo("en-US");
+
             this.image = new Image<Rgba32>(10, 10);
             this.collection = new ImageFrameCollection<Rgba32>(this.image, 10, 10);
         }


### PR DESCRIPTION
Ditched the use of modulo (%). Modulo is slow, and if you use it to just get the lower 8 bits (1 byte), you can just directly cast to byte.

Also moved one if < out of the loop for speed. The less branching the better.

Similarly replaced an if < 128 by cast to sbyte and taking its abs value.

Performance gain in writing to PNG file seems to be roughly 20% (release mode, 1000x1000 bitmap).

In ImageFramesCollectionTests I've set the culture to en-US to ensure getting english exception texts.

Edit: I've just done similar changes to the PNG decoding, but there's no or little performance improvement there.

EncodePng benchmark (before change):

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.371)
Intel Core i7-6500U CPU 2.50GHz (Skylake), 1 CPU, 4 logical cores and 2 physical cores
Frequency=2531247 Hz, Resolution=395.0622 ns, Timer=TSC
.NET Core SDK=2.1.104
  [Host]     : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
  Job-MJBKJC : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
  Job-MMODLS : .NET Framework 4.6.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0

LaunchCount=1  TargetCount=3  WarmupCount=3  

```
|               Method | Runtime | LargeImage |     Mean |     Error |    StdDev | Scaled | ScaledSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|--------------------- |-------- |----------- |---------:|----------:|----------:|-------:|---------:|---------:|---------:|---------:|----------:|
| &#39;System.Drawing Png&#39; |    Core |      False | 16.98 ms |  3.807 ms | 0.2151 ms |   1.00 |     0.00 | 781.2500 | 218.7500 | 218.7500 |   2.03 MB |
|     &#39;ImageSharp Png&#39; |    Core |      False | 61.95 ms | 19.663 ms | 1.1110 ms |   3.65 |     0.07 | 250.0000 | 187.5000 | 187.5000 |   1.18 MB |
|                      |         |            |          |           |           |        |          |          |          |          |           |
| &#39;System.Drawing Png&#39; |     Clr |      False | 16.15 ms |  2.070 ms | 0.1169 ms |   1.00 |     0.00 | 781.2500 | 218.7500 | 218.7500 |   2.03 MB |
|     &#39;ImageSharp Png&#39; |     Clr |      False | 81.96 ms |  5.216 ms | 0.2947 ms |   5.07 |     0.03 | 250.0000 | 187.5000 | 187.5000 |   1.18 MB |

EncodePng benchmark (after change):

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.371)
Intel Core i7-6500U CPU 2.50GHz (Skylake), 1 CPU, 4 logical cores and 2 physical cores
Frequency=2531247 Hz, Resolution=395.0622 ns, Timer=TSC
.NET Core SDK=2.1.104
  [Host]     : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
  Job-ATQUUE : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
  Job-QUFUDX : .NET Framework 4.6.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0

LaunchCount=1  TargetCount=3  WarmupCount=3  

```
|               Method | Runtime | LargeImage |     Mean |      Error |    StdDev | Scaled | ScaledSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|--------------------- |-------- |----------- |---------:|-----------:|----------:|-------:|---------:|---------:|---------:|---------:|----------:|
| &#39;System.Drawing Png&#39; |    Core |      False | 16.20 ms |  0.6100 ms | 0.0345 ms |   1.00 |     0.00 | 781.2500 | 218.7500 | 218.7500 |   2.03 MB |
|     &#39;ImageSharp Png&#39; |    Core |      False | 52.96 ms | 28.2241 ms | 1.5947 ms |   3.27 |     0.08 | 250.0000 | 187.5000 | 187.5000 |   1.18 MB |
|                      |         |            |          |            |           |        |          |          |          |          |           |
| &#39;System.Drawing Png&#39; |     Clr |      False | 16.45 ms |  3.3311 ms | 0.1882 ms |   1.00 |     0.00 | 781.2500 | 218.7500 | 218.7500 |   2.03 MB |
|     &#39;ImageSharp Png&#39; |     Clr |      False | 74.80 ms | 32.4062 ms | 1.8310 ms |   4.55 |     0.10 | 250.0000 | 187.5000 | 187.5000 |   1.18 MB |

DecodePng benchmark (before change):

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.371)
Intel Core i7-6500U CPU 2.50GHz (Skylake), 1 CPU, 4 logical cores and 2 physical cores
Frequency=2531247 Hz, Resolution=395.0622 ns, Timer=TSC
.NET Core SDK=2.1.104
  [Host]     : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
  Job-ADPASD : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
  Job-JVLCTB : .NET Framework 4.6.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0

LaunchCount=1  TargetCount=3  WarmupCount=3  

```
|               Method | Runtime |      TestImage |     Mean |     Error |    StdDev | Scaled | ScaledSD |   Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|--------------------- |-------- |--------------- |---------:|----------:|----------:|-------:|---------:|--------:|--------:|--------:|----------:|
| &#39;System.Drawing Png&#39; |    Core | Png/splash.png | 3.020 ms | 0.9129 ms | 0.0516 ms |   1.00 |     0.00 | 74.2188 | 74.2188 | 74.2188 | 239.95 KB |
|     &#39;ImageSharp Png&#39; |    Core | Png/splash.png | 4.021 ms | 2.3086 ms | 0.1304 ms |   1.33 |     0.04 |       - |       - |       - |   2.21 KB |
|                      |         |                |          |           |           |        |          |         |         |         |           |
| &#39;System.Drawing Png&#39; |     Clr | Png/splash.png | 2.922 ms | 0.5067 ms | 0.0286 ms |   1.00 |     0.00 | 74.2188 | 74.2188 | 74.2188 | 240.54 KB |
|     &#39;ImageSharp Png&#39; |     Clr | Png/splash.png | 7.546 ms | 4.3393 ms | 0.2452 ms |   2.58 |     0.07 | 46.8750 |       - |       - |  96.33 KB |

DecodePng benchmark (after change), no observable improvement here:

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.371)
Intel Core i7-6500U CPU 2.50GHz (Skylake), 1 CPU, 4 logical cores and 2 physical cores
Frequency=2531247 Hz, Resolution=395.0622 ns, Timer=TSC
.NET Core SDK=2.1.104
  [Host]     : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
  Job-PLYAIO : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
  Job-WWJIGX : .NET Framework 4.6.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0

LaunchCount=1  TargetCount=3  WarmupCount=3  

```
|               Method | Runtime |      TestImage |     Mean |     Error |    StdDev | Scaled | ScaledSD |   Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|--------------------- |-------- |--------------- |---------:|----------:|----------:|-------:|---------:|--------:|--------:|--------:|----------:|
| &#39;System.Drawing Png&#39; |    Core | Png/splash.png | 2.991 ms | 1.0078 ms | 0.0569 ms |   1.00 |     0.00 | 74.2188 | 74.2188 | 74.2188 | 239.95 KB |
|     &#39;ImageSharp Png&#39; |    Core | Png/splash.png | 3.942 ms | 1.4060 ms | 0.0794 ms |   1.32 |     0.03 |       - |       - |       - |   2.21 KB |
|                      |         |                |          |           |           |        |          |         |         |         |           |
| &#39;System.Drawing Png&#39; |     Clr | Png/splash.png | 2.963 ms | 0.4208 ms | 0.0238 ms |   1.00 |     0.00 | 74.2188 | 74.2188 | 74.2188 | 240.54 KB |
|     &#39;ImageSharp Png&#39; |     Clr | Png/splash.png | 7.524 ms | 2.1313 ms | 0.1204 ms |   2.54 |     0.04 | 46.8750 |       - |       - |  96.33 KB |

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
