### PR TITLE
#558: hide console windows during run-tests

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Jpg/Utils/LibJpegTools.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/Utils/LibJpegTools.cs
@@ -65,7 +65,16 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg.Utils
             }
 
             string args = $@"""{sourceFile}"" ""{destFile}""";
-            var process = Process.Start(DumpToolFullPath, args);
+            var process = new Process
+                              {
+                                  StartInfo =
+                                      {
+                                          FileName = DumpToolFullPath,
+                                          Arguments = args,
+                                          WindowStyle = ProcessWindowStyle.Hidden
+                                      }
+                              };
+            process.Start();
             process.WaitForExit();
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
As discussed in #558 - but shortened to the AFAIK minimum necessary:
With this PR the unit tests don't open additional application windows anymore when dump-jpeg-coeffs.exe is called.
