### PR TITLE
Better test file name formatting

### DIFF
--- a/tests/ImageSharp.Tests/Processing/Transforms/AffineTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/AffineTransformTests.cs
@@ -118,7 +118,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
 
                 image.Mutate(i => i.Transform(m, KnownResamplers.Bicubic));
 
-                string testOutputDetails = $"R({angleDeg})_S({sx},{sy})_T({tx},{ty})";
+                FormattableString testOutputDetails = $"R({angleDeg})_S({sx},{sy})_T({tx},{ty})";
                 image.DebugSave(provider, testOutputDetails);
                 image.CompareToReferenceOutput(ValidatorComparer, provider, testOutputDetails);
             }
@@ -135,7 +135,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
 
                 image.Mutate(i => i.Transform(m, KnownResamplers.Bicubic));
 
-                string testOutputDetails = $"R({angleDeg})_S({s})";
+                FormattableString testOutputDetails = $"R({angleDeg})_S({s})";
                 image.DebugSave(provider, testOutputDetails);
                 image.CompareToReferenceOutput(ValidatorComparer, provider, testOutputDetails);
             }

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/BlankProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/BlankProvider.cs
@@ -19,13 +19,14 @@ namespace SixLabors.ImageSharp.Tests
                 this.Width = width;
                 this.Height = height;
             }
+
             public BlankProvider()
             {
                 this.Width = 100;
                 this.Height = 100;
             }
 
-            public override string SourceFileOrDescription => $"Blank{this.Width}x{this.Height}";
+            public override string SourceFileOrDescription => TestUtils.AsInvariantString($"Blank{this.Width}x{this.Height}");
 
             protected int Height { get; private set; }
 

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/SolidProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/SolidProvider.cs
@@ -47,7 +47,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             public override string SourceFileOrDescription
-                => $"Solid{this.Width}x{this.Height}_({this.r},{this.g},{this.b},{this.a})";
+                => TestUtils.AsInvariantString($"Solid{this.Width}x{this.Height}_({this.r},{this.g},{this.b},{this.a})");
 
             public override Image<TPixel> GetImage()
             {

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Tests
             {
             }
 
-            public override string SourceFileOrDescription => $"TestPattern{this.Width}x{this.Height}";
+            public override string SourceFileOrDescription => TestUtils.AsInvariantString($"TestPattern{this.Width}x{this.Height}");
 
             public override Image<TPixel> GetImage()
             {

--- a/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
@@ -95,8 +95,6 @@ namespace SixLabors.ImageSharp.Tests
             return $"{this.GetTestOutputDir()}/{this.TestName}{pixName}{fn}{details}{extension}";
         }
 
-        private static string Inv(FormattableString formattable) => System.FormattableString.Invariant(formattable);
-
         /// <summary>
         /// Gets the recommended file name for the output of the test
         /// </summary>
@@ -123,7 +121,7 @@ namespace SixLabors.ImageSharp.Tests
                 TypeInfo info = type.GetTypeInfo();
                 if (info.IsPrimitive || info.IsEnum || type == typeof(decimal))
                 {
-                    detailsString = Inv($"{testOutputDetails}");
+                    detailsString = TestUtils.AsInvariantString($"{testOutputDetails}");
                 }
                 else
                 {
@@ -132,7 +130,7 @@ namespace SixLabors.ImageSharp.Tests
                     detailsString = string.Join(
                         "_",
                         properties.ToDictionary(x => x.Name, x => x.GetValue(testOutputDetails))
-                            .Select(x => Inv($"{x.Key}-{x.Value}"))
+                            .Select(x => TestUtils.AsInvariantString($"{x.Key}-{x.Value}"))
                         );
                 }
             }

--- a/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
@@ -111,7 +111,11 @@ namespace SixLabors.ImageSharp.Tests
         {
             string detailsString = null;
 
-            if (testOutputDetails is string s)
+            if (testOutputDetails is FormattableString fs)
+            {
+                detailsString = fs.AsInvariantString();
+            }
+            else if (testOutputDetails is string s)
             {
                 detailsString = s;
             }

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -52,6 +52,23 @@ namespace SixLabors.ImageSharp.Tests
             });
         }
 
+        public static Image<TPixel> DebugSave<TPixel>(
+            this Image<TPixel> image,
+            ITestImageProvider provider,
+            FormattableString testOutputDetails,
+            string extension = "png",
+            bool appendPixelTypeToFileName = true,
+            bool appendSourceFileOrDescription = true)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            return image.DebugSave(
+                provider,
+                (object)testOutputDetails,
+                extension,
+                appendPixelTypeToFileName,
+                appendSourceFileOrDescription);
+        }
+
         /// <summary>
         /// Saves the image only when not running in the CI server.
         /// </summary>
@@ -84,6 +101,17 @@ namespace SixLabors.ImageSharp.Tests
                 appendPixelTypeToFileName: appendPixelTypeToFileName,
                 appendSourceFileOrDescription: appendSourceFileOrDescription);
             return image;
+        }
+
+        public static Image<TPixel> DebugSave<TPixel>(
+            this Image<TPixel> image,
+            ITestImageProvider provider,
+            IImageEncoder encoder,
+            FormattableString testOutputDetails,
+            bool appendPixelTypeToFileName = true)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            return image.DebugSave(provider, encoder, (object)testOutputDetails, appendPixelTypeToFileName);
         }
 
         /// <summary>
@@ -139,6 +167,23 @@ namespace SixLabors.ImageSharp.Tests
             return image;
         }
 
+        public static Image<TPixel> CompareToReferenceOutput<TPixel>(
+            this Image<TPixel> image,
+            ITestImageProvider provider,
+            FormattableString testOutputDetails,
+            string extension = "png",
+            bool grayscale = false,
+            bool appendPixelTypeToFileName = true)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            return image.CompareToReferenceOutput(
+                provider,
+                (object)testOutputDetails,
+                extension,
+                grayscale,
+                appendPixelTypeToFileName);
+        }
+
         /// <summary>
         /// Compares the image against the expected Reference output, throws an exception if the images are not similar enough.
         /// The output file should be named identically to the output produced by <see cref="DebugSave{TPixel}(Image{TPixel}, ITestImageProvider, object, string, bool)"/>.
@@ -150,7 +195,6 @@ namespace SixLabors.ImageSharp.Tests
         /// <param name="extension">The extension</param>
         /// <param name="grayscale">A boolean indicating whether we should debug save + compare against a grayscale image, smaller in size.</param>
         /// <param name="appendPixelTypeToFileName">A boolean indicating whether to append the pixel type to the  output file name.</param>
-        /// <param name="comparer">A custom <see cref="ImageComparer"/> for the verification</param>
         /// <returns></returns>
         public static Image<TPixel> CompareToReferenceOutput<TPixel>(
             this Image<TPixel> image,
@@ -166,6 +210,25 @@ namespace SixLabors.ImageSharp.Tests
                 ImageComparer.Tolerant(),
                 provider,
                 testOutputDetails,
+                extension,
+                grayscale,
+                appendPixelTypeToFileName);
+        }
+
+        public static Image<TPixel> CompareToReferenceOutput<TPixel>(
+            this Image<TPixel> image,
+            ImageComparer comparer,
+            ITestImageProvider provider,
+            FormattableString testOutputDetails,
+            string extension = "png",
+            bool grayscale = false,
+            bool appendPixelTypeToFileName = true)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            return image.CompareToReferenceOutput(
+                comparer,
+                provider,
+                (object)testOutputDetails,
                 extension,
                 grayscale,
                 appendPixelTypeToFileName);

--- a/tests/ImageSharp.Tests/TestUtilities/TestUtils.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestUtils.cs
@@ -101,7 +101,7 @@ namespace SixLabors.ImageSharp.Tests
 
         public static string ToCsv<T>(this IEnumerable<T> items, string separator = ",")
         {
-            return string.Join(separator, items.Select(o => string.Format(CultureInfo.InvariantCulture, "{0}", o)));
+            return String.Join(separator, items.Select(o => String.Format(CultureInfo.InvariantCulture, "{0}", o)));
         }
 
         public static Type GetClrType(this PixelTypes pixelType) => PixelTypes2ClrTypes[pixelType];
@@ -227,5 +227,7 @@ namespace SixLabors.ImageSharp.Tests
                 image.DebugSave(provider, testOutputDetails);
             }
         }
+
+        public static string AsInvariantString(this FormattableString formattable) => System.FormattableString.Invariant(formattable);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I hope this will fix [some of the "reference output file missing" issues](https://gist.github.com/jongleur1983/cc54584d6420fbf5c90471dfbbfcfe22#file-powershelloutput-log-L1763) non-EN Windows users experience.