### PR TITLE
Use FormattableString instead of string in tests

### DIFF
--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
             {
                 SizeF newSize = image.Size() * ratio;
                 image.Mutate(x => x.Resize((Size)newSize, sampler, false));
-                string details = $"{name}-{ratio.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+                FormattableString details = $"{name}-{ratio.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
 
                 image.DebugSave(provider, details);
                 image.CompareToReferenceOutput(ImageComparer.TolerantPercentage(0.005f), provider, details);

--- a/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
@@ -94,7 +94,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
                 Matrix4x4 m = ProjectiveTransformHelper.CreateTaperMatrix(image.Size(), taperSide, taperCorner, .5F);
                 image.Mutate(i => { i.Transform(m); });
 
-                string testOutputDetails = $"{taperSide}-{taperCorner}";
+                FormattableString testOutputDetails = $"{taperSide}-{taperCorner}";
                 image.DebugSave(provider, testOutputDetails);
                 image.CompareFirstFrameToReferenceOutput(TolerantComparer, provider, testOutputDetails);
             }

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -273,6 +273,27 @@ namespace SixLabors.ImageSharp.Tests
             this Image<TPixel> image,
             ImageComparer comparer,
             ITestImageProvider provider,
+            FormattableString testOutputDetails,
+            string extension = "png",
+            bool grayscale = false,
+            bool appendPixelTypeToFileName = true,
+            bool appendSourceFileOrDescription = true)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            return image.CompareFirstFrameToReferenceOutput(
+                comparer,
+                provider,
+                (object)testOutputDetails,
+                extension,
+                grayscale,
+                appendPixelTypeToFileName,
+                appendSourceFileOrDescription);
+        }
+
+        public static Image<TPixel> CompareFirstFrameToReferenceOutput<TPixel>(
+            this Image<TPixel> image,
+            ImageComparer comparer,
+            ITestImageProvider provider,
             object testOutputDetails = null,
             string extension = "png",
             bool grayscale = false,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
More `FormattableString` -> more reliable test output file name formatting.