### PR TITLE
Fix #624

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/GolangPort/GolangJpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/GolangPort/GolangJpegDecoderCore.cs
@@ -338,6 +338,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort
 
                         break;
                     case JpegConstants.Markers.DHT:
+
                         if (metadataOnly)
                         {
                             this.InputProcessor.Skip(remaining);
@@ -721,7 +722,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.GolangPort
             {
                 if (remaining < 17)
                 {
-                    throw new ImageFormatException("DHT has wrong length");
+                    throw new ImageFormatException($"DHT has wrong length. {remaining}");
                 }
 
                 this.InputProcessor.ReadFull(this.Temp, 0, 17);

--- a/src/ImageSharp/Formats/Jpeg/PdfJsPort/PdfJsJpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/PdfJsPort/PdfJsJpegDecoderCore.cs
@@ -270,6 +270,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.PdfJsPort
                             }
 
                         case JpegConstants.Markers.DHT:
+
                             if (metadataOnly)
                             {
                                 this.InputStream.Skip(remaining);
@@ -698,11 +699,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.PdfJsPort
         /// <param name="remaining">The remaining bytes in the segment block.</param>
         private void ProcessDefineHuffmanTablesMarker(int remaining)
         {
-            if (remaining < 17)
-            {
-                throw new ImageFormatException($"DHT has wrong length: {remaining}");
-            }
-
             using (IManagedByteBuffer huffmanData = this.configuration.MemoryAllocator.AllocateCleanManagedByteBuffer(256))
             {
                 ref byte huffmanDataRef = ref MemoryMarshal.GetReference(huffmanData.GetSpan());


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
We were incorrectly throwing when we didn't need to. The code already handled images with empty DHT sections.

<!-- Thanks for contributing to ImageSharp! -->
