### PR TITLE
remove `SavePixelData()` apis in favour of `GetPixelSpan()`

### DIFF
--- a/src/ImageSharp/ImageExtensions.cs
+++ b/src/ImageSharp/ImageExtensions.cs
@@ -111,72 +111,6 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Returns the a copy of the image pixels as a byte array in row-major order.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <param name="source">The source image</param>
-        /// <returns>A copy of the pixel data as bytes from this frame.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static byte[] SavePixelData<TPixel>(this ImageFrame<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
-         => MemoryMarshal.AsBytes(source.GetPixelSpan()).ToArray();
-
-        /// <summary>
-        /// Writes the raw image pixels to the given byte array in row-major order.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <param name="source">The source image.</param>
-        /// <param name="buffer">The buffer to save the raw pixel data to.</param>
-        /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SavePixelData<TPixel>(this ImageFrame<TPixel> source, byte[] buffer)
-            where TPixel : struct, IPixel<TPixel>
-            => SavePixelData(source, MemoryMarshal.Cast<byte, TPixel>(buffer.AsSpan()));
-
-        /// <summary>
-        /// Writes the raw image pixels to the given TPixel array in row-major order.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <param name="source">The source image</param>
-        /// <param name="buffer">The buffer to save the raw pixel data to.</param>
-        /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SavePixelData<TPixel>(this ImageFrame<TPixel> source, TPixel[] buffer)
-            where TPixel : struct, IPixel<TPixel>
-            => SavePixelData(source, buffer.AsSpan());
-
-        /// <summary>
-        /// Returns a copy of the raw image pixels as a byte array in row-major order.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <param name="source">The source image.</param>
-        /// <returns>A copy of the pixel data from the first frame as bytes.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static byte[] SavePixelData<TPixel>(this Image<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
-         => source.Frames.RootFrame.SavePixelData();
-
-        /// <summary>
-        /// Writes the raw image pixels to the given byte array in row-major order.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <param name="source">The source image.</param>
-        /// <param name="buffer">The buffer to save the raw pixel data to.</param>
-        /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SavePixelData<TPixel>(this Image<TPixel> source, byte[] buffer)
-            where TPixel : struct, IPixel<TPixel>
-            => source.Frames.RootFrame.SavePixelData(buffer);
-
-        /// <summary>
-        /// Writes the raw image pixels to the given TPixel array in row-major order.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <param name="source">The source image</param>
-        /// <param name="buffer">The buffer to save the raw pixel data to.</param>
-        /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SavePixelData<TPixel>(this Image<TPixel> source, TPixel[] buffer)
-            where TPixel : struct, IPixel<TPixel>
-            => source.Frames.RootFrame.SavePixelData(buffer);
-
-        /// <summary>
         /// Returns a Base64 encoded string from the given image.
         /// </summary>
         /// <example><see href="data:image/gif;base64,R0lGODlhAQABAIABAEdJRgAAACwAAAAAAQABAAACAkQBAA=="/></example>
@@ -193,33 +127,6 @@ namespace SixLabors.ImageSharp
                 stream.Flush();
                 return $"data:{format.DefaultMimeType};base64,{Convert.ToBase64String(stream.ToArray())}";
             }
-        }
-
-        /// <summary>
-        /// Writes the raw image bytes to the given byte span.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <param name="source">The source image</param>
-        /// <param name="buffer">The span to save the raw pixel data to.</param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SavePixelData<TPixel>(this Image<TPixel> source, Span<byte> buffer)
-            where TPixel : struct, IPixel<TPixel>
-            => source.Frames.RootFrame.SavePixelData(MemoryMarshal.Cast<byte, TPixel>(buffer));
-
-        /// <summary>
-        /// Writes the raw image pixels to the given TPixel span.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <param name="source">The source image</param>
-        /// <param name="buffer">The span to save the raw pixel data to.</param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SavePixelData<TPixel>(this ImageFrame<TPixel> source, Span<TPixel> buffer)
-            where TPixel : struct, IPixel<TPixel>
-        {
-            Span<TPixel> sourceBuffer = source.GetPixelSpan();
-            Guard.MustBeGreaterThanOrEqualTo(buffer.Length, sourceBuffer.Length, nameof(buffer));
-
-            sourceBuffer.CopyTo(buffer);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Image/ImageSaveTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageSaveTests.cs
@@ -48,56 +48,6 @@ namespace SixLabors.ImageSharp.Tests
             this.Image = new Image<Rgba32>(config, 1, 1);
         }
 
-        [Theory]
-        [WithTestPatternImages(13, 19, PixelTypes.Rgba32 | PixelTypes.Bgr24)]
-        public void SavePixelData_ToPixelStructArray<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
-        {
-            using (Image<TPixel> image = provider.GetImage())
-            {
-                var buffer = new TPixel[image.Width * image.Height];
-                image.SavePixelData(buffer);
-
-                image.ComparePixelBufferTo(buffer);
-
-                // TODO: We need a separate test-case somewhere ensuring that image pixels are stored in row-major order!
-            }
-        }
-
-        [Theory]
-        [WithTestPatternImages(19, 13, PixelTypes.Rgba32 | PixelTypes.Bgr24)]
-        public void SavePixelData_ToByteArray<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
-        {
-            using (Image<TPixel> image = provider.GetImage())
-            {
-                byte[] buffer = new byte[image.Width * image.Height * Unsafe.SizeOf<TPixel>()];
-
-                image.SavePixelData(buffer);
-
-                image.ComparePixelBufferTo(MemoryMarshal.Cast<byte, TPixel>(buffer.AsSpan()));
-            }
-        }
-
-        [Fact]
-        public void SavePixelData_Rgba32_WhenBufferIsTooSmall_Throws()
-        {
-            using (var img = new Image<Rgba32>(2, 2))
-            {
-                img[0, 0] = Rgba32.White;
-                img[1, 0] = Rgba32.Black;
-
-                img[0, 1] = Rgba32.Red;
-                img[1, 1] = Rgba32.Blue;
-                byte[] buffer = new byte[2 * 2]; // width * height * bytes per pixel
-
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                {
-                    img.SavePixelData(buffer);
-                });
-            }
-        }
-
         [Fact]
         public void SavePath()
         {

--- a/tests/ImageSharp.Tests/Processing/Transforms/AffineTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/AffineTransformTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using System.Reflection;
-
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Transforms;
@@ -241,8 +241,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         private static void VerifyAllPixelsAreWhiteOrTransparent<TPixel>(Image<TPixel> image)
             where TPixel : struct, IPixel<TPixel>
         {
-            var data = new TPixel[image.Width * image.Height];
-            image.Frames.RootFrame.SavePixelData(data);
+            Span<TPixel> data = image.Frames.RootFrame.GetPixelSpan();
             var rgba = default(Rgba32);
             var white = new Rgb24(255, 255, 255);
             foreach (TPixel pixel in data)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
removed all the `SavePixelData()` apis (as they can cause confusion people see a save method with a byte array and assume its an encoded image they can pass into something else and its not it was just a raw dump of our internal buffer).

To get a copy of the image buffer now you should instead add the `using SixLabors.ImageSharp.Advanced;`  which will expose our Span<T> apis which can be used to access the raw pixel buffer for any inter-op scenarios.

resolves #623
