### PR TITLE
Remove NotNull guard on value type

### DIFF
--- a/src/ImageSharp/Processing/Dithering/ErrorDiffusion/ErrorDiffuserBase.cs
+++ b/src/ImageSharp/Processing/Dithering/ErrorDiffusion/ErrorDiffuserBase.cs
@@ -47,7 +47,6 @@ namespace SixLabors.ImageSharp.Processing.Dithering.ErrorDiffusion
         /// <param name="divisor">The divisor.</param>
         internal ErrorDiffuserBase(DenseMatrix<float> matrix, byte divisor)
         {
-            Guard.NotNull(matrix, nameof(matrix));
             Guard.MustBeGreaterThan(divisor, 0, nameof(divisor));
 
             this.matrix = matrix;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open

### Description
<!-- A description of the changes proposed in the pull-request -->
I came across this `NotNull` guard on a `DenseMatrix` while checking out the dithering code ;) (JetBrains' Heap Allocations Viewer plugin for Rider drew my attention to it, because it got boxed!)

<!-- Thanks for contributing to ImageSharp! -->
