### PR TITLE
Make Guard.NotNull() and DebugGuard.NotNull() generic

### DIFF
--- a/src/ImageSharp/Common/Helpers/DebugGuard.cs
+++ b/src/ImageSharp/Common/Helpers/DebugGuard.cs
@@ -17,13 +17,14 @@ namespace SixLabors.ImageSharp
         /// Verifies, that the method parameter with specified object value is not null
         /// and throws an exception if it is found to be so.
         /// </summary>
-        /// <param name="target">The target object, which cannot be null.</param>
+        /// <param name="value">The target object, which cannot be null.</param>
         /// <param name="parameterName">The name of the parameter that is to be checked.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="target"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null</exception>
         [Conditional("DEBUG")]
-        public static void NotNull(object target, string parameterName)
+        public static void NotNull<T>(T value, string parameterName)
+            where T : class
         {
-            if (target == null)
+            if (value == null)
             {
                 throw new ArgumentNullException(parameterName);
             }

--- a/src/ImageSharp/Common/Helpers/Guard.cs
+++ b/src/ImageSharp/Common/Helpers/Guard.cs
@@ -19,7 +19,8 @@ namespace SixLabors.ImageSharp
         /// <param name="value">The target object, which cannot be null.</param>
         /// <param name="parameterName">The name of the parameter that is to be checked.</param>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is null</exception>
-        public static void NotNull(object value, string parameterName)
+        public static void NotNull<T>(T value, string parameterName)
+            where T : class
         {
             if (value == null)
             {

--- a/tests/ImageSharp.Tests/Helpers/GuardTests.cs
+++ b/tests/ImageSharp.Tests/Helpers/GuardTests.cs
@@ -12,13 +12,17 @@ namespace SixLabors.ImageSharp.Tests.Helpers
     /// </summary>
     public class GuardTests
     {
+        class Test
+        {
+        }
+
         /// <summary>
         /// Tests that the <see cref="M:Guard.NotNull"/> method throws when the argument is null.
         /// </summary>
         [Fact]
         public void NotNullThrowsWhenArgIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => Guard.NotNull(null, "foo"));
+            Assert.Throws<ArgumentNullException>(() => Guard.NotNull((Test)null, "foo"));
         }
 
         /// <summary>
@@ -27,7 +31,7 @@ namespace SixLabors.ImageSharp.Tests.Helpers
         [Fact]
         public void NotNullThrowsWhenArgNameEmpty()
         {
-            Assert.Throws<ArgumentNullException>(() => Guard.NotNull(null, string.Empty));
+            Assert.Throws<ArgumentNullException>(() => Guard.NotNull((Test)null, string.Empty));
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
A tiny improvement. See [this comment](https://github.com/SixLabors/ImageSharp/pull/631#issuecomment-399770900) for explanation.