### PR TITLE
Add LoadResizeSave benchmark

### DIFF
--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/LoadResizeSave.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/LoadResizeSave.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using BenchmarkDotNet.Attributes;
+using System;
+using System.IO;
+using SixLabors.ImageSharp.Tests;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using SixLabors.ImageSharp.Processing;
+using SDImage = System.Drawing.Image;
+using SixLabors.ImageSharp.Formats.Jpeg;
+
+namespace SixLabors.ImageSharp.Benchmarks.Codecs.Jpeg
+{
+    [Config(typeof(Config.ShortClr))]
+    public class LoadResizeSave : BenchmarkBase
+    {
+        private readonly Configuration configuration = new Configuration(new JpegConfigurationModule());
+
+        private byte[] sourceBytes;
+
+        private byte[] destBytes;
+
+        private string TestImageFullPath => Path.Combine(TestEnvironment.InputImagesDirectoryFullPath, this.TestImage);
+
+        [Params(
+            TestImages.Jpeg.Baseline.Jpeg420Exif 
+            //, TestImages.Jpeg.Baseline.Calliphora
+            )]
+        public string TestImage { get; set; }
+
+        [Params(false, true)]
+        public bool EnableParallelExecution { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.configuration.ParallelOptions.MaxDegreeOfParallelism =
+                this.EnableParallelExecution ? Environment.ProcessorCount : 1;
+
+            if (this.sourceBytes == null)
+            {
+                this.sourceBytes = File.ReadAllBytes(this.TestImageFullPath);
+            }
+
+            if (this.destBytes == null)
+            {
+                this.destBytes = new byte[this.sourceBytes.Length];
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public void SystemDrawing()
+        {
+            using (var sourceStream = new MemoryStream(this.sourceBytes))
+            using (var destStream = new MemoryStream(this.destBytes))
+            using (var source = SDImage.FromStream(sourceStream))
+            using (var destination = new Bitmap(source.Width / 4, source.Height / 4))
+            {
+                using (var graphics = Graphics.FromImage(destination))
+                {
+                    graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                    graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                    graphics.CompositingQuality = CompositingQuality.HighQuality;
+                    graphics.DrawImage(source, 0, 0, 400, 400);
+                }
+
+                destination.Save(destStream, ImageFormat.Jpeg);
+            }
+        }
+
+        [Benchmark]
+        public void ImageSharp()
+        {
+            using (var source = Image.Load(
+                this.configuration,
+                this.sourceBytes,
+                new JpegDecoder { IgnoreMetadata = true }))
+            using (var destStream = new MemoryStream(this.destBytes))
+            {
+                source.Mutate(c => c.Resize(source.Width / 4, source.Height / 4));
+                source.SaveAsJpeg(destStream);
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Benchmarks/Samplers/Resize.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/Resize.cs
@@ -3,20 +3,38 @@
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+using BenchmarkDotNet.Attributes;
+
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+using CoreSize = SixLabors.Primitives.Size;
+
 namespace SixLabors.ImageSharp.Benchmarks
 {
-    using System.Drawing;
-    using System.Drawing.Drawing2D;
+    using System.Threading.Tasks;
 
-    using BenchmarkDotNet.Attributes;
+    using SixLabors.ImageSharp.Formats.Jpeg;
 
-    using SixLabors.ImageSharp.PixelFormats;
-    using SixLabors.ImageSharp.Processing;
-
-    using CoreSize = SixLabors.Primitives.Size;
-
+    [Config(typeof(Config.ShortClr))]
     public class Resize : BenchmarkBase
     {
+        private readonly Configuration configuration = new Configuration(new JpegConfigurationModule());
+
+        [Params(false, true)]
+        public bool EnableParallelExecution { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.configuration.ParallelOptions.MaxDegreeOfParallelism =
+                this.EnableParallelExecution ? Environment.ProcessorCount : 1;
+        }
+
         [Benchmark(Baseline = true, Description = "System.Drawing Resize")]
         public Size ResizeSystemDrawing()
         {
@@ -40,7 +58,7 @@ namespace SixLabors.ImageSharp.Benchmarks
         [Benchmark(Description = "ImageSharp Resize")]
         public CoreSize ResizeCore()
         {
-            using (Image<Rgba32> image = new Image<Rgba32>(2000, 2000))
+            using (var image = new Image<Rgba32>(this.configuration, 2000, 2000))
             {
                 image.Mutate(x => x.Resize(400, 400));
                 return new CoreSize(image.Width, image.Height);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
- Adding a LoadResizeSave benchmark aka. Bertrand Le Roy's golden standard for comparing image scaling solutions
- Adding EnableParallelExecution to Resize becnhmark, because it's an important parameter

This is part of a work updating the SixLabors documentation for beta5, and adding a new short article about ImageSharp performance.

### Benchmark Results

```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
Frequency=2742188 Hz, Resolution=364.6723 ns, Timer=TSC
.NET Core SDK=2.1.300
  [Host]     : .NET Core 2.0.7 (CoreCLR 4.6.26328.01, CoreFX 4.6.26403.03), 64bit RyuJIT
  Job-ILXLYY : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
  Job-OSTKHA : .NET Core 2.0.7 (CoreCLR 4.6.26328.01, CoreFX 4.6.26403.03), 64bit RyuJIT

LaunchCount=1  TargetCount=3  WarmupCount=3

        Method | Runtime | EnableParallelExecution |      Mean |     Error |    StdDev | Scaled | ScaledSD |    Gen 0 | Allocated |
-------------- |-------- |------------------------ |----------:|----------:|----------:|-------:|---------:|---------:|----------:|
 SystemDrawing |     Clr |                   False |  67.78 ms | 10.615 ms | 0.5998 ms |   1.00 |     0.00 | 250.0000 | 791.07 KB |
    ImageSharp |     Clr |                   False | 188.16 ms | 43.288 ms | 2.4459 ms |   2.78 |     0.04 |        - |  51.59 KB |
               |         |                         |           |           |           |        |          |          |           |
 SystemDrawing |    Core |                   False |  69.32 ms |  5.249 ms | 0.2966 ms |   1.00 |     0.00 | 250.0000 | 789.79 KB |
    ImageSharp |    Core |                   False | 209.43 ms | 55.936 ms | 3.1605 ms |   3.02 |     0.04 |        - |  50.53 KB |
               |         |                         |           |           |           |        |          |          |           |
 SystemDrawing |     Clr |                    True |  68.51 ms | 19.667 ms | 1.1112 ms |   1.00 |     0.00 | 250.0000 | 791.07 KB |
    ImageSharp |     Clr |                    True |  93.63 ms |  9.225 ms | 0.5212 ms |   1.37 |     0.02 |        - |  58.59 KB |
               |         |                         |           |           |           |        |          |          |           |
 SystemDrawing |    Core |                    True |  68.34 ms | 21.592 ms | 1.2200 ms |   1.00 |     0.00 | 250.0000 | 789.79 KB |
    ImageSharp |    Core |                    True | 100.43 ms | 11.180 ms | 0.6317 ms |   1.47 |     0.02 |        - |  51.93 KB |
```