### PR TITLE
Replace Configuration.ParallelOptions with Configuration.MaxDegreeOfParallelism

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor.cs
@@ -139,10 +139,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
             {
                 amount.GetSpan().Fill(this.Opacity);
 
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     minY,
                     maxY,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                         {
                             Span<TPixel> background = source.GetPixelRowSpan(y).Slice(minX, width);

--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor.cs
@@ -54,10 +54,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
             // If there's no reason for blending, then avoid it.
             if (this.IsSolidBrushWithoutBlending(out SolidBrush<TPixel> solidBrush))
             {
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     minY,
                     maxY,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                     {
                         source.GetPixelRowSpan(y).Slice(minX, width).Fill(solidBrush.Color);
@@ -84,10 +84,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
                 {
                     amount.GetSpan().Fill(1f);
 
-                    Parallel.For(
+                    ParallelFor.WithConfiguration(
                         minY,
                         maxY,
-                        configuration.ParallelOptions,
+                        configuration,
                         y =>
                             {
                                 int offsetY = y - startY;

--- a/src/ImageSharp/Common/Extensions/ConfigurationExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Threading.Tasks;
+
+namespace SixLabors.ImageSharp
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="Configuration"/>
+    /// </summary>
+    internal static class ConfigurationExtensions
+    {
+        /// <summary>
+        /// Creates a <see cref="ParallelOptions"/> object based on <paramref name="configuration"/>,
+        /// having <see cref="ParallelOptions.MaxDegreeOfParallelism"/> set to <see cref="Configuration.MaxDegreeOfParallelism"/>
+        /// </summary>
+        public static ParallelOptions GetParallelOptions(this Configuration configuration)
+        {
+            return new ParallelOptions() { MaxDegreeOfParallelism = configuration.MaxDegreeOfParallelism };
+        }
+    }
+}

--- a/src/ImageSharp/Common/Helpers/ParallelFor.cs
+++ b/src/ImageSharp/Common/Helpers/ParallelFor.cs
@@ -11,11 +11,11 @@ namespace SixLabors.ImageSharp
     internal static class ParallelFor
     {
         /// <summary>
-        /// Helper method to execute Parallel.For using the settings in <see cref="Configuration.ParallelOptions"/>
+        /// Helper method to execute Parallel.For using the settings in <paramref name="configuration"/>
         /// </summary>
         public static void WithConfiguration(int fromInclusive, int toExclusive, Configuration configuration, Action<int> body)
         {
-            Parallel.For(fromInclusive, toExclusive, configuration.ParallelOptions, body);
+            Parallel.For(fromInclusive, toExclusive, configuration.GetParallelOptions(), body);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp
             where T : struct
         {
             MemoryAllocator memoryAllocator = configuration.MemoryAllocator;
-            ParallelOptions parallelOptions = configuration.ParallelOptions;
+            ParallelOptions parallelOptions = configuration.GetParallelOptions();
 
             IMemoryOwner<T> InitBuffer()
             {

--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -27,6 +27,8 @@ namespace SixLabors.ImageSharp
         /// </summary>
         private static readonly Lazy<Configuration> Lazy = new Lazy<Configuration>(CreateDefaultInstance);
 
+        private int maxDegreeOfParallelism = Environment.ProcessorCount;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Configuration" /> class.
         /// </summary>
@@ -55,9 +57,22 @@ namespace SixLabors.ImageSharp
         public static Configuration Default { get; } = Lazy.Value;
 
         /// <summary>
-        /// Gets the global parallel options for processing tasks in parallel.
+        /// Gets or sets the maximum number of concurrent tasks enabled in ImageSharp algorithms
+        /// configured with this <see cref="Configuration"/> instance.
         /// </summary>
-        public ParallelOptions ParallelOptions { get; private set; } = new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount };
+        public int MaxDegreeOfParallelism
+        {
+            get => this.maxDegreeOfParallelism;
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(this.MaxDegreeOfParallelism));
+                }
+
+                this.maxDegreeOfParallelism = value;
+            }
+        }
 
         /// <summary>
         /// Gets the currently registered <see cref="IImageFormat"/>s.
@@ -114,7 +129,7 @@ namespace SixLabors.ImageSharp
         {
             return new Configuration
             {
-                ParallelOptions = this.ParallelOptions,
+                MaxDegreeOfParallelism = this.MaxDegreeOfParallelism,
                 ImageFormatsManager = this.ImageFormatsManager,
                 MemoryAllocator = this.MemoryAllocator,
                 ImageOperationsProvider = this.ImageOperationsProvider,

--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -89,7 +89,7 @@ namespace SixLabors.ImageSharp
             this.MemoryAllocator = configuration.MemoryAllocator;
             this.PixelBuffer = this.MemoryAllocator.Allocate2D<TPixel>(width, height);
             this.MetaData = metaData;
-            this.Clear(configuration.ParallelOptions, backgroundColor);
+            this.Clear(configuration.GetParallelOptions(), backgroundColor);
         }
 
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
@@ -70,25 +70,27 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
 
             bool isAlphaOnly = typeof(TPixel) == typeof(Alpha8);
 
-            Parallel.For(
+            ParallelFor.WithConfiguration(
                 startY,
                 endY,
-                configuration.ParallelOptions,
+                configuration,
                 y =>
-                {
-                    Span<TPixel> row = source.GetPixelRowSpan(y);
-                    Rgba32 rgba = default;
-
-                    for (int x = startX; x < endX; x++)
                     {
-                        ref TPixel color = ref row[x];
-                        color.ToRgba32(ref rgba);
+                        Span<TPixel> row = source.GetPixelRowSpan(y);
+                        Rgba32 rgba = default;
 
-                        // Convert to grayscale using ITU-R Recommendation BT.709 if required
-                        float luminance = isAlphaOnly ? rgba.A : (.2126F * rgba.R) + (.7152F * rgba.G) + (.0722F * rgba.B);
-                        color = luminance >= threshold ? upper : lower;
-                    }
-                });
+                        for (int x = startX; x < endX; x++)
+                        {
+                            ref TPixel color = ref row[x];
+                            color.ToRgba32(ref rgba);
+
+                            // Convert to grayscale using ITU-R Recommendation BT.709 if required
+                            float luminance = isAlphaOnly
+                                                  ? rgba.A
+                                                  : (.2126F * rgba.R) + (.7152F * rgba.G) + (.0722F * rgba.B);
+                            color = luminance >= threshold ? upper : lower;
+                        }
+                    });
         }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor.cs
@@ -61,10 +61,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
             {
                 source.CopyTo(targetPixels);
 
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     startY,
                     endY,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                     {
                         Span<TPixel> sourceRow = source.GetPixelRowSpan(y);

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor.cs
@@ -43,12 +43,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <inheritdoc/>
         protected override void OnFrameApply(ImageFrame<TPixel> source, Rectangle sourceRectangle, Configuration configuration)
         {
-            ParallelOptions parallelOptions = configuration.ParallelOptions;
-
             using (Buffer2D<TPixel> firstPassPixels = configuration.MemoryAllocator.Allocate2D<TPixel>(source.Size()))
             {
-                this.ApplyConvolution(firstPassPixels, source.PixelBuffer, source.Bounds(), this.KernelX, parallelOptions);
-                this.ApplyConvolution(source.PixelBuffer, firstPassPixels, sourceRectangle, this.KernelY, parallelOptions);
+                this.ApplyConvolution(firstPassPixels, source.PixelBuffer, source.Bounds(), this.KernelX, configuration);
+                this.ApplyConvolution(source.PixelBuffer, firstPassPixels, sourceRectangle, this.KernelY, configuration);
             }
         }
 
@@ -62,13 +60,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to draw.
         /// </param>
         /// <param name="kernel">The kernel operator.</param>
-        /// <param name="parallelOptions">The parallel options</param>
+        /// <param name="configuration">The <see cref="Configuration"/></param>
         private void ApplyConvolution(
             Buffer2D<TPixel> targetPixels,
             Buffer2D<TPixel> sourcePixels,
             Rectangle sourceRectangle,
             DenseMatrix<float> kernel,
-            ParallelOptions parallelOptions)
+            Configuration configuration)
         {
             int kernelHeight = kernel.Rows;
             int kernelWidth = kernel.Columns;
@@ -82,10 +80,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
             int maxY = endY - 1;
             int maxX = endX - 1;
 
-            Parallel.For(
+            ParallelFor.WithConfiguration(
                 startY,
                 endY,
-                parallelOptions,
+                configuration,
                 y =>
                 {
                     Span<TPixel> targetRow = targetPixels.GetRowSpan(y);

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor.cs
@@ -51,10 +51,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
             {
                 source.CopyTo(targetPixels);
 
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                  startY,
                  endY,
-                 configuration.ParallelOptions,
+                 configuration,
                  y =>
                  {
                      Span<TPixel> sourceRow = source.GetPixelRowSpan(y);

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor.cs
@@ -133,10 +133,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
                         Buffer2D<TPixel> passPixels = pass.PixelBuffer;
                         Buffer2D<TPixel> targetPixels = source.PixelBuffer;
 
-                        Parallel.For(
+                        ParallelFor.WithConfiguration(
                             minY,
                             maxY,
-                            configuration.ParallelOptions,
+                            configuration,
                             y =>
                                 {
                                     int offsetY = y - shiftY;

--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
@@ -69,10 +69,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
             {
                 source.CopyTo(targetPixels);
 
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     startY,
                     maxY,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                     {
                         Span<TPixel> sourceRow = source.GetPixelRowSpan(y);

--- a/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor.cs
@@ -73,7 +73,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
 
             Parallel.ForEach(
                 range,
-                configuration.ParallelOptions,
+                configuration.GetParallelOptions(),
                 y =>
                     {
                         int offsetY = y - startY;

--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
@@ -41,10 +41,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
             int endX = interest.Right;
             Matrix4x4 matrix = this.Matrix;
 
-            Parallel.For(
+            ParallelFor.WithConfiguration(
                 startY,
                 endY,
-                configuration.ParallelOptions,
+                configuration,
                 y =>
                     {
                         Span<TPixel> row = source.GetPixelRowSpan(y);

--- a/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor.cs
@@ -81,10 +81,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
                 }
 
                 PixelBlender<TPixel> blender = PixelOperations<TPixel>.Instance.GetPixelBlender(this.GraphicsOptions.BlenderMode);
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     minY,
                     maxY,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                     {
                         Span<TPixel> destination = source.GetPixelRowSpan(y - startY).Slice(minX - startX, width);

--- a/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
@@ -122,27 +122,25 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
                     rowColorsSpan[i] = glowColor;
                 }
 
-                Parallel.For(
+                ParallelFor.WithTemporaryBuffer<float>(
                     minY,
                     maxY,
-                    configuration.ParallelOptions,
-                    y =>
+                    configuration,
+                    width,
+                    (y, amounts) =>
                     {
-                        using (IMemoryOwner<float> amounts = source.MemoryAllocator.Allocate<float>(width))
+                        Span<float> amountsSpan = amounts.GetSpan();
+                        int offsetY = y - startY;
+                        int offsetX = minX - startX;
+                        for (int i = 0; i < width; i++)
                         {
-                            Span<float> amountsSpan = amounts.GetSpan();
-                            int offsetY = y - startY;
-                            int offsetX = minX - startX;
-                            for (int i = 0; i < width; i++)
-                            {
-                                float distance = Vector2.Distance(center, new Vector2(i + offsetX, offsetY));
-                                amountsSpan[i] = (this.GraphicsOptions.BlendPercentage * (1 - (.95F * (distance / maxDistance)))).Clamp(0, 1);
-                            }
-
-                            Span<TPixel> destination = source.GetPixelRowSpan(offsetY).Slice(offsetX, width);
-
-                            this.blender.Blend(source.MemoryAllocator, destination, destination, rowColors.GetSpan(), amountsSpan);
+                            float distance = Vector2.Distance(center, new Vector2(i + offsetX, offsetY));
+                            amountsSpan[i] = (this.GraphicsOptions.BlendPercentage * (1 - (.95F * (distance / maxDistance)))).Clamp(0, 1);
                         }
+
+                        Span<TPixel> destination = source.GetPixelRowSpan(offsetY).Slice(offsetX, width);
+
+                        this.blender.Blend(source.MemoryAllocator, destination, destination, rowColors.GetSpan(), amountsSpan);
                     });
             }
         }

--- a/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
@@ -124,27 +124,33 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
                     rowColorsSpan[i] = vignetteColor;
                 }
 
-                Parallel.For(
+                ParallelFor.WithTemporaryBuffer<float>(
                     minY,
                     maxY,
-                    configuration.ParallelOptions,
-                    y =>
+                    configuration,
+                    width,
+                    (y, amounts) =>
                         {
-                            using (IMemoryOwner<float> amounts = source.MemoryAllocator.Allocate<float>(width))
+                            Span<float> amountsSpan = amounts.GetSpan();
+                            int offsetY = y - startY;
+                            int offsetX = minX - startX;
+                            for (int i = 0; i < width; i++)
                             {
-                                Span<float> amountsSpan = amounts.GetSpan();
-                                int offsetY = y - startY;
-                                int offsetX = minX - startX;
-                                for (int i = 0; i < width; i++)
-                                {
-                                    float distance = Vector2.Distance(centre, new Vector2(i + offsetX, offsetY));
-                                    amountsSpan[i] = (this.GraphicsOptions.BlendPercentage * (.9F * (distance / maxDistance))).Clamp(0, 1);
-                                }
-
-                                Span<TPixel> destination = source.GetPixelRowSpan(offsetY).Slice(offsetX, width);
-
-                                this.blender.Blend(source.MemoryAllocator, destination, destination, rowColors.GetSpan(), amountsSpan);
+                                float distance = Vector2.Distance(centre, new Vector2(i + offsetX, offsetY));
+                                amountsSpan[i] =
+                                    (this.GraphicsOptions.BlendPercentage * (.9F * (distance / maxDistance))).Clamp(
+                                        0,
+                                        1);
                             }
+
+                            Span<TPixel> destination = source.GetPixelRowSpan(offsetY).Slice(offsetX, width);
+
+                            this.blender.Blend(
+                                source.MemoryAllocator,
+                                destination,
+                                destination,
+                                rowColors.GetSpan(),
+                                amountsSpan);
                         });
             }
         }

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -77,10 +77,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             if (this.Sampler is NearestNeighborResampler)
             {
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     height,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                     {
                         Span<TPixel> destRow = destination.GetPixelRowSpan(y);
@@ -115,10 +115,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             using (Buffer2D<float> yBuffer = memoryAllocator.Allocate2D<float>(yLength, height))
             using (Buffer2D<float> xBuffer = memoryAllocator.Allocate2D<float>(xLength, height))
             {
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     height,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                         {
                             ref TPixel destRowRef = ref MemoryMarshal.GetReference(destination.GetPixelRowSpan(y));

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -58,10 +58,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             int minX = Math.Max(this.CropRectangle.X, sourceRectangle.X);
             int maxX = Math.Min(this.CropRectangle.Right, sourceRectangle.Right);
 
-            Parallel.For(
+            ParallelFor.WithConfiguration(
                 minY,
                 maxY,
-                configuration.ParallelOptions,
+                configuration,
                 y =>
                 {
                     Span<TPixel> sourceRow = source.GetPixelRowSpan(y).Slice(minX);

--- a/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor.cs
@@ -58,10 +58,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             using (Buffer2D<TPixel> targetPixels = configuration.MemoryAllocator.Allocate2D<TPixel>(source.Size()))
             {
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     halfHeight,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                         {
                             int newY = height - y - 1;
@@ -91,10 +91,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             using (Buffer2D<TPixel> targetPixels = configuration.MemoryAllocator.Allocate2D<TPixel>(source.Size()))
             {
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     height,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                         {
                             Span<TPixel> sourceRow = source.GetPixelRowSpan(y);

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -74,10 +74,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             if (this.Sampler is NearestNeighborResampler)
             {
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     height,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                     {
                         Span<TPixel> destRow = destination.GetPixelRowSpan(y);
@@ -120,10 +120,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             using (Buffer2D<float> yBuffer = memoryAllocator.Allocate2D<float>(yLength, height))
             using (Buffer2D<float> xBuffer = memoryAllocator.Allocate2D<float>(xLength, height))
             {
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     height,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                     {
                         ref TPixel destRowRef = ref MemoryMarshal.GetReference(destination.GetPixelRowSpan(y));

--- a/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
@@ -270,10 +270,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 float widthFactor = sourceRectangle.Width / (float)this.ResizeRectangle.Width;
                 float heightFactor = sourceRectangle.Height / (float)this.ResizeRectangle.Height;
 
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     minY,
                     maxY,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                     {
                         // Y coordinates of source points
@@ -331,10 +331,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                         });
 
                 // Now process the rows.
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     minY,
                     maxY,
-                    configuration.ParallelOptions,
+                    configuration,
                     y =>
                     {
                         // Ensure offsets are normalized for cropping and padding.

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -147,10 +147,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             int height = source.Height;
             Rectangle destinationBounds = destination.Bounds();
 
-            Parallel.For(
+            ParallelFor.WithConfiguration(
                 0,
                 height,
-                configuration.ParallelOptions,
+                configuration,
                 y =>
                 {
                     Span<TPixel> sourceRow = source.GetPixelRowSpan(y);
@@ -179,10 +179,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             int width = source.Width;
             int height = source.Height;
 
-            Parallel.For(
+            ParallelFor.WithConfiguration(
                 0,
                 height,
-                configuration.ParallelOptions,
+                configuration,
                 y =>
                 {
                     Span<TPixel> sourceRow = source.GetPixelRowSpan(y);
@@ -207,10 +207,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             int height = source.Height;
             Rectangle destinationBounds = destination.Bounds();
 
-            Parallel.For(
+            ParallelFor.WithConfiguration(
                 0,
                 height,
-                configuration.ParallelOptions,
+                configuration,
                 y =>
                 {
                     Span<TPixel> sourceRow = source.GetPixelRowSpan(y);

--- a/tests/ImageSharp.Benchmarks/Codecs/CopyPixels.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/CopyPixels.cs
@@ -24,10 +24,10 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
             {
                 Buffer2D<Rgba32> sourcePixels = source.GetRootFramePixelBuffer();
                 Buffer2D<Rgba32> targetPixels = target.GetRootFramePixelBuffer();
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     source.Height,
-                    Configuration.Default.ParallelOptions,
+                    Configuration.Default,
                     y =>
                         {
                             for (int x = 0; x < source.Width; x++)
@@ -48,10 +48,10 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
             {
                 Buffer2D<Rgba32> sourcePixels = source.GetRootFramePixelBuffer();
                 Buffer2D<Rgba32> targetPixels = target.GetRootFramePixelBuffer();
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     source.Height,
-                    Configuration.Default.ParallelOptions,
+                    Configuration.Default,
                     y =>
                         {
                             Span<Rgba32> sourceRow = sourcePixels.GetRowSpan(y);
@@ -73,10 +73,10 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
             using (var source = new Image<Rgba32>(1024, 768))
             using (var target = new Image<Rgba32>(1024, 768))
             {
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     source.Height,
-                    Configuration.Default.ParallelOptions,
+                    Configuration.Default,
                     y =>
                     {
                         for (int x = 0; x < source.Width; x++)
@@ -95,10 +95,10 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
             using (var source = new Image<Rgba32>(1024, 768))
             using (var target = new Image<Rgba32>(1024, 768))
             {
-                Parallel.For(
+                ParallelFor.WithConfiguration(
                     0,
                     source.Height,
-                    Configuration.Default.ParallelOptions,
+                    Configuration.Default,
                     y =>
                     {
                         Span<Rgba32> sourceRow = source.Frames.RootFrame.GetPixelRowSpan(y);

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/LoadResizeSave.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/LoadResizeSave.cs
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs.Jpeg
         [GlobalSetup]
         public void Setup()
         {
-            this.configuration.ParallelOptions.MaxDegreeOfParallelism =
+            this.configuration.MaxDegreeOfParallelism =
                 this.EnableParallelExecution ? Environment.ProcessorCount : 1;
 
             if (this.sourceBytes == null)

--- a/tests/ImageSharp.Benchmarks/Samplers/Glow.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/Glow.cs
@@ -109,10 +109,10 @@ namespace SixLabors.ImageSharp.Benchmarks
                     Buffer2D<TPixel> sourcePixels = source.PixelBuffer;
                     rowColors.GetSpan().Fill(glowColor);
 
-                    Parallel.For(
+                    ParallelFor.WithConfiguration(
                         minY,
                         maxY,
-                        configuration.ParallelOptions,
+                        configuration,
                         y =>
                         {
                             int offsetY = y - startY;

--- a/tests/ImageSharp.Benchmarks/Samplers/Resize.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/Resize.cs
@@ -31,7 +31,7 @@ namespace SixLabors.ImageSharp.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            this.configuration.ParallelOptions.MaxDegreeOfParallelism =
+            this.configuration.MaxDegreeOfParallelism =
                 this.EnableParallelExecution ? Environment.ProcessorCount : 1;
         }
 

--- a/tests/ImageSharp.Tests/ConfigurationTests.cs
+++ b/tests/ImageSharp.Tests/ConfigurationTests.cs
@@ -10,6 +10,7 @@ using SixLabors.ImageSharp.IO;
 using SixLabors.ImageSharp.PixelFormats;
 using Moq;
 using Xunit;
+// ReSharper disable InconsistentNaming
 
 namespace SixLabors.ImageSharp.Tests
 {
@@ -46,15 +47,6 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         /// <summary>
-        /// Test that the default configuration parallel options is not null.
-        /// </summary>
-        [Fact]
-        public void TestDefaultConfigurationParallelOptionsIsNotNull()
-        {
-            Assert.True(Configuration.Default.ParallelOptions != null);
-        }
-
-        /// <summary>
         /// Test that the default configuration read origin options is set to begin.
         /// </summary>
         [Fact]
@@ -70,8 +62,21 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void TestDefaultConfigurationMaxDegreeOfParallelism()
         {
-            Assert.True(Configuration.Default.ParallelOptions.MaxDegreeOfParallelism == Environment.ProcessorCount);
+            Assert.True(Configuration.Default.MaxDegreeOfParallelism == Environment.ProcessorCount);
+
+            var cfg = new Configuration();
+            Assert.True(cfg.MaxDegreeOfParallelism == Environment.ProcessorCount);
         }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-42)]
+        public void Set_MaxDegreeOfParallelism_ToNonPositiveValue_Throws(int value)
+        {
+            var cfg = new Configuration();
+            Assert.Throws<ArgumentOutOfRangeException>(() => cfg.MaxDegreeOfParallelism = value);
+        }
+
 
         [Fact]
         public void ConstructorCallConfigureOnFormatProvider()

--- a/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
@@ -184,7 +184,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             string path = TestEnvironment.CreateOutputDirectory("Drawing", "FilledPolygons");
 
             var config = Configuration.CreateDefaultInstance();
-            config.ParallelOptions.MaxDegreeOfParallelism = 1;
+            config.MaxDegreeOfParallelism = 1;
             using (var image = new Image<Rgba32>(config, 100, 100))
             {
                 image.Mutate(x => x
@@ -200,7 +200,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             string path = TestEnvironment.CreateOutputDirectory("Drawing", "FilledPolygons");
 
             var config = Configuration.CreateDefaultInstance();
-            config.ParallelOptions.MaxDegreeOfParallelism = 1;
+            config.MaxDegreeOfParallelism = 1;
             using (var image = new Image<Rgba32>(config, 100, 100))
             {
                 image.Mutate(x => x
@@ -217,7 +217,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             string path = TestEnvironment.CreateOutputDirectory("Drawing", "FilledPolygons");
 
             var config = Configuration.CreateDefaultInstance();
-            config.ParallelOptions.MaxDegreeOfParallelism = 1;
+            config.MaxDegreeOfParallelism = 1;
             using (var image = new Image<Rgba32>(config, 200, 200))
             {
                 image.Mutate(x => x

--- a/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
@@ -8,6 +8,7 @@ using System.Drawing.Imaging;
 using System.Runtime.CompilerServices;
 
 using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.Common.Helpers;
 using SixLabors.ImageSharp.MetaData;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Shapes;
@@ -102,6 +103,11 @@ namespace SixLabors.ImageSharp.Tests
             [Fact]
             public void WrapSystemDrawingBitmap_WhenObserved()
             {
+                if (ShouldSkipBitmapTest)
+                {
+                    return;
+                }
+
                 using (var bmp = new Bitmap(51, 23))
                 {
                     using (var memoryManager = new BitmapMemoryManager(bmp))
@@ -130,6 +136,11 @@ namespace SixLabors.ImageSharp.Tests
             [Fact]
             public void WrapSystemDrawingBitmap_WhenOwned()
             {
+                if (ShouldSkipBitmapTest)
+                {
+                    return;
+                }
+
                 using (var bmp = new Bitmap(51, 23))
                 {
                     var memoryManager = new BitmapMemoryManager(bmp);
@@ -151,6 +162,9 @@ namespace SixLabors.ImageSharp.Tests
                     bmp.Save(fn, ImageFormat.Bmp);
                 }
             }
+
+            private static bool ShouldSkipBitmapTest =>
+                !TestEnvironment.Is64BitProcess || TestHelpers.ImageSharpBuiltAgainst != "netcoreapp2.1";
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #651. 
Internal helpers `ParallelFor.WithConfiguration(...)` and  `ParallelFor.WithTemporaryBuffer<T>(...)` are utilized more heavily.