### PR TITLE
Drop  .NET Core 2.0 from continuous integration test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - os: linux # Ubuntu 14.04
       dist: trusty
       sudo: required
-      dotnet: 2.1.300
+      dotnet: 2.1.401
       mono: latest
 #    - os: osx # OSX 10.11
 #      osx_image: xcode7.3.1

--- a/ImageSharp.sln
+++ b/ImageSharp.sln
@@ -1,7 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.3
 VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{C317F1B1-D75E-4C6D-83EB-80367343E0D7}"
@@ -19,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		NuGet.config = NuGet.config
 		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 		README.md = README.md
+		run-tests.ps1 = run-tests.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{815C0625-CD3D-440F-9F80-2D83856AB7AE}"
@@ -46,9 +46,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageSharp.Sandbox46", "tests\ImageSharp.Sandbox46\ImageSharp.Sandbox46.csproj", "{561B880A-D9EE-44EF-90F5-817C54A9D9AB}"
 EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
@@ -132,5 +129,8 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5F8B9D1F-CD8B-4CC5-8216-D531E25BD795}
+	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -117,12 +117,9 @@ For more examples check out:
 
 If you prefer, you can compile ImageSharp yourself (please do and help!)
 
-- Using [Visual Studio 2017 Preview](https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-preview-relnotes)
+- Using [Visual Studio 2017](https://visualstudio.microsoft.com/vs/)
   - Make sure you have the latest version installed
-  - Make sure you have [the newest 2.1 RC1 SDK installed](https://www.microsoft.com/net/core#windows)
-
-- Using [Visual Studio 2017](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes)
-  - If you are unable and/or don't want to build ImageSharp.Tests against 2.1 RC, remove the `netcoreapp2.1` target [from TargetFrameworks](https://github.com/SixLabors/ImageSharp/blob/master/tests/ImageSharp.Tests/ImageSharp.Tests.csproj#L3) locally
+  - Make sure you have [the .NET Core 2.1 SDK](https://www.microsoft.com/net/core#windows) installed
 
 Alternatively, you can work from command line and/or with a lightweight editor on **both Linux/Unix and Windows**:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,6 @@ environment:
     - target_framework: netcoreapp2.1
       is_32bit: True
 
-    - target_framework: netcoreapp2.0
-      is_32bit: False
-
     - target_framework: net471
       is_32bit: False
 
@@ -27,8 +24,6 @@ environment:
     - target_framework: net462
       is_32bit: True
     
-    #- target_framework: netcoreapp2.0 # As far as I understand, 32 bit test execution is not supported by "dotnet xunit"
-    #  is_32bit: True
     #- target_framework: mono
     #  is_32bit: False
     #- target_framework: mono

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -41,8 +41,8 @@ function CheckSubmoduleStatus() {
 }
 
 
-if ( ($targetFramework -eq "netcoreapp2.0") -and ($env:CI -eq "True") -and ($is32Bit -ne "True")) {
-    # We execute CodeCoverage.cmd only for one specific job on CI (netcoreapp2.0 + 64bit )
+if ( ($targetFramework -eq "netcoreapp2.1") -and ($env:CI -eq "True") -and ($is32Bit -ne "True")) {
+    # We execute CodeCoverage.cmd only for one specific job on CI (netcoreapp2.1 + 64bit )
     $testRunnerCmd = ".\tests\CodeCoverage\CodeCoverage.cmd"
 }
 elseif ($targetFramework -eq "mono") {
@@ -69,11 +69,6 @@ elseif ($targetFramework -eq "mono") {
 else {
     cd .\tests\ImageSharp.Tests
     $xunitArgs = "-nobuild -c Release -framework $targetFramework"
-
-    if ($targetFramework -eq "netcoreapp2.0") {
-        # There were issues matching the correct installed runtime if we do not specify it explicitly:
-        $xunitArgs += " --fx-version 2.0.0"
-    }
 
     if ($targetFramework -eq "netcoreapp2.1") {
         # There were issues matching the correct installed runtime if we do not specify it explicitly:

--- a/tests/CodeCoverage/CodeCoverage.cmd
+++ b/tests/CodeCoverage/CodeCoverage.cmd
@@ -12,7 +12,7 @@ dotnet restore ImageSharp.sln
 rem Clean the solution to force a rebuild with /p:codecov=true
 dotnet clean ImageSharp.sln -c Release
 rem The -threshold options prevents this taking ages...
-tests\CodeCoverage\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test tests\ImageSharp.Tests\ImageSharp.Tests.csproj -c Release -f netcoreapp2.0 /p:codecov=true" -register:user -threshold:10 -oldStyle -safemode:off -output:.\ImageSharp.Coverage.xml -hideskipped:All -returntargetcode -filter:"+[SixLabors.ImageSharp*]*" 
+tests\CodeCoverage\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test tests\ImageSharp.Tests\ImageSharp.Tests.csproj -c Release -f netcoreapp2.1 /p:codecov=true" -register:user -threshold:10 -oldStyle -safemode:off -output:.\ImageSharp.Coverage.xml -hideskipped:All -returntargetcode -filter:"+[SixLabors.ImageSharp*]*" 
 
 if %errorlevel% neq 0 exit /b %errorlevel%
 

--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net471;netcoreapp2.0;netcoreapp2.1;net47;net462</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp2.1;net47;net462</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <DebugType Condition="$(codecov) != ''">full</DebugType>
     <DebugType Condition="$(codecov) == ''">portable</DebugType>
     <DebugSymbols>True</DebugSymbols>

--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net471;netcoreapp2.1;net47;net462</TargetFrameworks>
+    <TargetFrameworks>net462;net471;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <LangVersion>7.3</LangVersion>
     <DebugType Condition="$(codecov) != ''">full</DebugType>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

With the declaration of 2.1.3 as the LTS release and NET Core 2.0 reaching end of life in October -- this PR removes .NET Core 2.0 from our test library.

This should help speed up the CI pipeline, simplify building the test library, and increase the feedback cycle when submitting PRs.  Things take a really long time now.

[0] https://blogs.msdn.microsoft.com/dotnet/2018/06/20/net-core-2-0-will-reach-end-of-life-on-september-1-2018/

<!-- Thanks for contributing to ImageSharp! -->
