### PR TITLE
Allow several invalid data types when reading the exif resolution.

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -463,13 +463,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             }
             else if (this.isExif)
             {
-                double horizontalValue = this.MetaData.ExifProfile.TryGetValue(ExifTag.XResolution, out ExifValue horizontalTag)
-                    ? ((Rational)horizontalTag.Value).ToDouble()
-                    : 0;
-
-                double verticalValue = this.MetaData.ExifProfile.TryGetValue(ExifTag.YResolution, out ExifValue verticalTag)
-                    ? ((Rational)verticalTag.Value).ToDouble()
-                    : 0;
+                double horizontalValue = this.GetExifResolutionValue(ExifTag.XResolution);
+                double verticalValue = this.GetExifResolutionValue(ExifTag.YResolution);
 
                 if (horizontalValue > 0 && verticalValue > 0)
                 {
@@ -477,6 +472,26 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     this.MetaData.VerticalResolution = verticalValue;
                     this.MetaData.ResolutionUnits = UnitConverter.ExifProfileToResolutionUnit(this.MetaData.ExifProfile);
                 }
+            }
+        }
+
+        private double GetExifResolutionValue(ExifTag tag)
+        {
+            if (!this.MetaData.ExifProfile.TryGetValue(tag, out ExifValue exifValue))
+            {
+                return 0;
+            }
+
+            switch (exifValue.DataType)
+            {
+                case ExifDataType.Rational:
+                    return ((Rational)exifValue.Value).ToDouble();
+                case ExifDataType.Long:
+                    return (uint)exifValue.Value;
+                case ExifDataType.DoubleFloat:
+                    return (double)exifValue.Value;
+                default:
+                    return 0;
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
This patch allows reading exif resolution values that have an invalid datatype. When the image is saved the values will be corrected. This should fix the issues reported in #521.

<!-- Thanks for contributing to ImageSharp! -->
