### PR TITLE
Png and Wu Quantizer fixes

### DIFF
--- a/src/ImageSharp/Common/Extensions/ComparableExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/ComparableExtensions.cs
@@ -138,17 +138,6 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Converts an <see cref="int"/> to a <see cref="byte"/> first restricting the value between the
-        /// minimum and maximum allowable ranges.
-        /// </summary>
-        /// <param name="value">The <see cref="int"/> this method extends.</param>
-        /// <returns>The <see cref="byte"/></returns>
-        public static byte ToByte(this int value)
-        {
-            return (byte)value.Clamp(0, 255);
-        }
-
-        /// <summary>
         /// Converts an <see cref="float"/> to a <see cref="byte"/> first restricting the value between the
         /// minimum and maximum allowable ranges.
         /// </summary>

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -217,7 +217,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             where TPixel : struct, IPixel<TPixel>
         {
             var metaData = new ImageMetaData();
-            var pngMetaData = metaData.GetFormatMetaData(PngFormat.Instance);
+            PngMetaData pngMetaData = metaData.GetFormatMetaData(PngFormat.Instance);
             this.currentStream = stream;
             this.currentStream.Skip(8);
             Image<TPixel> image = null;
@@ -307,7 +307,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         public IImageInfo Identify(Stream stream)
         {
             var metaData = new ImageMetaData();
-            var pngMetaData = metaData.GetFormatMetaData(PngFormat.Instance);
+            PngMetaData pngMetaData = metaData.GetFormatMetaData(PngFormat.Instance);
             this.currentStream = stream;
             this.currentStream.Skip(8);
             try


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
- Fixes png encoding when 256 colors are used.
- Optimized Wu Quantizer to reduce memory usage by > half.

<!-- Thanks for contributing to ImageSharp! -->
