### PR TITLE
Ensure frame metadata is a deep copy.

### DIFF
--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp
         /// Creates a shallow copy of the <see cref="Configuration"/>
         /// </summary>
         /// <returns>A new configuration instance</returns>
-        public Configuration ShallowCopy()
+        public Configuration Clone()
         {
             return new Configuration
             {

--- a/src/ImageSharp/Formats/Bmp/BmpMetaData.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpMetaData.cs
@@ -27,7 +27,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         public BmpBitsPerPixel BitsPerPixel { get; set; } = BmpBitsPerPixel.Pixel24;
 
         /// <inheritdoc/>
-        public IDeepCloneable Clone() => new BmpMetaData(this);
+        public IDeepCloneable DeepClone() => new BmpMetaData(this);
 
         // TODO: Colors used once we support encoding palette bmps.
     }

--- a/src/ImageSharp/Formats/Bmp/BmpMetaData.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpMetaData.cs
@@ -27,7 +27,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         public BmpBitsPerPixel BitsPerPixel { get; set; } = BmpBitsPerPixel.Pixel24;
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new BmpMetaData(this);
+        public IDeepCloneable Clone() => new BmpMetaData(this);
 
         // TODO: Colors used once we support encoding palette bmps.
     }

--- a/src/ImageSharp/Formats/Bmp/BmpMetaData.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpMetaData.cs
@@ -6,12 +6,28 @@ namespace SixLabors.ImageSharp.Formats.Bmp
     /// <summary>
     /// Provides Bmp specific metadata information for the image.
     /// </summary>
-    public class BmpMetaData
+    public class BmpMetaData : IDeepCloneable
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BmpMetaData"/> class.
+        /// </summary>
+        public BmpMetaData()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BmpMetaData"/> class.
+        /// </summary>
+        /// <param name="other">The metadata to create an instance from.</param>
+        private BmpMetaData(BmpMetaData other) => this.BitsPerPixel = other.BitsPerPixel;
+
         /// <summary>
         /// Gets or sets the number of bits per pixel.
         /// </summary>
         public BmpBitsPerPixel BitsPerPixel { get; set; } = BmpBitsPerPixel.Pixel24;
+
+        /// <inheritdoc/>
+        public IDeepCloneable DeepClone() => new BmpMetaData(this);
 
         // TODO: Colors used once we support encoding palette bmps.
     }

--- a/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
+++ b/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
@@ -49,6 +49,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public GifDisposalMethod DisposalMethod { get; set; }
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new GifFrameMetaData(this);
+        public IDeepCloneable Clone() => new GifFrameMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
+++ b/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
@@ -49,6 +49,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public GifDisposalMethod DisposalMethod { get; set; }
 
         /// <inheritdoc/>
-        public IDeepCloneable Clone() => new GifFrameMetaData(this);
+        public IDeepCloneable DeepClone() => new GifFrameMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
+++ b/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
@@ -6,8 +6,26 @@ namespace SixLabors.ImageSharp.Formats.Gif
     /// <summary>
     /// Provides Gif specific metadata information for the image frame.
     /// </summary>
-    public class GifFrameMetaData
+    public class GifFrameMetaData : IDeepCloneable
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GifFrameMetaData"/> class.
+        /// </summary>
+        public GifFrameMetaData()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GifFrameMetaData"/> class.
+        /// </summary>
+        /// <param name="other">The metadata to create an instance from.</param>
+        internal GifFrameMetaData(GifFrameMetaData other)
+        {
+            this.ColorTableLength = other.ColorTableLength;
+            this.FrameDelay = other.FrameDelay;
+            this.DisposalMethod = other.DisposalMethod;
+        }
+
         /// <summary>
         /// Gets or sets the length of the color table for paletted images.
         /// If not 0, then this field indicates the maximum number of colors to use when quantizing the
@@ -29,5 +47,8 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// be treated after being displayed.
         /// </summary>
         public GifDisposalMethod DisposalMethod { get; set; }
+
+        /// <inheritdoc/>
+        public IDeepCloneable DeepClone() => new GifFrameMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
+++ b/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// Initializes a new instance of the <see cref="GifFrameMetaData"/> class.
         /// </summary>
         /// <param name="other">The metadata to create an instance from.</param>
-        internal GifFrameMetaData(GifFrameMetaData other)
+        private GifFrameMetaData(GifFrameMetaData other)
         {
             this.ColorTableLength = other.ColorTableLength;
             this.FrameDelay = other.FrameDelay;

--- a/src/ImageSharp/Formats/Gif/GifMetaData.cs
+++ b/src/ImageSharp/Formats/Gif/GifMetaData.cs
@@ -45,6 +45,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public int GlobalColorTableLength { get; set; }
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new GifMetaData(this);
+        public IDeepCloneable Clone() => new GifMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifMetaData.cs
+++ b/src/ImageSharp/Formats/Gif/GifMetaData.cs
@@ -45,6 +45,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public int GlobalColorTableLength { get; set; }
 
         /// <inheritdoc/>
-        public IDeepCloneable Clone() => new GifMetaData(this);
+        public IDeepCloneable DeepClone() => new GifMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifMetaData.cs
+++ b/src/ImageSharp/Formats/Gif/GifMetaData.cs
@@ -6,8 +6,26 @@ namespace SixLabors.ImageSharp.Formats.Gif
     /// <summary>
     /// Provides Gif specific metadata information for the image.
     /// </summary>
-    public class GifMetaData
+    public class GifMetaData : IDeepCloneable
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GifMetaData"/> class.
+        /// </summary>
+        public GifMetaData()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GifMetaData"/> class.
+        /// </summary>
+        /// <param name="other">The metadata to create an instance from.</param>
+        private GifMetaData(GifMetaData other)
+        {
+            this.RepeatCount = other.RepeatCount;
+            this.ColorTableMode = other.ColorTableMode;
+            this.GlobalColorTableLength = other.GlobalColorTableLength;
+        }
+
         /// <summary>
         /// Gets or sets the number of times any animation is repeated.
         /// <remarks>
@@ -25,5 +43,8 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// Gets or sets the length of the global color table if present.
         /// </summary>
         public int GlobalColorTableLength { get; set; }
+
+        /// <inheritdoc/>
+        public IDeepCloneable DeepClone() => new GifMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/JpegMetaData.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegMetaData.cs
@@ -6,11 +6,27 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
     /// <summary>
     /// Provides Jpeg specific metadata information for the image.
     /// </summary>
-    public class JpegMetaData
+    public class JpegMetaData : IDeepCloneable
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JpegMetaData"/> class.
+        /// </summary>
+        public JpegMetaData()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JpegMetaData"/> class.
+        /// </summary>
+        /// <param name="other">The metadata to create an instance from.</param>
+        private JpegMetaData(JpegMetaData other) => this.Quality = other.Quality;
+
         /// <summary>
         /// Gets or sets the encoded quality.
         /// </summary>
         public int Quality { get; set; } = 75;
+
+        /// <inheritdoc/>
+        public IDeepCloneable DeepClone() => new JpegMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/JpegMetaData.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegMetaData.cs
@@ -27,6 +27,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         public int Quality { get; set; } = 75;
 
         /// <inheritdoc/>
-        public IDeepCloneable Clone() => new JpegMetaData(this);
+        public IDeepCloneable DeepClone() => new JpegMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/JpegMetaData.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegMetaData.cs
@@ -27,6 +27,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         public int Quality { get; set; } = 75;
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new JpegMetaData(this);
+        public IDeepCloneable Clone() => new JpegMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Png/PngMetaData.cs
+++ b/src/ImageSharp/Formats/Png/PngMetaData.cs
@@ -6,8 +6,26 @@ namespace SixLabors.ImageSharp.Formats.Png
     /// <summary>
     /// Provides Png specific metadata information for the image.
     /// </summary>
-    public class PngMetaData
+    public class PngMetaData : IDeepCloneable
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PngMetaData"/> class.
+        /// </summary>
+        public PngMetaData()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PngMetaData"/> class.
+        /// </summary>
+        /// <param name="other">The metadata to create an instance from.</param>
+        private PngMetaData(PngMetaData other)
+        {
+            this.BitDepth = other.BitDepth;
+            this.ColorType = other.ColorType;
+            this.Gamma = other.Gamma;
+        }
+
         /// <summary>
         /// Gets or sets the number of bits per sample or per palette index (not per pixel).
         /// Not all values are allowed for all <see cref="ColorType"/> values.
@@ -23,5 +41,8 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// Gets or sets the gamma value for the image.
         /// </summary>
         public float Gamma { get; set; }
+
+        /// <inheritdoc/>
+        public IDeepCloneable DeepClone() => new PngMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Png/PngMetaData.cs
+++ b/src/ImageSharp/Formats/Png/PngMetaData.cs
@@ -43,6 +43,6 @@ namespace SixLabors.ImageSharp.Formats.Png
         public float Gamma { get; set; }
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new PngMetaData(this);
+        public IDeepCloneable Clone() => new PngMetaData(this);
     }
 }

--- a/src/ImageSharp/Formats/Png/PngMetaData.cs
+++ b/src/ImageSharp/Formats/Png/PngMetaData.cs
@@ -43,6 +43,6 @@ namespace SixLabors.ImageSharp.Formats.Png
         public float Gamma { get; set; }
 
         /// <inheritdoc/>
-        public IDeepCloneable Clone() => new PngMetaData(this);
+        public IDeepCloneable DeepClone() => new PngMetaData(this);
     }
 }

--- a/src/ImageSharp/IDeepCloneable.cs
+++ b/src/ImageSharp/IDeepCloneable.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp
         /// Creates a new <typeparamref name="T"/> that is a deep copy of the current instance.
         /// </summary>
         /// <returns>The <typeparamref name="T"/>.</returns>
-        T DeepClone();
+        T Clone();
     }
 
     /// <summary>
@@ -26,6 +26,6 @@ namespace SixLabors.ImageSharp
         /// Creates a new object that is a deep copy of the current instance.
         /// </summary>
         /// <returns>The <see cref="IDeepCloneable"/>.</returns>
-        IDeepCloneable DeepClone();
+        IDeepCloneable Clone();
     }
 }

--- a/src/ImageSharp/IDeepCloneable.cs
+++ b/src/ImageSharp/IDeepCloneable.cs
@@ -7,8 +7,8 @@ namespace SixLabors.ImageSharp
     /// A generic interface for a deeply cloneable type.
     /// </summary>
     /// <typeparam name="T">The type of object to clone.</typeparam>
-    public interface IDeepCloneable<T>
-        where T : class, IDeepCloneable<T>
+    public interface IDeepCloneable<out T>
+        where T : class
     {
         /// <summary>
         /// Creates a new <typeparamref name="T"/> that is a deep copy of the current instance.

--- a/src/ImageSharp/IDeepCloneable.cs
+++ b/src/ImageSharp/IDeepCloneable.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp
+{
+    /// <summary>
+    /// A generic interface for a deeply cloneable type.
+    /// </summary>
+    /// <typeparam name="T">The type of object to clone.</typeparam>
+    public interface IDeepCloneable<T>
+        where T : class, IDeepCloneable<T>
+    {
+        /// <summary>
+        /// Creates a new <typeparamref name="T"/> that is a deep copy of the current instance.
+        /// </summary>
+        /// <returns>The <typeparamref name="T"/>.</returns>
+        T DeepClone();
+    }
+
+    /// <summary>
+    /// An interface for objects that can be cloned. This creates a deep copy of the object.
+    /// </summary>
+    public interface IDeepCloneable
+    {
+        /// <summary>
+        /// Creates a new object that is a deep copy of the current instance.
+        /// </summary>
+        /// <returns>The <see cref="IDeepCloneable"/>.</returns>
+        IDeepCloneable DeepClone();
+    }
+}

--- a/src/ImageSharp/IDeepCloneable.cs
+++ b/src/ImageSharp/IDeepCloneable.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp
         /// Creates a new <typeparamref name="T"/> that is a deep copy of the current instance.
         /// </summary>
         /// <returns>The <typeparamref name="T"/>.</returns>
-        T Clone();
+        T DeepClone();
     }
 
     /// <summary>
@@ -26,6 +26,6 @@ namespace SixLabors.ImageSharp
         /// Creates a new object that is a deep copy of the current instance.
         /// </summary>
         /// <returns>The <see cref="IDeepCloneable"/>.</returns>
-        IDeepCloneable Clone();
+        IDeepCloneable DeepClone();
     }
 }

--- a/src/ImageSharp/ImageFrameCollection.cs
+++ b/src/ImageSharp/ImageFrameCollection.cs
@@ -94,7 +94,7 @@ namespace SixLabors.ImageSharp
         public ImageFrame<TPixel> InsertFrame(int index, ImageFrame<TPixel> source)
         {
             this.ValidateFrame(source);
-            ImageFrame<TPixel> clonedFrame = source.Clone();
+            ImageFrame<TPixel> clonedFrame = source.Clone(this.parent.GetConfiguration());
             this.frames.Insert(index, clonedFrame);
             return clonedFrame;
         }
@@ -107,7 +107,7 @@ namespace SixLabors.ImageSharp
         public ImageFrame<TPixel> AddFrame(ImageFrame<TPixel> source)
         {
             this.ValidateFrame(source);
-            ImageFrame<TPixel> clonedFrame = source.Clone();
+            ImageFrame<TPixel> clonedFrame = source.Clone(this.parent.GetConfiguration());
             this.frames.Add(clonedFrame);
             return clonedFrame;
         }
@@ -155,10 +155,7 @@ namespace SixLabors.ImageSharp
         /// <returns>
         ///   <c>true</c> if the <seealso cref="ImageFrameCollection{TPixel}"/> contains the specified frame; otherwise, <c>false</c>.
         /// </returns>
-        public bool Contains(ImageFrame<TPixel> frame)
-        {
-            return this.frames.Contains(frame);
-        }
+        public bool Contains(ImageFrame<TPixel> frame) => this.frames.Contains(frame);
 
         /// <summary>
         /// Moves an <seealso cref="ImageFrame{TPixel}"/> from <paramref name="sourceIndex"/> to <paramref name="destinationIndex"/>.
@@ -195,7 +192,7 @@ namespace SixLabors.ImageSharp
 
             this.frames.Remove(frame);
 
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.Clone(), new[] { frame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.DeepClone(), new[] { frame });
         }
 
         /// <summary>
@@ -208,7 +205,7 @@ namespace SixLabors.ImageSharp
         {
             ImageFrame<TPixel> frame = this[index];
             ImageFrame<TPixel> clonedFrame = frame.Clone();
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.Clone(), new[] { clonedFrame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.DeepClone(), new[] { clonedFrame });
         }
 
         /// <summary>
@@ -217,10 +214,7 @@ namespace SixLabors.ImageSharp
         /// <returns>
         /// The new <see cref="ImageFrame{TPixel}" />.
         /// </returns>
-        public ImageFrame<TPixel> CreateFrame()
-        {
-            return this.CreateFrame(default);
-        }
+        public ImageFrame<TPixel> CreateFrame() => this.CreateFrame(default);
 
         /// <summary>
         /// Creates a new <seealso cref="ImageFrame{TPixel}" /> and appends it to the end of the collection.

--- a/src/ImageSharp/ImageFrameCollection.cs
+++ b/src/ImageSharp/ImageFrameCollection.cs
@@ -195,7 +195,7 @@ namespace SixLabors.ImageSharp
 
             this.frames.Remove(frame);
 
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.Clone(), new[] { frame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.DeepClone(), new[] { frame });
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace SixLabors.ImageSharp
         {
             ImageFrame<TPixel> frame = this[index];
             ImageFrame<TPixel> clonedFrame = frame.Clone();
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.Clone(), new[] { clonedFrame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.DeepClone(), new[] { clonedFrame });
         }
 
         /// <summary>

--- a/src/ImageSharp/ImageFrameCollection.cs
+++ b/src/ImageSharp/ImageFrameCollection.cs
@@ -195,7 +195,7 @@ namespace SixLabors.ImageSharp
 
             this.frames.Remove(frame);
 
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.DeepClone(), new[] { frame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.Clone(), new[] { frame });
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace SixLabors.ImageSharp
         {
             ImageFrame<TPixel> frame = this[index];
             ImageFrame<TPixel> clonedFrame = frame.Clone();
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.DeepClone(), new[] { clonedFrame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.Clone(), new[] { clonedFrame });
         }
 
         /// <summary>

--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -139,7 +139,7 @@ namespace SixLabors.ImageSharp
             this.MemoryAllocator = configuration.MemoryAllocator;
             this.PixelBuffer = this.MemoryAllocator.Allocate2D<TPixel>(source.PixelBuffer.Width, source.PixelBuffer.Height);
             source.PixelBuffer.GetSpan().CopyTo(this.PixelBuffer.GetSpan());
-            this.MetaData = source.MetaData.Clone();
+            this.MetaData = source.MetaData.DeepClone();
         }
 
         /// <summary>
@@ -286,7 +286,7 @@ namespace SixLabors.ImageSharp
                 return this.Clone(configuration) as ImageFrame<TPixel2>;
             }
 
-            var target = new ImageFrame<TPixel2>(configuration, this.Width, this.Height, this.MetaData.Clone());
+            var target = new ImageFrame<TPixel2>(configuration, this.Width, this.Height, this.MetaData.DeepClone());
 
             ParallelFor.WithTemporaryBuffer(
                 0,

--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -135,7 +135,7 @@ namespace SixLabors.ImageSharp
             this.MemoryAllocator = configuration.MemoryAllocator;
             this.PixelBuffer = this.MemoryAllocator.Allocate2D<TPixel>(source.PixelBuffer.Width, source.PixelBuffer.Height);
             source.PixelBuffer.GetSpan().CopyTo(this.PixelBuffer.GetSpan());
-            this.MetaData = source.MetaData.Clone();
+            this.MetaData = source.MetaData.DeepClone();
         }
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace SixLabors.ImageSharp
                 return this.Clone() as ImageFrame<TPixel2>;
             }
 
-            var target = new ImageFrame<TPixel2>(this.configuration, this.Width, this.Height, this.MetaData.Clone());
+            var target = new ImageFrame<TPixel2>(this.configuration, this.Width, this.Height, this.MetaData.DeepClone());
 
             ParallelFor.WithTemporaryBuffer(
                 0,

--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -135,7 +135,7 @@ namespace SixLabors.ImageSharp
             this.MemoryAllocator = configuration.MemoryAllocator;
             this.PixelBuffer = this.MemoryAllocator.Allocate2D<TPixel>(source.PixelBuffer.Width, source.PixelBuffer.Height);
             source.PixelBuffer.GetSpan().CopyTo(this.PixelBuffer.GetSpan());
-            this.MetaData = source.MetaData.DeepClone();
+            this.MetaData = source.MetaData.Clone();
         }
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace SixLabors.ImageSharp
                 return this.Clone() as ImageFrame<TPixel2>;
             }
 
-            var target = new ImageFrame<TPixel2>(this.configuration, this.Width, this.Height, this.MetaData.DeepClone());
+            var target = new ImageFrame<TPixel2>(this.configuration, this.Width, this.Height, this.MetaData.Clone());
 
             ParallelFor.WithTemporaryBuffer(
                 0,

--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -95,6 +95,10 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageFrame{TPixel}" /> class wrapping an existing buffer.
         /// </summary>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
+        /// <param name="width">The width of the image in pixels.</param>
+        /// <param name="height">The height of the image in pixels.</param>
+        /// <param name="memorySource">The memory source.</param>
         internal ImageFrame(Configuration configuration, int width, int height, MemorySource<TPixel> memorySource)
             : this(configuration, width, height, memorySource, new ImageFrameMetaData())
         {
@@ -103,12 +107,12 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageFrame{TPixel}" /> class wrapping an existing buffer.
         /// </summary>
-        internal ImageFrame(
-            Configuration configuration,
-            int width,
-            int height,
-            MemorySource<TPixel> memorySource,
-            ImageFrameMetaData metaData)
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
+        /// <param name="width">The width of the image in pixels.</param>
+        /// <param name="height">The height of the image in pixels.</param>
+        /// <param name="memorySource">The memory source.</param>
+        /// <param name="metaData">The meta data.</param>
+        internal ImageFrame(Configuration configuration, int width, int height, MemorySource<TPixel> memorySource, ImageFrameMetaData metaData)
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.MustBeGreaterThan(width, 0, nameof(width));
@@ -248,24 +252,46 @@ namespace SixLabors.ImageSharp
         public override string ToString() => $"ImageFrame<{typeof(TPixel).Name}>: {this.Width}x{this.Height}";
 
         /// <summary>
+        /// Clones the current instance.
+        /// </summary>
+        /// <returns>The <see cref="ImageFrame{TPixel}"/></returns>
+        internal ImageFrame<TPixel> Clone() => this.Clone(this.configuration);
+
+        /// <summary>
+        /// Clones the current instance.
+        /// </summary>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
+        /// <returns>The <see cref="ImageFrame{TPixel}"/></returns>
+        internal ImageFrame<TPixel> Clone(Configuration configuration) => new ImageFrame<TPixel>(configuration, this);
+
+        /// <summary>
         /// Returns a copy of the image frame in the given pixel format.
         /// </summary>
         /// <typeparam name="TPixel2">The pixel format.</typeparam>
         /// <returns>The <see cref="ImageFrame{TPixel2}"/></returns>
         internal ImageFrame<TPixel2> CloneAs<TPixel2>()
+            where TPixel2 : struct, IPixel<TPixel2> => this.CloneAs<TPixel2>(this.configuration);
+
+        /// <summary>
+        /// Returns a copy of the image frame in the given pixel format.
+        /// </summary>
+        /// <typeparam name="TPixel2">The pixel format.</typeparam>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
+        /// <returns>The <see cref="ImageFrame{TPixel2}"/></returns>
+        internal ImageFrame<TPixel2> CloneAs<TPixel2>(Configuration configuration)
             where TPixel2 : struct, IPixel<TPixel2>
         {
             if (typeof(TPixel2) == typeof(TPixel))
             {
-                return this.Clone() as ImageFrame<TPixel2>;
+                return this.Clone(configuration) as ImageFrame<TPixel2>;
             }
 
-            var target = new ImageFrame<TPixel2>(this.configuration, this.Width, this.Height, this.MetaData.Clone());
+            var target = new ImageFrame<TPixel2>(configuration, this.Width, this.Height, this.MetaData.Clone());
 
             ParallelFor.WithTemporaryBuffer(
                 0,
                 this.Height,
-                this.configuration,
+                configuration,
                 this.Width,
                 (int y, IMemoryOwner<Vector4> tempRowBuffer) =>
                 {
@@ -297,12 +323,6 @@ namespace SixLabors.ImageSharp
                     targetRow.Fill(value);
                 });
         }
-
-        /// <summary>
-        /// Clones the current instance.
-        /// </summary>
-        /// <returns>The <see cref="ImageFrame{TPixel}"/></returns>
-        internal ImageFrame<TPixel> Clone() => new ImageFrame<TPixel>(this.configuration, this);
 
         /// <inheritdoc/>
         void IDisposable.Dispose() => this.Dispose();

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -190,7 +190,7 @@ namespace SixLabors.ImageSharp
         public Image<TPixel> Clone()
         {
             IEnumerable<ImageFrame<TPixel>> clonedFrames = this.frames.Select(x => x.Clone());
-            return new Image<TPixel>(this.configuration, this.MetaData.Clone(), clonedFrames);
+            return new Image<TPixel>(this.configuration, this.MetaData.DeepClone(), clonedFrames);
         }
 
         /// <inheritdoc/>
@@ -208,7 +208,7 @@ namespace SixLabors.ImageSharp
             where TPixel2 : struct, IPixel<TPixel2>
         {
             IEnumerable<ImageFrame<TPixel2>> clonedFrames = this.frames.Select(x => x.CloneAs<TPixel2>());
-            var target = new Image<TPixel2>(this.configuration, this.MetaData.Clone(), clonedFrames);
+            var target = new Image<TPixel2>(this.configuration, this.MetaData.DeepClone(), clonedFrames);
 
             return target;
         }

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -193,7 +193,7 @@ namespace SixLabors.ImageSharp
         public Image<TPixel> Clone(Configuration configuration)
         {
             IEnumerable<ImageFrame<TPixel>> clonedFrames = this.Frames.Select(x => x.Clone(configuration));
-            return new Image<TPixel>(configuration, this.MetaData.Clone(), clonedFrames);
+            return new Image<TPixel>(configuration, this.MetaData.DeepClone(), clonedFrames);
         }
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace SixLabors.ImageSharp
             where TPixel2 : struct, IPixel<TPixel2>
         {
             IEnumerable<ImageFrame<TPixel2>> clonedFrames = this.Frames.Select(x => x.CloneAs<TPixel2>(configuration));
-            return new Image<TPixel2>(configuration, this.MetaData.Clone(), clonedFrames);
+            return new Image<TPixel2>(configuration, this.MetaData.DeepClone(), clonedFrames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -190,7 +190,7 @@ namespace SixLabors.ImageSharp
         public Image<TPixel> Clone()
         {
             IEnumerable<ImageFrame<TPixel>> clonedFrames = this.frames.Select(x => x.Clone());
-            return new Image<TPixel>(this.configuration, this.MetaData.DeepClone(), clonedFrames);
+            return new Image<TPixel>(this.configuration, this.MetaData.Clone(), clonedFrames);
         }
 
         /// <inheritdoc/>
@@ -208,7 +208,7 @@ namespace SixLabors.ImageSharp
             where TPixel2 : struct, IPixel<TPixel2>
         {
             IEnumerable<ImageFrame<TPixel2>> clonedFrames = this.frames.Select(x => x.CloneAs<TPixel2>());
-            var target = new Image<TPixel2>(this.configuration, this.MetaData.DeepClone(), clonedFrames);
+            var target = new Image<TPixel2>(this.configuration, this.MetaData.Clone(), clonedFrames);
 
             return target;
         }

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -11,7 +11,6 @@ using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.MetaData;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.Memory;
 
 namespace SixLabors.ImageSharp
 {
@@ -23,15 +22,12 @@ namespace SixLabors.ImageSharp
         where TPixel : struct, IPixel<TPixel>
     {
         private readonly Configuration configuration;
-        private readonly ImageFrameCollection<TPixel> frames;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Image{TPixel}"/> class
         /// with the height and the width of the image.
         /// </summary>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         public Image(Configuration configuration, int width, int height)
@@ -43,9 +39,7 @@ namespace SixLabors.ImageSharp
         /// Initializes a new instance of the <see cref="Image{TPixel}"/> class
         /// with the height and the width of the image.
         /// </summary>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="backgroundColor">The color to initialize the pixels with.</param>
@@ -69,9 +63,7 @@ namespace SixLabors.ImageSharp
         /// Initializes a new instance of the <see cref="Image{TPixel}"/> class
         /// with the height and the width of the image.
         /// </summary>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="metadata">The images metadata.</param>
@@ -80,37 +72,41 @@ namespace SixLabors.ImageSharp
             this.configuration = configuration ?? Configuration.Default;
             this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
             this.MetaData = metadata ?? new ImageMetaData();
-            this.frames = new ImageFrameCollection<TPixel>(this, width, height, default(TPixel));
+            this.Frames = new ImageFrameCollection<TPixel>(this, width, height, default(TPixel));
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Image{TPixel}"/> class
         /// wrapping an external <see cref="MemorySource{T}"/>
         /// </summary>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
+        /// <param name="memorySource">The memory source.</param>
+        /// <param name="width">The width of the image in pixels.</param>
+        /// <param name="height">The height of the image in pixels.</param>
+        /// <param name="metadata">The images metadata.</param>
         internal Image(Configuration configuration, MemorySource<TPixel> memorySource, int width, int height, ImageMetaData metadata)
         {
             this.configuration = configuration;
             this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
             this.MetaData = metadata;
-            this.frames = new ImageFrameCollection<TPixel>(this, width, height, memorySource);
+            this.Frames = new ImageFrameCollection<TPixel>(this, width, height, memorySource);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Image{TPixel}"/> class
         /// with the height and the width of the image.
         /// </summary>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="backgroundColor">The color to initialize the pixels with.</param>
         /// <param name="metadata">The images metadata.</param>
-        internal Image(Configuration configuration, int width, int height, TPixel backgroundColor, ImageMetaData metadata) {
+        internal Image(Configuration configuration, int width, int height, TPixel backgroundColor, ImageMetaData metadata)
+        {
             this.configuration = configuration ?? Configuration.Default;
             this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
             this.MetaData = metadata ?? new ImageMetaData();
-            this.frames = new ImageFrameCollection<TPixel>(this, width, height, backgroundColor);
+            this.Frames = new ImageFrameCollection<TPixel>(this, width, height, backgroundColor);
         }
 
         /// <summary>
@@ -126,7 +122,7 @@ namespace SixLabors.ImageSharp
             this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
             this.MetaData = metadata ?? new ImageMetaData();
 
-            this.frames = new ImageFrameCollection<TPixel>(this, frames);
+            this.Frames = new ImageFrameCollection<TPixel>(this, frames);
         }
 
         /// <summary>
@@ -138,10 +134,10 @@ namespace SixLabors.ImageSharp
         public PixelTypeInfo PixelType { get; }
 
         /// <inheritdoc/>
-        public int Width => this.frames.RootFrame.Width;
+        public int Width => this.Frames.RootFrame.Width;
 
         /// <inheritdoc/>
-        public int Height => this.frames.RootFrame.Height;
+        public int Height => this.Frames.RootFrame.Height;
 
         /// <inheritdoc/>
         public ImageMetaData MetaData { get; }
@@ -149,12 +145,12 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Gets the frames.
         /// </summary>
-        public ImageFrameCollection<TPixel> Frames => this.frames;
+        public ImageFrameCollection<TPixel> Frames { get; }
 
         /// <summary>
         /// Gets the root frame.
         /// </summary>
-        private IPixelSource<TPixel> PixelSource => this.frames?.RootFrame ?? throw new ObjectDisposedException(nameof(Image<TPixel>));
+        private IPixelSource<TPixel> PixelSource => this.Frames?.RootFrame ?? throw new ObjectDisposedException(nameof(Image<TPixel>));
 
         /// <summary>
         /// Gets or sets the pixel at the specified position.
@@ -187,16 +183,17 @@ namespace SixLabors.ImageSharp
         /// Clones the current image
         /// </summary>
         /// <returns>Returns a new image with all the same metadata as the original.</returns>
-        public Image<TPixel> Clone()
-        {
-            IEnumerable<ImageFrame<TPixel>> clonedFrames = this.frames.Select(x => x.Clone());
-            return new Image<TPixel>(this.configuration, this.MetaData.Clone(), clonedFrames);
-        }
+        public Image<TPixel> Clone() => this.Clone(this.configuration);
 
-        /// <inheritdoc/>
-        public override string ToString()
+        /// <summary>
+        /// Clones the current image with the given configueation.
+        /// </summary>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
+        /// <returns>Returns a new <see cref="Image{TPixel}"/> with all the same pixel data as the original.</returns>
+        public Image<TPixel> Clone(Configuration configuration)
         {
-            return $"Image<{typeof(TPixel).Name}>: {this.Width}x{this.Height}";
+            IEnumerable<ImageFrame<TPixel>> clonedFrames = this.Frames.Select(x => x.Clone(configuration));
+            return new Image<TPixel>(configuration, this.MetaData.Clone(), clonedFrames);
         }
 
         /// <summary>
@@ -205,21 +202,26 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel2">The pixel format.</typeparam>
         /// <returns>The <see cref="Image{TPixel2}"/></returns>
         public Image<TPixel2> CloneAs<TPixel2>()
-            where TPixel2 : struct, IPixel<TPixel2>
-        {
-            IEnumerable<ImageFrame<TPixel2>> clonedFrames = this.frames.Select(x => x.CloneAs<TPixel2>());
-            var target = new Image<TPixel2>(this.configuration, this.MetaData.Clone(), clonedFrames);
-
-            return target;
-        }
+            where TPixel2 : struct, IPixel<TPixel2> => this.CloneAs<TPixel2>(this.configuration);
 
         /// <summary>
-        /// Releases managed resources.
+        /// Returns a copy of the image in the given pixel format.
         /// </summary>
-        public void Dispose()
+        /// <typeparam name="TPixel2">The pixel format.</typeparam>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
+        /// <returns>The <see cref="Image{TPixel2}"/></returns>
+        public Image<TPixel2> CloneAs<TPixel2>(Configuration configuration)
+            where TPixel2 : struct, IPixel<TPixel2>
         {
-            this.frames.Dispose();
+            IEnumerable<ImageFrame<TPixel2>> clonedFrames = this.Frames.Select(x => x.CloneAs<TPixel2>(configuration));
+            return new Image<TPixel2>(configuration, this.MetaData.Clone(), clonedFrames);
         }
+
+        /// <inheritdoc/>
+        public void Dispose() => this.Frames.Dispose();
+
+        /// <inheritdoc/>
+        public override string ToString() => $"Image<{typeof(TPixel).Name}>: {this.Width}x{this.Height}";
 
         /// <summary>
         /// Switches the buffers used by the image and the pixelSource meaning that the Image will "own" the buffer from the pixelSource and the pixelSource will now own the Images buffer.
@@ -229,9 +231,9 @@ namespace SixLabors.ImageSharp
         {
             Guard.NotNull(pixelSource, nameof(pixelSource));
 
-            for (int i = 0; i < this.frames.Count; i++)
+            for (int i = 0; i < this.Frames.Count; i++)
             {
-                this.frames[i].SwapOrCopyPixelsBufferFrom(pixelSource.frames[i]);
+                this.Frames[i].SwapOrCopyPixelsBufferFrom(pixelSource.Frames[i]);
             }
         }
     }

--- a/src/ImageSharp/MetaData/ImageFrameMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageFrameMetaData.cs
@@ -33,12 +33,12 @@ namespace SixLabors.ImageSharp.MetaData
 
             foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetaData)
             {
-                this.formatMetaData.Add(meta.Key, meta.Value.DeepClone());
+                this.formatMetaData.Add(meta.Key, meta.Value.Clone());
             }
         }
 
         /// <inheritdoc/>
-        public ImageFrameMetaData DeepClone() => new ImageFrameMetaData(this);
+        public ImageFrameMetaData Clone() => new ImageFrameMetaData(this);
 
         /// <summary>
         /// Gets the metadata value associated with the specified key.

--- a/src/ImageSharp/MetaData/ImageFrameMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageFrameMetaData.cs
@@ -33,12 +33,12 @@ namespace SixLabors.ImageSharp.MetaData
 
             foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetaData)
             {
-                this.formatMetaData.Add(meta.Key, meta.Value.Clone());
+                this.formatMetaData.Add(meta.Key, meta.Value.DeepClone());
             }
         }
 
         /// <inheritdoc/>
-        public ImageFrameMetaData Clone() => new ImageFrameMetaData(this);
+        public ImageFrameMetaData DeepClone() => new ImageFrameMetaData(this);
 
         /// <summary>
         /// Gets the metadata value associated with the specified key.

--- a/src/ImageSharp/MetaData/ImageFrameMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageFrameMetaData.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
 using System.Collections.Generic;
 using SixLabors.ImageSharp.Formats;
 
@@ -10,9 +9,9 @@ namespace SixLabors.ImageSharp.MetaData
     /// <summary>
     /// Encapsulates the metadata of an image frame.
     /// </summary>
-    public sealed class ImageFrameMetaData
+    public sealed class ImageFrameMetaData : IDeepCloneable<ImageFrameMetaData>
     {
-        private readonly Dictionary<IImageFormat, object> formatMetaData = new Dictionary<IImageFormat, object>();
+        private readonly Dictionary<IImageFormat, IDeepCloneable> formatMetaData = new Dictionary<IImageFormat, IDeepCloneable>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageFrameMetaData"/> class.
@@ -32,17 +31,14 @@ namespace SixLabors.ImageSharp.MetaData
         {
             DebugGuard.NotNull(other, nameof(other));
 
-            foreach (KeyValuePair<IImageFormat, object> meta in other.formatMetaData)
+            foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetaData)
             {
-                this.formatMetaData.Add(meta.Key, meta.Value);
+                this.formatMetaData.Add(meta.Key, meta.Value.DeepClone());
             }
         }
 
-        /// <summary>
-        /// Clones this ImageFrameMetaData.
-        /// </summary>
-        /// <returns>The cloned instance.</returns>
-        public ImageFrameMetaData Clone() => new ImageFrameMetaData(this);
+        /// <inheritdoc/>
+        public ImageFrameMetaData DeepClone() => new ImageFrameMetaData(this);
 
         /// <summary>
         /// Gets the metadata value associated with the specified key.
@@ -55,9 +51,9 @@ namespace SixLabors.ImageSharp.MetaData
         /// </returns>
         public TFormatFrameMetaData GetFormatMetaData<TFormatMetaData, TFormatFrameMetaData>(IImageFormat<TFormatMetaData, TFormatFrameMetaData> key)
             where TFormatMetaData : class
-            where TFormatFrameMetaData : class
+            where TFormatFrameMetaData : class, IDeepCloneable
         {
-            if (this.formatMetaData.TryGetValue(key, out object meta))
+            if (this.formatMetaData.TryGetValue(key, out IDeepCloneable meta))
             {
                 return (TFormatFrameMetaData)meta;
             }

--- a/src/ImageSharp/MetaData/ImageMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageMetaData.cs
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.MetaData
 
             foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetaData)
             {
-                this.formatMetaData.Add(meta.Key, meta.Value.Clone());
+                this.formatMetaData.Add(meta.Key, meta.Value.DeepClone());
             }
 
             foreach (ImageProperty property in other.Properties)
@@ -68,8 +68,8 @@ namespace SixLabors.ImageSharp.MetaData
                 this.Properties.Add(property);
             }
 
-            this.ExifProfile = other.ExifProfile?.Clone();
-            this.IccProfile = other.IccProfile?.Clone();
+            this.ExifProfile = other.ExifProfile?.DeepClone();
+            this.IccProfile = other.IccProfile?.DeepClone();
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace SixLabors.ImageSharp.MetaData
         }
 
         /// <inheritdoc/>
-        public ImageMetaData Clone() => new ImageMetaData(this);
+        public ImageMetaData DeepClone() => new ImageMetaData(this);
 
         /// <summary>
         /// Looks up a property with the provided name.

--- a/src/ImageSharp/MetaData/ImageMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageMetaData.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
 using System.Collections.Generic;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.MetaData.Profiles.Exif;
@@ -12,7 +11,7 @@ namespace SixLabors.ImageSharp.MetaData
     /// <summary>
     /// Encapsulates the metadata of an image.
     /// </summary>
-    public sealed class ImageMetaData
+    public sealed class ImageMetaData : IDeepCloneable<ImageMetaData>
     {
         /// <summary>
         /// The default horizontal resolution value (dots per inch) in x direction.
@@ -26,7 +25,13 @@ namespace SixLabors.ImageSharp.MetaData
         /// </summary>
         public const double DefaultVerticalResolution = 96;
 
-        private readonly Dictionary<IImageFormat, object> formatMetaData = new Dictionary<IImageFormat, object>();
+        /// <summary>
+        /// The default pixel resolution units.
+        /// <remarks>The default value is <see cref="PixelResolutionUnit.PixelsPerInch"/>.</remarks>
+        /// </summary>
+        public const PixelResolutionUnit DefaultPixelResolutionUnits = PixelResolutionUnit.PixelsPerInch;
+
+        private readonly Dictionary<IImageFormat, IDeepCloneable> formatMetaData = new Dictionary<IImageFormat, IDeepCloneable>();
         private double horizontalResolution;
         private double verticalResolution;
 
@@ -37,6 +42,7 @@ namespace SixLabors.ImageSharp.MetaData
         {
             this.horizontalResolution = DefaultHorizontalResolution;
             this.verticalResolution = DefaultVerticalResolution;
+            this.ResolutionUnits = DefaultPixelResolutionUnits;
         }
 
         /// <summary>
@@ -52,9 +58,9 @@ namespace SixLabors.ImageSharp.MetaData
             this.VerticalResolution = other.VerticalResolution;
             this.ResolutionUnits = other.ResolutionUnits;
 
-            foreach (KeyValuePair<IImageFormat, object> meta in other.formatMetaData)
+            foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetaData)
             {
-                this.formatMetaData.Add(meta.Key, meta.Value);
+                this.formatMetaData.Add(meta.Key, meta.Value.DeepClone());
             }
 
             foreach (ImageProperty property in other.Properties)
@@ -62,13 +68,8 @@ namespace SixLabors.ImageSharp.MetaData
                 this.Properties.Add(property);
             }
 
-            this.ExifProfile = other.ExifProfile != null
-                ? new ExifProfile(other.ExifProfile)
-                : null;
-
-            this.IccProfile = other.IccProfile != null
-                ? new IccProfile(other.IccProfile)
-                : null;
+            this.ExifProfile = other.ExifProfile?.DeepClone();
+            this.IccProfile = other.IccProfile?.DeepClone();
         }
 
         /// <summary>
@@ -114,7 +115,7 @@ namespace SixLabors.ImageSharp.MetaData
         ///  02 : Pixels per centimeter
         ///  03 : Pixels per meter
         /// </summary>
-        public PixelResolutionUnit ResolutionUnits { get; set; } = PixelResolutionUnit.PixelsPerInch;
+        public PixelResolutionUnit ResolutionUnits { get; set; }
 
         /// <summary>
         /// Gets or sets the Exif profile.
@@ -140,9 +141,9 @@ namespace SixLabors.ImageSharp.MetaData
         /// The <typeparamref name="TFormatMetaData"/>.
         /// </returns>
         public TFormatMetaData GetFormatMetaData<TFormatMetaData>(IImageFormat<TFormatMetaData> key)
-             where TFormatMetaData : class
+             where TFormatMetaData : class, IDeepCloneable
         {
-            if (this.formatMetaData.TryGetValue(key, out object meta))
+            if (this.formatMetaData.TryGetValue(key, out IDeepCloneable meta))
             {
                 return (TFormatMetaData)meta;
             }
@@ -152,11 +153,8 @@ namespace SixLabors.ImageSharp.MetaData
             return newMeta;
         }
 
-        /// <summary>
-        /// Clones this into a new instance
-        /// </summary>
-        /// <returns>The cloned metadata instance</returns>
-        public ImageMetaData Clone() => new ImageMetaData(this);
+        /// <inheritdoc/>
+        public ImageMetaData DeepClone() => new ImageMetaData(this);
 
         /// <summary>
         /// Looks up a property with the provided name.

--- a/src/ImageSharp/MetaData/ImageMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageMetaData.cs
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.MetaData
 
             foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetaData)
             {
-                this.formatMetaData.Add(meta.Key, meta.Value.DeepClone());
+                this.formatMetaData.Add(meta.Key, meta.Value.Clone());
             }
 
             foreach (ImageProperty property in other.Properties)
@@ -68,8 +68,8 @@ namespace SixLabors.ImageSharp.MetaData
                 this.Properties.Add(property);
             }
 
-            this.ExifProfile = other.ExifProfile?.DeepClone();
-            this.IccProfile = other.IccProfile?.DeepClone();
+            this.ExifProfile = other.ExifProfile?.Clone();
+            this.IccProfile = other.IccProfile?.Clone();
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace SixLabors.ImageSharp.MetaData
         }
 
         /// <inheritdoc/>
-        public ImageMetaData DeepClone() => new ImageMetaData(this);
+        public ImageMetaData Clone() => new ImageMetaData(this);
 
         /// <summary>
         /// Looks up a property with the provided name.

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
 
                 foreach (ExifValue value in other.Values)
                 {
-                    this.values.Add(value.Clone());
+                    this.values.Add(value.DeepClone());
                 }
             }
 
@@ -242,7 +242,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
         }
 
         /// <inheritdoc/>
-        public ExifProfile Clone() => new ExifProfile(this);
+        public ExifProfile DeepClone() => new ExifProfile(this);
 
         /// <summary>
         /// Synchronizes the profiles with the specified meta data.

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
 
                 foreach (ExifValue value in other.Values)
                 {
-                    this.values.Add(value.DeepClone());
+                    this.values.Add(value.Clone());
                 }
             }
 
@@ -242,7 +242,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
         }
 
         /// <inheritdoc/>
-        public ExifProfile DeepClone() => new ExifProfile(this);
+        public ExifProfile Clone() => new ExifProfile(this);
 
         /// <summary>
         /// Synchronizes the profiles with the specified meta data.

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifValue.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifValue.cs
@@ -229,7 +229,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
         }
 
         /// <inheritdoc/>
-        public ExifValue DeepClone() => new ExifValue(this);
+        public ExifValue Clone() => new ExifValue(this);
 
         /// <summary>
         /// Creates a new <see cref="ExifValue"/>

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifValue.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifValue.cs
@@ -229,7 +229,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
         }
 
         /// <inheritdoc/>
-        public ExifValue Clone() => new ExifValue(this);
+        public ExifValue DeepClone() => new ExifValue(this);
 
         /// <summary>
         /// Creates a new <see cref="ExifValue"/>

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         }
 
         /// <inheritdoc/>
-        public IccProfile Clone() => new IccProfile(this);
+        public IccProfile DeepClone() => new IccProfile(this);
 
 #if !NETSTANDARD1_1
 

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     /// <summary>
     /// Represents an ICC profile
     /// </summary>
-    public sealed class IccProfile
+    public sealed class IccProfile : IDeepCloneable<IccProfile>
     {
         /// <summary>
         /// The byte array to read the ICC profile from
@@ -42,23 +42,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// Initializes a new instance of the <see cref="IccProfile"/> class.
         /// </summary>
         /// <param name="data">The raw ICC profile data</param>
-        public IccProfile(byte[] data)
-        {
-            this.data = data;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IccProfile"/> class
-        /// by making a copy from another ICC profile.
-        /// </summary>
-        /// <param name="other">The other ICC profile, where the clone should be made from.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="other"/> is null.</exception>>
-        public IccProfile(IccProfile other)
-        {
-            Guard.NotNull(other, nameof(other));
-
-            this.data = other.ToByteArray();
-        }
+        public IccProfile(byte[] data) => this.data = data;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IccProfile"/> class.
@@ -72,6 +56,19 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
 
             this.header = header;
             this.entries = new List<IccTagDataEntry>(entries);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IccProfile"/> class
+        /// by making a copy from another ICC profile.
+        /// </summary>
+        /// <param name="other">The other ICC profile, where the clone should be made from.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="other"/> is null.</exception>>
+        private IccProfile(IccProfile other)
+        {
+            Guard.NotNull(other, nameof(other));
+
+            this.data = other.ToByteArray();
         }
 
         /// <summary>
@@ -99,6 +96,9 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
                 return this.entries;
             }
         }
+
+        /// <inheritdoc/>
+        public IccProfile DeepClone() => new IccProfile(this);
 
 #if !NETSTANDARD1_1
 

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         }
 
         /// <inheritdoc/>
-        public IccProfile DeepClone() => new IccProfile(this);
+        public IccProfile Clone() => new IccProfile(this);
 
 #if !NETSTANDARD1_1
 

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -51,10 +51,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
             IEnumerable<ImageFrame<TPixel>> frames =
-                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions, x.MetaData.DeepClone()));
+                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions, x.MetaData.Clone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -51,10 +51,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
             IEnumerable<ImageFrame<TPixel>> frames =
-                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions, x.MetaData.Clone()));
+                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
             IEnumerable<ImageFrame<TPixel>> frames =
-                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions, x.MetaData.Clone()));
+                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
             return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.CropRectangle.Width, this.CropRectangle.Height, x.MetaData.Clone()));
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.CropRectangle.Width, this.CropRectangle.Height, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
             return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -36,10 +36,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.CropRectangle.Width, this.CropRectangle.Height, x.MetaData.DeepClone()));
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.CropRectangle.Width, this.CropRectangle.Height, x.MetaData.Clone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -36,10 +36,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.CropRectangle.Width, this.CropRectangle.Height, x.MetaData.Clone()));
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.CropRectangle.Width, this.CropRectangle.Height, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -39,7 +39,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.CropRectangle.Width, this.CropRectangle.Height, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions.Width, this.TargetDimensions.Height, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -51,10 +51,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
             IEnumerable<ImageFrame<TPixel>> frames =
-                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions.Width, this.TargetDimensions.Height, x.MetaData.Clone()));
+                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions.Width, this.TargetDimensions.Height, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
             IEnumerable<ImageFrame<TPixel>> frames =
-                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions.Width, this.TargetDimensions.Height, x.MetaData.Clone()));
+                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions.Width, this.TargetDimensions.Height, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
             return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -51,10 +51,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
             IEnumerable<ImageFrame<TPixel>> frames =
-                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions.Width, this.TargetDimensions.Height, x.MetaData.DeepClone()));
+                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions.Width, this.TargetDimensions.Height, x.MetaData.Clone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
@@ -218,7 +218,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
@@ -215,7 +215,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.MetaData.Clone()));
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
             return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);

--- a/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
@@ -215,10 +215,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.MetaData.DeepClone()));
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.MetaData.Clone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResizeProcessor.cs
@@ -215,10 +215,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.MetaData.Clone()));
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.MetaData.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.Clone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/tests/ImageSharp.Tests/ConfigurationTests.cs
+++ b/tests/ImageSharp.Tests/ConfigurationTests.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Tests
         {
             // the shallow copy of configuration should behave exactly like the default configuration,
             // so by using the copy, we test both the default and the copy.
-            this.DefaultConfiguration = Configuration.CreateDefaultInstance().ShallowCopy();
+            this.DefaultConfiguration = Configuration.CreateDefaultInstance().Clone();
             this.ConfigurationEmpty = new Configuration();
         }
 

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpMetaDataTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Formats.Bmp;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Bmp
+{
+    public class BmpMetaDataTests
+    {
+        [Fact]
+        public void CloneIsDeep()
+        {
+            var meta = new BmpMetaData() { BitsPerPixel = BmpBitsPerPixel.Pixel24 };
+            var clone = (BmpMetaData)meta.DeepClone();
+
+            clone.BitsPerPixel = BmpBitsPerPixel.Pixel32;
+
+            Assert.False(meta.BitsPerPixel.Equals(clone.BitsPerPixel));
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpMetaDataTests.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         public void CloneIsDeep()
         {
             var meta = new BmpMetaData() { BitsPerPixel = BmpBitsPerPixel.Pixel24 };
-            var clone = (BmpMetaData)meta.DeepClone();
+            var clone = (BmpMetaData)meta.Clone();
 
             clone.BitsPerPixel = BmpBitsPerPixel.Pixel32;
 

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpMetaDataTests.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         public void CloneIsDeep()
         {
             var meta = new BmpMetaData() { BitsPerPixel = BmpBitsPerPixel.Pixel24 };
-            var clone = (BmpMetaData)meta.Clone();
+            var clone = (BmpMetaData)meta.DeepClone();
 
             clone.BitsPerPixel = BmpBitsPerPixel.Pixel32;
 

--- a/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetaDataTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Formats.Gif;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Gif
+{
+    public class GifFrameMetaDataTests
+    {
+        [Fact]
+        public void CloneIsDeep()
+        {
+            var meta = new GifFrameMetaData()
+            {
+                FrameDelay = 1,
+                DisposalMethod = GifDisposalMethod.RestoreToBackground,
+                ColorTableLength = 2
+            };
+
+            var clone = (GifFrameMetaData)meta.DeepClone();
+
+            clone.FrameDelay = 2;
+            clone.DisposalMethod = GifDisposalMethod.RestoreToPrevious;
+            clone.ColorTableLength = 1;
+
+            Assert.False(meta.FrameDelay.Equals(clone.FrameDelay));
+            Assert.False(meta.DisposalMethod.Equals(clone.DisposalMethod));
+            Assert.False(meta.ColorTableLength.Equals(clone.ColorTableLength));
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetaDataTests.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 ColorTableLength = 2
             };
 
-            var clone = (GifFrameMetaData)meta.DeepClone();
+            var clone = (GifFrameMetaData)meta.Clone();
 
             clone.FrameDelay = 2;
             clone.DisposalMethod = GifDisposalMethod.RestoreToPrevious;

--- a/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetaDataTests.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 ColorTableLength = 2
             };
 
-            var clone = (GifFrameMetaData)meta.Clone();
+            var clone = (GifFrameMetaData)meta.DeepClone();
 
             clone.FrameDelay = 2;
             clone.DisposalMethod = GifDisposalMethod.RestoreToPrevious;

--- a/tests/ImageSharp.Tests/Formats/Gif/GifMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifMetaDataTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Formats.Gif;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Gif
+{
+    public class GifMetaDataTests
+    {
+        [Fact]
+        public void CloneIsDeep()
+        {
+            var meta = new GifMetaData()
+            {
+                RepeatCount = 1,
+                ColorTableMode = GifColorTableMode.Global,
+                GlobalColorTableLength = 2
+            };
+
+            var clone = (GifMetaData)meta.DeepClone();
+
+            clone.RepeatCount = 2;
+            clone.ColorTableMode = GifColorTableMode.Local;
+            clone.GlobalColorTableLength = 1;
+
+            Assert.False(meta.RepeatCount.Equals(clone.RepeatCount));
+            Assert.False(meta.ColorTableMode.Equals(clone.ColorTableMode));
+            Assert.False(meta.GlobalColorTableLength.Equals(clone.GlobalColorTableLength));
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Gif/GifMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifMetaDataTests.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 GlobalColorTableLength = 2
             };
 
-            var clone = (GifMetaData)meta.Clone();
+            var clone = (GifMetaData)meta.DeepClone();
 
             clone.RepeatCount = 2;
             clone.ColorTableMode = GifColorTableMode.Local;

--- a/tests/ImageSharp.Tests/Formats/Gif/GifMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifMetaDataTests.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 GlobalColorTableLength = 2
             };
 
-            var clone = (GifMetaData)meta.DeepClone();
+            var clone = (GifMetaData)meta.Clone();
 
             clone.RepeatCount = 2;
             clone.ColorTableMode = GifColorTableMode.Local;

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegMetaDataTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Formats.Jpeg;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Jpg
+{
+    public class JpegMetaDataTests
+    {
+        [Fact]
+        public void CloneIsDeep()
+        {
+            var meta = new JpegMetaData() { Quality = 50 };
+            var clone = (JpegMetaData)meta.DeepClone();
+
+            clone.Quality = 99;
+
+            Assert.False(meta.Quality.Equals(clone.Quality));
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegMetaDataTests.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         public void CloneIsDeep()
         {
             var meta = new JpegMetaData() { Quality = 50 };
-            var clone = (JpegMetaData)meta.DeepClone();
+            var clone = (JpegMetaData)meta.Clone();
 
             clone.Quality = 99;
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegMetaDataTests.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         public void CloneIsDeep()
         {
             var meta = new JpegMetaData() { Quality = 50 };
-            var clone = (JpegMetaData)meta.Clone();
+            var clone = (JpegMetaData)meta.DeepClone();
 
             clone.Quality = 99;
 

--- a/tests/ImageSharp.Tests/Formats/Png/PngMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngMetaDataTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Formats.Png;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Png
+{
+    public class PngMetaDataTests
+    {
+        [Fact]
+        public void CloneIsDeep()
+        {
+            var meta = new PngMetaData()
+            {
+                BitDepth = PngBitDepth.Bit16,
+                ColorType = PngColorType.GrayscaleWithAlpha,
+                Gamma = 2
+            };
+            var clone = (PngMetaData)meta.DeepClone();
+
+            clone.BitDepth = PngBitDepth.Bit2;
+            clone.ColorType = PngColorType.Palette;
+            clone.Gamma = 1;
+
+            Assert.False(meta.BitDepth.Equals(clone.BitDepth));
+            Assert.False(meta.ColorType.Equals(clone.ColorType));
+            Assert.False(meta.Gamma.Equals(clone.Gamma));
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Png/PngMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngMetaDataTests.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 ColorType = PngColorType.GrayscaleWithAlpha,
                 Gamma = 2
             };
-            var clone = (PngMetaData)meta.Clone();
+            var clone = (PngMetaData)meta.DeepClone();
 
             clone.BitDepth = PngBitDepth.Bit2;
             clone.ColorType = PngColorType.Palette;

--- a/tests/ImageSharp.Tests/Formats/Png/PngMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngMetaDataTests.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 ColorType = PngColorType.GrayscaleWithAlpha,
                 Gamma = 2
             };
-            var clone = (PngMetaData)meta.DeepClone();
+            var clone = (PngMetaData)meta.Clone();
 
             clone.BitDepth = PngBitDepth.Bit2;
             clone.ColorType = PngColorType.Palette;

--- a/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
@@ -84,7 +84,7 @@ namespace SixLabors.ImageSharp.Tests
             [Fact]
             public void WrapMemory_CreatedImageIsCorrect()
             {
-                Configuration cfg = Configuration.Default.ShallowCopy();
+                Configuration cfg = Configuration.Default.Clone();
                 var metaData = new ImageMetaData();
 
                 var array = new Rgba32[25];

--- a/tests/ImageSharp.Tests/Image/ImageTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Tests
             [Fact]
             public void Configuration_Width_Height()
             {
-                Configuration configuration = Configuration.Default.ShallowCopy();
+                Configuration configuration = Configuration.Default.Clone();
 
                 using (var image = new Image<Rgba32>(configuration, 11, 23))
                 {
@@ -48,7 +48,7 @@ namespace SixLabors.ImageSharp.Tests
             [Fact]
             public void Configuration_Width_Height_BackroundColor()
             {
-                Configuration configuration = Configuration.Default.ShallowCopy();
+                Configuration configuration = Configuration.Default.Clone();
                 Rgba32 color = Rgba32.Aquamarine;
 
                 using (var image = new Image<Rgba32>(configuration, 11, 23, color))

--- a/tests/ImageSharp.Tests/MetaData/ImageFrameMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImageFrameMetaDataTests.cs
@@ -32,5 +32,13 @@ namespace SixLabors.ImageSharp.Tests
             Assert.Equal(colorTableLength, cloneGifFrameMetaData.ColorTableLength);
             Assert.Equal(disposalMethod, cloneGifFrameMetaData.DisposalMethod);
         }
+
+        [Fact]
+        public void CloneIsDeep()
+        {
+            var metaData = new ImageFrameMetaData();
+            ImageFrameMetaData clone = metaData.DeepClone();
+            Assert.False(metaData.GetFormatMetaData(GifFormat.Instance).Equals(clone.GetFormatMetaData(GifFormat.Instance)));
+        }
     }
 }

--- a/tests/ImageSharp.Tests/MetaData/ImageFrameMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImageFrameMetaDataTests.cs
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Tests
         public void CloneIsDeep()
         {
             var metaData = new ImageFrameMetaData();
-            ImageFrameMetaData clone = metaData.Clone();
+            ImageFrameMetaData clone = metaData.DeepClone();
             Assert.False(metaData.GetFormatMetaData(GifFormat.Instance).Equals(clone.GetFormatMetaData(GifFormat.Instance)));
         }
     }

--- a/tests/ImageSharp.Tests/MetaData/ImageFrameMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImageFrameMetaDataTests.cs
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Tests
         public void CloneIsDeep()
         {
             var metaData = new ImageFrameMetaData();
-            ImageFrameMetaData clone = metaData.DeepClone();
+            ImageFrameMetaData clone = metaData.Clone();
             Assert.False(metaData.GetFormatMetaData(GifFormat.Instance).Equals(clone.GetFormatMetaData(GifFormat.Instance)));
         }
     }

--- a/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Tests
             metaData.VerticalResolution = 2;
             metaData.Properties.Add(imageProperty);
 
-            ImageMetaData clone = metaData.Clone();
+            ImageMetaData clone = metaData.DeepClone();
 
             Assert.Equal(exifProfile.ToByteArray(), clone.ExifProfile.ToByteArray());
             Assert.Equal(4, clone.HorizontalResolution);
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Tests
             metaData.VerticalResolution = 2;
             metaData.Properties.Add(imageProperty);
 
-            ImageMetaData clone = metaData.Clone();
+            ImageMetaData clone = metaData.DeepClone();
             clone.HorizontalResolution = 2;
             clone.VerticalResolution = 4;
 

--- a/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Tests
             metaData.VerticalResolution = 2;
             metaData.Properties.Add(imageProperty);
 
-            ImageMetaData clone = metaData.DeepClone();
+            ImageMetaData clone = metaData.Clone();
 
             Assert.Equal(exifProfile.ToByteArray(), clone.ExifProfile.ToByteArray());
             Assert.Equal(4, clone.HorizontalResolution);
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Tests
             metaData.VerticalResolution = 2;
             metaData.Properties.Add(imageProperty);
 
-            ImageMetaData clone = metaData.DeepClone();
+            ImageMetaData clone = metaData.Clone();
             clone.HorizontalResolution = 2;
             clone.VerticalResolution = 4;
 

--- a/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
+using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.MetaData;
 using SixLabors.ImageSharp.MetaData.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
@@ -38,18 +38,42 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         [Fact]
+        public void CloneIsDeep()
+        {
+            var metaData = new ImageMetaData();
+
+            var exifProfile = new ExifProfile();
+            var imageProperty = new ImageProperty("name", "value");
+
+            metaData.ExifProfile = exifProfile;
+            metaData.HorizontalResolution = 4;
+            metaData.VerticalResolution = 2;
+            metaData.Properties.Add(imageProperty);
+
+            ImageMetaData clone = metaData.DeepClone();
+            clone.HorizontalResolution = 2;
+            clone.VerticalResolution = 4;
+
+            Assert.False(metaData.ExifProfile.Equals(clone.ExifProfile));
+            Assert.False(metaData.HorizontalResolution.Equals(clone.HorizontalResolution));
+            Assert.False(metaData.VerticalResolution.Equals(clone.VerticalResolution));
+            Assert.False(metaData.Properties.Equals(clone.Properties));
+            Assert.False(metaData.GetFormatMetaData(GifFormat.Instance).Equals(clone.GetFormatMetaData(GifFormat.Instance)));
+        }
+
+        [Fact]
         public void HorizontalResolution()
         {
             var metaData = new ImageMetaData();
             Assert.Equal(96, metaData.HorizontalResolution);
 
-            metaData.HorizontalResolution=0;
+            metaData.HorizontalResolution = 0;
             Assert.Equal(96, metaData.HorizontalResolution);
 
-            metaData.HorizontalResolution=-1;
+            metaData.HorizontalResolution = -1;
             Assert.Equal(96, metaData.HorizontalResolution);
 
-            metaData.HorizontalResolution=1;
+            metaData.HorizontalResolution = 1;
             Assert.Equal(1, metaData.HorizontalResolution);
         }
 

--- a/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Tests
             metaData.VerticalResolution = 2;
             metaData.Properties.Add(imageProperty);
 
-            ImageMetaData clone = metaData.Clone();
+            ImageMetaData clone = metaData.DeepClone();
 
             Assert.Equal(exifProfile.ToByteArray(), clone.ExifProfile.ToByteArray());
             Assert.Equal(4, clone.HorizontalResolution);

--- a/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
@@ -67,16 +67,16 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void ConstructorCopy()
         {
-            Assert.Throws<ArgumentNullException>(() => { new ExifProfile((ExifProfile)null); });
+            Assert.Throws<NullReferenceException>(() => ((ExifProfile)null).DeepClone());
 
             ExifProfile profile = GetExifProfile();
 
-            var clone = new ExifProfile(profile);
+            ExifProfile clone = profile.DeepClone();
             TestProfile(clone);
 
             profile.SetValue(ExifTag.ColorSpace, (ushort)2);
 
-            clone = new ExifProfile(profile);
+            clone = profile.DeepClone();
             TestProfile(clone);
         }
 
@@ -234,10 +234,12 @@ namespace SixLabors.ImageSharp.Tests
             exifProfile.SetValue(ExifTag.XResolution, new Rational(200));
             exifProfile.SetValue(ExifTag.YResolution, new Rational(300));
 
-            var metaData = new ImageMetaData();
-            metaData.ExifProfile = exifProfile;
-            metaData.HorizontalResolution = 200;
-            metaData.VerticalResolution = 300;
+            var metaData = new ImageMetaData
+            {
+                ExifProfile = exifProfile,
+                HorizontalResolution = 200,
+                VerticalResolution = 300
+            };
 
             metaData.HorizontalResolution = 100;
 
@@ -355,11 +357,11 @@ namespace SixLabors.ImageSharp.Tests
 
             // act
             Image<Rgba32> reloadedImage = WriteAndRead(image, imageFormat);
-            
+
             // assert
             ExifProfile actual = reloadedImage.MetaData.ExifProfile;
             Assert.NotNull(actual);
-            foreach(KeyValuePair<ExifTag, object> expectedProfileValue in TestProfileValues)
+            foreach (KeyValuePair<ExifTag, object> expectedProfileValue in TestProfileValues)
             {
                 ExifValue actualProfileValue = actual.GetValue(expectedProfileValue.Key);
                 Assert.NotNull(actualProfileValue);
@@ -371,7 +373,7 @@ namespace SixLabors.ImageSharp.Tests
         public void ProfileToByteArray()
         {
             // arrange
-            byte[] exifBytesWithExifCode = ProfileResolver.ExifMarker.Concat(ExifConstants.LittleEndianByteOrderMarker).ToArray(); 
+            byte[] exifBytesWithExifCode = ProfileResolver.ExifMarker.Concat(ExifConstants.LittleEndianByteOrderMarker).ToArray();
             byte[] exifBytesWithoutExifCode = ExifConstants.LittleEndianByteOrderMarker;
             ExifProfile expectedProfile = CreateExifProfile();
             var expectedProfileTags = expectedProfile.Values.Select(x => x.Tag).ToList();
@@ -384,7 +386,7 @@ namespace SixLabors.ImageSharp.Tests
             Assert.NotNull(actualBytes);
             Assert.NotEmpty(actualBytes);
             Assert.Equal(exifBytesWithoutExifCode, actualBytes.Take(exifBytesWithoutExifCode.Length).ToArray());
-            foreach(ExifTag expectedProfileTag in expectedProfileTags)
+            foreach (ExifTag expectedProfileTag in expectedProfileTags)
             {
                 ExifValue actualProfileValue = actualProfile.GetValue(expectedProfileTag);
                 ExifValue expectedProfileValue = expectedProfile.GetValue(expectedProfileTag);
@@ -396,7 +398,7 @@ namespace SixLabors.ImageSharp.Tests
         {
             var profile = new ExifProfile();
 
-            foreach(KeyValuePair<ExifTag, object> exifProfileValue in TestProfileValues)
+            foreach (KeyValuePair<ExifTag, object> exifProfileValue in TestProfileValues)
             {
                 profile.SetValue(exifProfileValue.Key, exifProfileValue.Value);
             }
@@ -416,7 +418,7 @@ namespace SixLabors.ImageSharp.Tests
 
         private static Image<Rgba32> WriteAndRead(Image<Rgba32> image, TestImageWriteFormat imageFormat)
         {
-            switch(imageFormat)
+            switch (imageFormat)
             {
                 case TestImageWriteFormat.Jpeg:
                     return WriteAndReadJpeg(image);

--- a/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
@@ -67,16 +67,16 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void ConstructorCopy()
         {
-            Assert.Throws<NullReferenceException>(() => ((ExifProfile)null).Clone());
+            Assert.Throws<NullReferenceException>(() => ((ExifProfile)null).DeepClone());
 
             ExifProfile profile = GetExifProfile();
 
-            ExifProfile clone = profile.Clone();
+            ExifProfile clone = profile.DeepClone();
             TestProfile(clone);
 
             profile.SetValue(ExifTag.ColorSpace, (ushort)2);
 
-            clone = profile.Clone();
+            clone = profile.DeepClone();
             TestProfile(clone);
         }
 

--- a/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
@@ -67,16 +67,16 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void ConstructorCopy()
         {
-            Assert.Throws<NullReferenceException>(() => ((ExifProfile)null).DeepClone());
+            Assert.Throws<NullReferenceException>(() => ((ExifProfile)null).Clone());
 
             ExifProfile profile = GetExifProfile();
 
-            ExifProfile clone = profile.DeepClone();
+            ExifProfile clone = profile.Clone();
             TestProfile(clone);
 
             profile.SetValue(ExifTag.ColorSpace, (ushort)2);
 
-            clone = profile.DeepClone();
+            clone = profile.Clone();
             TestProfile(clone);
         }
 

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp.Tests
 
         public virtual string SourceFileOrDescription => "";
 
-        public Configuration Configuration { get; set; } = Configuration.Default.ShallowCopy();
+        public Configuration Configuration { get; set; } = Configuration.Default.Clone();
 
         /// <summary>
         /// Utility instance to provide informations about the test image & manage input/output


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I've introduced a new pair of interfaces here `IDeepCloneable` and `IDeepCloneable<T>` to ensure we force deep cloning of metadata objects in the library. This fixes an issue we introduced in #693 

I'd like to add the interface in a few more places actually to ensure that any cloning intent is unambiguous. There's a few places where it's not clear. I think adding a `IShallowCloneable` interface might be wise also since `ICloneable` is not available across all our target frameworks.

<!-- Thanks for contributing to ImageSharp! -->
