### PR TITLE
Fix issue on mono <= 5.14 when reading multiple png data chunks.

### DIFF
--- a/src/ImageSharp/Formats/Png/Zlib/ZlibInflateStream.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/ZlibInflateStream.cs
@@ -53,12 +53,19 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         private int currentDataRemaining;
 
         /// <summary>
+        /// Delegate to get more data once we've exhausted the current data remaining
+        /// </summary>
+        private Func<int> getData;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ZlibInflateStream"/> class.
         /// </summary>
         /// <param name="innerStream">The inner raw stream</param>
-        public ZlibInflateStream(Stream innerStream)
+        /// <param name="getData">A delegate to get more data from the inner stream</param>
+        public ZlibInflateStream(Stream innerStream, Func<int> getData)
         {
             this.innerStream = innerStream;
+            this.getData = getData;
         }
 
         /// <inheritdoc/>
@@ -112,7 +119,12 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         {
             if (this.currentDataRemaining == 0)
             {
-                return 0;
+				this.currentDataRemaining = this.getData();
+
+				if (this.currentDataRemaining == 0)
+				{
+					return 0;
+				}
             }
 
             int bytesToRead = Math.Min(count, this.currentDataRemaining);

--- a/src/ImageSharp/Formats/Png/Zlib/ZlibInflateStream.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/ZlibInflateStream.cs
@@ -43,11 +43,6 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         private bool isDisposed;
 
         /// <summary>
-        /// Whether the crc value has been read.
-        /// </summary>
-        private bool crcRead;
-
-        /// <summary>
         /// The current data remaining to be read
         /// </summary>
         private int currentDataRemaining;
@@ -119,17 +114,36 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         {
             if (this.currentDataRemaining == 0)
             {
-				this.currentDataRemaining = this.getData();
+                // last buffer was read in its entirety, let's make sure we don't actually have more
+                this.currentDataRemaining = this.getData();
 
-				if (this.currentDataRemaining == 0)
-				{
-					return 0;
-				}
+                if (this.currentDataRemaining == 0)
+                {
+                    return 0;
+                }
             }
 
             int bytesToRead = Math.Min(count, this.currentDataRemaining);
             this.currentDataRemaining -= bytesToRead;
-            return this.innerStream.Read(buffer, offset, bytesToRead);
+            int bytesRead = this.innerStream.Read(buffer, offset, bytesToRead);
+
+            // keep reading data until we've reached the end of the stream or filled the buffer
+            while (this.currentDataRemaining == 0 && bytesRead < count)
+            {
+                this.currentDataRemaining = this.getData();
+
+                if (this.currentDataRemaining == 0)
+                {
+                    return bytesRead;
+                }
+
+                offset += bytesRead;
+                bytesToRead = Math.Min(count - bytesRead, this.currentDataRemaining);
+                this.currentDataRemaining -= bytesToRead;
+                bytesRead += this.innerStream.Read(buffer, offset, bytesToRead);
+            }
+
+            return bytesRead;
         }
 
         /// <inheritdoc/>
@@ -165,14 +179,6 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
                 {
                     this.compressedStream.Dispose();
                     this.compressedStream = null;
-
-                    if (!this.crcRead)
-                    {
-                        // Consume the trailing 4 bytes
-                        this.innerStream.Read(ChecksumBuffer, 0, 4);
-                        this.currentDataRemaining -= 4;
-                        this.crcRead = true;
-                    }
                 }
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
This fixes #598 when decoding PNG data chunks in mono.  

Some people might appreciate this fix, as: 
- it will take a while for the [fix in mono](https://github.com/mono/mono/pull/10329) to make it to a stable release (looks like it is back ported to 5.18 at least)
- sometimes you are developing for software that embeds an old version of mono (like we do)
- or, you might not have control over what version of mono you get to target

What this does is changes `PngDecoderCore` and `ZlibInflateStream` so that when it is finished with the current chunk, it attempts to read the next data chunk before returning less than the buffer count from its `Read()` method.  Doing so would stop the `DeflateStream` from continuing, even on Windows.  It will only return less than the buffer count after it reads a non-data chunk, then forwards that chunk to the next call of `TryReadChunk`.

The [PNG spec](http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html) specifies that all data chunks must be consecutive, which this code takes advantage of. Specifically:

>There can be multiple IDAT chunks; if so, they must appear consecutively with no other intervening chunks

I've tried to follow the same coding conventions (no warnings in VS), and tried to make the changes as minimal as possible.  I also ran all unit tests to ensure they pass.  I believe a few of the existing unit tests will fail on mono, so I didn't add any new unit tests (plus, I can't seem to figure out how to run the xunit tests on macOS, they all fail with `System.TypeLoadException : Could not resolve the signature of a virtual method`).

Please let me know if there's anything that isn't quite right, and thanks for your time!