### PR TITLE
Add 1, 2, and 4 bit Png Encoding

### DIFF
--- a/src/ImageSharp/Formats/Png/IPngEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Png/IPngEncoderOptions.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <summary>
         /// Gets the filter method.
         /// </summary>
-        PngFilterMethod FilterMethod { get; }
+        PngFilterMethod? FilterMethod { get; }
 
         /// <summary>
         /// Gets the compression level 1-9.

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -396,18 +396,18 @@ namespace SixLabors.ImageSharp.Formats.Png
             }
 
             buffer = this.memoryAllocator.AllocateManagedByteBuffer(bytesPerScanline * 8 / bits, AllocationOptions.Clean);
-            byte[] result = buffer.Array;
+            ref byte sourceRef = ref MemoryMarshal.GetReference(source);
+            ref byte resultRef = ref buffer.Array[0];
             int mask = 0xFF >> (8 - bits);
             int resultOffset = 0;
 
             for (int i = 0; i < bytesPerScanline; i++)
             {
-                byte b = source[i];
+                byte b = Unsafe.Add(ref sourceRef, i);
                 for (int shift = 0; shift < 8; shift += bits)
                 {
                     int colorIndex = (b >> (8 - bits - shift)) & mask;
-                    result[resultOffset] = (byte)colorIndex;
-
+                    Unsafe.Add(ref resultRef, resultOffset) = (byte)colorIndex;
                     resultOffset++;
                 }
             }

--- a/src/ImageSharp/Formats/Png/PngEncoder.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoder.cs
@@ -27,7 +27,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <summary>
         /// Gets or sets the filter method.
         /// </summary>
-        public PngFilterMethod FilterMethod { get; set; } = PngFilterMethod.Paeth;
+        public PngFilterMethod? FilterMethod { get; set; }
 
         /// <summary>
         /// Gets or sets the compression level 1-9.

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -852,17 +852,18 @@ namespace SixLabors.ImageSharp.Formats.Png
             byte shift0 = (byte)(8 - bits);
             int shift = 8 - bits;
             int v = 0;
+            int resultOffset = 0;
 
-            for (int i = 0, j = 0; j < source.Length; j++)
+            for (int i = 0; i < source.Length; i++)
             {
-                int value = source[j] & mask;
+                int value = source[i] & mask;
                 v |= value << shift;
 
                 if (shift == 0)
                 {
                     shift = shift0;
-                    result[i] = (byte)v;
-                    i++;
+                    result[resultOffset] = (byte)v;
+                    resultOffset++;
                     v = 0;
                 }
                 else
@@ -873,7 +874,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
             if (shift != shift0)
             {
-                result[0] = (byte)v;
+                result[resultOffset] = (byte)v;
             }
         }
 

--- a/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
+++ b/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
@@ -1,0 +1,600 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Png
+{
+    /// <summary>
+    /// Provides methods to allow the decoding of raw scanlines to image rows of different pixel formats.
+    /// </summary>
+    internal static class PngScanlineProcessor
+    {
+        public static void ProcessGrayscaleScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            bool hasTrans,
+            ushort luminance16Trans,
+            byte luminanceTrans)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+            int scaleFactor = 255 / (ImageMaths.GetColorCountForBitDepth(header.BitDepth) - 1);
+
+            if (!hasTrans)
+            {
+                if (header.BitDepth == 16)
+                {
+                    Rgb48 rgb48 = default;
+                    for (int x = 0, o = 0; x < header.Width; x++, o += 2)
+                    {
+                        ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
+                        rgb48.R = luminance;
+                        rgb48.G = luminance;
+                        rgb48.B = luminance;
+
+                        pixel.PackFromRgb48(rgb48);
+                        Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    }
+                }
+                else
+                {
+                    // TODO: We should really be using Rgb24 here but IPixel does not have a PackFromRgb24 method.
+                    var rgba32 = new Rgba32(0, 0, 0, byte.MaxValue);
+                    for (int x = 0; x < header.Width; x++)
+                    {
+                        byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, x) * scaleFactor);
+                        rgba32.R = luminance;
+                        rgba32.G = luminance;
+                        rgba32.B = luminance;
+
+                        pixel.PackFromRgba32(rgba32);
+                        Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    }
+                }
+
+                return;
+            }
+
+            if (header.BitDepth == 16)
+            {
+                Rgba64 rgba64 = default;
+                for (int x = 0, o = 0; x < header.Width; x++, o += 2)
+                {
+                    ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
+                    rgba64.R = luminance;
+                    rgba64.G = luminance;
+                    rgba64.B = luminance;
+                    rgba64.A = luminance.Equals(luminance16Trans) ? ushort.MinValue : ushort.MaxValue;
+
+                    pixel.PackFromRgba64(rgba64);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                Rgba32 rgba32 = default;
+                for (int x = 0; x < header.Width; x++)
+                {
+                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, x) * scaleFactor);
+                    rgba32.R = luminance;
+                    rgba32.G = luminance;
+                    rgba32.B = luminance;
+                    rgba32.A = luminance.Equals(luminanceTrans) ? byte.MinValue : byte.MaxValue;
+
+                    pixel.PackFromRgba32(rgba32);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+        }
+
+        public static void ProcessInterlacedGrayscaleScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            int pixelOffset,
+            int increment,
+            bool hasTrans,
+            ushort luminance16Trans,
+            byte luminanceTrans)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+            int scaleFactor = 255 / (ImageMaths.GetColorCountForBitDepth(header.BitDepth) - 1);
+
+            if (!hasTrans)
+            {
+                if (header.BitDepth == 16)
+                {
+                    Rgb48 rgb48 = default;
+                    for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += 2)
+                    {
+                        ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
+                        rgb48.R = luminance;
+                        rgb48.G = luminance;
+                        rgb48.B = luminance;
+
+                        pixel.PackFromRgb48(rgb48);
+                        Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    }
+                }
+                else
+                {
+                    // TODO: We should really be using Rgb24 here but IPixel does not have a PackFromRgb24 method.
+                    var rgba32 = new Rgba32(0, 0, 0, byte.MaxValue);
+                    for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
+                    {
+                        byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, o) * scaleFactor);
+                        rgba32.R = luminance;
+                        rgba32.G = luminance;
+                        rgba32.B = luminance;
+
+                        pixel.PackFromRgba32(rgba32);
+                        Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    }
+                }
+
+                return;
+            }
+
+            if (header.BitDepth == 16)
+            {
+                Rgba64 rgba64 = default;
+                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += 2)
+                {
+                    ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
+                    rgba64.R = luminance;
+                    rgba64.G = luminance;
+                    rgba64.B = luminance;
+                    rgba64.A = luminance.Equals(luminance16Trans) ? ushort.MinValue : ushort.MaxValue;
+
+                    pixel.PackFromRgba64(rgba64);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                Rgba32 rgba32 = default;
+                for (int x = pixelOffset; x < header.Width; x += increment)
+                {
+                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, x) * scaleFactor);
+                    rgba32.R = luminance;
+                    rgba32.G = luminance;
+                    rgba32.B = luminance;
+                    rgba32.A = luminance.Equals(luminanceTrans) ? byte.MinValue : byte.MaxValue;
+
+                    pixel.PackFromRgba32(rgba32);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+        }
+
+        public static void ProcessGrayscaleWithAlphaScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            int bytesPerPixel,
+            int bytesPerSample)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+
+            if (header.BitDepth == 16)
+            {
+                Rgba64 rgba64 = default;
+                for (int x = 0, o = 0; x < header.Width; x++, o += 4)
+                {
+                    ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
+                    ushort alpha = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + 2, 2));
+                    rgba64.R = luminance;
+                    rgba64.G = luminance;
+                    rgba64.B = luminance;
+                    rgba64.A = alpha;
+
+                    pixel.PackFromRgba64(rgba64);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                Rgba32 rgba32 = default;
+                int bps = bytesPerSample;
+                for (int x = 0; x < header.Width; x++)
+                {
+                    int offset = x * bytesPerPixel;
+                    byte luminance = Unsafe.Add(ref scanlineSpanRef, offset);
+                    byte alpha = Unsafe.Add(ref scanlineSpanRef, offset + bps);
+
+                    rgba32.R = luminance;
+                    rgba32.G = luminance;
+                    rgba32.B = luminance;
+                    rgba32.A = alpha;
+
+                    pixel.PackFromRgba32(rgba32);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+        }
+
+        public static void ProcessInterlacedGrayscaleWithAlphaScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            int pixelOffset,
+            int increment,
+            int bytesPerPixel,
+            int bytesPerSample)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+
+            if (header.BitDepth == 16)
+            {
+                Rgba64 rgba64 = default;
+                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += 4)
+                {
+                    ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
+                    ushort alpha = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + 2, 2));
+                    rgba64.R = luminance;
+                    rgba64.G = luminance;
+                    rgba64.B = luminance;
+                    rgba64.A = alpha;
+
+                    pixel.PackFromRgba64(rgba64);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                Rgba32 rgba32 = default;
+                for (int x = pixelOffset; x < header.Width; x += increment)
+                {
+                    int offset = x * bytesPerPixel;
+                    byte luminance = Unsafe.Add(ref scanlineSpanRef, offset);
+                    byte alpha = Unsafe.Add(ref scanlineSpanRef, offset + bytesPerSample);
+                    rgba32.R = luminance;
+                    rgba32.G = luminance;
+                    rgba32.B = luminance;
+                    rgba32.A = alpha;
+
+                    pixel.PackFromRgba32(rgba32);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+        }
+
+        public static void ProcessPaletteScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            ReadOnlySpan<byte> palette,
+            byte[] paletteAlpha)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+            ReadOnlySpan<Rgb24> palettePixels = MemoryMarshal.Cast<byte, Rgb24>(palette);
+            ref Rgb24 palettePixelsRef = ref MemoryMarshal.GetReference(palettePixels);
+
+            if (paletteAlpha?.Length > 0)
+            {
+                // If the alpha palette is not null and has one or more entries, this means, that the image contains an alpha
+                // channel and we should try to read it.
+                Rgba32 rgba = default;
+                ref byte paletteAlphaRef = ref paletteAlpha[0];
+
+                for (int x = 0; x < header.Width; x++)
+                {
+                    int index = Unsafe.Add(ref scanlineSpanRef, x);
+                    rgba.Rgb = Unsafe.Add(ref palettePixelsRef, index);
+                    rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, index) : byte.MaxValue;
+
+                    pixel.PackFromRgba32(rgba);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                // TODO: We should have PackFromRgb24.
+                var rgba = new Rgba32(0, 0, 0, byte.MaxValue);
+                for (int x = 0; x < header.Width; x++)
+                {
+                    int index = Unsafe.Add(ref scanlineSpanRef, x);
+                    rgba.Rgb = Unsafe.Add(ref palettePixelsRef, index);
+
+                    pixel.PackFromRgba32(rgba);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+        }
+
+        public static void ProcessInterlacedPaletteScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            int pixelOffset,
+            int increment,
+            ReadOnlySpan<byte> palette,
+            byte[] paletteAlpha)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+            ReadOnlySpan<Rgb24> palettePixels = MemoryMarshal.Cast<byte, Rgb24>(palette);
+            ref Rgb24 palettePixelsRef = ref MemoryMarshal.GetReference(palettePixels);
+
+            if (paletteAlpha?.Length > 0)
+            {
+                // If the alpha palette is not null and has one or more entries, this means, that the image contains an alpha
+                // channel and we should try to read it.
+                Rgba32 rgba = default;
+                ref byte paletteAlphaRef = ref paletteAlpha[0];
+                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
+                {
+                    int index = Unsafe.Add(ref scanlineSpanRef, o);
+                    rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, index) : byte.MaxValue;
+                    rgba.Rgb = Unsafe.Add(ref palettePixelsRef, index);
+
+                    pixel.PackFromRgba32(rgba);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                var rgba = new Rgba32(0, 0, 0, byte.MaxValue);
+                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
+                {
+                    int index = Unsafe.Add(ref scanlineSpanRef, o);
+                    rgba.Rgb = Unsafe.Add(ref palettePixelsRef, index);
+
+                    pixel.PackFromRgba32(rgba);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+        }
+
+        public static void ProcessRgbScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            int bytesPerPixel,
+            int bytesPerSample,
+            bool hasTrans,
+            Rgb48 rgb48Trans,
+            Rgb24 rgb24Trans)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+
+            if (!hasTrans)
+            {
+                if (header.BitDepth == 16)
+                {
+                    Rgb48 rgb48 = default;
+                    for (int x = 0, o = 0; x < header.Width; x++, o += bytesPerPixel)
+                    {
+                        rgb48.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
+                        rgb48.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
+                        rgb48.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
+
+                        pixel.PackFromRgb48(rgb48);
+                        Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    }
+                }
+                else
+                {
+                    PixelOperations<TPixel>.Instance.PackFromRgb24Bytes(scanlineSpan, rowSpan, header.Width);
+                }
+
+                return;
+            }
+
+            if (header.BitDepth == 16)
+            {
+                Rgb48 rgb48 = default;
+                Rgba64 rgba64 = default;
+                for (int x = 0, o = 0; x < header.Width; x++, o += bytesPerPixel)
+                {
+                    rgb48.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
+                    rgb48.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
+                    rgb48.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
+
+                    rgba64.Rgb = rgb48;
+                    rgba64.A = rgb48.Equals(rgb48Trans) ? ushort.MinValue : ushort.MaxValue;
+
+                    pixel.PackFromRgba64(rgba64);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                ReadOnlySpan<Rgb24> rgb24Span = MemoryMarshal.Cast<byte, Rgb24>(scanlineSpan);
+                ref Rgb24 rgb24SpanRef = ref MemoryMarshal.GetReference(rgb24Span);
+                for (int x = 0; x < header.Width; x++)
+                {
+                    ref readonly Rgb24 rgb24 = ref Unsafe.Add(ref rgb24SpanRef, x);
+                    Rgba32 rgba32 = default;
+                    rgba32.Rgb = rgb24;
+                    rgba32.A = rgb24.Equals(rgb24Trans) ? byte.MinValue : byte.MaxValue;
+
+                    pixel.PackFromRgba32(rgba32);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+        }
+
+        public static void ProcessInterlacedRgbScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            int pixelOffset,
+            int increment,
+            int bytesPerPixel,
+            int bytesPerSample,
+            bool hasTrans,
+            Rgb48 rgb48Trans,
+            Rgb24 rgb24Trans)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+
+            if (header.BitDepth == 16)
+            {
+                if (hasTrans)
+                {
+                    Rgb48 rgb48 = default;
+                    Rgba64 rgba64 = default;
+                    for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+                    {
+                        rgb48.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
+                        rgb48.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
+                        rgb48.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
+
+                        rgba64.Rgb = rgb48;
+                        rgba64.A = rgb48.Equals(rgb48Trans) ? ushort.MinValue : ushort.MaxValue;
+
+                        pixel.PackFromRgba64(rgba64);
+                        Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    }
+                }
+                else
+                {
+                    Rgb48 rgb48 = default;
+                    for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+                    {
+                        rgb48.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
+                        rgb48.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
+                        rgb48.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
+
+                        pixel.PackFromRgb48(rgb48);
+                        Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    }
+                }
+
+                return;
+            }
+
+            if (hasTrans)
+            {
+                Rgba32 rgba = default;
+                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+                {
+                    rgba.R = Unsafe.Add(ref scanlineSpanRef, o);
+                    rgba.G = Unsafe.Add(ref scanlineSpanRef, o + bytesPerSample);
+                    rgba.B = Unsafe.Add(ref scanlineSpanRef, o + (2 * bytesPerSample));
+                    rgba.A = rgb24Trans.Equals(rgba.Rgb) ? byte.MinValue : byte.MaxValue;
+
+                    pixel.PackFromRgba32(rgba);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                var rgba = new Rgba32(0, 0, 0, byte.MaxValue);
+                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+                {
+                    rgba.R = Unsafe.Add(ref scanlineSpanRef, o);
+                    rgba.G = Unsafe.Add(ref scanlineSpanRef, o + bytesPerSample);
+                    rgba.B = Unsafe.Add(ref scanlineSpanRef, o + (2 * bytesPerSample));
+
+                    pixel.PackFromRgba32(rgba);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+        }
+
+        public static void ProcessRgbaScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            int bytesPerPixel,
+            int bytesPerSample)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+
+            if (header.BitDepth == 16)
+            {
+                Rgba64 rgba64 = default;
+                for (int x = 0, o = 0; x < header.Width; x++, o += bytesPerPixel)
+                {
+                    rgba64.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
+                    rgba64.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
+                    rgba64.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
+                    rgba64.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (3 * bytesPerSample), bytesPerSample));
+
+                    pixel.PackFromRgba64(rgba64);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                PixelOperations<TPixel>.Instance.PackFromRgba32Bytes(scanlineSpan, rowSpan, header.Width);
+            }
+        }
+
+        public static void ProcessInterlacedRgbaScanline<TPixel>(
+            in PngHeader header,
+            ReadOnlySpan<byte> scanlineSpan,
+            Span<TPixel> rowSpan,
+            int pixelOffset,
+            int increment,
+            int bytesPerPixel,
+            int bytesPerSample)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            TPixel pixel = default;
+            ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
+            ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
+
+            if (header.BitDepth == 16)
+            {
+                Rgba64 rgba64 = default;
+                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+                {
+                    rgba64.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
+                    rgba64.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
+                    rgba64.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
+                    rgba64.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (3 * bytesPerSample), bytesPerSample));
+
+                    pixel.PackFromRgba64(rgba64);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+            else
+            {
+                Rgba32 rgba = default;
+                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+                {
+                    rgba.R = Unsafe.Add(ref scanlineSpanRef, o);
+                    rgba.G = Unsafe.Add(ref scanlineSpanRef, o + bytesPerSample);
+                    rgba.B = Unsafe.Add(ref scanlineSpanRef, o + (2 * bytesPerSample));
+                    rgba.A = Unsafe.Add(ref scanlineSpanRef, o + (3 * bytesPerSample));
+
+                    pixel.PackFromRgba32(rgba);
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                }
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizedFrame{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizedFrame{TPixel}.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Buffers;
-
+using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Memory;
@@ -57,6 +57,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         /// Gets the pixels of this <see cref="QuantizedFrame{TPixel}"/>.
         /// </summary>
         /// <returns>The <see cref="Span{T}"/></returns>
+        [MethodImpl(InliningOptions.ShortMethod)]
         public Span<byte> GetPixelSpan() => this.pixels.GetSpan();
 
         /// <summary>
@@ -65,6 +66,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         /// </summary>
         /// <param name="rowIndex">The row.</param>
         /// <returns>The <see cref="Span{T}"/></returns>
+        [MethodImpl(InliningOptions.ShortMethod)]
         public Span<byte> GetRowSpan(int rowIndex) => this.GetPixelSpan().Slice(rowIndex * this.Width, this.Width);
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizedFrame{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizedFrame{TPixel}.cs
@@ -59,6 +59,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         /// <returns>The <see cref="Span{T}"/></returns>
         public Span<byte> GetPixelSpan() => this.pixels.GetSpan();
 
+        /// <summary>
+        /// Gets the representation of the pixels as a <see cref="Span{T}"/> of contiguous memory
+        /// at row <paramref name="rowIndex"/> beginning from the the first pixel on that row.
+        /// </summary>
+        /// <param name="rowIndex">The row.</param>
+        /// <returns>The <see cref="Span{T}"/></returns>
+        public Span<byte> GetRowSpan(int rowIndex) => this.GetPixelSpan().Slice(rowIndex * this.Width, this.Width);
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -9,7 +9,6 @@ using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.MetaData;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 
@@ -19,10 +18,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
     public class PngEncoderTests
     {
-        // This is bull. Failing online for no good reason. 
-        // The images are an exact match. Maybe the submodule isn't updating?
-        private const float ToleranceThresholdForPaletteEncoder = 1.3F / 100;
-
         public static readonly TheoryData<string, PngBitDepth> PngBitDepthFiles =
         new TheoryData<string, PngBitDepth>
         {
@@ -137,19 +132,32 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         }
 
         [Theory]
-        [WithTestPatternImages(24, 24, PixelTypes.Rgba64, PngColorType.Rgb)]
-        [WithTestPatternImages(24, 24, PixelTypes.Rgba64, PngColorType.RgbWithAlpha)]
-        [WithTestPatternImages(24, 24, PixelTypes.Rgba32, PngColorType.RgbWithAlpha)]
-        public void WorksWithBitDepth16<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType)
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba32, PngColorType.Rgb, PngBitDepth.Bit8)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba64, PngColorType.Rgb, PngBitDepth.Bit16)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba32, PngColorType.RgbWithAlpha, PngBitDepth.Bit8)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba64, PngColorType.RgbWithAlpha, PngBitDepth.Bit16)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba32, PngColorType.Palette, PngBitDepth.Bit1)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba32, PngColorType.Palette, PngBitDepth.Bit2)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba32, PngColorType.Palette, PngBitDepth.Bit4)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba32, PngColorType.Palette, PngBitDepth.Bit8)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgb24, PngColorType.Grayscale, PngBitDepth.Bit1)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgb24, PngColorType.Grayscale, PngBitDepth.Bit2)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgb24, PngColorType.Grayscale, PngBitDepth.Bit4)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgb24, PngColorType.Grayscale, PngBitDepth.Bit8)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgb48, PngColorType.Grayscale, PngBitDepth.Bit16)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba32, PngColorType.GrayscaleWithAlpha, PngBitDepth.Bit8)]
+        [WithTestPatternImages(24, 24, PixelTypes.Rgba64, PngColorType.GrayscaleWithAlpha, PngBitDepth.Bit16)]
+        public void WorksWithAllBitDepths<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType, PngBitDepth pngBitDepth)
             where TPixel : struct, IPixel<TPixel>
         {
             TestPngEncoderCore(
                 provider,
                 pngColorType,
                 PngFilterMethod.Adaptive,
-                PngBitDepth.Bit16,
+                pngBitDepth,
                 appendPngColorType: true,
-                appendPixelType: true);
+                appendPixelType: true,
+                appendPngBitDepth: true);
         }
 
         [Theory]
@@ -164,87 +172,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 PngBitDepth.Bit8,
                 paletteSize: paletteSize,
                 appendPaletteSize: true);
-        }
-
-        private static bool HasAlpha(PngColorType pngColorType) =>
-            pngColorType == PngColorType.GrayscaleWithAlpha || pngColorType == PngColorType.RgbWithAlpha;
-
-        private static void TestPngEncoderCore<TPixel>(
-            TestImageProvider<TPixel> provider,
-            PngColorType pngColorType,
-            PngFilterMethod pngFilterMethod,
-            PngBitDepth bitDepth,
-            int compressionLevel = 6,
-            int paletteSize = 255,
-            bool appendPngColorType = false,
-            bool appendPngFilterMethod = false,
-            bool appendPixelType = false,
-            bool appendCompressionLevel = false,
-            bool appendPaletteSize = false)
-            where TPixel : struct, IPixel<TPixel>
-        {
-            using (Image<TPixel> image = provider.GetImage())
-            {
-                if (!HasAlpha(pngColorType))
-                {
-                    image.Mutate(c => c.MakeOpaque());
-                }
-
-                var encoder = new PngEncoder
-                {
-                    ColorType = pngColorType,
-                    FilterMethod = pngFilterMethod,
-                    CompressionLevel = compressionLevel,
-                    BitDepth = bitDepth,
-                    Quantizer = new WuQuantizer(paletteSize)
-                };
-
-                string pngColorTypeInfo = appendPngColorType ? pngColorType.ToString() : string.Empty;
-                string pngFilterMethodInfo = appendPngFilterMethod ? pngFilterMethod.ToString() : string.Empty;
-                string compressionLevelInfo = appendCompressionLevel ? $"_C{compressionLevel}" : string.Empty;
-                string paletteSizeInfo = appendPaletteSize ? $"_PaletteSize-{paletteSize}" : string.Empty;
-                string debugInfo = $"{pngColorTypeInfo}{pngFilterMethodInfo}{compressionLevelInfo}{paletteSizeInfo}";
-                //string referenceInfo = $"{pngColorTypeInfo}";
-
-                // Does DebugSave & load reference CompareToReferenceInput():
-                string actualOutputFile = ((ITestImageProvider)provider).Utility.SaveTestOutputFile(image, "png", encoder, debugInfo, appendPixelType);
-
-                if (TestEnvironment.IsMono)
-                {
-                    // There are bugs in mono's System.Drawing implementation, reference decoders are not always reliable!
-                    return;
-                }
-
-                IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(actualOutputFile);
-                string referenceOutputFile = ((ITestImageProvider)provider).Utility.GetReferenceOutputFileName("png", debugInfo, appendPixelType, true);
-
-                bool referenceOutputFileExists = File.Exists(referenceOutputFile);
-
-                using (var actualImage = Image.Load<TPixel>(actualOutputFile, referenceDecoder))
-                {
-                    // TODO: Do we still need the reference output files?
-                    Image<TPixel> referenceImage = referenceOutputFileExists
-                                               ? Image.Load<TPixel>(referenceOutputFile, referenceDecoder)
-                                               : image;
-
-                    float paletteToleranceHack = 80f / paletteSize;
-                    paletteToleranceHack *= paletteToleranceHack;
-                    ImageComparer comparer = pngColorType == PngColorType.Palette
-                                                 ? ImageComparer.Tolerant(ToleranceThresholdForPaletteEncoder * paletteToleranceHack)
-                                                 : ImageComparer.Exact;
-                    try
-                    {
-                        comparer.VerifySimilarity(referenceImage, actualImage);
-                    }
-                    finally
-                    {
-                        if (referenceOutputFileExists)
-                        {
-                            referenceImage.Dispose();
-                        }
-                    }
-                }
-            }
         }
 
         [Theory]
@@ -318,6 +245,55 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
                         Assert.Equal(pngBitDepth, meta.BitDepth);
                     }
+                }
+            }
+        }
+
+        private static void TestPngEncoderCore<TPixel>(
+            TestImageProvider<TPixel> provider,
+            PngColorType pngColorType,
+            PngFilterMethod pngFilterMethod,
+            PngBitDepth bitDepth,
+            int compressionLevel = 6,
+            int paletteSize = 255,
+            bool appendPngColorType = false,
+            bool appendPngFilterMethod = false,
+            bool appendPixelType = false,
+            bool appendCompressionLevel = false,
+            bool appendPaletteSize = false,
+            bool appendPngBitDepth = false)
+        where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                var encoder = new PngEncoder
+                {
+                    ColorType = pngColorType,
+                    FilterMethod = pngFilterMethod,
+                    CompressionLevel = compressionLevel,
+                    BitDepth = bitDepth,
+                    Quantizer = new WuQuantizer(paletteSize)
+                };
+
+                string pngColorTypeInfo = appendPngColorType ? pngColorType.ToString() : string.Empty;
+                string pngFilterMethodInfo = appendPngFilterMethod ? pngFilterMethod.ToString() : string.Empty;
+                string compressionLevelInfo = appendCompressionLevel ? $"_C{compressionLevel}" : string.Empty;
+                string paletteSizeInfo = appendPaletteSize ? $"_PaletteSize-{paletteSize}" : string.Empty;
+                string pngBitDepthInfo = appendPngBitDepth ? bitDepth.ToString() : string.Empty;
+                string debugInfo = $"{pngColorTypeInfo}{pngFilterMethodInfo}{compressionLevelInfo}{paletteSizeInfo}{pngBitDepthInfo}";
+
+                string actualOutputFile = provider.Utility.SaveTestOutputFile(image, "png", encoder, debugInfo, appendPixelType);
+
+                // Compare to the Magick reference decoder.
+                IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(actualOutputFile);
+
+                // We compare using both our decoder and the reference decoder as pixel transformation
+                // occurrs within the encoder itself leaving the input image unaffected.
+                // This means we are benefiting from testing our decoder also.
+                using (var imageSharpImage = Image.Load<TPixel>(actualOutputFile, new PngDecoder()))
+                using (var referenceImage = Image.Load<TPixel>(actualOutputFile, referenceDecoder))
+                {
+                    ImageComparer.Exact.VerifySimilarity(referenceImage, imageSharpImage);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -29,13 +29,13 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
                 {
                     if (magickImage.Depth == 8)
                     {
-                        byte[] data = pixels.ToByteArray("RGBA");
-                        
+                        byte[] data = pixels.ToByteArray(PixelMapping.RGBA);
+
                         PixelOperations<TPixel>.Instance.PackFromRgba32Bytes(data, resultPixels, resultPixels.Length);
                     }
                     else if (magickImage.Depth == 16)
                     {
-                        ushort[] data = pixels.ToShortArray("RGBA");
+                        ushort[] data = pixels.ToShortArray(PixelMapping.RGBA);
                         Span<byte> bytes = MemoryMarshal.Cast<ushort, byte>(data.AsSpan());
 
                         PixelOperations<TPixel>.Instance.PackFromRgba64Bytes(bytes, resultPixels, resultPixels.Length);

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/MagickReferenceCodecTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/MagickReferenceCodecTests.cs
@@ -14,10 +14,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
 
     public class MagickReferenceCodecTests
     {
-        public MagickReferenceCodecTests(ITestOutputHelper output)
-        {
-            this.Output = output;
-        }
+        public MagickReferenceCodecTests(ITestOutputHelper output) => this.Output = output;
 
         private ITestOutputHelper Output { get; }
 
@@ -61,6 +58,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [WithBlankImages(1, 1, PixelTypesToTest48, TestImages.Png.Rgb48Bpp)]
         [WithBlankImages(1, 1, PixelTypesToTest48, TestImages.Png.Rgb48BppInterlaced)]
         [WithBlankImages(1, 1, PixelTypesToTest48, TestImages.Png.Rgb48BppTrans)]
+        [WithBlankImages(1, 1, PixelTypesToTest48, TestImages.Png.Gray16Bit)]
         public void MagickDecode_16BitDepthImage_IsApproximatelyEquivalentTo_SystemDrawingResult<TPixel>(TestImageProvider<TPixel> dummyProvider, string testImage)
             where TPixel : struct, IPixel<TPixel>
         {
@@ -71,7 +69,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
 
             // 1020 == 4 * 255 (Equivalent to manhattan distance of 1+1+1+1=4 in Rgba32 space)
             var comparer = ImageComparer.TolerantPercentage(1, 1020);
-            
+
             using (var mImage = Image.Load<TPixel>(path, magickDecoder))
             using (var sdImage = Image.Load<TPixel>(path, sdDecoder))
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
This PR will add 1,2, and 4 bit encoding to png. 

- [x] Add encoding for paletted images
- [x] Add encoding for grayscale images
- [x] Add tests and optimize performance and readability
<!-- Thanks for contributing to ImageSharp! -->
