### PR TITLE
Use clean buffer when detecting format

### DIFF
--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp
                 return null;
             }
 
-            using (IManagedByteBuffer buffer = config.MemoryAllocator.AllocateManagedByteBuffer(maxHeaderSize))
+            using (IManagedByteBuffer buffer = config.MemoryAllocator.AllocateManagedByteBuffer(maxHeaderSize, AllocationOptions.Clean))
             {
                 long startPosition = stream.Position;
                 stream.Read(buffer.Array, 0, maxHeaderSize);

--- a/tests/ImageSharp.Tests/Formats/ImageFormatManagerTests.cs
+++ b/tests/ImageSharp.Tests/Formats/ImageFormatManagerTests.cs
@@ -2,17 +2,15 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.IO;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.Formats.Bmp;
-using SixLabors.ImageSharp.Formats.Jpeg;
-using SixLabors.ImageSharp.Formats.Gif;
 using Moq;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 
@@ -27,7 +25,7 @@ namespace SixLabors.ImageSharp.Tests
         {
             this.DefaultFormatsManager = Configuration.CreateDefaultInstance().ImageFormatsManager;
             this.FormatsManagerEmpty = new ImageFormatManager();
-        }        
+        }
 
         [Fact]
         public void IfAutoloadWellKnownFormatsIsTrueAllFormatsAreLoaded()
@@ -114,7 +112,7 @@ namespace SixLabors.ImageSharp.Tests
             IImageDecoder found2 = this.FormatsManagerEmpty.FindDecoder(TestFormat.GlobalTestFormat);
             Assert.Equal(decoder2, found2);
             Assert.NotEqual(found, found2);
-        }        
+        }
 
         [Fact]
         public void AddFormatCallsConfig()
@@ -124,6 +122,25 @@ namespace SixLabors.ImageSharp.Tests
             config.Configure(provider.Object);
 
             provider.Verify(x => x.Configure(config));
+        }
+
+        [Fact]
+        public void DetectFormatAllocatesCleanBuffer()
+        {
+            byte[] jpegImage;
+            using (var buffer = new MemoryStream())
+            {
+                using (var image = new Image<Rgba32>(100, 100))
+                {
+                    image.SaveAsJpeg(buffer);
+                    jpegImage = buffer.ToArray();
+                }
+            }
+
+            byte[] invalidImage = { 1, 2, 3 };
+
+            Assert.Equal(Image.DetectFormat(jpegImage), JpegFormat.Instance);
+            Assert.True(Image.DetectFormat(invalidImage) is null);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
See #714 

<!-- Thanks for contributing to ImageSharp! -->
