### PR TITLE
Improve PNG CQ

### DIFF
--- a/src/ImageSharp/Formats/Png/Adam7.cs
+++ b/src/ImageSharp/Formats/Png/Adam7.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace SixLabors.ImageSharp.Formats.Png
+{
+    /// <summary>
+    /// Constants and helper methods for the Adam7 interlacing algorithm.
+    /// </summary>
+    internal static class Adam7
+    {
+        /// <summary>
+        /// The amount to increment when processing each column per scanline for each interlaced pass.
+        /// </summary>
+        public static readonly int[] ColumnIncrement = { 8, 8, 4, 4, 2, 2, 1 };
+
+        /// <summary>
+        /// The index to start at when processing each column per scanline for each interlaced pass.
+        /// </summary>
+        public static readonly int[] FirstColumn = { 0, 4, 0, 2, 0, 1, 0 };
+
+        /// <summary>
+        /// The index to start at when processing each row per scanline for each interlaced pass.
+        /// </summary>
+        public static readonly int[] FirstRow = { 0, 0, 4, 0, 2, 0, 1 };
+
+        /// <summary>
+        /// The amount to increment when processing each row per scanline for each interlaced pass.
+        /// </summary>
+        public static readonly int[] RowIncrement = { 8, 8, 8, 4, 4, 2, 2 };
+
+        /// <summary>
+        /// Returns the correct number of columns for each interlaced pass.
+        /// </summary>
+        /// <param name="width">The line width.</param>
+        /// <param name="passIndex">The current pass index.</param>
+        /// <returns>The <see cref="int"/></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ComputeColumns(int width, int passIndex)
+        {
+            switch (passIndex)
+            {
+                case 0: return (width + 7) / 8;
+                case 1: return (width + 3) / 8;
+                case 2: return (width + 3) / 4;
+                case 3: return (width + 1) / 4;
+                case 4: return (width + 1) / 2;
+                case 5: return width / 2;
+                case 6: return width;
+                default: throw new ArgumentException($"Not a valid pass index: {passIndex}");
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Png/PngBitDepth.cs
+++ b/src/ImageSharp/Formats/Png/PngBitDepth.cs
@@ -7,7 +7,7 @@ namespace SixLabors.ImageSharp.Formats.Png
     /// <summary>
     /// Provides enumeration for the available PNG bit depths.
     /// </summary>
-    public enum PngBitDepth
+    public enum PngBitDepth : byte
     {
         /// <summary>
         /// 1 bit per sample or per palette index (not per pixel).

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -38,26 +38,6 @@ namespace SixLabors.ImageSharp.Formats.Png
         };
 
         /// <summary>
-        /// The amount to increment when processing each column per scanline for each interlaced pass
-        /// </summary>
-        private static readonly int[] Adam7ColumnIncrement = { 8, 8, 4, 4, 2, 2, 1 };
-
-        /// <summary>
-        /// The index to start at when processing each column per scanline for each interlaced pass
-        /// </summary>
-        private static readonly int[] Adam7FirstColumn = { 0, 4, 0, 2, 0, 1, 0 };
-
-        /// <summary>
-        /// The index to start at when processing each row per scanline for each interlaced pass
-        /// </summary>
-        private static readonly int[] Adam7FirstRow = { 0, 0, 4, 0, 2, 0, 1 };
-
-        /// <summary>
-        /// The amount to increment when processing each row per scanline for each interlaced pass
-        /// </summary>
-        private static readonly int[] Adam7RowIncrement = { 8, 8, 8, 4, 4, 2, 2 };
-
-        /// <summary>
         /// Reusable buffer for reading chunk types.
         /// </summary>
         private readonly byte[] chunkTypeBuffer = new byte[4];
@@ -150,7 +130,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <summary>
         /// The index of the current scanline being processed
         /// </summary>
-        private int currentRow = Adam7FirstRow[0];
+        private int currentRow = Adam7.FirstRow[0];
 
         /// <summary>
         /// The current pass for an interlaced PNG
@@ -635,7 +615,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         {
             while (true)
             {
-                int numColumns = this.ComputeColumnsAdam7(this.pass);
+                int numColumns = Adam7.ComputeColumns(this.header.Width, this.pass);
 
                 if (numColumns == 0)
                 {
@@ -691,11 +671,11 @@ namespace SixLabors.ImageSharp.Formats.Png
                     }
 
                     Span<TPixel> rowSpan = image.GetPixelRowSpan(this.currentRow);
-                    this.ProcessInterlacedDefilteredScanline(this.scanline.GetSpan(), rowSpan, Adam7FirstColumn[this.pass], Adam7ColumnIncrement[this.pass]);
+                    this.ProcessInterlacedDefilteredScanline(this.scanline.GetSpan(), rowSpan, Adam7.FirstColumn[this.pass], Adam7.ColumnIncrement[this.pass]);
 
                     this.SwapBuffers();
 
-                    this.currentRow += Adam7RowIncrement[this.pass];
+                    this.currentRow += Adam7.RowIncrement[this.pass];
                 }
 
                 this.pass++;
@@ -703,7 +683,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
                 if (this.pass < 7)
                 {
-                    this.currentRow = Adam7FirstRow[this.pass];
+                    this.currentRow = Adam7.FirstRow[this.pass];
                 }
                 else
                 {
@@ -1196,28 +1176,6 @@ namespace SixLabors.ImageSharp.Formats.Png
             result = default;
 
             return false;
-        }
-
-        /// <summary>
-        /// Returns the correct number of columns for each interlaced pass.
-        /// </summary>
-        /// <param name="passIndex">Th current pass index</param>
-        /// <returns>The <see cref="int"/></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int ComputeColumnsAdam7(int passIndex)
-        {
-            int width = this.header.Width;
-            switch (passIndex)
-            {
-                case 0: return (width + 7) / 8;
-                case 1: return (width + 3) / 8;
-                case 2: return (width + 3) / 4;
-                case 3: return (width + 1) / 4;
-                case 4: return (width + 1) / 2;
-                case 5: return width / 2;
-                case 6: return width;
-                default: throw new ArgumentException($"Not a valid pass index: {passIndex}");
-            }
         }
 
         private void SwapBuffers()

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -943,17 +943,9 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="data">The <see cref="T:ReadOnlySpan{byte}"/> containing data.</param>
         private void ReadHeaderChunk(PngMetaData pngMetaData, ReadOnlySpan<byte> data)
         {
-            byte bitDepth = data[8];
-            this.header = new PngHeader(
-                width: BinaryPrimitives.ReadInt32BigEndian(data.Slice(0, 4)),
-                height: BinaryPrimitives.ReadInt32BigEndian(data.Slice(4, 4)),
-                bitDepth: bitDepth,
-                colorType: (PngColorType)data[9],
-                compressionMethod: data[10],
-                filterMethod: data[11],
-                interlaceMethod: (PngInterlaceMode)data[12]);
+            this.header = PngHeader.Parse(data);
 
-            pngMetaData.BitDepth = (PngBitDepth)bitDepth;
+            pngMetaData.BitDepth = (PngBitDepth)this.header.BitDepth;
             pngMetaData.ColorType = this.header.ColorType;
         }
 

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1148,14 +1148,9 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </exception>
         private PngChunkType ReadChunkType()
         {
-            int numBytes = this.currentStream.Read(this.chunkTypeBuffer, 0, 4);
-
-            if (numBytes >= 1 && numBytes <= 3)
-            {
-                throw new ImageFormatException("Image stream is not valid!");
-            }
-
-            return (PngChunkType)BinaryPrimitives.ReadUInt32BigEndian(this.chunkTypeBuffer.AsSpan());
+            return this.currentStream.Read(this.chunkTypeBuffer, 0, 4) == 4
+                ? (PngChunkType)BinaryPrimitives.ReadUInt32BigEndian(this.chunkTypeBuffer.AsSpan())
+                : throw new ImageFormatException("Invalid PNG data.");
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1054,9 +1054,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                 return true;
             }
 
-            int length = this.ReadChunkLength();
-
-            if (length == -1)
+            if (!this.TryReadChunkLength(out int length))
             {
                 chunk = default;
 
@@ -1070,9 +1068,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                 // That lets us read one byte at a time until we reach a known chunk.
                 this.currentStream.Position -= 3;
 
-                length = this.ReadChunkLength();
-
-                if (length == -1)
+                if (!this.TryReadChunkLength(out length))
                 {
                     chunk = default;
 
@@ -1188,16 +1184,18 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <exception cref="ImageFormatException">
         /// Thrown if the input stream is not valid.
         /// </exception>
-        private int ReadChunkLength()
+        private bool TryReadChunkLength(out int result)
         {
-            int numBytes = this.currentStream.Read(this.chunkLengthBuffer, 0, 4);
-
-            if (numBytes < 4)
+            if (this.currentStream.Read(this.chunkLengthBuffer, 0, 4) == 4)
             {
-                return -1;
+                result = BinaryPrimitives.ReadInt32BigEndian(this.chunkLengthBuffer);
+
+                return true;
             }
 
-            return BinaryPrimitives.ReadInt32BigEndian(this.chunkLengthBuffer);
+            result = default;
+
+            return false;
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -606,16 +606,9 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="header">The <see cref="PngHeader"/>.</param>
         private void WriteHeaderChunk(Stream stream, in PngHeader header)
         {
-            BinaryPrimitives.WriteInt32BigEndian(this.chunkDataBuffer.AsSpan(0, 4), header.Width);
-            BinaryPrimitives.WriteInt32BigEndian(this.chunkDataBuffer.AsSpan(4, 4), header.Height);
+            header.WriteTo(this.chunkDataBuffer);
 
-            this.chunkDataBuffer[8] = header.BitDepth;
-            this.chunkDataBuffer[9] = (byte)header.ColorType;
-            this.chunkDataBuffer[10] = header.CompressionMethod;
-            this.chunkDataBuffer[11] = header.FilterMethod;
-            this.chunkDataBuffer[12] = (byte)header.InterlaceMethod;
-
-            this.WriteChunk(stream, PngChunkType.Header, this.chunkDataBuffer, 0, 13);
+            this.WriteChunk(stream, PngChunkType.Header, this.chunkDataBuffer, 0, PngHeader.Size);
         }
 
         /// <summary>
@@ -697,28 +690,24 @@ namespace SixLabors.ImageSharp.Formats.Png
             switch (meta.ResolutionUnits)
             {
                 case PixelResolutionUnit.AspectRatio:
-
                     this.chunkDataBuffer[8] = 0;
                     BinaryPrimitives.WriteInt32BigEndian(hResolution, (int)Math.Round(meta.HorizontalResolution));
                     BinaryPrimitives.WriteInt32BigEndian(vResolution, (int)Math.Round(meta.VerticalResolution));
                     break;
 
                 case PixelResolutionUnit.PixelsPerInch:
-
                     this.chunkDataBuffer[8] = 1; // Per meter
                     BinaryPrimitives.WriteInt32BigEndian(hResolution, (int)Math.Round(UnitConverter.InchToMeter(meta.HorizontalResolution)));
                     BinaryPrimitives.WriteInt32BigEndian(vResolution, (int)Math.Round(UnitConverter.InchToMeter(meta.VerticalResolution)));
                     break;
 
                 case PixelResolutionUnit.PixelsPerCentimeter:
-
                     this.chunkDataBuffer[8] = 1; // Per meter
                     BinaryPrimitives.WriteInt32BigEndian(hResolution, (int)Math.Round(UnitConverter.CmToMeter(meta.HorizontalResolution)));
                     BinaryPrimitives.WriteInt32BigEndian(vResolution, (int)Math.Round(UnitConverter.CmToMeter(meta.VerticalResolution)));
                     break;
 
                 default:
-
                     this.chunkDataBuffer[8] = 1; // Per meter
                     BinaryPrimitives.WriteInt32BigEndian(hResolution, (int)Math.Round(meta.HorizontalResolution));
                     BinaryPrimitives.WriteInt32BigEndian(vResolution, (int)Math.Round(meta.VerticalResolution));
@@ -782,26 +771,22 @@ namespace SixLabors.ImageSharp.Formats.Png
                     break;
 
                 case PngFilterMethod.Sub:
-
                     this.sub = this.memoryAllocator.AllocateManagedByteBuffer(resultLength, AllocationOptions.Clean);
                     break;
 
                 case PngFilterMethod.Up:
-
                     this.up = this.memoryAllocator.AllocateManagedByteBuffer(resultLength, AllocationOptions.Clean);
                     break;
 
                 case PngFilterMethod.Average:
-
                     this.average = this.memoryAllocator.AllocateManagedByteBuffer(resultLength, AllocationOptions.Clean);
                     break;
 
                 case PngFilterMethod.Paeth:
-
                     this.paeth = this.memoryAllocator.AllocateManagedByteBuffer(resultLength, AllocationOptions.Clean);
                     break;
-                case PngFilterMethod.Adaptive:
 
+                case PngFilterMethod.Adaptive:
                     this.sub = this.memoryAllocator.AllocateManagedByteBuffer(resultLength, AllocationOptions.Clean);
                     this.up = this.memoryAllocator.AllocateManagedByteBuffer(resultLength, AllocationOptions.Clean);
                     this.average = this.memoryAllocator.AllocateManagedByteBuffer(resultLength, AllocationOptions.Clean);

--- a/src/ImageSharp/Formats/Png/PngHeader.cs
+++ b/src/ImageSharp/Formats/Png/PngHeader.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
+using System.Buffers.Binary;
+
 namespace SixLabors.ImageSharp.Formats.Png
 {
     /// <summary>
@@ -74,5 +77,22 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// Two values are currently defined: 0 (no interlace) or 1 (Adam7 interlace).
         /// </summary>
         public PngInterlaceMode InterlaceMethod { get; }
+
+        /// <summary>
+        /// Parses the PngHeader from the given data buffer.
+        /// </summary>
+        /// <param name="data">The data to parse.</param>
+        /// <returns>The parsed PngHeader.</returns>
+        public static PngHeader Parse(ReadOnlySpan<byte> data)
+        {
+            return new PngHeader(
+              width: BinaryPrimitives.ReadInt32BigEndian(data.Slice(0, 4)),
+              height: BinaryPrimitives.ReadInt32BigEndian(data.Slice(4, 4)),
+              bitDepth: data[8],
+              colorType: (PngColorType)data[9],
+              compressionMethod: data[10],
+              filterMethod: data[11],
+              interlaceMethod: (PngInterlaceMode)data[12]);
+        }
     }
 }

--- a/src/ImageSharp/Formats/Png/PngHeader.cs
+++ b/src/ImageSharp/Formats/Png/PngHeader.cs
@@ -11,6 +11,8 @@ namespace SixLabors.ImageSharp.Formats.Png
     /// </summary>
     internal readonly struct PngHeader
     {
+        public const int Size = 13;
+
         public PngHeader(
             int width,
             int height,
@@ -77,6 +79,22 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// Two values are currently defined: 0 (no interlace) or 1 (Adam7 interlace).
         /// </summary>
         public PngInterlaceMode InterlaceMethod { get; }
+
+        /// <summary>
+        /// Writes the header to the given buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write to.</param>
+        public void WriteTo(Span<byte> buffer)
+        {
+            BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(0, 4), this.Width);
+            BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(4, 4), this.Height);
+
+            buffer[8] = this.BitDepth;
+            buffer[9] = (byte)this.ColorType;
+            buffer[10] = this.CompressionMethod;
+            buffer[11] = this.FilterMethod;
+            buffer[12] = (byte)this.InterlaceMethod;
+        }
 
         /// <summary>
         /// Parses the PngHeader from the given data buffer.

--- a/src/ImageSharp/Formats/Png/Zlib/ZlibInflateStream.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/ZlibInflateStream.cs
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         /// <summary>
         /// Delegate to get more data once we've exhausted the current data remaining
         /// </summary>
-        private Func<int> getData;
+        private readonly Func<int> getData;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ZlibInflateStream"/> class.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

There's a lot of logic in the PNG encoder and decoder. This breaks some out to make it easier to extend / maintain.

- Moves the PngHeader read/write logic to it's struct
- Makes PngBitDepth a byte
- Breaks out the Adam7 functions to it's own class
- Ensures that a valid chunk type is read

<!-- Thanks for contributing to ImageSharp! -->
