### PR TITLE
Improve PNG CQ2

### DIFF
--- a/src/ImageSharp/Common/Extensions/EncoderExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/EncoderExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+#if !NETCOREAPP2_1
+using System;
+using System.Text;
+
+namespace SixLabors.ImageSharp
+{
+    /// <summary>
+    /// Extension methods for the <see cref="Encoder"/> type.
+    /// </summary>
+    internal static unsafe class EncoderExtensions
+    {
+        /// <summary>
+        /// Gets a string from the provided buffer data.
+        /// </summary>
+        /// <param name="encoding">The encoding.</param>
+        /// <param name="buffer">The buffer.</param>
+        /// <returns>The string.</returns>
+        public static string GetString(this Encoding encoding, ReadOnlySpan<byte> buffer)
+        {
+#if NETSTANDARD1_1
+            return encoding.GetString(buffer.ToArray());
+#else
+            fixed (byte* bytes = buffer)
+            {
+                return encoding.GetString(bytes, buffer.Length);
+            }
+#endif
+        }
+    }
+}
+#endif

--- a/src/ImageSharp/Formats/Png/Chunks/PhysicalChunkData.cs
+++ b/src/ImageSharp/Formats/Png/Chunks/PhysicalChunkData.cs
@@ -3,16 +3,16 @@ using System.Buffers.Binary;
 using SixLabors.ImageSharp.Common.Helpers;
 using SixLabors.ImageSharp.MetaData;
 
-namespace SixLabors.ImageSharp.Formats.Png
+namespace SixLabors.ImageSharp.Formats.Png.Chunks
 {
     /// <summary>
     /// The pHYs chunk specifies the intended pixel size or aspect ratio for display of the image.
     /// </summary>
-    internal readonly struct PngPhysicalChunkData
+    internal readonly struct PhysicalChunkData
     {
         public const int Size = 9;
 
-        public PngPhysicalChunkData(uint x, uint y, byte unitSpecifier)
+        public PhysicalChunkData(uint x, uint y, byte unitSpecifier)
         {
             this.XAxisPixelsPerUnit = x;
             this.YAxisPixelsPerUnit = y;
@@ -43,7 +43,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </summary>
         /// <param name="meta">The metadata.</param>
         /// <returns>The constructed PngPhysicalChunkData instance.</returns>
-        public static PngPhysicalChunkData FromMetadata(ImageMetaData meta)
+        public static PhysicalChunkData FromMetadata(ImageMetaData meta)
         {
             byte unitSpecifier = 0;
             uint x;

--- a/src/ImageSharp/Formats/Png/Chunks/PhysicalChunkData.cs
+++ b/src/ImageSharp/Formats/Png/Chunks/PhysicalChunkData.cs
@@ -38,6 +38,20 @@ namespace SixLabors.ImageSharp.Formats.Png.Chunks
         public byte UnitSpecifier { get; }
 
         /// <summary>
+        /// Parses the PhysicalChunkData from the given buffer.
+        /// </summary>
+        /// <param name="data">The data buffer.</param>
+        /// <returns>The parsed PhysicalChunkData.</returns>
+        public static PhysicalChunkData Parse(ReadOnlySpan<byte> data)
+        {
+            uint hResolution = BinaryPrimitives.ReadUInt32BigEndian(data.Slice(0, 4));
+            uint vResolution = BinaryPrimitives.ReadUInt32BigEndian(data.Slice(4, 4));
+            byte unit = data[8];
+
+            return new PhysicalChunkData(hResolution, vResolution, unit);
+        }
+
+        /// <summary>
         /// Constructs the PngPhysicalChunkData from the provided metadata.
         /// If the resolution units are not in meters, they are automatically convereted.
         /// </summary>
@@ -76,7 +90,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Chunks
                     break;
             }
 
-            return new PngPhysicalChunkData(x, y, unitSpecifier);
+            return new PhysicalChunkData(x, y, unitSpecifier);
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Png/Chunks/PngPhysicalChunkData.cs
+++ b/src/ImageSharp/Formats/Png/Chunks/PngPhysicalChunkData.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Buffers.Binary;
+using SixLabors.ImageSharp.Common.Helpers;
+using SixLabors.ImageSharp.MetaData;
+
+namespace SixLabors.ImageSharp.Formats.Png
+{
+    /// <summary>
+    /// The pHYs chunk specifies the intended pixel size or aspect ratio for display of the image.
+    /// </summary>
+    internal readonly struct PngPhysicalChunkData
+    {
+        public const int Size = 9;
+
+        public PngPhysicalChunkData(uint x, uint y, byte unitSpecifier)
+        {
+            this.XAxisPixelsPerUnit = x;
+            this.YAxisPixelsPerUnit = y;
+            this.UnitSpecifier = unitSpecifier;
+        }
+
+        /// <summary>
+        /// Gets the number of pixels per unit on the X axis.
+        /// </summary>
+        public uint XAxisPixelsPerUnit { get; }
+
+        /// <summary>
+        /// Gets the number of pixels per unit on the Y axis.
+        /// </summary>
+        public uint YAxisPixelsPerUnit { get; }
+
+        /// <summary>
+        /// Gets the unit specifier.
+        /// 0: unit is unknown
+        /// 1: unit is the meter
+        /// When the unit specifier is 0, the pHYs chunk defines pixel aspect ratio only; the actual size of the pixels remains unspecified.
+        /// </summary>
+        public byte UnitSpecifier { get; }
+
+        /// <summary>
+        /// Constructs the PngPhysicalChunkData from the provided metadata.
+        /// If the resolution units are not in meters, they are automatically convereted.
+        /// </summary>
+        /// <param name="meta">The metadata.</param>
+        /// <returns>The constructed PngPhysicalChunkData instance.</returns>
+        public static PngPhysicalChunkData FromMetadata(ImageMetaData meta)
+        {
+            byte unitSpecifier = 0;
+            uint x;
+            uint y;
+
+            switch (meta.ResolutionUnits)
+            {
+                case PixelResolutionUnit.AspectRatio:
+                    unitSpecifier = 0; // Unspecified
+                    x = (uint)Math.Round(meta.HorizontalResolution);
+                    y = (uint)Math.Round(meta.VerticalResolution);
+                    break;
+
+                case PixelResolutionUnit.PixelsPerInch:
+                    unitSpecifier = 1; // Per meter
+                    x = (uint)Math.Round(UnitConverter.InchToMeter(meta.HorizontalResolution));
+                    y = (uint)Math.Round(UnitConverter.InchToMeter(meta.VerticalResolution));
+                    break;
+
+                case PixelResolutionUnit.PixelsPerCentimeter:
+                    unitSpecifier = 1; // Per meter
+                    x = (uint)Math.Round(UnitConverter.CmToMeter(meta.HorizontalResolution));
+                    y = (uint)Math.Round(UnitConverter.CmToMeter(meta.VerticalResolution));
+                    break;
+
+                default:
+                    unitSpecifier = 1; // Per meter
+                    x = (uint)Math.Round(meta.HorizontalResolution);
+                    y = (uint)Math.Round(meta.VerticalResolution);
+                    break;
+            }
+
+            return new PngPhysicalChunkData(x, y, unitSpecifier);
+        }
+
+        /// <summary>
+        /// Writes the data to the given buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer.</param>
+        public void WriteTo(Span<byte> buffer)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(0, 4), this.XAxisPixelsPerUnit);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(4, 4), this.YAxisPixelsPerUnit);
+            buffer[8] = this.UnitSpecifier;
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Png/PngConstants.cs
+++ b/src/ImageSharp/Formats/Png/PngConstants.cs
@@ -41,5 +41,17 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// The header bytes as a big endian coded ulong.
         /// </summary>
         public const ulong HeaderValue = 0x89504E470D0A1A0AUL;
+
+        /// <summary>
+        /// The dictionary of available color types.
+        /// </summary>
+        public static readonly Dictionary<PngColorType, byte[]> ColorTypes = new Dictionary<PngColorType, byte[]>()
+        {
+            [PngColorType.Grayscale] = new byte[] { 1, 2, 4, 8, 16 },
+            [PngColorType.Rgb] = new byte[] { 8, 16 },
+            [PngColorType.Palette] = new byte[] { 1, 2, 4, 8 },
+            [PngColorType.GrayscaleWithAlpha] = new byte[] { 8, 16 },
+            [PngColorType.RgbWithAlpha] = new byte[] { 8, 16 }
+        };
     }
 }

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -563,22 +563,18 @@ namespace SixLabors.ImageSharp.Formats.Png
                         break;
 
                     case FilterType.Sub:
-
                         SubFilter.Decode(scanlineSpan, this.bytesPerPixel);
                         break;
 
                     case FilterType.Up:
-
                         UpFilter.Decode(scanlineSpan, this.previousScanline.GetSpan());
                         break;
 
                     case FilterType.Average:
-
                         AverageFilter.Decode(scanlineSpan, this.previousScanline.GetSpan(), this.bytesPerPixel);
                         break;
 
                     case FilterType.Paeth:
-
                         PaethFilter.Decode(scanlineSpan, this.previousScanline.GetSpan(), this.bytesPerPixel);
                         break;
 
@@ -637,22 +633,18 @@ namespace SixLabors.ImageSharp.Formats.Png
                             break;
 
                         case FilterType.Sub:
-
                             SubFilter.Decode(scanSpan, this.bytesPerPixel);
                             break;
 
                         case FilterType.Up:
-
                             UpFilter.Decode(scanSpan, prevSpan);
                             break;
 
                         case FilterType.Average:
-
                             AverageFilter.Decode(scanSpan, prevSpan, this.bytesPerPixel);
                             break;
 
                         case FilterType.Paeth:
-
                             PaethFilter.Decode(scanSpan, prevSpan, this.bytesPerPixel);
                             break;
 
@@ -705,7 +697,6 @@ namespace SixLabors.ImageSharp.Formats.Png
             switch (this.pngColorType)
             {
                 case PngColorType.Grayscale:
-
                     PngScanlineProcessor.ProcessGrayscaleScanline(
                         this.header,
                         scanlineSpan,
@@ -717,7 +708,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                     break;
 
                 case PngColorType.GrayscaleWithAlpha:
-
                     PngScanlineProcessor.ProcessGrayscaleWithAlphaScanline(
                         this.header,
                         scanlineSpan,
@@ -728,7 +718,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                     break;
 
                 case PngColorType.Palette:
-
                     PngScanlineProcessor.ProcessPaletteScanline(
                         this.header,
                         scanlineSpan,
@@ -739,7 +728,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                     break;
 
                 case PngColorType.Rgb:
-
                     PngScanlineProcessor.ProcessRgbScanline(
                         this.header,
                         scanlineSpan,
@@ -753,7 +741,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                     break;
 
                 case PngColorType.RgbWithAlpha:
-
                     PngScanlineProcessor.ProcessRgbaScanline(
                         this.header,
                         scanlineSpan,
@@ -789,7 +776,6 @@ namespace SixLabors.ImageSharp.Formats.Png
             switch (this.pngColorType)
             {
                 case PngColorType.Grayscale:
-
                     PngScanlineProcessor.ProcessInterlacedGrayscaleScanline(
                         this.header,
                         scanlineSpan,
@@ -803,7 +789,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                     break;
 
                 case PngColorType.GrayscaleWithAlpha:
-
                     PngScanlineProcessor.ProcessInterlacedGrayscaleWithAlphaScanline(
                         this.header,
                         scanlineSpan,
@@ -816,7 +801,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                     break;
 
                 case PngColorType.Palette:
-
                     PngScanlineProcessor.ProcessInterlacedPaletteScanline(
                         this.header,
                         scanlineSpan,
@@ -829,7 +813,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                     break;
 
                 case PngColorType.Rgb:
-
                     PngScanlineProcessor.ProcessInterlacedRgbScanline(
                         this.header,
                         scanlineSpan,
@@ -845,7 +828,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                     break;
 
                 case PngColorType.RgbWithAlpha:
-
                     PngScanlineProcessor.ProcessInterlacedRgbaScanline(
                         this.header,
                         scanlineSpan,

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -198,7 +198,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                         {
                             case PngChunkType.Header:
                                 this.ReadHeaderChunk(pngMetaData, chunk.Data.Array);
-                                this.ValidateHeader();
                                 break;
                             case PngChunkType.Physical:
                                 this.ReadPhysicalChunk(metaData, chunk.Data.GetSpan());
@@ -287,7 +286,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                         {
                             case PngChunkType.Header:
                                 this.ReadHeaderChunk(pngMetaData, chunk.Data.Array);
-                                this.ValidateHeader();
                                 break;
                             case PngChunkType.Physical:
                                 this.ReadPhysicalChunk(metaData, chunk.Data.GetSpan());
@@ -886,37 +884,10 @@ namespace SixLabors.ImageSharp.Formats.Png
         {
             this.header = PngHeader.Parse(data);
 
+            this.header.Validate();
+
             pngMetaData.BitDepth = (PngBitDepth)this.header.BitDepth;
             pngMetaData.ColorType = this.header.ColorType;
-        }
-
-        /// <summary>
-        /// Validates the png header.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        /// Thrown if the image does pass validation.
-        /// </exception>
-        private void ValidateHeader()
-        {
-            if (!PngConstants.ColorTypes.ContainsKey(this.header.ColorType))
-            {
-                throw new NotSupportedException("Color type is not supported or not valid.");
-            }
-
-            if (!PngConstants.ColorTypes[this.header.ColorType].Contains(this.header.BitDepth))
-            {
-                throw new NotSupportedException("Bit depth is not supported or not valid.");
-            }
-
-            if (this.header.FilterMethod != 0)
-            {
-                throw new NotSupportedException("The png specification only defines 0 as filter method.");
-            }
-
-            if (this.header.InterlaceMethod != PngInterlaceMode.None && this.header.InterlaceMethod != PngInterlaceMode.Adam7)
-            {
-                throw new NotSupportedException("The png specification only defines 'None' and 'Adam7' as interlaced methods.");
-            }
 
             this.pngColorType = this.header.ColorType;
         }

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1016,7 +1016,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
             if (this.crc.Value != chunk.Crc)
             {
-                string chunkTypeName = Encoding.UTF8.GetString(chunkType.ToArray(), 0, 4);
+                string chunkTypeName = Encoding.UTF8.GetString(chunkType);
 
                 throw new ImageFormatException($"CRC Error. PNG {chunkTypeName} chunk is corrupt!");
             }

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -26,18 +26,6 @@ namespace SixLabors.ImageSharp.Formats.Png
     internal sealed class PngDecoderCore
     {
         /// <summary>
-        /// The dictionary of available color types.
-        /// </summary>
-        private static readonly Dictionary<PngColorType, byte[]> ColorTypes = new Dictionary<PngColorType, byte[]>()
-        {
-            [PngColorType.Grayscale] = new byte[] { 1, 2, 4, 8, 16 },
-            [PngColorType.Rgb] = new byte[] { 8, 16 },
-            [PngColorType.Palette] = new byte[] { 1, 2, 4, 8 },
-            [PngColorType.GrayscaleWithAlpha] = new byte[] { 8, 16 },
-            [PngColorType.RgbWithAlpha] = new byte[] { 8, 16 }
-        };
-
-        /// <summary>
         /// Reusable buffer.
         /// </summary>
         private readonly byte[] buffer = new byte[4];
@@ -858,6 +846,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                         ushort rc = BinaryPrimitives.ReadUInt16LittleEndian(alpha.Slice(0, 2));
                         ushort gc = BinaryPrimitives.ReadUInt16LittleEndian(alpha.Slice(2, 2));
                         ushort bc = BinaryPrimitives.ReadUInt16LittleEndian(alpha.Slice(4, 2));
+
                         this.rgb48Trans = new Rgb48(rc, gc, bc);
                         this.hasTrans = true;
                         return;
@@ -909,12 +898,12 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </exception>
         private void ValidateHeader()
         {
-            if (!ColorTypes.ContainsKey(this.header.ColorType))
+            if (!PngConstants.ColorTypes.ContainsKey(this.header.ColorType))
             {
                 throw new NotSupportedException("Color type is not supported or not valid.");
             }
 
-            if (!ColorTypes[this.header.ColorType].Contains(this.header.BitDepth))
+            if (!PngConstants.ColorTypes[this.header.ColorType].Contains(this.header.BitDepth))
             {
                 throw new NotSupportedException("Bit depth is not supported or not valid.");
             }

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.Formats.Png.Chunks;
 using SixLabors.ImageSharp.Formats.Png.Filters;
 using SixLabors.ImageSharp.Formats.Png.Zlib;
 using SixLabors.ImageSharp.Memory;

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -674,47 +674,9 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="meta">The image meta data.</param>
         private void WritePhysicalChunk(Stream stream, ImageMetaData meta)
         {
-            // The pHYs chunk specifies the intended pixel size or aspect ratio for display of the image. It contains:
-            // Pixels per unit, X axis: 4 bytes (unsigned integer)
-            // Pixels per unit, Y axis: 4 bytes (unsigned integer)
-            // Unit specifier:          1 byte
-            //
-            // The following values are legal for the unit specifier:
-            //   0: unit is unknown
-            //   1: unit is the meter
-            //
-            // When the unit specifier is 0, the pHYs chunk defines pixel aspect ratio only; the actual size of the pixels remains unspecified.
-            Span<byte> hResolution = this.chunkDataBuffer.AsSpan(0, 4);
-            Span<byte> vResolution = this.chunkDataBuffer.AsSpan(4, 4);
+            PngPhysicalChunkData.FromMetadata(meta).WriteTo(this.chunkDataBuffer);
 
-            switch (meta.ResolutionUnits)
-            {
-                case PixelResolutionUnit.AspectRatio:
-                    this.chunkDataBuffer[8] = 0;
-                    BinaryPrimitives.WriteInt32BigEndian(hResolution, (int)Math.Round(meta.HorizontalResolution));
-                    BinaryPrimitives.WriteInt32BigEndian(vResolution, (int)Math.Round(meta.VerticalResolution));
-                    break;
-
-                case PixelResolutionUnit.PixelsPerInch:
-                    this.chunkDataBuffer[8] = 1; // Per meter
-                    BinaryPrimitives.WriteInt32BigEndian(hResolution, (int)Math.Round(UnitConverter.InchToMeter(meta.HorizontalResolution)));
-                    BinaryPrimitives.WriteInt32BigEndian(vResolution, (int)Math.Round(UnitConverter.InchToMeter(meta.VerticalResolution)));
-                    break;
-
-                case PixelResolutionUnit.PixelsPerCentimeter:
-                    this.chunkDataBuffer[8] = 1; // Per meter
-                    BinaryPrimitives.WriteInt32BigEndian(hResolution, (int)Math.Round(UnitConverter.CmToMeter(meta.HorizontalResolution)));
-                    BinaryPrimitives.WriteInt32BigEndian(vResolution, (int)Math.Round(UnitConverter.CmToMeter(meta.VerticalResolution)));
-                    break;
-
-                default:
-                    this.chunkDataBuffer[8] = 1; // Per meter
-                    BinaryPrimitives.WriteInt32BigEndian(hResolution, (int)Math.Round(meta.HorizontalResolution));
-                    BinaryPrimitives.WriteInt32BigEndian(vResolution, (int)Math.Round(meta.VerticalResolution));
-                    break;
-            }
-
-            this.WriteChunk(stream, PngChunkType.Physical, this.chunkDataBuffer, 0, 9);
+            this.WriteChunk(stream, PngChunkType.Physical, this.chunkDataBuffer, 0, PngPhysicalChunkData.Size);
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.Advanced;
-using SixLabors.ImageSharp.Common.Helpers;
 using SixLabors.ImageSharp.Formats.Png.Filters;
 using SixLabors.ImageSharp.Formats.Png.Zlib;
 using SixLabors.ImageSharp.Memory;
@@ -674,9 +673,9 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="meta">The image meta data.</param>
         private void WritePhysicalChunk(Stream stream, ImageMetaData meta)
         {
-            PngPhysicalChunkData.FromMetadata(meta).WriteTo(this.chunkDataBuffer);
+            PhysicalChunkData.FromMetadata(meta).WriteTo(this.chunkDataBuffer);
 
-            this.WriteChunk(stream, PngChunkType.Physical, this.chunkDataBuffer, 0, PngPhysicalChunkData.Size);
+            this.WriteChunk(stream, PngChunkType.Physical, this.chunkDataBuffer, 0, PhysicalChunkData.Size);
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Png/PngHeader.cs
+++ b/src/ImageSharp/Formats/Png/PngHeader.cs
@@ -88,24 +88,25 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </exception>
         public void Validate()
         {
-            if (!PngConstants.ColorTypes.ContainsKey(this.ColorType))
+            if (!PngConstants.ColorTypes.TryGetValue(this.ColorType, out byte[] supportedBitDepths))
             {
-                throw new NotSupportedException("Color type is not supported or not valid.");
+                throw new NotSupportedException($"Invalid or unsupported color type. Was '{this.ColorType}'.");
             }
 
-            if (PngConstants.ColorTypes[this.ColorType].AsSpan().IndexOf(this.BitDepth) == -1)
+            if (supportedBitDepths.AsSpan().IndexOf(this.BitDepth) == -1)
             {
-                throw new NotSupportedException("Bit depth is not supported or not valid.");
+                throw new NotSupportedException($"Invalid or unsupported bit depth. Was '{this.BitDepth}'.");
             }
 
             if (this.FilterMethod != 0)
             {
-                throw new NotSupportedException("The png specification only defines 0 as filter method.");
+                throw new NotSupportedException($"Invalid filter method. Expected 0. Was '{this.FilterMethod}'.");
             }
 
+            // The png specification only defines 'None' and 'Adam7' as interlaced methods.
             if (this.InterlaceMethod != PngInterlaceMode.None && this.InterlaceMethod != PngInterlaceMode.Adam7)
             {
-                throw new NotSupportedException("The png specification only defines 'None' and 'Adam7' as interlaced methods.");
+                throw new NotSupportedException($"Invalid interlace method. Expected 'None' or 'Adam7'. Was '{this.InterlaceMethod}'.");
             }
         }
 

--- a/src/ImageSharp/Formats/Png/PngHeader.cs
+++ b/src/ImageSharp/Formats/Png/PngHeader.cs
@@ -81,6 +81,35 @@ namespace SixLabors.ImageSharp.Formats.Png
         public PngInterlaceMode InterlaceMethod { get; }
 
         /// <summary>
+        /// Validates the png header.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the image does pass validation.
+        /// </exception>
+        public void Validate()
+        {
+            if (!PngConstants.ColorTypes.ContainsKey(this.ColorType))
+            {
+                throw new NotSupportedException("Color type is not supported or not valid.");
+            }
+
+            if (PngConstants.ColorTypes[this.ColorType].AsSpan().IndexOf(this.BitDepth) == -1)
+            {
+                throw new NotSupportedException("Bit depth is not supported or not valid.");
+            }
+
+            if (this.FilterMethod != 0)
+            {
+                throw new NotSupportedException("The png specification only defines 0 as filter method.");
+            }
+
+            if (this.InterlaceMethod != PngInterlaceMode.None && this.InterlaceMethod != PngInterlaceMode.Adam7)
+            {
+                throw new NotSupportedException("The png specification only defines 'None' and 'Adam7' as interlaced methods.");
+            }
+        }
+
+        /// <summary>
         /// Writes the header to the given buffer.
         /// </summary>
         /// <param name="buffer">The buffer to write to.</param>

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifReader.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifReader.cs
@@ -127,25 +127,14 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
 
         private unsafe string ConvertToString(ReadOnlySpan<byte> buffer)
         {
-            Span<byte> nullChar = stackalloc byte[1] { 0 };
-
-            int nullCharIndex = buffer.IndexOf(nullChar);
+            int nullCharIndex = buffer.IndexOf((byte)0);
 
             if (nullCharIndex > -1)
             {
                 buffer = buffer.Slice(0, nullCharIndex);
             }
 
-#if NETSTANDARD1_1
-            return Encoding.UTF8.GetString(buffer.ToArray(), 0, buffer.Length);
-#elif NETCOREAPP2_1
             return Encoding.UTF8.GetString(buffer);
-#else
-            fixed (byte* pointer = &MemoryMarshal.GetReference(buffer))
-            {
-                return Encoding.UTF8.GetString(pointer, buffer.Length);
-            }
-#endif
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

- Unify buffers in PngDecoder 
- Add Encoding.GetString(ROS<byte>) polyfill
- Utilize polyfill
- Move ColorTypes to PngConstants
- Optimize ReadTextChunk
- Move PngHeader validation to struct
- Improve descriptions on PNG exceptions
- Breakout the PhysicalChunkData conversion and encoding logic and add parse method

<!-- Thanks for contributing to ImageSharp! -->
