### PR TITLE
Uniformize T4 generator methods for PixelOperations<T>

### DIFF
--- a/src/ImageSharp/PixelFormats/Generated/PixelOperations{TPixel}.Generated.cs
+++ b/src/ImageSharp/PixelFormats/Generated/PixelOperations{TPixel}.Generated.cs
@@ -24,6 +24,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
+            // For conversion methods writing only to RGB channels, we need to keep the alpha channel opaque!
             var temp = NamedColors<Rgba64>.Black;
 
             for (int i = 0; i < count; i++)
@@ -95,6 +96,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
+            // For conversion methods writing only to RGB channels, we need to keep the alpha channel opaque!
             var temp = NamedColors<Rgb48>.Black;
 
             for (int i = 0; i < count; i++)
@@ -166,6 +168,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Rgba32 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
+            // For conversion methods writing only to RGB channels, we need to keep the alpha channel opaque!
             var temp = NamedColors<Rgba32>.Black;
 
             for (int i = 0; i < count; i++)
@@ -237,6 +240,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
+            // For conversion methods writing only to RGB channels, we need to keep the alpha channel opaque!
             var temp = NamedColors<Bgra32>.Black;
 
             for (int i = 0; i < count; i++)
@@ -308,6 +312,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
+            // For conversion methods writing only to RGB channels, we need to keep the alpha channel opaque!
             var temp = NamedColors<Rgba32>.Black;
 
             for (int i = 0; i < count; i++)
@@ -379,6 +384,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
+            // For conversion methods writing only to RGB channels, we need to keep the alpha channel opaque!
             var temp = NamedColors<Rgba32>.Black;
 
             for (int i = 0; i < count; i++)
@@ -450,6 +456,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
+            // For conversion methods writing only to RGB channels, we need to keep the alpha channel opaque!
             var temp = NamedColors<Argb32>.Black;
 
             for (int i = 0; i < count; i++)

--- a/src/ImageSharp/PixelFormats/Generated/PixelOperations{TPixel}.Generated.cs
+++ b/src/ImageSharp/PixelFormats/Generated/PixelOperations{TPixel}.Generated.cs
@@ -24,13 +24,13 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
-            var rgba = new Rgba64(0, 0, 0, 65535);
+            var temp = NamedColors<Rgba64>.Black;
 
             for (int i = 0; i < count; i++)
             {
                 ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                rgba = Unsafe.Add(ref sourceRef, i);
-                dp.PackFromRgba64(rgba);
+                temp = Unsafe.Add(ref sourceRef, i);
+                dp.PackFromRgba64(temp);
             }
         }
 		
@@ -95,13 +95,13 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
-            var rgb = default(Rgb48);
+            var temp = NamedColors<Rgb48>.Black;
 
             for (int i = 0; i < count; i++)
             {
                 ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                rgb = Unsafe.Add(ref sourceRef, i);
-                dp.PackFromRgb48(rgb);
+                temp = Unsafe.Add(ref sourceRef, i);
+                dp.PackFromRgb48(temp);
             }
         }
 		
@@ -166,13 +166,13 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Rgba32 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
-            var rgba = new Rgba32(0, 0, 0, 255);
+            var temp = NamedColors<Rgba32>.Black;
 
             for (int i = 0; i < count; i++)
             {
                 ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                rgba = Unsafe.Add(ref sourceRef, i);
-                dp.PackFromRgba32(rgba);
+                temp = Unsafe.Add(ref sourceRef, i);
+                dp.PackFromRgba32(temp);
             }
         }
 		
@@ -237,13 +237,13 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
-            var bgra = new Bgra32(0, 0, 0, 255);
+            var temp = NamedColors<Bgra32>.Black;
 
             for (int i = 0; i < count; i++)
             {
                 ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                bgra = Unsafe.Add(ref sourceRef, i);
-                dp.PackFromBgra32(bgra);
+                temp = Unsafe.Add(ref sourceRef, i);
+                dp.PackFromBgra32(temp);
             }
         }
 		
@@ -308,13 +308,13 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
-            var rgba = new Rgba32(0, 0, 0, 255);
+            var temp = NamedColors<Rgba32>.Black;
 
             for (int i = 0; i < count; i++)
             {
                 ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                rgba.Rgb = Unsafe.Add(ref sourceRef, i);
-                dp.PackFromRgba32(rgba);
+                temp.Rgb = Unsafe.Add(ref sourceRef, i);
+                dp.PackFromRgba32(temp);
             }
         }
 		
@@ -379,13 +379,13 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
-            var rgba = new Rgba32(0, 0, 0, 255);
+            var temp = NamedColors<Rgba32>.Black;
 
             for (int i = 0; i < count; i++)
             {
                 ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                rgba.Bgr = Unsafe.Add(ref sourceRef, i);
-                dp.PackFromRgba32(rgba);
+                temp.Bgr = Unsafe.Add(ref sourceRef, i);
+                dp.PackFromRgba32(temp);
             }
         }
 		
@@ -450,13 +450,13 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
-            var argb = new Argb32(0, 0, 0, 255);
+            var temp = NamedColors<Argb32>.Black;
 
             for (int i = 0; i < count; i++)
             {
                 ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                argb = Unsafe.Add(ref sourceRef, i);
-				dp.PackFromArgb32(argb);
+                temp = Unsafe.Add(ref sourceRef, i);
+                dp.PackFromArgb32(temp);
             }
         }
 		
@@ -509,4 +509,5 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 		
 	}
+
 }

--- a/src/ImageSharp/PixelFormats/Generated/PixelOperations{TPixel}.Generated.tt
+++ b/src/ImageSharp/PixelFormats/Generated/PixelOperations{TPixel}.Generated.tt
@@ -28,6 +28,7 @@
             ref <#=pixelType#> sourceRef = ref MemoryMarshal.GetReference(source);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
+            // For conversion methods writing only to RGB channels, we need to keep the alpha channel opaque!
             var temp = NamedColors<<#=tempPixelType#>>.Black;
 
             for (int i = 0; i < count; i++)
@@ -94,216 +95,6 @@
 		<#
     }
 
-    void GeneratePackFromMethodUsingPackFromRgba64(string pixelType, string rgbaOperationCode)
-    {		
-		#>
-
-		/// <summary>
-        /// Converts 'count' elements in 'source` span of <see cref="<#=pixelType#>"/> data to a span of <typeparamref name="TPixel"/>-s.
-        /// </summary>
-        /// <param name="source">The source <see cref="Span{T}"/> of <see cref="<#=pixelType#>"/> data.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        internal virtual void PackFrom<#=pixelType#>(ReadOnlySpan<<#=pixelType#>> source, Span<TPixel> destPixels, int count)
-        {
-			GuardSpans(source, nameof(source), destPixels, nameof(destPixels), count);
-            
-            ref <#=pixelType#> sourceRef = ref MemoryMarshal.GetReference(source);
-            ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
-
-            var rgba = new Rgba64(0, 0, 0, 65535);
-
-            for (int i = 0; i < count; i++)
-            {
-                ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                <#=rgbaOperationCode#>
-                dp.PackFromRgba64(rgba);
-            }
-        }
-		
-		/// <summary>
-        /// A helper for <see cref="PackFrom<#=pixelType#>(ReadOnlySpan{<#=pixelType#>}, Span{TPixel}, int)"/> that expects a byte span.
-        /// The layout of the data in 'sourceBytes' must be compatible with <see cref="<#=pixelType#>"/> layout.
-        /// </summary>
-        /// <param name="sourceBytes">The <see cref="ReadOnlySpan{T}"/> to the source bytes.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void PackFrom<#=pixelType#>Bytes(ReadOnlySpan<byte> sourceBytes, Span<TPixel> destPixels, int count)
-        {
-            this.PackFrom<#=pixelType#>(MemoryMarshal.Cast<byte, <#=pixelType#>>(sourceBytes), destPixels, count);
-        }
-		<#
-    }
-
-    void GeneratePackFromMethodUsingPackFromRgb48(string pixelType, string rgbaOperationCode)
-    {		
-		#>
-
-		/// <summary>
-        /// Converts 'count' elements in 'source` span of <see cref="<#=pixelType#>"/> data to a span of <typeparamref name="TPixel"/>-s.
-        /// </summary>
-        /// <param name="source">The source <see cref="Span{T}"/> of <see cref="<#=pixelType#>"/> data.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        internal virtual void PackFrom<#=pixelType#>(ReadOnlySpan<<#=pixelType#>> source, Span<TPixel> destPixels, int count)
-        {
-			GuardSpans(source, nameof(source), destPixels, nameof(destPixels), count);
-            
-            ref <#=pixelType#> sourceRef = ref MemoryMarshal.GetReference(source);
-            ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
-
-            var rgb = default(Rgb48);
-
-            for (int i = 0; i < count; i++)
-            {
-                ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                <#=rgbaOperationCode#>
-                dp.PackFromRgb48(rgb);
-            }
-        }
-		
-		/// <summary>
-        /// A helper for <see cref="PackFrom<#=pixelType#>(ReadOnlySpan{<#=pixelType#>}, Span{TPixel}, int)"/> that expects a byte span.
-        /// The layout of the data in 'sourceBytes' must be compatible with <see cref="<#=pixelType#>"/> layout.
-        /// </summary>
-        /// <param name="sourceBytes">The <see cref="ReadOnlySpan{T}"/> to the source bytes.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void PackFrom<#=pixelType#>Bytes(ReadOnlySpan<byte> sourceBytes, Span<TPixel> destPixels, int count)
-        {
-            this.PackFrom<#=pixelType#>(MemoryMarshal.Cast<byte, <#=pixelType#>>(sourceBytes), destPixels, count);
-        }
-		<#
-    }
-
-    void GeneratePackFromMethodUsingPackFromRgba32(string pixelType, string rgbaOperationCode)
-    {		
-		#>
-
-		/// <summary>
-        /// Converts 'count' elements in 'source` span of <see cref="<#=pixelType#>"/> data to a span of <typeparamref name="TPixel"/>-s.
-        /// </summary>
-        /// <param name="source">The source <see cref="Span{T}"/> of <see cref="<#=pixelType#>"/> data.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        internal virtual void PackFrom<#=pixelType#>(ReadOnlySpan<<#=pixelType#>> source, Span<TPixel> destPixels, int count)
-        {
-			GuardSpans(source, nameof(source), destPixels, nameof(destPixels), count);
-            
-            ref <#=pixelType#> sourceRef = ref MemoryMarshal.GetReference(source);
-            ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
-
-            var rgba = new Rgba32(0, 0, 0, 255);
-
-            for (int i = 0; i < count; i++)
-            {
-                ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                <#=rgbaOperationCode#>
-                dp.PackFromRgba32(rgba);
-            }
-        }
-		
-		/// <summary>
-        /// A helper for <see cref="PackFrom<#=pixelType#>(ReadOnlySpan{<#=pixelType#>}, Span{TPixel}, int)"/> that expects a byte span.
-        /// The layout of the data in 'sourceBytes' must be compatible with <see cref="<#=pixelType#>"/> layout.
-        /// </summary>
-        /// <param name="sourceBytes">The <see cref="ReadOnlySpan{T}"/> to the source bytes.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void PackFrom<#=pixelType#>Bytes(ReadOnlySpan<byte> sourceBytes, Span<TPixel> destPixels, int count)
-        {
-            this.PackFrom<#=pixelType#>(MemoryMarshal.Cast<byte, <#=pixelType#>>(sourceBytes), destPixels, count);
-        }
-		<#
-    }
-
-    void GeneratePackFromMethodUsingPackFromArgb32(string pixelType, string argbOperationCode)
-    {		
-		#>
-
-		/// <summary>
-        /// Converts 'count' elements in 'source` span of <see cref="<#=pixelType#>"/> data to a span of <typeparamref name="TPixel"/>-s.
-        /// </summary>
-        /// <param name="source">The source <see cref="Span{T}"/> of <see cref="<#=pixelType#>"/> data.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        internal virtual void PackFrom<#=pixelType#>(ReadOnlySpan<<#=pixelType#>> source, Span<TPixel> destPixels, int count)
-        {
-			GuardSpans(source, nameof(source), destPixels, nameof(destPixels), count);
-            
-            ref <#=pixelType#> sourceRef = ref MemoryMarshal.GetReference(source);
-            ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
-
-            var argb = new Argb32(0, 0, 0, 255);
-
-            for (int i = 0; i < count; i++)
-            {
-                ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                <#=argbOperationCode#>
-				dp.PackFromArgb32(argb);
-            }
-        }
-		
-		/// <summary>
-        /// A helper for <see cref="PackFrom<#=pixelType#>(ReadOnlySpan{<#=pixelType#>}, Span{TPixel}, int)"/> that expects a byte span.
-        /// The layout of the data in 'sourceBytes' must be compatible with <see cref="<#=pixelType#>"/> layout.
-        /// </summary>
-        /// <param name="sourceBytes">The <see cref="ReadOnlySpan{T}"/> to the source bytes.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void PackFrom<#=pixelType#>Bytes(ReadOnlySpan<byte> sourceBytes, Span<TPixel> destPixels, int count)
-        {
-            this.PackFrom<#=pixelType#>(MemoryMarshal.Cast<byte, <#=pixelType#>>(sourceBytes), destPixels, count);
-        }
-		<#
-    }
-
-    void GeneratePackFromMethodUsingPackFromBgra32(string pixelType, string bgraOperationCode)
-    {		
-		#>
-
-		/// <summary>
-        /// Converts 'count' elements in 'source` span of <see cref="<#=pixelType#>"/> data to a span of <typeparamref name="TPixel"/>-s.
-        /// </summary>
-        /// <param name="source">The source <see cref="Span{T}"/> of <see cref="<#=pixelType#>"/> data.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        internal virtual void PackFrom<#=pixelType#>(ReadOnlySpan<<#=pixelType#>> source, Span<TPixel> destPixels, int count)
-        {
-			GuardSpans(source, nameof(source), destPixels, nameof(destPixels), count);
-            
-            ref <#=pixelType#> sourceRef = ref MemoryMarshal.GetReference(source);
-            ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
-
-            var bgra = new Bgra32(0, 0, 0, 255);
-
-            for (int i = 0; i < count; i++)
-            {
-                ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                <#=bgraOperationCode#>
-                dp.PackFromBgra32(bgra);
-            }
-        }
-		
-		/// <summary>
-        /// A helper for <see cref="PackFrom<#=pixelType#>(ReadOnlySpan{<#=pixelType#>}, Span{TPixel}, int)"/> that expects a byte span.
-        /// The layout of the data in 'sourceBytes' must be compatible with <see cref="<#=pixelType#>"/> layout.
-        /// </summary>
-        /// <param name="sourceBytes">The <see cref="ReadOnlySpan{T}"/> to the source bytes.</param>
-        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void PackFrom<#=pixelType#>Bytes(ReadOnlySpan<byte> sourceBytes, Span<TPixel> destPixels, int count)
-        {
-            this.PackFrom<#=pixelType#>(MemoryMarshal.Cast<byte, <#=pixelType#>>(sourceBytes), destPixels, count);
-        }
-		<#
-    }
-
 #>
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
@@ -318,35 +109,26 @@ namespace SixLabors.ImageSharp.PixelFormats
     public partial class PixelOperations<TPixel>
     {
 		<#
-
-    // GeneratePackFromMethodUsingPackFromRgba64("Rgba64", "rgba = Unsafe.Add(ref sourceRef, i);");
-
     GeneratePackFromMethods("Rgba64", "Rgba64", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Rgba64");
 
-    // GeneratePackFromMethodUsingPackFromRgb48("Rgb48", "rgb = Unsafe.Add(ref sourceRef, i);");
     GeneratePackFromMethods("Rgb48", "Rgb48", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Rgb48");
 
     GeneratePackFromMethods("Rgba32", "Rgba32", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Rgba32");
 
-    // GeneratePackFromMethodUsingPackFromBgra32("Bgra32", "bgra = Unsafe.Add(ref sourceRef, i);");
     GeneratePackFromMethods("Bgra32", "Bgra32", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Bgra32");
 	
-	// GeneratePackFromMethodUsingPackFromRgba32("Rgb24", "rgba.Rgb = Unsafe.Add(ref sourceRef, i);");
     GeneratePackFromMethods("Rgb24", "Rgba32", "temp.Rgb = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Rgb24");
 
-    // GeneratePackFromMethodUsingPackFromRgba32("Bgr24", "rgba.Bgr = Unsafe.Add(ref sourceRef, i);");
     GeneratePackFromMethods("Bgr24", "Rgba32", "temp.Bgr = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Bgr24");
 
-    // GeneratePackFromMethodUsingPackFromArgb32("Argb32", "argb = Unsafe.Add(ref sourceRef, i);");
     GeneratePackFromMethods("Argb32", "Argb32", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Argb32");
-
 		#>
 
 	}

--- a/src/ImageSharp/PixelFormats/Generated/PixelOperations{TPixel}.Generated.tt
+++ b/src/ImageSharp/PixelFormats/Generated/PixelOperations{TPixel}.Generated.tt
@@ -10,6 +10,49 @@
 <#@ import namespace="System.Runtime.InteropServices" #>
 <#@ output extension=".cs" #>
 <#    
+
+    void GeneratePackFromMethods(string pixelType, string tempPixelType, string assignToTempCode)
+    {		
+		#>
+
+		/// <summary>
+        /// Converts 'count' elements in 'source` span of <see cref="<#=pixelType#>"/> data to a span of <typeparamref name="TPixel"/>-s.
+        /// </summary>
+        /// <param name="source">The source <see cref="Span{T}"/> of <see cref="<#=pixelType#>"/> data.</param>
+        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
+        /// <param name="count">The number of pixels to convert.</param>
+        internal virtual void PackFrom<#=pixelType#>(ReadOnlySpan<<#=pixelType#>> source, Span<TPixel> destPixels, int count)
+        {
+			GuardSpans(source, nameof(source), destPixels, nameof(destPixels), count);
+            
+            ref <#=pixelType#> sourceRef = ref MemoryMarshal.GetReference(source);
+            ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
+
+            var temp = NamedColors<<#=tempPixelType#>>.Black;
+
+            for (int i = 0; i < count; i++)
+            {
+                ref TPixel dp = ref Unsafe.Add(ref destRef, i);
+                <#=assignToTempCode#>
+                dp.PackFrom<#=tempPixelType#>(temp);
+            }
+        }
+		
+		/// <summary>
+        /// A helper for <see cref="PackFrom<#=pixelType#>(ReadOnlySpan{<#=pixelType#>}, Span{TPixel}, int)"/> that expects a byte span.
+        /// The layout of the data in 'sourceBytes' must be compatible with <see cref="<#=pixelType#>"/> layout.
+        /// </summary>
+        /// <param name="sourceBytes">The <see cref="ReadOnlySpan{T}"/> to the source bytes.</param>
+        /// <param name="destPixels">The <see cref="Span{T}"/> to the destination pixels.</param>
+        /// <param name="count">The number of pixels to convert.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void PackFrom<#=pixelType#>Bytes(ReadOnlySpan<byte> sourceBytes, Span<TPixel> destPixels, int count)
+        {
+            this.PackFrom<#=pixelType#>(MemoryMarshal.Cast<byte, <#=pixelType#>>(sourceBytes), destPixels, count);
+        }
+		<#
+    }
+
     void GenerateToDestFormatMethods(string pixelType)
     {
         #>
@@ -276,28 +319,36 @@ namespace SixLabors.ImageSharp.PixelFormats
     {
 		<#
 
-    GeneratePackFromMethodUsingPackFromRgba64("Rgba64", "rgba = Unsafe.Add(ref sourceRef, i);");
+    // GeneratePackFromMethodUsingPackFromRgba64("Rgba64", "rgba = Unsafe.Add(ref sourceRef, i);");
+
+    GeneratePackFromMethods("Rgba64", "Rgba64", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Rgba64");
 
-    GeneratePackFromMethodUsingPackFromRgb48("Rgb48", "rgb = Unsafe.Add(ref sourceRef, i);");
+    // GeneratePackFromMethodUsingPackFromRgb48("Rgb48", "rgb = Unsafe.Add(ref sourceRef, i);");
+    GeneratePackFromMethods("Rgb48", "Rgb48", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Rgb48");
 
-    GeneratePackFromMethodUsingPackFromRgba32("Rgba32", "rgba = Unsafe.Add(ref sourceRef, i);");
+    GeneratePackFromMethods("Rgba32", "Rgba32", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Rgba32");
 
-    GeneratePackFromMethodUsingPackFromBgra32("Bgra32", "bgra = Unsafe.Add(ref sourceRef, i);");
+    // GeneratePackFromMethodUsingPackFromBgra32("Bgra32", "bgra = Unsafe.Add(ref sourceRef, i);");
+    GeneratePackFromMethods("Bgra32", "Bgra32", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Bgra32");
 	
-	GeneratePackFromMethodUsingPackFromRgba32("Rgb24", "rgba.Rgb = Unsafe.Add(ref sourceRef, i);");
+	// GeneratePackFromMethodUsingPackFromRgba32("Rgb24", "rgba.Rgb = Unsafe.Add(ref sourceRef, i);");
+    GeneratePackFromMethods("Rgb24", "Rgba32", "temp.Rgb = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Rgb24");
 
-    GeneratePackFromMethodUsingPackFromRgba32("Bgr24", "rgba.Bgr = Unsafe.Add(ref sourceRef, i);");
+    // GeneratePackFromMethodUsingPackFromRgba32("Bgr24", "rgba.Bgr = Unsafe.Add(ref sourceRef, i);");
+    GeneratePackFromMethods("Bgr24", "Rgba32", "temp.Bgr = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Bgr24");
 
-    GeneratePackFromMethodUsingPackFromArgb32("Argb32", "argb = Unsafe.Add(ref sourceRef, i);");
+    // GeneratePackFromMethodUsingPackFromArgb32("Argb32", "argb = Unsafe.Add(ref sourceRef, i);");
+    GeneratePackFromMethods("Argb32", "Argb32", "temp = Unsafe.Add(ref sourceRef, i);");
     GenerateToDestFormatMethods("Argb32");
 
 		#>
 
 	}
+
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Uniformizing and simplifying generator methods in `PixelOperations{TPixel}.Generated.tt`, DRY-ing away redundant T4 code. Hope it will help @jongleur1983's work on #718.