### PR TITLE
Add ToString implementations to Bgr24 and Bgra32

### DIFF
--- a/src/ImageSharp/PixelFormats/Bgr24.cs
+++ b/src/ImageSharp/PixelFormats/Bgr24.cs
@@ -197,5 +197,11 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ToRgba64(ref Rgba64 dest) => dest.PackFromScaledVector4(this.ToScaledVector4());
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"({this.B},{this.G},{this.R})";
+        }
     }
 }

--- a/src/ImageSharp/PixelFormats/Bgra32.cs
+++ b/src/ImageSharp/PixelFormats/Bgra32.cs
@@ -280,5 +280,11 @@ namespace SixLabors.ImageSharp.PixelFormats
             this.B = (byte)vector.Z;
             this.A = (byte)vector.W;
         }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"({this.B},{this.G},{this.R},{this.A})";
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Bgr24 and Bgra32 did not yet override ToString(). Did that now, following the same pattern as other Pixel formats (printing the components)