### PR TITLE
Drop netstandard1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Designed to democratize image processing, ImageSharp brings you an incredibly po
 
 Compared to `System.Drawing` we have been able to develop something much more flexible, easier to code against, and much, much less prone to memory leaks. Gone are system-wide process-locks; ImageSharp images are thread-safe and fully supported in web environments.
 
-Built against .Net Standard 1.3 ImageSharp can be used in device, cloud, and embedded/IoT scenarios. 
+Built against .NET Standard 1.3 ImageSharp can be used in device, cloud, and embedded/IoT scenarios. 
 
 ### Documentation
 For all SixLabors projects, including ImageSharp:
@@ -115,7 +115,7 @@ If you prefer, you can compile ImageSharp yourself (please do and help!)
 Alternatively, you can work from command line and/or with a lightweight editor on **both Linux/Unix and Windows**:
 
 - [Visual Studio Code](https://code.visualstudio.com/) with [C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
-- [.Net Core](https://www.microsoft.com/net/core#linuxubuntu)
+- [.NET Core](https://www.microsoft.com/net/core#linuxubuntu)
 
 To clone ImageSharp locally click the "Clone in Windows" button above or run the following git commands.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Designed to democratize image processing, ImageSharp brings you an incredibly po
 
 Compared to `System.Drawing` we have been able to develop something much more flexible, easier to code against, and much, much less prone to memory leaks. Gone are system-wide process-locks; ImageSharp images are thread-safe and fully supported in web environments.
 
-Built against .Net Standard 1.1 ImageSharp can be used in device, cloud, and embedded/IoT scenarios. 
+Built against .Net Standard 1.3 ImageSharp can be used in device, cloud, and embedded/IoT scenarios. 
 
 ### Documentation
 For all SixLabors projects, including ImageSharp:
@@ -81,24 +81,6 @@ using (Image<Rgba32> image = Image.Load("foo.jpg"))
          .Resize(image.Width / 2, image.Height / 2)
          .Grayscale());
     image.Save("bar.jpg"); // Automatic encoder selected based on extension.
-}
-```
-On netstandard 1.1 - 1.2
-
-```csharp
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Processing;
-
-// Image.Load(Stream stream) is a shortcut for our default type.
-// Other pixel formats use Image.Load<TPixel>(Stream stream))
-using (FileStream stream = File.OpenRead("foo.jpg"))
-using (FileStream output = File.OpenWrite("bar.jpg"))
-using (Image<Rgba32> image = Image.Load(stream))
-{
-    image.Mutate(x => x
-         .Resize(image.Width / 2, image.Height / 2)
-         .Grayscale());
-    image.Save(output);
 }
 ```
 

--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -5,8 +5,8 @@
         <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
         <VersionPrefix Condition="$(packageversion) == ''">0.0.1</VersionPrefix>
         <Authors>SixLabors and contributors</Authors>
-        <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
-        <LangVersion>7.2</LangVersion>
+        <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+        <LangVersion>7.3</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AssemblyName>SixLabors.ImageSharp.Drawing</AssemblyName>

--- a/src/ImageSharp/Common/Extensions/EncoderExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/EncoderExtensions.cs
@@ -20,14 +20,10 @@ namespace SixLabors.ImageSharp
         /// <returns>The string.</returns>
         public static string GetString(this Encoding encoding, ReadOnlySpan<byte> buffer)
         {
-#if NETSTANDARD1_1
-            return encoding.GetString(buffer.ToArray());
-#else
             fixed (byte* bytes = buffer)
             {
                 return encoding.GetString(bytes, buffer.Length);
             }
-#endif
         }
     }
 }

--- a/src/ImageSharp/Common/Helpers/TestHelpers.cs
+++ b/src/ImageSharp/Common/Helpers/TestHelpers.cs
@@ -13,9 +13,7 @@ namespace SixLabors.ImageSharp.Common.Helpers
         /// Only intended to be used in tests!
         /// </summary>
         internal const string ImageSharpBuiltAgainst =
-#if NETSTANDARD1_1
-            "netstandard1.1";
-#elif NETCOREAPP2_1
+#if NETCOREAPP2_1
             "netcoreapp2.1";
 #else
             "netstandard2.0";

--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -3,15 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
-#if !NETSTANDARD1_1
 using SixLabors.ImageSharp.IO;
-#endif
 using SixLabors.ImageSharp.Processing;
 using SixLabors.Memory;
 
@@ -100,12 +97,10 @@ namespace SixLabors.ImageSharp
         /// </summary>
         internal int MaxHeaderSize => this.ImageFormatsManager.MaxHeaderSize;
 
-#if !NETSTANDARD1_1
         /// <summary>
         /// Gets or sets the filesystem helper for accessing the local file system.
         /// </summary>
         internal IFileSystem FileSystem { get; set; } = new LocalFileSystem();
-#endif
 
         /// <summary>
         /// Gets or sets the image operations provider factory.
@@ -135,10 +130,7 @@ namespace SixLabors.ImageSharp
                 MemoryAllocator = this.MemoryAllocator,
                 ImageOperationsProvider = this.ImageOperationsProvider,
                 ReadOrigin = this.ReadOrigin,
-
-#if !NETSTANDARD1_1
                 FileSystem = this.FileSystem
-#endif
             };
         }
 

--- a/src/ImageSharp/Formats/Gif/GifConstants.cs
+++ b/src/ImageSharp/Formats/Gif/GifConstants.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <summary>
         /// The ASCII encoded bytes used to identify the GIF file.
         /// </summary>
-        internal static readonly byte[] MagicNumber = Encoding.UTF8.GetBytes(FileType + FileVersion);
+        internal static readonly byte[] MagicNumber = Encoding.ASCII.GetBytes(FileType + FileVersion);
 
         /// <summary>
         /// The extension block introducer <value>!</value>.
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <summary>
         /// The ASCII encoded application identification bytes.
         /// </summary>
-        internal static readonly byte[] NetscapeApplicationIdentificationBytes = Encoding.UTF8.GetBytes(NetscapeApplicationIdentification);
+        internal static readonly byte[] NetscapeApplicationIdentificationBytes = Encoding.ASCII.GetBytes(NetscapeApplicationIdentification);
 
         /// <summary>
         /// The Netscape looping application sub block size.

--- a/src/ImageSharp/Formats/Gif/GifConstants.cs
+++ b/src/ImageSharp/Formats/Gif/GifConstants.cs
@@ -104,7 +104,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <summary>
         /// Gets the default encoding to use when reading comments.
         /// </summary>
-        public static readonly Encoding DefaultEncoding = Encoding.GetEncoding("ASCII");
+        public static readonly Encoding DefaultEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The list of mimetypes that equate to a gif.

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ProfileResolver.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ProfileResolver.cs
@@ -14,22 +14,22 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <summary>
         /// Describes the EXIF specific markers
         /// </summary>
-        public static readonly byte[] JFifMarker = Encoding.UTF8.GetBytes("JFIF\0");
+        public static readonly byte[] JFifMarker = Encoding.ASCII.GetBytes("JFIF\0");
 
         /// <summary>
         /// Describes the EXIF specific markers
         /// </summary>
-        public static readonly byte[] IccMarker = Encoding.UTF8.GetBytes("ICC_PROFILE\0");
+        public static readonly byte[] IccMarker = Encoding.ASCII.GetBytes("ICC_PROFILE\0");
 
         /// <summary>
         /// Describes the ICC specific markers
         /// </summary>
-        public static readonly byte[] ExifMarker = Encoding.UTF8.GetBytes("Exif\0\0");
+        public static readonly byte[] ExifMarker = Encoding.ASCII.GetBytes("Exif\0\0");
 
         /// <summary>
         /// Describes Adobe specific markers <see href="http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/JPEG.html#Adobe"/>
         /// </summary>
-        public static readonly byte[] AdobeMarker = Encoding.UTF8.GetBytes("Adobe");
+        public static readonly byte[] AdobeMarker = Encoding.ASCII.GetBytes("Adobe");
 
         /// <summary>
         /// Returns a value indicating whether the passed bytes are a match to the profile identifier

--- a/src/ImageSharp/Formats/Png/PngConstants.cs
+++ b/src/ImageSharp/Formats/Png/PngConstants.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <summary>
         /// The default encoding for text metadata.
         /// </summary>
-        public static readonly Encoding DefaultEncoding = Encoding.GetEncoding("ASCII");
+        public static readonly Encoding DefaultEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The list of mimetypes that equate to a png.

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1005,7 +1005,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
             if (this.crc.Value != chunk.Crc)
             {
-                string chunkTypeName = Encoding.UTF8.GetString(chunkType);
+                string chunkTypeName = Encoding.ASCII.GetString(chunkType);
 
                 throw new ImageFormatException($"CRC Error. PNG {chunkTypeName} chunk is corrupt!");
             }

--- a/src/ImageSharp/IO/IFileSystem.cs
+++ b/src/ImageSharp/IO/IFileSystem.cs
@@ -5,7 +5,6 @@ using System.IO;
 
 namespace SixLabors.ImageSharp.IO
 {
- #if !NETSTANDARD1_1
     /// <summary>
     /// A simple interface representing the filesystem.
     /// </summary>
@@ -25,5 +24,4 @@ namespace SixLabors.ImageSharp.IO
         /// <returns>A stream representing the file to open.</returns>
         Stream Create(string path);
     }
-#endif
 }

--- a/src/ImageSharp/IO/LocalFileSystem.cs
+++ b/src/ImageSharp/IO/LocalFileSystem.cs
@@ -1,30 +1,19 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace SixLabors.ImageSharp.IO
 {
- #if !NETSTANDARD1_1
     /// <summary>
     /// A wrapper around the local File apis.
     /// </summary>
     internal class LocalFileSystem : IFileSystem
     {
         /// <inheritdoc/>
-        public Stream OpenRead(string path)
-        {
-            return File.OpenRead(path);
-        }
+        public Stream OpenRead(string path) => File.OpenRead(path);
 
         /// <inheritdoc/>
-        public Stream Create(string path)
-        {
-            return File.Create(path);
-        }
+        public Stream Create(string path) => File.Create(path);
     }
-#endif
 }

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -174,8 +174,6 @@ namespace SixLabors.ImageSharp
             }
         }
 
-#if !NETSTANDARD1_1
-
         /// <summary>
         /// By reading the header on the provided byte array this calculates the images format.
         /// </summary>
@@ -303,6 +301,5 @@ namespace SixLabors.ImageSharp
                 }
             }
         }
-#endif
     }
 }

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-#if !NETSTANDARD1_1
 using System;
 using System.IO;
 using SixLabors.ImageSharp.Formats;
@@ -213,4 +212,3 @@ namespace SixLabors.ImageSharp
         }
     }
 }
-#endif

--- a/src/ImageSharp/ImageExtensions.cs
+++ b/src/ImageSharp/ImageExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
@@ -17,7 +16,6 @@ namespace SixLabors.ImageSharp
     /// </summary>
     public static partial class ImageExtensions
     {
-#if !NETSTANDARD1_1
         /// <summary>
         /// Writes the image to the given stream using the currently loaded image format.
         /// </summary>
@@ -78,7 +76,6 @@ namespace SixLabors.ImageSharp
                 source.Save(fs, encoder);
             }
         }
-#endif
 
         /// <summary>
         /// Writes the image to the given stream using the currently loaded image format.

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
     <VersionPrefix Condition="$(packageversion) == ''">0.0.1</VersionPrefix>
     <Authors>Six Labors and contributors</Authors>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SixLabors.ImageSharp</AssemblyName>
@@ -47,7 +47,7 @@
     <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' OR '$(TargetFramework)' == 'netstandard1.3'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Primitives.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Primitives.cs
@@ -102,7 +102,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
             }
 
             Guard.MustBeGreaterThan(length, 0, nameof(length));
-            string value = AsciiEncoding.GetString(this.data, this.AddIndex(length), length);
+            string value = Encoding.ASCII.GetString(this.data, this.AddIndex(length), length);
 
             // remove data after (potential) null terminator
             int pos = value.IndexOf('\0');

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     /// </summary>
     internal sealed partial class IccDataReader
     {
-        private static readonly Encoding AsciiEncoding = Encoding.GetEncoding("ASCII");
+        private static readonly Encoding AsciiEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The data that is read

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.cs
@@ -11,8 +11,6 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     /// </summary>
     internal sealed partial class IccDataReader
     {
-        private static readonly Encoding AsciiEncoding = Encoding.ASCII;
-
         /// <summary>
         /// The data that is read
         /// </summary>

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Primitives.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Primitives.cs
@@ -178,7 +178,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
                 return 0;
             }
 
-            byte[] data = AsciiEncoding.GetBytes(value);
+            byte[] data = Encoding.ASCII.GetBytes(value);
             this.dataStream.Write(data, 0, data.Length);
             return data.Length;
         }
@@ -215,7 +215,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
 
             value = value.Substring(0, Math.Min(length - lengthAdjust, value.Length));
 
-            byte[] textData = AsciiEncoding.GetBytes(value);
+            byte[] textData = Encoding.ASCII.GetBytes(value);
             int actualLength = Math.Min(length - lengthAdjust, textData.Length);
             this.dataStream.Write(textData, 0, actualLength);
             for (int i = 0; i < length - actualLength; i++)

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
@@ -11,8 +11,6 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     /// </summary>
     internal sealed partial class IccDataWriter : IDisposable
     {
-        private static readonly bool IsLittleEndian = BitConverter.IsLittleEndian;
-
         /// <summary>
         /// The underlying stream where the data is written to
         /// </summary>
@@ -179,7 +177,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// <returns>The number of bytes written</returns>
         private unsafe int WriteBytes(byte* data, int length)
         {
-            if (IsLittleEndian)
+            if (BitConverter.IsLittleEndian)
             {
                 for (int i = length - 1; i >= 0; i--)
                 {

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Text;
 
 namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
 {
@@ -13,7 +12,6 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     internal sealed partial class IccDataWriter : IDisposable
     {
         private static readonly bool IsLittleEndian = BitConverter.IsLittleEndian;
-        private static readonly Encoding AsciiEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The underlying stream where the data is written to

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     internal sealed partial class IccDataWriter : IDisposable
     {
         private static readonly bool IsLittleEndian = BitConverter.IsLittleEndian;
-        private static readonly Encoding AsciiEncoding = Encoding.GetEncoding("ASCII");
+        private static readonly Encoding AsciiEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The underlying stream where the data is written to

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-
-#if !NETSTANDARD1_1
 using System.Security.Cryptography;
-#endif
 
 namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
 {
@@ -100,8 +97,6 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// <inheritdoc/>
         public IccProfile DeepClone() => new IccProfile(this);
 
-#if !NETSTANDARD1_1
-
         /// <summary>
         /// Calculates the MD5 hash value of an ICC profile
         /// </summary>
@@ -146,8 +141,6 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
                 }
             }
         }
-
-#endif
 
         /// <summary>
         /// Checks for signs of a corrupt profile.

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccWriter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -51,12 +50,8 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
             writer.WriteXyzNumber(header.PcsIlluminant);
             writer.WriteAsciiString(header.CreatorSignature, 4, false);
 
-#if !NETSTANDARD1_1
             IccProfileId id = IccProfile.CalculateHash(writer.GetData());
             writer.WriteProfileId(id);
-#else
-            writer.WriteProfileId(IccProfileId.Zero);
-#endif
         }
 
         private void WriteTagTable(IccDataWriter writer, IccTagTableEntry[] table)

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDataTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDataTagDataEntry.cs
@@ -12,8 +12,6 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     /// </summary>
     internal sealed class IccDataTagDataEntry : IccTagDataEntry, IEquatable<IccDataTagDataEntry>
     {
-        private static readonly Encoding AsciiEncoding = Encoding.ASCII;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="IccDataTagDataEntry"/> class.
         /// </summary>
@@ -60,7 +58,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// Gets the <see cref="Data"/> decoded as 7bit ASCII.
         /// If <see cref="IsAscii"/> is false, returns null
         /// </summary>
-        public string AsciiString => this.IsAscii ? AsciiEncoding.GetString(this.Data, 0, this.Data.Length) : null;
+        public string AsciiString => this.IsAscii ? Encoding.ASCII.GetString(this.Data, 0, this.Data.Length) : null;
 
         /// <inheritdoc/>
         public override bool Equals(IccTagDataEntry other)

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDataTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDataTagDataEntry.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     /// </summary>
     internal sealed class IccDataTagDataEntry : IccTagDataEntry, IEquatable<IccDataTagDataEntry>
     {
-        private static readonly Encoding AsciiEncoding = Encoding.GetEncoding("ASCII");
+        private static readonly Encoding AsciiEncoding = Encoding.ASCII;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IccDataTagDataEntry"/> class.

--- a/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
+++ b/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace>SixLabors.ImageSharp.Benchmarks</RootNamespace>
     <AssemblyName>ImageSharp.Benchmarks</AssemblyName>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>

--- a/tests/ImageSharp.Tests/Formats/Png/PngChunkTypeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngChunkTypeTests.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
         private static PngChunkType GetType(string text)
         {
-            return (PngChunkType)BinaryPrimitives.ReadInt32BigEndian(Encoding.UTF8.GetBytes(text));
+            return (PngChunkType)BinaryPrimitives.ReadInt32BigEndian(Encoding.ASCII.GetBytes(text));
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.Chunks.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.Chunks.cs
@@ -113,7 +113,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         {
             // Needs a minimum length of 9 for pHYs chunk.
             memStream.Write(new byte[] { 0, 0, 0, 9 }, 0, 4);
-            memStream.Write(Encoding.GetEncoding("ASCII").GetBytes(chunkName), 0, 4); // 4 bytes chunk header
+            memStream.Write(Encoding.ASCII.GetBytes(chunkName), 0, 4); // 4 bytes chunk header
             memStream.Write(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, 0, 9); // 9 bytes of chunk data
             memStream.Write(new byte[] { 0, 0, 0, 0 }, 0, 4); // Junk Crc
         }

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccProfileTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccProfileTests.cs
@@ -9,9 +9,6 @@ namespace SixLabors.ImageSharp.Tests.Icc
 {
     public class IccProfileTests
     {
-
-#if !NETSTANDARD1_1
-
         [Theory]
         [MemberData(nameof(IccTestDataProfiles.ProfileIdTestData), MemberType = typeof(IccTestDataProfiles))]
         public void CalculateHash_WithByteArray_CalculatesProfileHash(byte[] data, IccProfileId expected)
@@ -32,8 +29,6 @@ namespace SixLabors.ImageSharp.Tests.Icc
 
             Assert.Equal(data, copy);
         }
-
-#endif
 
         [Theory]
         [MemberData(nameof(IccTestDataProfiles.ProfileValidityTestData), MemberType = typeof(IccTestDataProfiles))]

--- a/tests/ImageSharp.Tests/TestDataIcc/IccTestDataProfiles.cs
+++ b/tests/ImageSharp.Tests/TestDataIcc/IccTestDataProfiles.cs
@@ -14,20 +14,12 @@ namespace SixLabors.ImageSharp.Tests
 
         public static readonly byte[] Header_Random_Id_Array =
         {
-#if !NETSTANDARD1_1
-                0x84, 0xA8, 0xD4, 0x60, 0xC7, 0x16, 0xB6, 0xF3, 0x9B, 0x0E, 0x4C, 0x3D, 0xAB, 0x95, 0xF8, 0x38,
-#else
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-#endif
+            0x84, 0xA8, 0xD4, 0x60, 0xC7, 0x16, 0xB6, 0xF3, 0x9B, 0x0E, 0x4C, 0x3D, 0xAB, 0x95, 0xF8, 0x38,
         };
 
         public static readonly byte[] Profile_Random_Id_Array =
         {
-#if !NETSTANDARD1_1
-                0x91, 0x7D, 0x6D, 0xE6, 0x84, 0xC9, 0x58, 0xD1, 0x3B, 0xB0, 0xF5, 0xBB, 0xAD, 0xD1, 0x13, 0x4F,
-#else
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-#endif
+            0x91, 0x7D, 0x6D, 0xE6, 0x84, 0xC9, 0x58, 0xD1, 0x3B, 0xB0, 0xF5, 0xBB, 0xAD, 0xD1, 0x13, 0x4F,
         };
 
         public static readonly IccProfileHeader Header_Random_Write = CreateHeaderRandomValue(
@@ -35,13 +27,7 @@ namespace SixLabors.ImageSharp.Tests
             new IccProfileId(1, 2, 3, 4),   // should be overwritten
             "ijkl");    // should be overwritten to "acsp"
 
-        public static readonly IccProfileHeader Header_Random_Read = CreateHeaderRandomValue(132,
-#if !NETSTANDARD1_1
-            Header_Random_Id_Value,
-#else
-            IccProfileId.Zero,
-#endif
-            "acsp");
+        public static readonly IccProfileHeader Header_Random_Read = CreateHeaderRandomValue(132, Header_Random_Id_Value, "acsp");
 
         public static readonly byte[] Header_Random_Array = CreateHeaderRandomArray(132, 0, Header_Random_Id_Array);
 
@@ -120,11 +106,7 @@ namespace SixLabors.ImageSharp.Tests
         );
 
         public static readonly IccProfile Profile_Random_Val = new IccProfile(CreateHeaderRandomValue(168,
-#if !NETSTANDARD1_1
             Profile_Random_Id_Value,
-#else
-            IccProfileId.Zero,
-#endif
             "acsp"),
             new IccTagDataEntry[]
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Drops support for netstandard1.1.

<!-- Thanks for contributing to ImageSharp! -->
