### PR TITLE
Cross target NET472 and enable extended intrinsics behind symbol

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     - target_framework: netcoreapp2.1
       is_32bit: True
 
-    - target_framework: net471
+    - target_framework: net472
       is_32bit: False
 
     - target_framework: net472

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
     - target_framework: net471
       is_32bit: False
 
-    - target_framework: net471
+    - target_framework: net472
       is_32bit: True
 
     - target_framework: net462

--- a/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -20,8 +19,7 @@ namespace SixLabors.ImageSharp
         public static class ExtendedIntrinsics
         {
             public static bool IsAvailable { get; } =
-#if NETCOREAPP2_1
-                // TODO: Also available in .NET 4.7.2, we need to add a build target!
+#if SUPPORTS_EXTENDED_INTRINSICS
                 Vector.IsHardwareAccelerated;
 #else
                 false;

--- a/src/ImageSharp/Common/Helpers/SimdUtils.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.cs
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp
         {
             DebugGuard.IsTrue(source.Length == dest.Length, nameof(source), "Input spans must be of same length!");
 
-#if NETCOREAPP2_1
+#if SUPPORTS_EXTENDED_INTRINSICS
             ExtendedIntrinsics.BulkConvertByteToNormalizedFloatReduce(ref source, ref dest);
 #else
             BasicIntrinsics256.BulkConvertByteToNormalizedFloatReduce(ref source, ref dest);
@@ -94,7 +94,7 @@ namespace SixLabors.ImageSharp
         {
             DebugGuard.IsTrue(source.Length == dest.Length, nameof(source), "Input spans must be of same length!");
 
-#if NETCOREAPP2_1
+#if SUPPORTS_EXTENDED_INTRINSICS
             ExtendedIntrinsics.BulkConvertNormalizedFloatToByteClampOverflowsReduce(ref source, ref dest);
 #else
             BasicIntrinsics256.BulkConvertNormalizedFloatToByteClampOverflowsReduce(ref source, ref dest);

--- a/src/ImageSharp/Common/Helpers/TestHelpers.cs
+++ b/src/ImageSharp/Common/Helpers/TestHelpers.cs
@@ -13,8 +13,12 @@ namespace SixLabors.ImageSharp.Common.Helpers
         /// Only intended to be used in tests!
         /// </summary>
         internal const string ImageSharpBuiltAgainst =
-#if NETCOREAPP2_1
+#if NET472
+            "netfx4.7.2";
+#elif NETCOREAPP2_1
             "netcoreapp2.1";
+#elif NETSTANDARD1_3
+            "netstandard1.3";
 #else
             "netstandard2.0";
 #endif

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
     <VersionPrefix Condition="$(packageversion) == ''">0.0.1</VersionPrefix>
     <Authors>Six Labors and contributors</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.1;net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SixLabors.ImageSharp</AssemblyName>
@@ -31,9 +31,15 @@
     <Features>IOperation</Features>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net472' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Compile Include="..\Shared\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
     <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0006" />
@@ -43,15 +49,14 @@
     </PackageReference>
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
-  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
+  
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\..\ImageSharp.ruleset</CodeAnalysisRuleSet>
     <RootNamespace>SixLabors.ImageSharp</RootNamespace>

--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net471;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net462;net472;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <DebugType Condition="$(codecov) != ''">full</DebugType>

--- a/tests/ImageSharp.Tests/RunExtendedTests.cmd
+++ b/tests/ImageSharp.Tests/RunExtendedTests.cmd
@@ -5,3 +5,5 @@ dotnet xunit -nobuild -c Release -f net47
 dotnet xunit -nobuild -c Release -f net47 -x86
 dotnet xunit -nobuild -c Release -f net471
 dotnet xunit -nobuild -c Release -f net471 -x86
+dotnet xunit -nobuild -c Release -f net472
+dotnet xunit -nobuild -c Release -f net472 -x86


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

This PR cross targets NET472 and introduces a SUPPORTS_EXTENDED_INTRINSICS symbol to enable the new extended intrinsics support on modern runtimes (NET472+ & NETCOREAPP2.1+).

This PR also retarget the NET471 tests to NET472. Extended tests continue to run against NET471.

<!-- Thanks for contributing to ImageSharp! -->
