### PR TITLE
Improve CQ8

### DIFF
--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
@@ -64,14 +64,9 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
             this.thumbnailLength = other.thumbnailLength;
             this.thumbnailOffset = other.thumbnailOffset;
 
-            if (other.InvalidTags.Count > 0)
-            {
-                this.InvalidTags = new List<ExifTag>(other.InvalidTags);
-            }
-            else
-            {
-                this.InvalidTags = Array.Empty<ExifTag>();
-            }
+            this.InvalidTags = other.InvalidTags.Count > 0
+                ? new List<ExifTag>(other.InvalidTags)
+                : (IReadOnlyList<ExifTag>)Array.Empty<ExifTag>();
 
             if (other.values != null)
             {
@@ -298,14 +293,9 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
 
             this.values = reader.ReadValues();
 
-            if (reader.InvalidTags.Count > 0)
-            {
-                this.InvalidTags = new List<ExifTag>(reader.InvalidTags);
-            }
-            else
-            {
-                this.InvalidTags = Array.Empty<ExifTag>();
-            }
+            this.InvalidTags = reader.InvalidTags.Count > 0
+                ? new List<ExifTag>(reader.InvalidTags)
+                : (IReadOnlyList<ExifTag>)Array.Empty<ExifTag>();
 
             this.thumbnailOffset = (int)reader.ThumbnailOffset;
             this.thumbnailLength = (int)reader.ThumbnailLength;

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
         {
             this.Parts = ExifParts.All;
             this.data = data;
-            this.InvalidTags = new List<ExifTag>();
+            this.InvalidTags = Array.Empty<ExifTag>();
         }
 
         /// <summary>
@@ -289,7 +289,15 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
 
             this.values = reader.ReadValues();
 
-            this.InvalidTags = new List<ExifTag>(reader.InvalidTags);
+            if (reader.InvalidTags.Count > 0)
+            {
+                this.InvalidTags = new List<ExifTag>(reader.InvalidTags);
+            }
+            else
+            {
+                this.InvalidTags = Array.Empty<ExifTag>();
+            }
+
             this.thumbnailOffset = (int)reader.ThumbnailOffset;
             this.thumbnailLength = (int)reader.ThumbnailLength;
         }

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
@@ -63,7 +63,16 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
             this.Parts = other.Parts;
             this.thumbnailLength = other.thumbnailLength;
             this.thumbnailOffset = other.thumbnailOffset;
-            this.InvalidTags = new List<ExifTag>(other.InvalidTags);
+
+            if (other.InvalidTags.Count > 0)
+            {
+                this.InvalidTags = new List<ExifTag>(other.InvalidTags);
+            }
+            else
+            {
+                this.InvalidTags = Array.Empty<ExifTag>();
+            }
+
             if (other.values != null)
             {
                 this.values = new List<ExifValue>(other.Values.Count);

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifWriter.cs
@@ -17,8 +17,8 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
         /// <summary>
         /// Which parts will be written.
         /// </summary>
-        private ExifParts allowedParts;
-        private IList<ExifValue> values;
+        private readonly ExifParts allowedParts;
+        private readonly IList<ExifValue> values;
         private List<int> dataOffsets;
         private readonly List<int> ifdIndexes;
         private readonly List<int> exifIndexes;

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 
 namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
@@ -20,7 +21,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// <summary>
         /// The backing file for the <see cref="Entries"/> property
         /// </summary>
-        private List<IccTagDataEntry> entries;
+        private IccTagDataEntry[] entries;
 
         /// <summary>
         /// ICC profile header
@@ -52,7 +53,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
             Guard.NotNull(entries, nameof(entries));
 
             this.header = header;
-            this.entries = new List<IccTagDataEntry>(entries);
+            this.entries = entries.ToArray();
         }
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// <summary>
         /// Gets the actual profile data
         /// </summary>
-        public List<IccTagDataEntry> Entries
+        public IccTagDataEntry[] Entries
         {
             get
             {
@@ -212,12 +213,12 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
 
             if (this.data is null)
             {
-                this.entries = new List<IccTagDataEntry>();
+                this.entries = Array.Empty<IccTagDataEntry>();
                 return;
             }
 
             var reader = new IccReader();
-            this.entries = new List<IccTagDataEntry>(reader.ReadTagData(this.data));
+            this.entries = reader.ReadTagData(this.data);
         }
     }
 }

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.Cryptography;
 
 namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
@@ -47,13 +45,10 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// </summary>
         /// <param name="header">The profile header</param>
         /// <param name="entries">The actual profile data</param>
-        internal IccProfile(IccProfileHeader header, IEnumerable<IccTagDataEntry> entries)
+        internal IccProfile(IccProfileHeader header, IccTagDataEntry[] entries)
         {
-            Guard.NotNull(header, nameof(header));
-            Guard.NotNull(entries, nameof(entries));
-
-            this.header = header;
-            this.entries = entries.ToArray();
+            this.header = header ?? throw new ArgumentNullException(nameof(header));
+            this.entries = entries ?? throw new ArgumentNullException(nameof(entries));
         }
 
         /// <summary>

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccReader.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccReader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 
 namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
@@ -126,7 +127,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
             // A normal profile usually has 5-15 entries
             if (tagCount > 100)
             {
-                return new IccTagTableEntry[0];
+                return Array.Empty<IccTagTableEntry>();
             }
 
             var table = new List<IccTagTableEntry>((int)tagCount);

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccWriter.cs
@@ -68,12 +68,12 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
             }
         }
 
-        private IccTagTableEntry[] WriteTagData(IccDataWriter writer, List<IccTagDataEntry> entries)
+        private IccTagTableEntry[] WriteTagData(IccDataWriter writer, IccTagDataEntry[] entries)
         {
             IEnumerable<IGrouping<IccTagDataEntry, IccTagDataEntry>> grouped = entries.GroupBy(t => t);
 
             // (Header size) + (entry count) + (nr of entries) * (size of table entry)
-            writer.SetIndex(128 + 4 + (entries.Count * 12));
+            writer.SetIndex(128 + 4 + (entries.Length * 12));
 
             var table = new List<IccTagTableEntry>();
             foreach (IGrouping<IccTagDataEntry, IccTagDataEntry> group in grouped)

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccCurveTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccCurveTagDataEntry.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// Initializes a new instance of the <see cref="IccCurveTagDataEntry"/> class.
         /// </summary>
         public IccCurveTagDataEntry()
-            : this(new float[0], IccProfileTag.Unknown)
+            : this(Array.Empty<float>(), IccProfileTag.Unknown)
         {
         }
 
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// </summary>
         /// <param name="tagSignature">Tag Signature</param>
         public IccCurveTagDataEntry(IccProfileTag tagSignature)
-            : this(new float[0], tagSignature)
+            : this(Array.Empty<float>(), tagSignature)
         {
         }
 
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         public IccCurveTagDataEntry(float[] curveData, IccProfileTag tagSignature)
             : base(IccTypeSignature.Curve, tagSignature)
         {
-            this.CurveData = curveData ?? new float[0];
+            this.CurveData = curveData ?? Array.Empty<float>();
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.PrimitivesTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.PrimitivesTests.cs
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Tests.Icc
             byte[] output = writer.GetData();
 
             Assert.Equal(0, count);
-            Assert.Equal(new byte[0], output);
+            Assert.Equal(Array.Empty<byte>(), output);
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.Tests.Icc
             byte[] output = writer.GetData();
 
             Assert.Equal(0, count);
-            Assert.Equal(new byte[0], output);
+            Assert.Equal(Array.Empty<byte>(), output);
         }
 
         [Theory]

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccReaderTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccReaderTests.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests.Icc
 
             IccProfile output = reader.Read(IccTestDataProfiles.Header_Random_Array);
 
-            Assert.Equal(0, output.Entries.Count);
+            Assert.Equal(0, output.Entries.Length);
             Assert.NotNull(output.Header);
 
             IccProfileHeader header = output.Header;
@@ -46,7 +46,7 @@ namespace SixLabors.ImageSharp.Tests.Icc
 
             IccProfile output = reader.Read(IccTestDataProfiles.Profile_Random_Array);
 
-            Assert.Equal(2, output.Entries.Count);
+            Assert.Equal(2, output.Entries.Length);
             Assert.True(ReferenceEquals(output.Entries[0], output.Entries[1]));
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

- Uses Array.Empty<> where possible
- Eliminates a few ICC allocations
- Eliminates a few Exif allocations when profiles are valid
- Annotates a few readonly fields

<!-- Thanks for contributing to ImageSharp! -->
