### PR TITLE
Prevent text wandering from baseline

### DIFF
--- a/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -22,8 +22,8 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Text
 
         private const string TestText = "Sphinx of black quartz, judge my vow\n0123456789";
 
-        public static ImageComparer TextDrawingComparer = ImageComparer.Exact;//.TolerantPercentage(0.01f);
-        public static ImageComparer OutlinedTextDrawingComparer = ImageComparer.Exact;// TolerantPercentage(0.5f, 3);
+        public static ImageComparer TextDrawingComparer = ImageComparer.Exact;
+        public static ImageComparer OutlinedTextDrawingComparer = ImageComparer.Exact;
 
         [Theory]
         [WithSolidFilledImages(200, 100, "White", PixelTypes.Rgba32, 50, 0, 0, "SixLaborsSampleAB.woff", AB)]

--- a/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -22,8 +22,8 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Text
 
         private const string TestText = "Sphinx of black quartz, judge my vow\n0123456789";
 
-        public static ImageComparer TextDrawingComparer = ImageComparer.Exact;
-        public static ImageComparer OutlinedTextDrawingComparer = ImageComparer.Exact;
+        public static ImageComparer TextDrawingComparer = ImageComparer.TolerantPercentage(1e-5f);
+        public static ImageComparer OutlinedTextDrawingComparer = ImageComparer.TolerantPercentage(1e-4f);
 
         [Theory]
         [WithSolidFilledImages(200, 100, "White", PixelTypes.Rgba32, 50, 0, 0, "SixLaborsSampleAB.woff", AB)]

--- a/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -151,6 +151,27 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Text
                 appendSourceFileOrDescription: true);
         }
 
+        [Theory]
+        [WithSolidFilledImages(1000, 1500, "White", PixelTypes.Rgba32)]
+        public static void TextPositioningIsRobust<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            if (!TestEnvironment.IsWindows)
+            {
+                // Does the system font "Baskerville Old Face" exist on most Linux/MAC machines?
+                return;
+            }
+            
+            Font font = SystemFonts.CreateFont("Baskerville Old Face", 30, FontStyle.Regular);
+
+            string text = Repeat("Beware the Jabberwock, my son!  The jaws that bite, the claws that catch!  Beware the Jubjub bird, and shun The frumious Bandersnatch!\n",
+                20);
+            var textOptions = new TextGraphicsOptions(true) { WrapTextWidth = 1000 };
+
+            provider.RunValidatingProcessorTest(
+                x => x.DrawText(textOptions, text, font, NamedColors<TPixel>.Black, new PointF(10, 50)), appendPixelTypeToFileName: false, appendSourceFileOrDescription: false);
+        }
+
         private static string Repeat(string str, int times) => string.Concat(Enumerable.Repeat(str, times));
 
         private static string ToTestOutputDisplayText(string text)
@@ -167,5 +188,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Text
             Font font = fontCollection.Install(fontPath).CreateFont(size);
             return font;
         }
+
+        
     }
 }

--- a/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -165,18 +165,11 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Text
         }
 
         [Theory]
-        [WithSolidFilledImages(1000, 1500, "White", PixelTypes.Rgba32, "Baskerville Old Face")]
-        [WithSolidFilledImages(1000, 1500, "White", PixelTypes.Rgba32, "Arial")]
+        [WithSolidFilledImages(1000, 1500, "White", PixelTypes.Rgba32, "OpenSans-Regular.ttf")]
         public void TextPositioningIsRobust<TPixel>(TestImageProvider<TPixel> provider, string fontName)
             where TPixel : struct, IPixel<TPixel>
         {
-            if (!TestEnvironment.IsWindows)
-            {
-                // Does the system font "Baskerville Old Face" exist on most Linux/MAC machines?
-                return;
-            }
-            
-            Font font = SystemFonts.CreateFont(fontName, 30, FontStyle.Regular);
+            Font font = CreateFont(fontName, 30);
 
             string text = Repeat("Beware the Jabberwock, my son!  The jaws that bite, the claws that catch!  Beware the Jubjub bird, and shun The frumious Bandersnatch!\n",
                 20);

--- a/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -22,8 +22,8 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Text
 
         private const string TestText = "Sphinx of black quartz, judge my vow\n0123456789";
 
-        public static ImageComparer TextDrawingComparer = ImageComparer.TolerantPercentage(0.01f);
-        public static ImageComparer OutlinedTextDrawingComparer = ImageComparer.TolerantPercentage(0.5f, 3);
+        public static ImageComparer TextDrawingComparer = ImageComparer.Exact;//.TolerantPercentage(0.01f);
+        public static ImageComparer OutlinedTextDrawingComparer = ImageComparer.Exact;// TolerantPercentage(0.5f, 3);
 
         [Theory]
         [WithSolidFilledImages(200, 100, "White", PixelTypes.Rgba32, 50, 0, 0, "SixLaborsSampleAB.woff", AB)]

--- a/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Text
         private const string TestText = "Sphinx of black quartz, judge my vow\n0123456789";
 
         public static ImageComparer TextDrawingComparer = ImageComparer.TolerantPercentage(1e-5f);
-        public static ImageComparer OutlinedTextDrawingComparer = ImageComparer.TolerantPercentage(1e-4f);
+        public static ImageComparer OutlinedTextDrawingComparer = ImageComparer.TolerantPercentage(5e-4f);
 
         public DrawTextOnImageTests(ITestOutputHelper output)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
this fixes #685 

The issue was the fact we where being to aggressive when caching rendered/repeated glyphs.

We now should be allowing approx 4 slightly offset variants of a single glyph (+/- 1 pixel on both axis).

### before
![before image with wandering text](https://user-images.githubusercontent.com/166440/47605452-8caf0100-d9fe-11e8-8db7-7ac535a097ed.png)

### after
![after with baseline fixed](https://user-images.githubusercontent.com/166440/47605434-6721f780-d9fe-11e8-94c0-14bf41b603bc.png)





