### PR TITLE
constrain destination span and scanline to same length

### DIFF
--- a/src/ImageSharp.Drawing/Processing/SolidBrush{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/SolidBrush{TPixel}.cs
@@ -89,7 +89,17 @@ namespace SixLabors.ImageSharp.Processing
             /// <inheritdoc />
             internal override void Apply(Span<float> scanline, int x, int y)
             {
-                Span<TPixel> destinationRow = this.Target.GetPixelRowSpan(y).Slice(x, scanline.Length);
+                Span<TPixel> destinationRow = this.Target.GetPixelRowSpan(y).Slice(x);
+
+                // constrain the spans to eachother
+                if (destinationRow.Length > scanline.Length)
+                {
+                    destinationRow = destinationRow.Slice(0, scanline.Length);
+                }
+                else
+                {
+                    scanline = scanline.Slice(0, destinationRow.Length);
+                }
 
                 MemoryAllocator memoryAllocator = this.Target.MemoryAllocator;
                 Configuration configuration = this.Target.Configuration;

--- a/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -26,6 +26,41 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Text
         public static ImageComparer OutlinedTextDrawingComparer = ImageComparer.TolerantPercentage(0.5f, 3);
 
         [Theory]
+        [WithSolidFilledImages(276, 336, "White", PixelTypes.Rgba32)]
+        public void DoesntThrowExceptionWhenOverlappingRightEdge_Issue688<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            Font font = CreateFont("OpenSans-Regular.ttf", 36);
+            TPixel color = NamedColors<TPixel>.Black;
+            float padding = 5;
+            var text = "A short piece of text";
+
+            using (var img = provider.GetImage())
+            {
+                float targetWidth = img.Width - (padding * 2);
+                float targetHeight = img.Height - (padding * 2);
+
+                // measure the text size
+                SizeF size = TextMeasurer.Measure(text, new RendererOptions(font));
+
+                //find out how much we need to scale the text to fill the space (up or down)
+                float scalingFactor = Math.Min(img.Width / size.Width, img.Height / size.Height);
+
+                //create a new font 
+                Font scaledFont = new Font(font, scalingFactor * font.Size);
+
+                var center = new PointF(img.Width / 2, img.Height / 2);
+                var textGraphicOptions = new TextGraphicsOptions(true)
+                {
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center
+                };
+                
+                img.Mutate(i => i.DrawText(textGraphicOptions, text, scaledFont, color, center));
+            }
+        }
+
+        [Theory]
         [WithSolidFilledImages(200, 100, "White", PixelTypes.Rgba32, 50, 0, 0, "SixLaborsSampleAB.woff", AB)]
         [WithSolidFilledImages(900, 100, "White", PixelTypes.Rgba32, 50, 0, 0, "OpenSans-Regular.ttf", TestText)]
         [WithSolidFilledImages(400, 40, "White", PixelTypes.Rgba32, 20, 0, 0, "OpenSans-Regular.ttf", TestText)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
ensure we constrain the the spans we use in solid brushes.

resolves #688 
this will also resolve the exception being thrown in SixLabors/Samples#4
