### PR TITLE
fix typos in documentation comments all over the library

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor.cs
@@ -82,11 +82,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
             // we need to offset the pixel grid to account for when we outline a path.
             // basically if the line is [1,2] => [3,2] then when outlining at 1 we end up with a region of [0.5,1.5],[1.5, 1.5],[3.5,2.5],[2.5,2.5]
             // and this can cause missed fills when not using antialiasing.so we offset the pixel grid by 0.5 in the x & y direction thus causing the#
-            // region to alline with the pixel grid.
+            // region to align with the pixel grid.
             float offset = 0.5f;
             if (this.Options.Antialias)
             {
-                offset = 0f; // we are antialising skip offsetting as real antalising should take care of offset.
+                offset = 0f; // we are antialiasing skip offsetting as real antialiasing should take care of offset.
                 subpixelCount = this.Options.AntialiasSubpixelDepth;
                 if (subpixelCount < 4)
                 {
@@ -121,7 +121,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
                             int pointsFound = region.Scan(subPixel + offset, buffer, configuration);
                             if (pointsFound == 0)
                             {
-                                // nothing on this line skip
+                                // nothing on this line, skip
                                 continue;
                             }
 

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Text
         /// <param name="font">The font we want to render with</param>
         /// <param name="brush">The brush to source pixel colors from.</param>
         /// <param name="pen">The pen to outline text with.</param>
-        /// <param name="location">The location on the image to start drawign the text from.</param>
+        /// <param name="location">The location on the image to start drawing the text from.</param>
         public DrawTextProcessor(TextGraphicsOptions options, string text, Font font, IBrush<TPixel> brush, IPen<TPixel> pen, PointF location)
         {
             Guard.NotNull(text, nameof(text));
@@ -85,7 +85,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Text
         {
             base.BeforeImageApply(source, sourceRectangle);
 
-            // do everythign at the image level as we are deligating the processing down to other processors
+            // do everything at the image level as we are delegating the processing down to other processors
             var style = new RendererOptions(this.Font, this.Options.DpiX, this.Options.DpiY, this.Location)
             {
                 ApplyKerning = this.Options.ApplyKerning,

--- a/src/ImageSharp.Drawing/Processing/SolidBrush{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/SolidBrush{TPixel}.cs
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp.Processing
             {
                 Span<TPixel> destinationRow = this.Target.GetPixelRowSpan(y).Slice(x);
 
-                // constrain the spans to eachother
+                // constrain the spans to each other
                 if (destinationRow.Length > scanline.Length)
                 {
                     destinationRow = destinationRow.Slice(0, scanline.Length);

--- a/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
+++ b/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
@@ -160,7 +160,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// </summary>
         /// <typeparam name="TPixel">The type of the pixel.</typeparam>
         /// <param name="source">The source.</param>
-        /// <returns>The span retuned from Pixel source</returns>
+        /// <returns>The span returned from Pixel source</returns>
         private static Span<TPixel> GetSpan<TPixel>(IPixelSource<TPixel> source)
             where TPixel : struct, IPixel<TPixel>
             => source.PixelBuffer.GetSpan();
@@ -172,7 +172,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// <param name="source">The source.</param>
         /// <param name="row">The row.</param>
         /// <returns>
-        /// The span retuned from Pixel source
+        /// The span returned from Pixel source
         /// </returns>
         private static Span<TPixel> GetSpan<TPixel>(IPixelSource<TPixel> source, int row)
             where TPixel : struct, IPixel<TPixel>
@@ -185,7 +185,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// <param name="source">The source.</param>
         /// <param name="row">The row.</param>
         /// <returns>
-        /// The span retuned from Pixel source
+        /// The span returned from Pixel source
         /// </returns>
         private static Span<TPixel> GetSpan<TPixel>(Buffer2D<TPixel> source, int row)
             where TPixel : struct, IPixel<TPixel>

--- a/src/ImageSharp/Common/Helpers/ImageMaths.cs
+++ b/src/ImageSharp/Common/Helpers/ImageMaths.cs
@@ -76,7 +76,7 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Scales a value from an 8 bit <see cref="byte"/> to it's 16 bit <see cref="ushort"/> equivalent.
         /// </summary>
-        /// <param name="component">The 8 bit compoonent value.</param>
+        /// <param name="component">The 8 bit component value.</param>
         /// <returns>The <see cref="ushort"/></returns>
         [MethodImpl(InliningOptions.ShortMethod)]
         public static ushort UpscaleFrom8BitTo16Bit(byte component) => (ushort)(component * 257);

--- a/src/ImageSharp/Common/Helpers/SimdUtils.BasicIntrinsics256.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.BasicIntrinsics256.cs
@@ -90,7 +90,7 @@ namespace SixLabors.ImageSharp
 
                 var bVec = new Vector<float>(256.0f / 255.0f);
                 var magicFloat = new Vector<float>(32768.0f);
-                var magicInt = new Vector<uint>(1191182336); // reinterpreded value of 32768.0f
+                var magicInt = new Vector<uint>(1191182336); // reinterpreted value of 32768.0f
                 var mask = new Vector<uint>(255);
 
                 ref Octet.OfByte sourceBase = ref Unsafe.As<byte, Octet.OfByte>(ref MemoryMarshal.GetReference(source));

--- a/src/ImageSharp/Common/Helpers/SimdUtils.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.cs
@@ -169,7 +169,7 @@ namespace SixLabors.ImageSharp
             DebugGuard.IsTrue(
                 ImageMaths.ModuloP2(dest.Length, shouldBeDivisibleBy) == 0,
                 nameof(source),
-                $"length should be divisable by {shouldBeDivisibleBy}!");
+                $"length should be divisible by {shouldBeDivisibleBy}!");
         }
 
         [Conditional("DEBUG")]
@@ -179,7 +179,7 @@ namespace SixLabors.ImageSharp
             DebugGuard.IsTrue(
                 ImageMaths.ModuloP2(dest.Length, shouldBeDivisibleBy) == 0,
                 nameof(source),
-                $"length should be divisable by {shouldBeDivisibleBy}!");
+                $"length should be divisible by {shouldBeDivisibleBy}!");
         }
     }
 }

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -207,7 +207,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
 
         /// <summary>
         /// Looks up color values and builds the image from de-compressed RLE8 data.
-        /// Compresssed RLE8 stream is uncompressed by <see cref="UncompressRle8(int, Span{byte})"/>
+        /// Compressed RLE8 stream is uncompressed by <see cref="UncompressRle8(int, Span{byte})"/>
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> to assign the palette to.</param>

--- a/src/ImageSharp/Formats/Bmp/IBmpDecoderOptions.cs
+++ b/src/ImageSharp/Formats/Bmp/IBmpDecoderOptions.cs
@@ -8,6 +8,6 @@ namespace SixLabors.ImageSharp.Formats.Bmp
     /// </summary>
     internal interface IBmpDecoderOptions
     {
-        // added this for consistancy so we can add stuff as required, no options currently availible
+        // added this for consistency so we can add stuff as required, no options currently available
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -56,7 +56,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         private GifGraphicControlExtension graphicsControlExtension;
 
         /// <summary>
-        /// The image desciptor.
+        /// The image descriptor.
         /// </summary>
         private GifImageDescriptor imageDescriptor;
 

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
     internal sealed class GifEncoderCore
     {
         /// <summary>
-        /// Used for allocating memory during procesing operations.
+        /// Used for allocating memory during processing operations.
         /// </summary>
         private readonly MemoryAllocator memoryAllocator;
 
@@ -421,7 +421,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         private void WriteColorTable<TPixel>(QuantizedFrame<TPixel> image, Stream stream)
             where TPixel : struct, IPixel<TPixel>
         {
-            // The maximium number of colors for the bit depth
+            // The maximum number of colors for the bit depth
             int colorTableLength = ImageMaths.GetColorCountForBitDepth(this.bitDepth) * 3;
             int pixelCount = image.Palette.Length;
 

--- a/src/ImageSharp/Formats/Gif/LzwEncoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwEncoder.cs
@@ -52,7 +52,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         };
 
         /// <summary>
-        /// The maximium number of bits/code.
+        /// The maximum number of bits/code.
         /// </summary>
         private const int MaxBits = 12;
 
@@ -210,7 +210,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// flush the packet to disk.
         /// </summary>
         /// <param name="c">The character to add.</param>
-        /// <param name="accumulatorsRef">The reference to the storage for packat accumulators</param>
+        /// <param name="accumulatorsRef">The reference to the storage for packet accumulators</param>
         /// <param name="stream">The stream to write to.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AddCharacter(byte c, ref byte accumulatorsRef, Stream stream)

--- a/src/ImageSharp/Formats/IImageFormat.cs
+++ b/src/ImageSharp/Formats/IImageFormat.cs
@@ -16,12 +16,12 @@ namespace SixLabors.ImageSharp.Formats
         string Name { get; }
 
         /// <summary>
-        /// Gets the default mimetype that the image foramt uses
+        /// Gets the default mimetype that the image format uses
         /// </summary>
         string DefaultMimeType { get; }
 
         /// <summary>
-        /// Gets all the mimetypes that have been used by this image foramt.
+        /// Gets all the mimetypes that have been used by this image format.
         /// </summary>
         IEnumerable<string> MimeTypes { get; }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8.cs
@@ -10,7 +10,7 @@ using System.Text;
 namespace SixLabors.ImageSharp.Formats.Jpeg.Components
 {
     /// <summary>
-    /// Represents a Jpeg block with <see cref="short"/> coefficiens.
+    /// Represents a Jpeg block with <see cref="short"/> coefficients.
     /// </summary>
     // ReSharper disable once InconsistentNaming
     internal unsafe struct Block8x8 : IEquatable<Block8x8>
@@ -64,7 +64,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
         }
 
         /// <summary>
-        /// Gets or sets a value in a row+coulumn of the 8x8 block
+        /// Gets or sets a value in a row+column of the 8x8 block
         /// </summary>
         /// <param name="x">The x position index in the row</param>
         /// <param name="y">The column index</param>
@@ -283,7 +283,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
         }
 
         /// <summary>
-        /// Calculate the total sum of absoulute differences of elements in 'a' and 'b'.
+        /// Calculate the total sum of absolute differences of elements in 'a' and 'b'.
         /// </summary>
         public static long TotalDifference(ref Block8x8 a, ref Block8x8 b)
         {

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
@@ -395,7 +395,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
         }
 
         /// <summary>
-        /// Scales the 16x16 region represented by the 4 source blocks to the 8x8  DST block.
+        /// Scales the 16x16 region represented by the 4 source blocks to the 8x8 DST block.
         /// </summary>
         /// <param name="destination">The destination block.</param>
         /// <param name="source">The source block.</param>
@@ -571,7 +571,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
             // sign(dividend) = max(min(dividend, 1), -1)
             var sign = Vector4.Clamp(dividend, NegativeOne, Vector4.One);
 
-            // AlmostRound(dividend/divisor) = dividend/divisior + 0.5*sign(dividend)
+            // AlmostRound(dividend/divisor) = dividend/divisor + 0.5*sign(dividend)
             return (dividend / divisor) + (sign * Offset);
         }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ColorConverters/JpegColorConverter.FromYCbCrSimd.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ColorConverters/JpegColorConverter.FromYCbCrSimd.cs
@@ -32,11 +32,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder.ColorConverters
             }
 
             /// <summary>
-            /// SIMD convert using buffers of sizes divisable by 8.
+            /// SIMD convert using buffers of sizes divisible by 8.
             /// </summary>
             internal static void ConvertCore(in ComponentValues values, Span<Vector4> result)
             {
-                DebugGuard.IsTrue(result.Length % 8 == 0, nameof(result), "result.Length should be divisable by 8!");
+                DebugGuard.IsTrue(result.Length % 8 == 0, nameof(result), "result.Length should be divisible by 8!");
 
                 ref Vector4Pair yBase =
                     ref Unsafe.As<float, Vector4Pair>(ref MemoryMarshal.GetReference(values.Component0));

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ColorConverters/JpegColorConverter.FromYCbCrSimdAvx2.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ColorConverters/JpegColorConverter.FromYCbCrSimdAvx2.cs
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder.ColorConverters
             }
 
             /// <summary>
-            /// SIMD convert using buffers of sizes divisable by 8.
+            /// SIMD convert using buffers of sizes divisible by 8.
             /// </summary>
             internal static void ConvertCore(in ComponentValues values, Span<Vector4> result)
             {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ColorConverters/JpegColorConverter.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ColorConverters/JpegColorConverter.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder.ColorConverters
     internal abstract partial class JpegColorConverter
     {
         /// <summary>
-        /// The avalilable converters
+        /// The available converters
         /// </summary>
         private static readonly JpegColorConverter[] Converters =
             {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
                     }
 
                     // Figure F.15: generate decoding tables for bit-sequential decoding.
-                    // Compute largest code + 1 for this size. preshifted as we needit later.
+                    // Compute largest code + 1 for this size. preshifted as we need it later.
                     Unsafe.Add(ref maxcodeRef, k) = code << (16 - k);
                     code <<= 1;
                 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/IRawJpegData.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/IRawJpegData.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         Size ImageSizeInPixels { get; }
 
         /// <summary>
-        /// Gets the number of coponents.
+        /// Gets the number of components.
         /// </summary>
         int ComponentCount { get; }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <param name="minorVersion">The minor version</param>
         /// <param name="densityUnits">The units for the density values</param>
         /// <param name="xDensity">The horizontal pixel density</param>
-        /// <param name="yDensity">The veritcal pixel density</param>
+        /// <param name="yDensity">The vertical pixel density</param>
         private JFifMarker(byte majorVersion, byte minorVersion, byte densityUnits, short xDensity, short yDensity)
         {
             Guard.MustBeGreaterThan(xDensity, 0, nameof(xDensity));

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBlockPostProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBlockPostProcessor.cs
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// - Dequantize
         /// - Applying IDCT
         /// - Level shift by +128, clip to [0, 255]
-        /// - Copy the resultin color values into 'destArea' scaling up the block by amount defined in <see cref="subSamplingDivisors"/>
+        /// - Copy the resulting color values into 'destArea' scaling up the block by amount defined in <see cref="subSamplingDivisors"/>
         /// </summary>
         /// <param name="sourceBlock">The source block.</param>
         /// <param name="destArea">The destination buffer area.</param>

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponentPostProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponentPostProcessor.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         private int currentComponentRowInBlocks;
 
         /// <summary>
-        /// The size of the area in <see cref="ColorBuffer"/> corrsponding to one 8x8 Jpeg block
+        /// The size of the area in <see cref="ColorBuffer"/> corresponding to one 8x8 Jpeg block
         /// </summary>
         private readonly Size blockAreaSize;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ScanDecoder.cs
@@ -755,7 +755,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         [MethodImpl(InliningOptions.ColdPath)]
         private void FillBuffer()
         {
-            // Attempt to load at least the minimum nbumber of required bits into the buffer.
+            // Attempt to load at least the minimum number of required bits into the buffer.
             // We fail to do so only if we hit a marker or reach the end of the input stream.
             do
             {
@@ -912,7 +912,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             }
 
             // If it's NOT a restart, then just bail, so we get corrupt data rather than no data.
-            // Reset the stream to before any bad markers to ensure we can read sucessive segments.
+            // Reset the stream to before any bad markers to ensure we can read successive segments.
             if (this.badMarker)
             {
                 this.stream.Position = this.markerPosition;

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrTables.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrTables.cs
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
         /// <summary>
         /// Initializes the YCbCr tables
         /// </summary>
-        /// <returns>The intialized <see cref="RgbToYCbCrTables"/></returns>
+        /// <returns>The initialized <see cref="RgbToYCbCrTables"/></returns>
         public static RgbToYCbCrTables Create()
         {
             RgbToYCbCrTables tables = default;

--- a/src/ImageSharp/Formats/Jpeg/Components/GenericBlock8x8.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/GenericBlock8x8.cs
@@ -44,7 +44,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
 
         /// <summary>
         /// FOR TESTING ONLY!
-        /// Gets or sets a value in a row+coulumn of the 8x8 block
+        /// Gets or sets a value in a row+column of the 8x8 block
         /// </summary>
         /// <param name="x">The x position index in the row</param>
         /// <param name="y">The column index</param>

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -51,12 +51,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         private readonly byte[] markerBuffer = new byte[2];
 
         /// <summary>
-        /// The DC HUffman tables
+        /// The DC Huffman tables
         /// </summary>
         private HuffmanTables dcHuffmanTables;
 
         /// <summary>
-        /// The AC HUffman tables
+        /// The AC Huffman tables
         /// </summary>
         private HuffmanTables acHuffmanTables;
 

--- a/src/ImageSharp/Formats/Png/Chunks/PhysicalChunkData.cs
+++ b/src/ImageSharp/Formats/Png/Chunks/PhysicalChunkData.cs
@@ -53,7 +53,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Chunks
 
         /// <summary>
         /// Constructs the PngPhysicalChunkData from the provided metadata.
-        /// If the resolution units are not in meters, they are automatically convereted.
+        /// If the resolution units are not in meters, they are automatically converted.
         /// </summary>
         /// <param name="meta">The metadata.</param>
         /// <returns>The constructed PngPhysicalChunkData instance.</returns>

--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
 
             // Paeth(x) + PaethPredictor(Raw(x-bpp), Prior(x), Prior(x-bpp))
-            int offset = bytesPerPixel + 1; // Add one bcause x starts at one.
+            int offset = bytesPerPixel + 1; // Add one because x starts at one.
             int x = 1;
             for (; x < offset; x++)
             {

--- a/src/ImageSharp/Formats/Png/IPngDecoderOptions.cs
+++ b/src/ImageSharp/Formats/Png/IPngDecoderOptions.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace SixLabors.ImageSharp.Formats.Png
 {
     /// <summary>
-    /// The optioas for decoding png images
+    /// The options for decoding png images
     /// </summary>
     internal interface IPngDecoderOptions
     {

--- a/src/ImageSharp/IImageInfo.cs
+++ b/src/ImageSharp/IImageInfo.cs
@@ -7,7 +7,7 @@ using SixLabors.ImageSharp.MetaData;
 namespace SixLabors.ImageSharp
 {
     /// <summary>
-    /// Encapsulates properties that descibe basic image information including dimensions, pixel type information
+    /// Encapsulates properties that describe basic image information including dimensions, pixel type information
     /// and additional metadata
     /// </summary>
     public interface IImageInfo

--- a/src/ImageSharp/Image.WrapMemory.cs
+++ b/src/ImageSharp/Image.WrapMemory.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp
     public static partial class Image
     {
         /// <summary>
-        /// Wraps an existing contigous memory area of 'width'x'height' pixels,
+        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels,
         /// allowing to view/manipulate it as an ImageSharp <see cref="Image{TPixel}"/> instance.
         /// </summary>
         /// <typeparam name="TPixel">The pixel type</typeparam>
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Wraps an existing contigous memory area of 'width'x'height' pixels,
+        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels,
         /// allowing to view/manipulate it as an ImageSharp <see cref="Image{TPixel}"/> instance.
         /// </summary>
         /// <typeparam name="TPixel">The pixel type</typeparam>
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Wraps an existing contigous memory area of 'width'x'height' pixels,
+        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels,
         /// allowing to view/manipulate it as an ImageSharp <see cref="Image{TPixel}"/> instance.
         /// The memory is being observed, the caller remains responsible for managing it's lifecycle.
         /// </summary>
@@ -79,15 +79,15 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Wraps an existing contigous memory area of 'width'x'height' pixels,
+        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels,
         /// allowing to view/manipulate it as an ImageSharp <see cref="Image{TPixel}"/> instance.
-        /// The ownership of the <paramref name="pixelMemoryOwner"/> is being transfered to the new <see cref="Image{TPixel}"/> instance,
+        /// The ownership of the <paramref name="pixelMemoryOwner"/> is being transferred to the new <see cref="Image{TPixel}"/> instance,
         /// meaning that the caller is not allowed to dispose <paramref name="pixelMemoryOwner"/>.
         /// It will be disposed together with the result image.
         /// </summary>
         /// <typeparam name="TPixel">The pixel type</typeparam>
         /// <param name="config">The <see cref="Configuration"/></param>
-        /// <param name="pixelMemoryOwner">The <see cref="IMemoryOwner{T}"/> that is being transfered to the image</param>
+        /// <param name="pixelMemoryOwner">The <see cref="IMemoryOwner{T}"/> that is being transferred to the image</param>
         /// <param name="width">The width of the memory image</param>
         /// <param name="height">The height of the memory image</param>
         /// <param name="metaData">The <see cref="ImageMetaData"/></param>
@@ -105,15 +105,15 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Wraps an existing contigous memory area of 'width'x'height' pixels,
+        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels,
         /// allowing to view/manipulate it as an ImageSharp <see cref="Image{TPixel}"/> instance.
-        /// The ownership of the <paramref name="pixelMemoryOwner"/> is being transfered to the new <see cref="Image{TPixel}"/> instance,
+        /// The ownership of the <paramref name="pixelMemoryOwner"/> is being transferred to the new <see cref="Image{TPixel}"/> instance,
         /// meaning that the caller is not allowed to dispose <paramref name="pixelMemoryOwner"/>.
         /// It will be disposed together with the result image.
         /// </summary>
         /// <typeparam name="TPixel">The pixel type</typeparam>
         /// <param name="config">The <see cref="Configuration"/></param>
-        /// <param name="pixelMemoryOwner">The <see cref="IMemoryOwner{T}"/> that is being transfered to the image</param>
+        /// <param name="pixelMemoryOwner">The <see cref="IMemoryOwner{T}"/> that is being transferred to the image</param>
         /// <param name="width">The width of the memory image</param>
         /// <param name="height">The height of the memory image</param>
         /// <returns>An <see cref="Image{TPixel}"/> instance</returns>
@@ -128,14 +128,14 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Wraps an existing contigous memory area of 'width'x'height' pixels,
+        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels,
         /// allowing to view/manipulate it as an ImageSharp <see cref="Image{TPixel}"/> instance.
-        /// The ownership of the <paramref name="pixelMemoryOwner"/> is being transfered to the new <see cref="Image{TPixel}"/> instance,
+        /// The ownership of the <paramref name="pixelMemoryOwner"/> is being transferred to the new <see cref="Image{TPixel}"/> instance,
         /// meaning that the caller is not allowed to dispose <paramref name="pixelMemoryOwner"/>.
         /// It will be disposed together with the result image.
         /// </summary>
         /// <typeparam name="TPixel">The pixel type</typeparam>
-        /// <param name="pixelMemoryOwner">The <see cref="IMemoryOwner{T}"/> that is being transfered to the image</param>
+        /// <param name="pixelMemoryOwner">The <see cref="IMemoryOwner{T}"/> that is being transferred to the image</param>
         /// <param name="width">The width of the memory image</param>
         /// <param name="height">The height of the memory image</param>
         /// <returns>An <see cref="Image{TPixel}"/> instance</returns>

--- a/src/ImageSharp/ImageExtensions.cs
+++ b/src/ImageSharp/ImageExtensions.cs
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp
             if (format is null)
             {
                 var sb = new StringBuilder();
-                sb.AppendLine($"Can't find a format that is associated with the file extention '{ext}'. Registered formats with there extensions include:");
+                sb.AppendLine($"Can't find a format that is associated with the file extension '{ext}'. Registered formats with there extensions include:");
                 foreach (IImageFormat fmt in source.GetConfiguration().ImageFormats)
                 {
                     sb.AppendLine($" - {fmt.Name} : {string.Join(", ", fmt.FileExtensions)}");
@@ -47,7 +47,7 @@ namespace SixLabors.ImageSharp
             if (encoder is null)
             {
                 var sb = new StringBuilder();
-                sb.AppendLine($"Can't find encoder for file extention '{ext}' using image format '{format.Name}'. Registered encoders include:");
+                sb.AppendLine($"Can't find encoder for file extension '{ext}' using image format '{format.Name}'. Registered encoders include:");
                 foreach (KeyValuePair<IImageFormat, IImageEncoder> enc in source.GetConfiguration().ImageFormatsManager.ImageEncoders)
                 {
                     sb.AppendLine($" - {enc.Key} : {enc.Value.GetType().Name}");

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -186,7 +186,7 @@ namespace SixLabors.ImageSharp
         public Image<TPixel> Clone() => this.Clone(this.configuration);
 
         /// <summary>
-        /// Clones the current image with the given configueation.
+        /// Clones the current image with the given configuration.
         /// </summary>
         /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
         /// <returns>Returns a new <see cref="Image{TPixel}"/> with all the same pixel data as the original.</returns>

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileClass.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileClass.cs
@@ -39,15 +39,15 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
 
         /// <summary>
         /// This profile provides the relevant information to perform a transformation
-        /// between colour encodings and the PCS. This type of profile is based on
-        /// modelling rather than device measurement or characterization data.
+        /// between color encodings and the PCS. This type of profile is based on
+        /// modeling rather than device measurement or characterization data.
         /// ColorSpace profiles may be embedded in images.
         /// </summary>
         ColorSpace = 0x73706163,        // spac
 
         /// <summary>
         /// This profile represents abstract transforms and does not represent any
-        /// device model. Colour transformations using Abstract profiles are performed
+        /// device model. Color transformations using Abstract profiles are performed
         /// from PCS to PCS. Abstract profiles cannot be embedded in images.
         /// </summary>
         Abstract = 0x61627374,          // abst
@@ -55,8 +55,8 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// <summary>
         /// NamedColor profiles can be thought of as sibling profiles to device profiles.
         /// For a given device there would be one or more device profiles to handle
-        /// process colour conversions and one or more named colour profiles to handle
-        /// named colours.
+        /// process color conversions and one or more named color profiles to handle
+        /// named colors.
         /// </summary>
         NamedColor = 0x6E6D636C,        // nmcl
     }

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileFlag.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileFlag.cs
@@ -29,12 +29,12 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         NotEmbedded = 0,
 
         /// <summary>
-        /// Profile cannot be used independently of the embedded colour data
+        /// Profile cannot be used independently of the embedded color data
         /// </summary>
         NotIndependent = 1 << 1,
 
         /// <summary>
-        /// Profile can be used independently of the embedded colour data
+        /// Profile can be used independently of the embedded color data
         /// </summary>
         Independent = 0,
     }

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileTag.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileTag.cs
@@ -19,18 +19,18 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         Unknown,
 
         /// <summary>
-        /// A2B0 - This tag defines a colour transform from Device, Colour Encoding or PCS, to PCS, or a colour transform
+        /// A2B0 - This tag defines a color transform from Device, Color Encoding or PCS, to PCS, or a color transform
         /// from Device 1 to Device 2, using lookup table tag element structures
         /// </summary>
         AToB0 = 0x41324230,
 
         /// <summary>
-        /// A2B2 - This tag describes the colour transform from Device or Colour Encoding to PCS using lookup table tag element structures
+        /// A2B2 - This tag describes the color transform from Device or Color Encoding to PCS using lookup table tag element structures
         /// </summary>
         AToB1 = 0x41324231,
 
         /// <summary>
-        /// A2B2 - This tag describes the colour transform from Device or Colour Encoding to PCS using lookup table tag element structures
+        /// A2B2 - This tag describes the color transform from Device or Color Encoding to PCS using lookup table tag element structures
         /// </summary>
         AToB2 = 0x41324232,
 
@@ -46,40 +46,40 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         BlueTrc = 0x62545243,
 
         /// <summary>
-        /// B2A0 - This tag defines a colour transform from PCS to Device or Colour Encoding using the lookup table tag element structures
+        /// B2A0 - This tag defines a color transform from PCS to Device or Color Encoding using the lookup table tag element structures
         /// </summary>
         BToA0 = 0x42324130,
 
         /// <summary>
-        /// B2A1 - This tag defines a colour transform from PCS to Device or Colour Encoding using the lookup table tag element structures.
+        /// B2A1 - This tag defines a color transform from PCS to Device or Color Encoding using the lookup table tag element structures.
         /// </summary>
         BToA1 = 0x42324131,
 
         /// <summary>
-        /// B2A2 - This tag defines a colour transform from PCS to Device or Colour Encoding using the lookup table tag element structures.
+        /// B2A2 - This tag defines a color transform from PCS to Device or Color Encoding using the lookup table tag element structures.
         /// </summary>
         BToA2 = 0x42324132,
 
         /// <summary>
-        /// B2D0 - This tag defines a colour transform from PCS to Device. It supports float32Number-encoded input range, output range and transform, and
+        /// B2D0 - This tag defines a color transform from PCS to Device. It supports float32Number-encoded input range, output range and transform, and
         /// provides a means to override the BToA0 tag.
         /// </summary>
         BToD0 = 0x42324430,
 
         /// <summary>
-        /// B2D1 - This tag defines a colour transform from PCS to Device. It supports float32Number-encoded input range, output range and transform, and
+        /// B2D1 - This tag defines a color transform from PCS to Device. It supports float32Number-encoded input range, output range and transform, and
         /// provides a means to override the BToA1 tag.
         /// </summary>
         BToD1 = 0x42324431,
 
         /// <summary>
-        /// B2D2 - This tag defines a colour transform from PCS to Device. It supports float32Number-encoded input range, output range and transform, and
+        /// B2D2 - This tag defines a color transform from PCS to Device. It supports float32Number-encoded input range, output range and transform, and
         /// provides a means to override the BToA2 tag.
         /// </summary>
         BToD2 = 0x42324432,
 
         /// <summary>
-        /// B2D3 - This tag defines a colour transform from PCS to Device. It supports float32Number-encoded input range, output range and transform, and
+        /// B2D3 - This tag defines a color transform from PCS to Device. It supports float32Number-encoded input range, output range and transform, and
         /// provides a means to override the BToA1 tag.
         /// </summary>
         BToD3 = 0x42324433,
@@ -97,8 +97,8 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         CharTarget = 0x74617267,
 
         /// <summary>
-        /// chad - This tag contains a matrix, which shall be invertible, and which converts an nCIEXYZ colour, measured using the actual illumination
-        /// conditions and relative to the actual adopted white, to an nCIEXYZ colour relative to the PCS adopted white
+        /// chad - This tag contains a matrix, which shall be invertible, and which converts an nCIEXYZ color, measured using the actual illumination
+        /// conditions and relative to the actual adopted white, to an nCIEXYZ color relative to the PCS adopted white
         /// </summary>
         ChromaticAdaptation = 0x63686164,
 
@@ -166,33 +166,33 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         DeviceSettings = 0x64657673,
 
         /// <summary>
-        /// D2B0 - This tag defines a colour transform from Device to PCS. It supports float32Number-encoded
+        /// D2B0 - This tag defines a color transform from Device to PCS. It supports float32Number-encoded
         /// input range, output range and transform, and provides a means to override the AToB0 tag
         /// </summary>
         DToB0 = 0x44324230,
 
         /// <summary>
-        /// D2B1 - This tag defines a colour transform from Device to PCS. It supports float32Number-encoded
+        /// D2B1 - This tag defines a color transform from Device to PCS. It supports float32Number-encoded
         /// input range, output range and transform, and provides a means to override the AToB1 tag
         /// </summary>
         DToB1 = 0x44324230,
 
         /// <summary>
-        /// D2B2 - This tag defines a colour transform from Device to PCS. It supports float32Number-encoded
+        /// D2B2 - This tag defines a color transform from Device to PCS. It supports float32Number-encoded
         /// input range, output range and transform, and provides a means to override the AToB1 tag
         /// </summary>
         DToB2 = 0x44324230,
 
         /// <summary>
-        /// D2B3 - This tag defines a colour transform from Device to PCS. It supports float32Number-encoded
+        /// D2B3 - This tag defines a color transform from Device to PCS. It supports float32Number-encoded
         /// input range, output range and transform, and provides a means to override the AToB1 tag
         /// </summary>
         DToB3 = 0x44324230,
 
         /// <summary>
         /// gamt - This tag provides a table in which PCS values are the input and a single
-        /// output value for each input value is the output. If the output value is 0, the PCS colour is in-gamut.
-        /// If the output is non-zero, the PCS colour is out-of-gamut
+        /// output value for each input value is the output. If the output value is 0, the PCS color is in-gamut.
+        /// If the output is non-zero, the PCS color is out-of-gamut
         /// </summary>
         Gamut = 0x67616D74,
 
@@ -214,7 +214,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         GreenTrc = 0x67545243,
 
         /// <summary>
-        /// lumi - This tag contains the absolute luminance of emissive devices in candelas per square metre as described by the Y channel.
+        /// lumi - This tag contains the absolute luminance of emissive devices in candelas per square meter as described by the Y channel.
         /// </summary>
         Luminance = 0x6C756d69,
 
@@ -240,8 +240,8 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         NamedColor = 0x6E636f6C,
 
         /// <summary>
-        /// ncl2 - This tag contains the named colour information providing a PCS and optional device representation
-        /// for a list of named colours.
+        /// ncl2 - This tag contains the named color information providing a PCS and optional device representation
+        /// for a list of named colors.
         /// </summary>
         NamedColor2 = 0x6E636C32,
 

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccRenderingIntent.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccRenderingIntent.cs
@@ -10,11 +10,11 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
     {
         /// <summary>
         /// In perceptual transforms the PCS values represent hypothetical
-        /// measurements of a colour reproduction on the reference reflective
+        /// measurements of a color reproduction on the reference reflective
         /// medium. By extension, for the perceptual intent, the PCS represents
         /// the appearance of that reproduction as viewed in the reference viewing
         /// environment by a human observer adapted to that environment. The exact
-        /// colour rendering of the perceptual intent is vendor specific.
+        /// color rendering of the perceptual intent is vendor specific.
         /// </summary>
         Perceptual = 0,
 
@@ -27,15 +27,15 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         MediaRelativeColorimetric = 1,
 
         /// <summary>
-        /// The exact colour rendering of the saturation intent is vendor
+        /// The exact color rendering of the saturation intent is vendor
         /// specific and involves compromises such as trading off
-        /// preservation of hue in order to preserve the vividness of pure colours.
+        /// preservation of hue in order to preserve the vividness of pure colors.
         /// </summary>
         Saturation = 2,
 
         /// <summary>
         /// Transformations for this intent shall leave the chromatically
-        /// adapted nCIEXYZ tristimulus values of the in-gamut colours unchanged.
+        /// adapted nCIEXYZ tristimulus values of the in-gamut colors unchanged.
         /// </summary>
         AbsoluteColorimetric = 3,
     }

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccTypeSignature.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccTypeSignature.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// This is an optional tag which specifies the laydown order in which colorants
         /// will be printed on an n-colorant device. The laydown order may be the same
         /// as the channel generation order listed in the colorantTableTag or the channel
-        /// order of a colour encoding type such as CMYK, in which case this tag is not
+        /// order of a color encoding type such as CMYK, in which case this tag is not
         /// needed. When this is not the case (for example, ink-towers sometimes use
         /// the order KCMY), this tag may be used to specify the laydown order of the
         /// colorants
@@ -59,25 +59,25 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         DateTime = 0x6474696D,
 
         /// <summary>
-        /// This structure represents a colour transform using tables with 16-bit
+        /// This structure represents a color transform using tables with 16-bit
         /// precision. This type contains four processing elements: a 3 × 3 matrix
-        /// (which shall be the identity matrix unless the input colour space is
+        /// (which shall be the identity matrix unless the input color space is
         /// PCSXYZ), a set of one-dimensional input tables, a multi-dimensional
         /// lookup table, and a set of one-dimensional output tables
         /// </summary>
         Lut16 = 0x6D667432,
 
         /// <summary>
-        /// This structure represents a colour transform using tables of 8-bit
+        /// This structure represents a color transform using tables of 8-bit
         /// precision. This type contains four processing elements: a 3 × 3 matrix
-        /// (which shall be the identity matrix unless the input colour space is
+        /// (which shall be the identity matrix unless the input color space is
         /// PCSXYZ), a set of one-dimensional input tables, a multi-dimensional
         /// lookup table, and a set of one-dimensional output tables.
         /// </summary>
         Lut8 = 0x6D667431,
 
         /// <summary>
-        /// This structure represents a colour transform. The type contains up
+        /// This structure represents a color transform. The type contains up
         /// to five processing elements which are stored in the AToBTag tag
         /// in the following order: a set of one-dimensional curves, a 3 × 3
         /// matrix with offset terms, a set of one-dimensional curves, a
@@ -87,7 +87,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         LutAToB = 0x6D414220,
 
         /// <summary>
-        /// This structure represents a colour transform. The type contains
+        /// This structure represents a color transform. The type contains
         /// up to five processing elements which are stored in the BToATag
         /// in the following order: a set of one-dimensional curves, a 3 × 3
         /// matrix with offset terms, a set of one-dimensional curves, a
@@ -111,7 +111,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         MultiLocalizedUnicode = 0x6D6C7563,
 
         /// <summary>
-        /// This structure represents a colour transform, containing a sequence
+        /// This structure represents a color transform, containing a sequence
         /// of processing elements. The processing elements contained in the
         /// structure are defined in the structure itself, allowing for a flexible
         /// structure. Currently supported processing elements are: a set of one
@@ -123,15 +123,15 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         MultiProcessElements = 0x6D706574,
 
         /// <summary>
-        /// This type is a count value and array of structures that provide colour
-        /// coordinates for colour names. For each named colour, a PCS and optional
-        /// device representation of the colour are given. Both representations are
+        /// This type is a count value and array of structures that provide color
+        /// coordinates for color names. For each named color, a PCS and optional
+        /// device representation of the color are given. Both representations are
         /// 16-bit values and PCS values shall be relative colorimetric. The device
-        /// representation corresponds to the header’s "data colour space" field.
+        /// representation corresponds to the header’s "data color space" field.
         /// This representation should be consistent with the "number of device
         /// coordinates" field in the namedColor2Type. If this field is 0, device
         /// coordinates are not provided. The PCS representation corresponds to the
-        /// header's PCS field. The PCS representation is always provided. Colour
+        /// header's PCS field. The PCS representation is always provided. Color
         /// names are fixed-length, 32-byte fields including null termination. In
         /// order to maintain maximum portability, it is strongly recommended that
         /// special characters of the 7-bit ASCII set not be used.
@@ -168,7 +168,7 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         /// so that corrections can be made for variation in the device without
         /// having to produce a new profile. The mechanism can be used by applications
         /// to allow users with relatively inexpensive and readily available
-        /// instrumentation to apply corrections to individual output colour
+        /// instrumentation to apply corrections to individual output color
         /// channels in order to achieve consistent results.
         /// </summary>
         ResponseCurveSet16 = 0x72637332,

--- a/src/ImageSharp/PixelFormats/ColorBuilder{TPixel}.cs
+++ b/src/ImageSharp/PixelFormats/ColorBuilder{TPixel}.cs
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// The hexadecimal representation of the combined color components arranged
         /// in rgb, rgba, rrggbb, or rrggbbaa format to match web syntax.
         /// </param>
-        /// <returns>Returns a <typeparamref name="TPixel"/> that represents the color defined by the provided RGBA heax string.</returns>
+        /// <returns>Returns a <typeparamref name="TPixel"/> that represents the color defined by the provided RGBA hex string.</returns>
         public static TPixel FromHex(string hex)
         {
             Guard.NotNullOrWhiteSpace(hex, nameof(hex));

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
@@ -110,7 +110,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ref TPixel sourceRef = ref MemoryMarshal.GetReference(sourceColors);
 
             // Gray8 and Gray16 are special implementations of IPixel in that they do not conform to the
-            // standard RGBA colorspace format and must be converted from RGBA using the special ITU BT709 alogrithm.
+            // standard RGBA colorspace format and must be converted from RGBA using the special ITU BT709 algorithm.
             // One of the requirements of FromScaledVector4/ToScaledVector4 is that it unaware of this and
             // packs/unpacks the pixel without and conversion so we employ custom methods do do this.
             if (typeof(TDestinationPixel) == typeof(Gray16))

--- a/src/ImageSharp/PixelFormats/Utils/PixelConverter.cs
+++ b/src/ImageSharp/PixelFormats/Utils/PixelConverter.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
                 // packedRgba          = [aa bb gg rr]
                 // tmp1                = [aa 00 gg 00]
                 // tmp2                = [00 bb 00 rr]
-                // tmp3=ROTL(16, tmp2)  = [00 rr 00 bb]
+                // tmp3=ROTL(16, tmp2) = [00 rr 00 bb]
                 // tmp1 + tmp3         = [aa rr gg bb]
                 uint tmp1 = packedRgba & 0xFF00FF00;
                 uint tmp2 = packedRgba & 0x00FF00FF;

--- a/src/ImageSharp/PixelFormats/Utils/Vector4Converters.RgbaCompatible.cs
+++ b/src/ImageSharp/PixelFormats/Utils/Vector4Converters.RgbaCompatible.cs
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
                 Span<Rgba32> lastQuarterOfDestBuffer = MemoryMarshal.Cast<Vector4, Rgba32>(destVectors).Slice((3 * count) + 1, countWithoutLastItem);
                 pixelOperations.ToRgba32(configuration, reducedSource, lastQuarterOfDestBuffer);
 
-                // 'destVectors' and 'lastQuarterOfDestBuffer' are ovelapping buffers,
+                // 'destVectors' and 'lastQuarterOfDestBuffer' are overlapping buffers,
                 // but we are always reading/writing at different positions:
                 SimdUtils.BulkConvertByteToNormalizedFloat(
                     MemoryMarshal.Cast<Rgba32, byte>(lastQuarterOfDestBuffer),


### PR DESCRIPTION
Went through the whole library to find small things to fix and fixed typos along the way.
This PR only contains typo fixes in code comments, nothing functional.