### PR TITLE
Fix infinite loop when a GIF prematurely terminates

### DIFF
--- a/tests/ImageSharp.Sandbox46/ImageSharp.Sandbox46.csproj
+++ b/tests/ImageSharp.Sandbox46/ImageSharp.Sandbox46.csproj
@@ -11,7 +11,7 @@
     <Authors>James Jackson-South and contributors</Authors>
     <Company>James Jackson-South</Company>
     <RootNamespace>SixLabors.ImageSharp.Sandbox46</RootNamespace>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ImageSharp.Drawing\ImageSharp.Drawing.csproj" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
When the last frame of a GIF isn't properly terminated, Skip loops forever.

This ensures we break at the EOF.

This PR also renames Skip to SkipBlock to better describe it's behavior.

<!-- Thanks for contributing to ImageSharp! -->
