### PR TITLE
Fix naming of variable and class

### DIFF
--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Curves.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Curves.cs
@@ -41,10 +41,10 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         public IccResponseCurve ReadResponseCurve(int channelCount)
         {
             var type = (IccCurveMeasurementEncodings)this.ReadUInt32();
-            uint[] measurment = new uint[channelCount];
+            uint[] measurement = new uint[channelCount];
             for (int i = 0; i < channelCount; i++)
             {
-                measurment[i] = this.ReadUInt32();
+                measurement[i] = this.ReadUInt32();
             }
 
             Vector3[] xyzValues = new Vector3[channelCount];
@@ -56,8 +56,8 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
             IccResponseNumber[][] response = new IccResponseNumber[channelCount][];
             for (int i = 0; i < channelCount; i++)
             {
-                response[i] = new IccResponseNumber[measurment[i]];
-                for (uint j = 0; j < measurment[i]; j++)
+                response[i] = new IccResponseNumber[measurement[i]];
+                for (uint j = 0; j < measurement[i]; j++)
                 {
                     response[i][j] = this.ReadResponseNumber();
                 }

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.TagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.TagDataEntry.cs
@@ -628,16 +628,16 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
         {
             int start = this.currentIndex - 8; // 8 is the tag header size
             ushort channelCount = this.ReadUInt16();
-            ushort measurmentCount = this.ReadUInt16();
+            ushort measurementCount = this.ReadUInt16();
 
-            uint[] offset = new uint[measurmentCount];
-            for (int i = 0; i < measurmentCount; i++)
+            uint[] offset = new uint[measurementCount];
+            for (int i = 0; i < measurementCount; i++)
             {
                 offset[i] = this.ReadUInt32();
             }
 
-            var curves = new IccResponseCurve[measurmentCount];
-            for (int i = 0; i < measurmentCount; i++)
+            var curves = new IccResponseCurve[measurementCount];
+            for (int i = 0; i < measurementCount; i++)
             {
                 this.currentIndex = (int)(start + offset[i]);
                 curves[i] = this.ReadResponseCurve(channelCount);

--- a/src/ImageSharp/Processing/Processors/Convolution/KirschKernels.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KirschKernels.cs
@@ -6,9 +6,9 @@ using SixLabors.ImageSharp.Primitives;
 namespace SixLabors.ImageSharp.Processing.Processors.Convolution
 {
     /// <summary>
-    /// Contains the eight matrices used for Kirsh edge detection
+    /// Contains the eight matrices used for Kirsch edge detection
     /// </summary>
-    internal static class KirshKernels
+    internal static class KirschKernels
     {
         /// <summary>
         /// Gets the North gradient operator

--- a/src/ImageSharp/Processing/Processors/Convolution/KirschProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KirschProcessor.cs
@@ -23,27 +23,27 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc/>
-        public override DenseMatrix<float> North => KirshKernels.KirschNorth;
+        public override DenseMatrix<float> North => KirschKernels.KirschNorth;
 
         /// <inheritdoc/>
-        public override DenseMatrix<float> NorthWest => KirshKernels.KirschNorthWest;
+        public override DenseMatrix<float> NorthWest => KirschKernels.KirschNorthWest;
 
         /// <inheritdoc/>
-        public override DenseMatrix<float> West => KirshKernels.KirschWest;
+        public override DenseMatrix<float> West => KirschKernels.KirschWest;
 
         /// <inheritdoc/>
-        public override DenseMatrix<float> SouthWest => KirshKernels.KirschSouthWest;
+        public override DenseMatrix<float> SouthWest => KirschKernels.KirschSouthWest;
 
         /// <inheritdoc/>
-        public override DenseMatrix<float> South => KirshKernels.KirschSouth;
+        public override DenseMatrix<float> South => KirschKernels.KirschSouth;
 
         /// <inheritdoc/>
-        public override DenseMatrix<float> SouthEast => KirshKernels.KirschSouthEast;
+        public override DenseMatrix<float> SouthEast => KirschKernels.KirschSouthEast;
 
         /// <inheritdoc/>
-        public override DenseMatrix<float> East => KirshKernels.KirschEast;
+        public override DenseMatrix<float> East => KirschKernels.KirschEast;
 
         /// <inheritdoc/>
-        public override DenseMatrix<float> NorthEast => KirshKernels.KirschNorthEast;
+        public override DenseMatrix<float> NorthEast => KirschKernels.KirschNorthEast;
     }
 }


### PR DESCRIPTION
fixes typos in class name (and usages of that class) as well as for a local variable in code.