### PR TITLE
Add more seeding to the AoT compiler for iOS

### DIFF
--- a/src/ImageSharp/Advanced/AotCompilerTools.cs
+++ b/src/ImageSharp/Advanced/AotCompilerTools.cs
@@ -43,10 +43,10 @@ namespace SixLabors.ImageSharp.Advanced
 
             System.Runtime.CompilerServices.Unsafe.SizeOf<TPixel>();
 
-            AotDecoder<TPixel>(new Formats.Png.PngDecoder());
-            AotDecoder<TPixel>(new Formats.Bmp.BmpDecoder());
-            AotDecoder<TPixel>(new Formats.Gif.GifDecoder());
-            AotDecoder<TPixel>(new Formats.Jpeg.JpegDecoder());
+            AotCodec<TPixel>(new Formats.Png.PngDecoder(), new Formats.Png.PngEncoder());
+            AotCodec<TPixel>(new Formats.Bmp.BmpDecoder(), new Formats.Bmp.BmpEncoder());
+            AotCodec<TPixel>(new Formats.Gif.GifDecoder(), new Formats.Gif.GifEncoder());
+            AotCodec<TPixel>(new Formats.Jpeg.JpegDecoder(), new Formats.Jpeg.JpegEncoder());
 
             // TODO: Do the discovery work to figure out what works and what doesn't.
         }
@@ -122,16 +122,24 @@ namespace SixLabors.ImageSharp.Advanced
         }
 
         /// <summary>
-        /// This method pre-seeds the decoder for a given pixel format in the AoT compiler for iOS.
+        /// This method pre-seeds the decoder and encoder for a given pixel format in the AoT compiler for iOS.
         /// </summary>
-        /// <param name="decoder">The image decoder to seed..</param>
+        /// <param name="decoder">The image decoder to seed.</param>
+        /// <param name="encoder">The image encoder to seed.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
-        private static void AotDecoder<TPixel>(IImageDecoder decoder)
+        private static void AotCodec<TPixel>(IImageDecoder decoder, IImageEncoder encoder)
             where TPixel : struct, IPixel<TPixel>
         {
             try
             {
                 decoder.Decode<TPixel>(Configuration.Default, null);
+            }
+            catch
+            {
+            }
+            try
+            {
+                encoder.Encode<TPixel>(null, null);
             }
             catch
             {

--- a/src/ImageSharp/Advanced/AotCompilerTools.cs
+++ b/src/ImageSharp/Advanced/AotCompilerTools.cs
@@ -18,10 +18,7 @@ namespace SixLabors.ImageSharp.Advanced
     /// </summary>
     public static class AotCompilerTools
     {
-        /// <summary>
-        /// Seeds the <see cref="System.Runtime.CompilerServices.Unsafe"/> calls.
-        /// </summary>
-        public static void SeedUnsafe()
+        static AotCompilerTools()
         {
             System.Runtime.CompilerServices.Unsafe.SizeOf<long>();
             System.Runtime.CompilerServices.Unsafe.SizeOf<short>();

--- a/src/ImageSharp/Advanced/AotCompilerTools.cs
+++ b/src/ImageSharp/Advanced/AotCompilerTools.cs
@@ -137,6 +137,7 @@ namespace SixLabors.ImageSharp.Advanced
             catch
             {
             }
+
             try
             {
                 encoder.Encode<TPixel>(null, null);

--- a/src/ImageSharp/Advanced/AotCompilerTools.cs
+++ b/src/ImageSharp/Advanced/AotCompilerTools.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Numerics;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Jpeg.Components;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors.Dithering;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
@@ -16,6 +19,20 @@ namespace SixLabors.ImageSharp.Advanced
     public static class AotCompilerTools
     {
         /// <summary>
+        /// Seeds the <see cref="System.Runtime.CompilerServices.Unsafe"/> calls.
+        /// </summary>
+        public static void SeedUnsafe()
+        {
+            System.Runtime.CompilerServices.Unsafe.SizeOf<long>();
+            System.Runtime.CompilerServices.Unsafe.SizeOf<short>();
+            System.Runtime.CompilerServices.Unsafe.SizeOf<float>();
+            System.Runtime.CompilerServices.Unsafe.SizeOf<double>();
+            System.Runtime.CompilerServices.Unsafe.SizeOf<byte>();
+            System.Runtime.CompilerServices.Unsafe.SizeOf<Block8x8>();
+            System.Runtime.CompilerServices.Unsafe.SizeOf<Vector4>();
+        }
+
+        /// <summary>
         /// Seeds the compiler using the given pixel format.
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
@@ -26,6 +43,13 @@ namespace SixLabors.ImageSharp.Advanced
             AotCompileOctreeQuantizer<TPixel>();
             AotCompileWuQuantizer<TPixel>();
             AotCompileDithering<TPixel>();
+
+            System.Runtime.CompilerServices.Unsafe.SizeOf<TPixel>();
+
+            AotDecoder<TPixel>(new Formats.Png.PngDecoder());
+            AotDecoder<TPixel>(new Formats.Bmp.BmpDecoder());
+            AotDecoder<TPixel>(new Formats.Gif.GifDecoder());
+            AotDecoder<TPixel>(new Formats.Jpeg.JpegDecoder());
 
             // TODO: Do the discovery work to figure out what works and what doesn't.
         }
@@ -98,6 +122,23 @@ namespace SixLabors.ImageSharp.Advanced
             var test = new FloydSteinbergDiffuser();
             TPixel pixel = default;
             test.Dither<TPixel>(new ImageFrame<TPixel>(Configuration.Default, 1, 1), pixel, pixel, 0, 0, 0, 0, 0, 0);
+        }
+
+        /// <summary>
+        /// This method pre-seeds the decoder for a given pixel format in the AoT compiler for iOS.
+        /// </summary>
+        /// <param name="decoder">The image decoder to seed..</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        private static void AotDecoder<TPixel>(IImageDecoder decoder)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            try
+            {
+                decoder.Decode<TPixel>(Configuration.Default, null);
+            }
+            catch
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

Adds some calls to `Unsafe.SizeOf` for various primitives and structs to prevent JIT errors on iOS.
Also seeds the decoders for a given pixel format, which should solve #776.
Note that although JPEG will now also load without crashing, it is incredibly slow on Xamarin.iOS.  A 1366x768 JPEG takes about 5 seconds to load on an iPad Pro.

As per the previous PR #767, this is a difficult one to write tests for.

<!-- Thanks for contributing to ImageSharp! -->
