### PR TITLE
Fix Projective Transforms

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -75,7 +75,6 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             // Convert from screen to world space.
             Matrix4x4.Invert(this.TransformMatrix, out Matrix4x4 matrix);
-            const float Epsilon = 0.0000001F;
 
             if (this.Sampler is NearestNeighborResampler)
             {
@@ -90,11 +89,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
                                 for (int x = 0; x < width; x++)
                                 {
-                                    var v3 = Vector3.Transform(new Vector3(x, y, 1), matrix);
-
-                                    float z = MathF.Max(v3.Z, Epsilon);
-                                    int px = (int)MathF.Round(v3.X / z);
-                                    int py = (int)MathF.Round(v3.Y / z);
+                                    Vector2 point = TransformUtils.ProjectiveTransform2D(x, y, matrix);
+                                    int px = (int)MathF.Round(point.X);
+                                    int py = (int)MathF.Round(point.Y);
 
                                     if (sourceRectangle.Contains(px, py))
                                     {
@@ -127,9 +124,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                             {
                                 // Use the single precision position to calculate correct bounding pixels
                                 // otherwise we get rogue pixels outside of the bounds.
-                                var v3 = Vector3.Transform(new Vector3(x, y, 1F), matrix);
-                                Vector2 point = new Vector2(v3.X, v3.Y) / MathF.Max(v3.Z, Epsilon);
-
+                                Vector2 point = TransformUtils.ProjectiveTransform2D(x, y, matrix);
                                 kernel.Convolve(point, x, ref ySpanRef, ref xSpanRef, source.PixelBuffer, vectorSpan);
                             }
 

--- a/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
@@ -111,7 +111,32 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
             using (Image<TPixel> image = provider.GetImage())
             {
                 Matrix4x4 matrix = Matrix4x4.Identity;
-                matrix.M13 = 0.01F;
+                matrix.M14 = 0.01F;
+
+                ProjectiveTransformBuilder builder = new ProjectiveTransformBuilder()
+                .AppendMatrix(matrix);
+
+                image.Mutate(i => i.Transform(builder));
+
+                image.DebugSave(provider);
+                image.CompareToReferenceOutput(TolerantComparer, provider);
+            }
+        }
+
+        [Theory]
+        [WithSolidFilledImages(290, 154, 0, 0, 255, PixelTypes.Rgba32)]
+        public void PerspectiveTransformMatchesCSS<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            // https://jsfiddle.net/dFrHS/545/
+            // https://github.com/SixLabors/ImageSharp/issues/787
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                var matrix = new Matrix4x4(
+                   0.260987f, -0.434909f, 0, -0.0022184f,
+                   0.373196f, 0.949882f, 0, -0.000312129f,
+                   0, 0, 1, 0,
+                   52, 165, 0, 1);
 
                 ProjectiveTransformBuilder builder = new ProjectiveTransformBuilder()
                 .AppendMatrix(matrix);


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [ ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
Previously we were modifying the wrong row/column in our taper matrices and then flattening the transform using `Vector3` to compensate when we should have been using `Vector4` instead to take into account perspective changes. These changes update the code to fix this. 

<!-- Thanks for contributing to ImageSharp! -->
