### PR TITLE
Exposed processing classes so that they can be extended

### DIFF
--- a/src/ImageSharp/Memory/Buffer2DExtensions.cs
+++ b/src/ImageSharp/Memory/Buffer2DExtensions.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Memory
     /// <summary>
     /// Defines extension methods for <see cref="Buffer2D{T}"/>.
     /// </summary>
-    internal static class Buffer2DExtensions
+    public static class Buffer2DExtensions
     {
         /// <summary>
         /// Gets a <see cref="Span{T}"/> to the backing buffer of <paramref name="buffer"/>.

--- a/src/ImageSharp/Memory/Buffer2D{T}.cs
+++ b/src/ImageSharp/Memory/Buffer2D{T}.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Memory
     /// interpreted as a 2D region of <see cref="Width"/> x <see cref="Height"/> elements.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>
-    internal sealed class Buffer2D<T> : IDisposable
+    public sealed class Buffer2D<T> : IDisposable
         where T : struct
     {
         private MemorySource<T> memorySource;

--- a/src/ImageSharp/Memory/BufferArea{T}.cs
+++ b/src/ImageSharp/Memory/BufferArea{T}.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Memory
     /// This type is kind-of 2D Span, but it can live on heap.
     /// </summary>
     /// <typeparam name="T">The element type</typeparam>
-    internal readonly struct BufferArea<T>
+    public readonly struct BufferArea<T>
         where T : struct
     {
         /// <summary>

--- a/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
+++ b/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Memory
     /// <summary>
     /// Extension methods for <see cref="MemoryAllocator"/>.
     /// </summary>
-    internal static class MemoryAllocatorExtensions
+    public static class MemoryAllocatorExtensions
     {
         public static Buffer2D<T> Allocate2D<T>(
             this MemoryAllocator memoryAllocator,

--- a/src/ImageSharp/Memory/MemoryOwnerExtensions.cs
+++ b/src/ImageSharp/Memory/MemoryOwnerExtensions.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Memory
     /// <summary>
     /// Extension methods for <see cref="IMemoryOwner{T}"/>
     /// </summary>
-    internal static class MemoryOwnerExtensions
+    public static class MemoryOwnerExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Span<T> GetSpan<T>(this IMemoryOwner<T> buffer)

--- a/src/ImageSharp/Memory/MemorySource.cs
+++ b/src/ImageSharp/Memory/MemorySource.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Memory
     /// https://gist.github.com/GrabYourPitchforks/4c3e1935fd4d9fa2831dbfcab35dffc6
     /// https://www.codemag.com/Article/1807051/Introducing-.NET-Core-2.1-Flagship-Types-Span-T-and-Memory-T
     /// </remarks>
-    internal struct MemorySource<T> : IDisposable
+    public struct MemorySource<T> : IDisposable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MemorySource{T}"/> struct

--- a/src/ImageSharp/Memory/RowInterval.cs
+++ b/src/ImageSharp/Memory/RowInterval.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Memory
     /// <summary>
     /// Represents an interval of rows in a <see cref="Rectangle"/> and/or <see cref="Buffer2D{T}"/>
     /// </summary>
-    internal readonly struct RowInterval
+    public readonly struct RowInterval
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RowInterval"/> struct.

--- a/src/ImageSharp/Primitives/LongRational.cs
+++ b/src/ImageSharp/Primitives/LongRational.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Primitives
     /// <remarks>
     /// This is a very simplified implementation of a rational number designed for use with metadata only.
     /// </remarks>
-    internal readonly struct LongRational : IEquatable<LongRational>
+    public readonly struct LongRational : IEquatable<LongRational>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LongRational"/> struct.

--- a/src/ImageSharp/Primitives/ValueSize.cs
+++ b/src/ImageSharp/Primitives/ValueSize.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Primitives
     /// <summary>
     /// Represents a value in relation to a value on the image
     /// </summary>
-    internal readonly struct ValueSize : IEquatable<ValueSize>
+    public readonly struct ValueSize : IEquatable<ValueSize>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValueSize"/> struct.

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryErrorDiffusionProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryErrorDiffusionProcessor.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
     /// Performs binary threshold filtering against an image using error diffusion.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class BinaryErrorDiffusionProcessor<TPixel> : ImageProcessor<TPixel>
+    public class BinaryErrorDiffusionProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryOrderedDitherProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryOrderedDitherProcessor.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
     /// Performs binary threshold filtering against an image using ordered dithering.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class BinaryOrderedDitherProcessor<TPixel> : ImageProcessor<TPixel>
+    public class BinaryOrderedDitherProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
     /// Performs simple binary threshold filtering against an image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class BinaryThresholdProcessor<TPixel> : ImageProcessor<TPixel>
+    public class BinaryThresholdProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// Allows the application of processing algorithms to a clone of the original image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal abstract class CloningImageProcessor<TPixel> : ICloningImageProcessor<TPixel>
+    public abstract class CloningImageProcessor<TPixel> : ICloningImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Applies box blur processing to the image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class BoxBlurProcessor<TPixel> : ImageProcessor<TPixel>
+    public class BoxBlurProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Defines a processor that uses two one-dimensional matrices to perform convolution against an image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class Convolution2DProcessor<TPixel> : ImageProcessor<TPixel>
+    public class Convolution2DProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Defines a processor that uses two one-dimensional matrices to perform two-pass convolution against an image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
+    public class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Defines a processor that uses a 2 dimensional matrix to perform convolution against an image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
+    public class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Defines a processor that detects edges within an image using two one-dimensional matrices.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal abstract class EdgeDetector2DProcessor<TPixel> : ImageProcessor<TPixel>, IEdgeDetectorProcessor<TPixel>
+    public abstract class EdgeDetector2DProcessor<TPixel> : ImageProcessor<TPixel>, IEdgeDetectorProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor.cs
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Defines a processor that detects edges within an image using a eight two dimensional matrices.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal abstract class EdgeDetectorCompassProcessor<TPixel> : ImageProcessor<TPixel>, IEdgeDetectorProcessor<TPixel>
+    public abstract class EdgeDetectorCompassProcessor<TPixel> : ImageProcessor<TPixel>, IEdgeDetectorProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Defines a processor that detects edges within an image using a single two dimensional matrix.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal abstract class EdgeDetectorProcessor<TPixel> : ImageProcessor<TPixel>, IEdgeDetectorProcessor<TPixel>
+    public abstract class EdgeDetectorProcessor<TPixel> : ImageProcessor<TPixel>, IEdgeDetectorProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Applies Gaussian blur processing to the image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class GaussianBlurProcessor<TPixel> : ImageProcessor<TPixel>
+    public class GaussianBlurProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Applies Gaussian sharpening processing to the image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class GaussianSharpenProcessor<TPixel> : ImageProcessor<TPixel>
+    public class GaussianSharpenProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/KayyaliKernels.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KayyaliKernels.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <summary>
     /// Contains the kernels used for Kayyali edge detection
     /// </summary>
-    internal static class KayyaliKernels
+    public static class KayyaliKernels
     {
         /// <summary>
         /// Gets the horizontal gradient operator.

--- a/src/ImageSharp/Processing/Processors/Convolution/KayyaliProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KayyaliProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Applies edge detection processing to the image using the Kayyali operator filter. <see href="http://edgedetection.webs.com/"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class KayyaliProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
+    public class KayyaliProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/KirschKernels.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KirschKernels.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <summary>
     /// Contains the eight matrices used for Kirsch edge detection
     /// </summary>
-    internal static class KirschKernels
+    public static class KirschKernels
     {
         /// <summary>
         /// Gets the North gradient operator

--- a/src/ImageSharp/Processing/Processors/Convolution/KirschProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KirschProcessor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// Applies edge detection processing to the image using the Kirsch operator filter. <see href="http://en.wikipedia.org/wiki/Kirsch_operator"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class KirschProcessor<TPixel> : EdgeDetectorCompassProcessor<TPixel>
+    public class KirschProcessor<TPixel> : EdgeDetectorCompassProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/Laplacian3x3Processor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Laplacian3x3Processor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <see href="http://en.wikipedia.org/wiki/Discrete_Laplace_operator"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class Laplacian3x3Processor<TPixel> : EdgeDetectorProcessor<TPixel>
+    public class Laplacian3x3Processor<TPixel> : EdgeDetectorProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/Laplacian5x5Processor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Laplacian5x5Processor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <see href="http://en.wikipedia.org/wiki/Discrete_Laplace_operator"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class Laplacian5x5Processor<TPixel> : EdgeDetectorProcessor<TPixel>
+    public class Laplacian5x5Processor<TPixel> : EdgeDetectorProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/LaplacianKernelFactory.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/LaplacianKernelFactory.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <summary>
     /// A factory for creating Laplacian kernel matrices.
     /// </summary>
-    internal static class LaplacianKernelFactory
+    public static class LaplacianKernelFactory
     {
         /// <summary>
         /// Creates a Laplacian matrix, 2nd derivative, of an arbitrary length.

--- a/src/ImageSharp/Processing/Processors/Convolution/LaplacianKernels.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/LaplacianKernels.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <summary>
     /// Contains Laplacian kernels of different sizes
     /// </summary>
-    internal static class LaplacianKernels
+    public static class LaplacianKernels
     {
         /// <summary>
         /// Gets the 3x3 Laplacian kernel

--- a/src/ImageSharp/Processing/Processors/Convolution/LaplacianOfGaussianProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/LaplacianOfGaussianProcessor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <see href="http://fourier.eng.hmc.edu/e161/lectures/gradient/node8.html"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class LaplacianOfGaussianProcessor<TPixel> : EdgeDetectorProcessor<TPixel>
+    public class LaplacianOfGaussianProcessor<TPixel> : EdgeDetectorProcessor<TPixel>
           where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/PrewittKernels.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/PrewittKernels.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <summary>
     /// Contains the kernels used for Prewitt edge detection
     /// </summary>
-    internal static class PrewittKernels
+    public static class PrewittKernels
     {
         /// <summary>
         /// Gets the horizontal gradient operator.

--- a/src/ImageSharp/Processing/Processors/Convolution/PrewittProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/PrewittProcessor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <see href="http://en.wikipedia.org/wiki/Prewitt_operator"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class PrewittProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
+    public class PrewittProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/RobertsCrossKernels.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/RobertsCrossKernels.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <summary>
     /// Contains the kernels used for RobertsCross edge detection
     /// </summary>
-    internal static class RobertsCrossKernels
+    public static class RobertsCrossKernels
     {
         /// <summary>
         /// Gets the horizontal gradient operator.

--- a/src/ImageSharp/Processing/Processors/Convolution/RobertsCrossProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/RobertsCrossProcessor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <see href="http://en.wikipedia.org/wiki/Roberts_cross"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class RobertsCrossProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
+    public class RobertsCrossProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/RobinsonKernels.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/RobinsonKernels.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <summary>
     /// Contains the kernels used for Robinson edge detection
     /// </summary>
-    internal static class RobinsonKernels
+    public static class RobinsonKernels
     {
         /// <summary>
         /// Gets the North gradient operator

--- a/src/ImageSharp/Processing/Processors/Convolution/RobinsonProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/RobinsonProcessor.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <see href="http://www.tutorialspoint.com/dip/Robinson_Compass_Mask.htm"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class RobinsonProcessor<TPixel> : EdgeDetectorCompassProcessor<TPixel>
+    public class RobinsonProcessor<TPixel> : EdgeDetectorCompassProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/ScharrKernels.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ScharrKernels.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <summary>
     /// Contains the kernels used for Scharr edge detection
     /// </summary>
-    internal static class ScharrKernels
+    public static class ScharrKernels
     {
         /// <summary>
         /// Gets the horizontal gradient operator.

--- a/src/ImageSharp/Processing/Processors/Convolution/ScharrProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ScharrProcessor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <see href="http://en.wikipedia.org/wiki/Sobel_operator#Alternative_operators"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class ScharrProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
+    public class ScharrProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
           where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/SobelKernels.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/SobelKernels.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <summary>
     /// Contains the kernels used for Sobel edge detection
     /// </summary>
-    internal static class SobelKernels
+    public static class SobelKernels
     {
         /// <summary>
         /// Gets the horizontal gradient operator.

--- a/src/ImageSharp/Processing/Processors/Convolution/SobelProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/SobelProcessor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <see href="http://en.wikipedia.org/wiki/Sobel_operator"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class SobelProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
+    public class SobelProcessor<TPixel> : EdgeDetector2DProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/DelegateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/DelegateProcessor.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// Allows the application of processing algorithms to images via an action delegate
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class DelegateProcessor<TPixel> : ImageProcessor<TPixel>
+    public class DelegateProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Dithering/ErrorDiffusionPaletteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/ErrorDiffusionPaletteProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
     /// An <see cref="IImageProcessor{TPixel}"/> that dithers an image using error diffusion.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class ErrorDiffusionPaletteProcessor<TPixel> : PaletteDitherProcessorBase<TPixel>
+    public class ErrorDiffusionPaletteProcessor<TPixel> : PaletteDitherProcessorBase<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Dithering/OrderedDitherFactory.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/OrderedDitherFactory.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
     /// <summary>
     /// A factory for creating ordered dither matrices.
     /// </summary>
-    internal static class OrderedDitherFactory
+    public static class OrderedDitherFactory
     {
         /// <summary>
         /// Creates an ordered dithering matrix with equal sides of arbitrary length.

--- a/src/ImageSharp/Processing/Processors/Dithering/OrderedDitherPaletteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/OrderedDitherPaletteProcessor.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
     /// If no palette is given this will default to the web safe colors defined in the CSS Color Module Level 4.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class OrderedDitherPaletteProcessor<TPixel> : PaletteDitherProcessorBase<TPixel>
+    public class OrderedDitherPaletteProcessor<TPixel> : PaletteDitherProcessorBase<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessorBase.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessorBase.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
     /// The base class for dither and diffusion processors that consume a palette.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal abstract class PaletteDitherProcessorBase<TPixel> : ImageProcessor<TPixel>
+    public abstract class PaletteDitherProcessorBase<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         private readonly Dictionary<TPixel, PixelPair<TPixel>> cache = new Dictionary<TPixel, PixelPair<TPixel>>();

--- a/src/ImageSharp/Processing/Processors/Dithering/PixelPair.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/PixelPair.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
     /// Represents a composite pair of pixels. Used for caching color distance lookups.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal readonly struct PixelPair<TPixel> : IEquatable<PixelPair<TPixel>>
+    public readonly struct PixelPair<TPixel> : IEquatable<PixelPair<TPixel>>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
     /// </summary>
     /// <remarks>Adapted from <see href="https://softwarebydefault.com/2013/06/29/oil-painting-cartoon-filter/"/> by Dewald Esterhuizen.</remarks>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class OilPaintingProcessor<TPixel> : ImageProcessor<TPixel>
+    public class OilPaintingProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
     /// Applies a pixelation effect processing to the image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class PixelateProcessor<TPixel> : ImageProcessor<TPixel>
+    public class PixelateProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/AchromatomalyProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/AchromatomalyProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating Achromatomaly (Color desensitivity) color blindness.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class AchromatomalyProcessor<TPixel> : FilterProcessor<TPixel>
+    public class AchromatomalyProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/AchromatopsiaProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/AchromatopsiaProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating Achromatopsia (Monochrome) color blindness.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class AchromatopsiaProcessor<TPixel> : FilterProcessor<TPixel>
+    public class AchromatopsiaProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/BlackWhiteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/BlackWhiteProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a black and white filter matrix to the image
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class BlackWhiteProcessor<TPixel> : FilterProcessor<TPixel>
+    public class BlackWhiteProcessor<TPixel> : FilterProcessor<TPixel>
           where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/BrightnessProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/BrightnessProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a brightness filter matrix using the given amount.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class BrightnessProcessor<TPixel> : FilterProcessor<TPixel>
+    public class BrightnessProcessor<TPixel> : FilterProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/ContrastProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/ContrastProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a contrast filter matrix using the given amount.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class ContrastProcessor<TPixel> : FilterProcessor<TPixel>
+    public class ContrastProcessor<TPixel> : FilterProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/DeuteranomalyProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/DeuteranomalyProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating Deuteranomaly (Green-Weak) color blindness.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class DeuteranomalyProcessor<TPixel> : FilterProcessor<TPixel>
+    public class DeuteranomalyProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/DeuteranopiaProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/DeuteranopiaProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating Deuteranopia (Green-Blind) color blindness.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class DeuteranopiaProcessor<TPixel> : FilterProcessor<TPixel>
+    public class DeuteranopiaProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Provides methods that accept a <see cref="ColorMatrix"/> matrix to apply free-form filters to images.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class FilterProcessor<TPixel> : ImageProcessor<TPixel>
+    public class FilterProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/GrayscaleBt601Processor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/GrayscaleBt601Processor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a grayscale filter matrix using the given amount and the formula as specified by ITU-R Recommendation BT.601
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class GrayscaleBt601Processor<TPixel> : FilterProcessor<TPixel>
+    public class GrayscaleBt601Processor<TPixel> : FilterProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/GrayscaleBt709Processor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/GrayscaleBt709Processor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a grayscale filter matrix using the given amount and the formula as specified by ITU-R Recommendation BT.709
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class GrayscaleBt709Processor<TPixel> : FilterProcessor<TPixel>
+    public class GrayscaleBt709Processor<TPixel> : FilterProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/HueProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/HueProcessor.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// <summary>
     /// Applies a hue filter matrix using the given angle of rotation in degrees
     /// </summary>
-    internal class HueProcessor<TPixel> : FilterProcessor<TPixel>
+    public class HueProcessor<TPixel> : FilterProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/InvertProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/InvertProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a filter matrix that inverts the colors of an image
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class InvertProcessor<TPixel> : FilterProcessor<TPixel>
+    public class InvertProcessor<TPixel> : FilterProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/KodachromeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/KodachromeProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a filter matrix recreating an old Kodachrome camera effect matrix to the image
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class KodachromeProcessor<TPixel> : FilterProcessor<TPixel>
+    public class KodachromeProcessor<TPixel> : FilterProcessor<TPixel>
           where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/LomographProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/LomographProcessor.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating an old Lomograph effect.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class LomographProcessor<TPixel> : FilterProcessor<TPixel>
+    public class LomographProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         private static readonly TPixel VeryDarkGreen = ColorBuilder<TPixel>.FromRGBA(0, 10, 0, 255);

--- a/src/ImageSharp/Processing/Processors/Filters/OpacityProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/OpacityProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies an opacity filter matrix using the given amount.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class OpacityProcessor<TPixel> : FilterProcessor<TPixel>
+    public class OpacityProcessor<TPixel> : FilterProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating an old Polaroid effect.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class PolaroidProcessor<TPixel> : FilterProcessor<TPixel>
+    public class PolaroidProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         private static readonly TPixel VeryDarkOrange = ColorBuilder<TPixel>.FromRGB(102, 34, 0);

--- a/src/ImageSharp/Processing/Processors/Filters/ProtanomalyProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/ProtanomalyProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating Protanomaly (Red-Weak) color blindness.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class ProtanomalyProcessor<TPixel> : FilterProcessor<TPixel>
+    public class ProtanomalyProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/ProtanopiaProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/ProtanopiaProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating Protanopia (Red-Blind) color blindness.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class ProtanopiaProcessor<TPixel> : FilterProcessor<TPixel>
+    public class ProtanopiaProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/SaturateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/SaturateProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a saturation filter matrix using the given amount.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class SaturateProcessor<TPixel> : FilterProcessor<TPixel>
+    public class SaturateProcessor<TPixel> : FilterProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/SepiaProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/SepiaProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a sepia filter matrix using the given amount.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class SepiaProcessor<TPixel> : FilterProcessor<TPixel>
+    public class SepiaProcessor<TPixel> : FilterProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/TritanomalyProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/TritanomalyProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating Tritanomaly (Blue-Weak) color blindness.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class TritanomalyProcessor<TPixel> : FilterProcessor<TPixel>
+    public class TritanomalyProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Filters/TritanopiaProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/TritanopiaProcessor.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating Tritanopia (Blue-Blind) color blindness.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class TritanopiaProcessor<TPixel> : FilterProcessor<TPixel>
+    public class TritanopiaProcessor<TPixel> : FilterProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/ICloningImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/ICloningImageProcessor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// Encapsulates methods to alter the pixels of a new image, cloned from the original image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal interface ICloningImageProcessor<TPixel> : IImageProcessor<TPixel>
+    public interface ICloningImageProcessor<TPixel> : IImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/ImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// Allows the application of processors to images.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal abstract class ImageProcessor<TPixel> : IImageProcessor<TPixel>
+    public abstract class ImageProcessor<TPixel> : IImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
     /// Applies a global histogram equalization to the image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class HistogramEqualizationProcessor<TPixel> : ImageProcessor<TPixel>
+    public class HistogramEqualizationProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
     /// Sets the background color of the image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class BackgroundColorProcessor<TPixel> : ImageProcessor<TPixel>
+    public class BackgroundColorProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
     /// An <see cref="IImageProcessor{TPixel}"/> that applies a radial glow effect an <see cref="Image{TPixel}"/>.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class GlowProcessor<TPixel> : ImageProcessor<TPixel>
+    public class GlowProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         private readonly PixelBlender<TPixel> blender;

--- a/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
     /// An <see cref="IImageProcessor{TPixel}"/> that applies a radial vignette effect to an <see cref="Image{TPixel}"/>.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class VignetteProcessor<TPixel> : ImageProcessor<TPixel>
+    public class VignetteProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         private readonly PixelBlender<TPixel> blender;

--- a/src/ImageSharp/Processing/Processors/Quantization/OctreeFrameQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/OctreeFrameQuantizer{TPixel}.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// <see href="http://msdn.microsoft.com/en-us/library/aa479306.aspx"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal sealed class OctreeFrameQuantizer<TPixel> : FrameQuantizerBase<TPixel>
+    public sealed class OctreeFrameQuantizer<TPixel> : FrameQuantizerBase<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteFrameQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteFrameQuantizer{TPixel}.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// <see href="http://msdn.microsoft.com/en-us/library/aa479306.aspx"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal sealed class PaletteFrameQuantizer<TPixel> : FrameQuantizerBase<TPixel>
+    public sealed class PaletteFrameQuantizer<TPixel> : FrameQuantizerBase<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// Enables the quantization of images to reduce the number of colors used in the image palette.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class QuantizeProcessor<TPixel> : ImageProcessor<TPixel>
+    public class QuantizeProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizerConstants.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizerConstants.cs
@@ -6,7 +6,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// <summary>
     /// Contains color quantization specific constants.
     /// </summary>
-    internal static class QuantizerConstants
+    public static class QuantizerConstants
     {
         /// <summary>
         /// The minimum number of colors to use when quantizing an image.

--- a/src/ImageSharp/Processing/Processors/Quantization/WuFrameQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/WuFrameQuantizer{TPixel}.cs
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </para>
     /// </remarks>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal sealed class WuFrameQuantizer<TPixel> : FrameQuantizerBase<TPixel>
+    public sealed class WuFrameQuantizer<TPixel> : FrameQuantizerBase<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         // TODO: The WuFrameQuantizer<TPixel> code is rising several questions:

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Provides the base methods to perform affine transforms on an image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class AffineTransformProcessor<TPixel> : TransformProcessorBase<TPixel>
+    public class AffineTransformProcessor<TPixel> : TransformProcessorBase<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Adjusts an image so that its orientation is suitable for viewing. Adjustments are based on EXIF metadata embedded in the image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class AutoOrientProcessor<TPixel> : ImageProcessor<TPixel>
+    public class AutoOrientProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Provides methods to allow the cropping of an image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class CropProcessor<TPixel> : TransformProcessorBase<TPixel>
+    public class CropProcessor<TPixel> : TransformProcessorBase<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Provides methods to allow the cropping of an image to preserve areas of highest entropy.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class EntropyCropProcessor<TPixel> : ImageProcessor<TPixel>
+    public class EntropyCropProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Provides methods that allow the flipping of an image around its center point.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class FlipProcessor<TPixel> : ImageProcessor<TPixel>
+    public class FlipProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Provides the base methods to perform non-affine transforms on an image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class ProjectiveTransformProcessor<TPixel> : TransformProcessorBase<TPixel>
+    public class ProjectiveTransformProcessor<TPixel> : TransformProcessorBase<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// <summary>
     /// Points to a collection of of weights allocated in <see cref="ResizeKernelMap"/>.
     /// </summary>
-    internal readonly unsafe struct ResizeKernel
+    public readonly unsafe struct ResizeKernel
     {
         private readonly float* bufferPtr;
 

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.PeriodicKernelMap.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.PeriodicKernelMap.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// <content>
     /// Contains <see cref="PeriodicKernelMap"/>
     /// </content>
-    internal partial class ResizeKernelMap
+    public partial class ResizeKernelMap
     {
         /// <summary>
         /// Memory-optimized <see cref="ResizeKernelMap"/> where repeating rows are stored only once.

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Provides <see cref="ResizeKernel"/> values from an optimized,
     /// contiguous memory region.
     /// </summary>
-    internal partial class ResizeKernelMap : IDisposable
+    public partial class ResizeKernelMap : IDisposable
     {
         private static readonly TolerantMath TolerantMath = TolerantMath.Default;
 

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Adapted from <see href="http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/filter_rcg.c"/>
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class ResizeProcessor<TPixel> : TransformProcessorBase<TPixel>
+    public class ResizeProcessor<TPixel> : TransformProcessorBase<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         // The following fields are not immutable but are optionally created on demand.

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Provides methods that allow the rotating of images.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class RotateProcessor<TPixel> : AffineTransformProcessor<TPixel>
+    public class RotateProcessor<TPixel> : AffineTransformProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Transforms/SkewProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/SkewProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// Provides methods that allow the skewing of images.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class SkewProcessor<TPixel> : AffineTransformProcessor<TPixel>
+    public class SkewProcessor<TPixel> : AffineTransformProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformKernelMap.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformKernelMap.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// <summary>
     /// Contains the methods required to calculate transform kernel convolution.
     /// </summary>
-    internal class TransformKernelMap : IDisposable
+    public class TransformKernelMap : IDisposable
     {
         private readonly Buffer2D<float> yBuffer;
         private readonly Buffer2D<float> xBuffer;

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorBase.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorBase.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// The base class for all transform processors. Any processor that changes the dimensions of the image should inherit from this.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal abstract class TransformProcessorBase<TPixel> : CloningImageProcessor<TPixel>
+    public abstract class TransformProcessorBase<TPixel> : CloningImageProcessor<TPixel>
          where TPixel : struct, IPixel<TPixel>
     {
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorHelpers.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorHelpers.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// <summary>
     /// Contains helper methods for working with transforms.
     /// </summary>
-    internal static class TransformProcessorHelpers
+    public static class TransformProcessorHelpers
     {
         /// <summary>
         /// Updates the dimensional metadata of a transformed image

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformUtils.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformUtils.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// <summary>
     /// Contains utility methods for working with transforms.
     /// </summary>
-    internal static class TransformUtils
+    public static class TransformUtils
     {
         /// <summary>
         /// Applies the projective transform against the given coordinates flattened into the 2D space.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

As per https://github.com/SixLabors/ImageSharp/issues/621 I have exposed all the processing classes and some others that needed to be in order for ImageSharp to compile e.g. some of the Memory + Primitives classes
