### PR TITLE
GDI+ stability fixes for the benchmark and tests

### DIFF
--- a/tests/ImageSharp.Benchmarks/Drawing/DrawBeziers.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/DrawBeziers.cs
@@ -26,13 +26,15 @@ namespace SixLabors.ImageSharp.Benchmarks
                 {
                     graphics.InterpolationMode = InterpolationMode.Default;
                     graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                    Pen pen = new Pen(System.Drawing.Color.HotPink, 10);
-                    graphics.DrawBeziers(pen, new[] {
-                        new PointF(10, 500),
-                        new PointF(30, 10),
-                        new PointF(240, 30),
-                        new PointF(300, 500)
-                    });
+                    using (var pen = new Pen(System.Drawing.Color.HotPink, 10))
+                    {
+                        graphics.DrawBeziers(pen, new[] {
+                                                                new PointF(10, 500),
+                                                                new PointF(30, 10),
+                                                                new PointF(240, 30),
+                                                                new PointF(300, 500)
+                                                            });
+                    }
                 }
 
                 using (MemoryStream ms = new MemoryStream())

--- a/tests/ImageSharp.Benchmarks/Drawing/DrawLines.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/DrawLines.cs
@@ -26,12 +26,14 @@ namespace SixLabors.ImageSharp.Benchmarks
                 {
                     graphics.InterpolationMode = InterpolationMode.Default;
                     graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                    var pen = new Pen(System.Drawing.Color.HotPink, 10);
-                    graphics.DrawLines(pen, new[] {
-                        new PointF(10, 10),
-                        new PointF(550, 50),
-                        new PointF(200, 400)
-                    });
+                    using (var pen = new Pen(System.Drawing.Color.HotPink, 10))
+                    {
+                        graphics.DrawLines(pen, new[] {
+                                                              new PointF(10, 10),
+                                                              new PointF(550, 50),
+                                                              new PointF(200, 400)
+                                                          });
+                    }
                 }
 
                 using (var ms = new MemoryStream())

--- a/tests/ImageSharp.Benchmarks/Drawing/DrawPolygon.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/DrawPolygon.cs
@@ -26,12 +26,14 @@ namespace SixLabors.ImageSharp.Benchmarks
                 {
                     graphics.InterpolationMode = InterpolationMode.Default;
                     graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                    Pen pen = new Pen(System.Drawing.Color.HotPink, 10);
-                    graphics.DrawPolygon(pen, new[] {
-                        new PointF(10, 10),
-                        new PointF(550, 50),
-                        new PointF(200, 400)
-                    });
+                    using (var pen = new Pen(System.Drawing.Color.HotPink, 10))
+                    {
+                        graphics.DrawPolygon(pen, new[] {
+                                                                new PointF(10, 10),
+                                                                new PointF(550, 50),
+                                                                new PointF(200, 400)
+                                                            });
+                    }
                 }
 
                 using (MemoryStream ms = new MemoryStream())

--- a/tests/ImageSharp.Benchmarks/Drawing/DrawText.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/DrawText.cs
@@ -35,9 +35,10 @@ namespace SixLabors.ImageSharp.Benchmarks
                 {
                     graphics.InterpolationMode = InterpolationMode.Default;
                     graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                    Pen pen = new Pen(System.Drawing.Color.HotPink, 10);
-                    var font = new Font("Arial", 12, GraphicsUnit.Point);
-                    graphics.DrawString(TextToRender, font, System.Drawing.Brushes.HotPink, new RectangleF(10, 10, 780, 780));
+                    using (var font = new Font("Arial", 12, GraphicsUnit.Point))
+                    {
+                        graphics.DrawString(TextToRender, font, System.Drawing.Brushes.HotPink, new RectangleF(10, 10, 780, 780));
+                    }
                 }
             }
         }

--- a/tests/ImageSharp.Benchmarks/Drawing/DrawTextOutline.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/DrawTextOutline.cs
@@ -34,11 +34,13 @@ namespace SixLabors.ImageSharp.Benchmarks
                 {
                     graphics.InterpolationMode = InterpolationMode.Default;
                     graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                    Pen pen = new Pen(System.Drawing.Color.HotPink, 10);
-                    var font = new Font("Arial", 12, GraphicsUnit.Point);
-                    var gp = new GraphicsPath();
-                    gp.AddString(TextToRender, font.FontFamily, (int)font.Style, font.Size, new RectangleF(10, 10, 780, 780), new StringFormat());
-                    graphics.DrawPath(pen, gp);
+                    using (var pen = new Pen(System.Drawing.Color.HotPink, 10))
+                    using (var font = new Font("Arial", 12, GraphicsUnit.Point))
+                    using (var gp = new GraphicsPath())
+                    {
+                        gp.AddString(TextToRender, font.FontFamily, (int)font.Style, font.Size, new RectangleF(10, 10, 780, 780), new StringFormat());
+                        graphics.DrawPath(pen, gp);
+                    }
                 }
             }
         }

--- a/tests/ImageSharp.Benchmarks/Drawing/FillWithPattern.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/FillWithPattern.cs
@@ -26,8 +26,10 @@ namespace SixLabors.ImageSharp.Benchmarks
                 using (Graphics graphics = Graphics.FromImage(destination))
                 {
                     graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                    HatchBrush brush = new HatchBrush(HatchStyle.BackwardDiagonal, Color.HotPink);
-                    graphics.FillRectangle(brush, new Rectangle(0, 0, 800, 800)); // can't find a way to flood fill with a brush
+                    using (var brush = new HatchBrush(HatchStyle.BackwardDiagonal, Color.HotPink))
+                    {
+                        graphics.FillRectangle(brush, new Rectangle(0, 0, 800, 800)); // can't find a way to flood fill with a brush
+                    }
                 }
                 using (MemoryStream ms = new MemoryStream())
                 {

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingBridge.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingBridge.cs
@@ -39,31 +39,38 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
             }
 
             BitmapData data = bmp.LockBits(fullRect, ImageLockMode.ReadWrite, bmp.PixelFormat);
-            byte* sourcePtrBase = (byte*)data.Scan0;
-
-            long sourceRowByteCount = data.Stride;
-            long destRowByteCount = w * sizeof(Bgra32);
-
             var image = new Image<TPixel>(w, h);
-            Configuration configuration = image.GetConfiguration();
-
-            using (IMemoryOwner<Bgra32> workBuffer = Configuration.Default.MemoryAllocator.Allocate<Bgra32>(w))
+            try
             {
-                fixed (Bgra32* destPtr = &workBuffer.GetReference())
+                byte* sourcePtrBase = (byte*)data.Scan0;
+
+                long sourceRowByteCount = data.Stride;
+                long destRowByteCount = w * sizeof(Bgra32);
+
+                Configuration configuration = image.GetConfiguration();
+
+                using (IMemoryOwner<Bgra32> workBuffer = Configuration.Default.MemoryAllocator.Allocate<Bgra32>(w))
                 {
-                    for (int y = 0; y < h; y++)
+                    fixed (Bgra32* destPtr = &workBuffer.GetReference())
                     {
-                        Span<TPixel> row = image.Frames.RootFrame.GetPixelRowSpan(y);
+                        for (int y = 0; y < h; y++)
+                        {
+                            Span<TPixel> row = image.Frames.RootFrame.GetPixelRowSpan(y);
 
-                        byte* sourcePtr = sourcePtrBase + (data.Stride * y);
+                            byte* sourcePtr = sourcePtrBase + (data.Stride * y);
 
-                        Buffer.MemoryCopy(sourcePtr, destPtr, destRowByteCount, sourceRowByteCount);
-                        PixelOperations<TPixel>.Instance.FromBgra32(
-                            configuration,
-                            workBuffer.GetSpan().Slice(0, w),
-                            row);
+                            Buffer.MemoryCopy(sourcePtr, destPtr, destRowByteCount, sourceRowByteCount);
+                            PixelOperations<TPixel>.Instance.FromBgra32(
+                                configuration,
+                                workBuffer.GetSpan().Slice(0, w),
+                                row);
+                        }
                     }
                 }
+            }
+            finally
+            {
+                bmp.UnlockBits(data);
             }
 
             return image;
@@ -91,33 +98,36 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
             }
 
             BitmapData data = bmp.LockBits(fullRect, ImageLockMode.ReadWrite, bmp.PixelFormat);
-            byte* sourcePtrBase = (byte*)data.Scan0;
-
-            long sourceRowByteCount = data.Stride;
-            long destRowByteCount = w * sizeof(Bgr24);
-
             var image = new Image<TPixel>(w, h);
-            Configuration configuration = image.GetConfiguration();
-
-            using (IMemoryOwner<Bgr24> workBuffer = Configuration.Default.MemoryAllocator.Allocate<Bgr24>(w))
+            try
             {
-                fixed (Bgr24* destPtr = &workBuffer.GetReference())
+                byte* sourcePtrBase = (byte*)data.Scan0;
+
+                long sourceRowByteCount = data.Stride;
+                long destRowByteCount = w * sizeof(Bgr24);
+
+                Configuration configuration = image.GetConfiguration();
+
+                using (IMemoryOwner<Bgr24> workBuffer = Configuration.Default.MemoryAllocator.Allocate<Bgr24>(w))
                 {
-                    for (int y = 0; y < h; y++)
+                    fixed (Bgr24* destPtr = &workBuffer.GetReference())
                     {
-                        Span<TPixel> row = image.Frames.RootFrame.GetPixelRowSpan(y);
+                        for (int y = 0; y < h; y++)
+                        {
+                            Span<TPixel> row = image.Frames.RootFrame.GetPixelRowSpan(y);
 
-                        byte* sourcePtr = sourcePtrBase + (data.Stride * y);
+                            byte* sourcePtr = sourcePtrBase + (data.Stride * y);
 
-                        Buffer.MemoryCopy(sourcePtr, destPtr, destRowByteCount, sourceRowByteCount);
-                        PixelOperations<TPixel>.Instance.FromBgr24(
-                            configuration,
-                            workBuffer.GetSpan().Slice(0, w),
-                            row);
+                            Buffer.MemoryCopy(sourcePtr, destPtr, destRowByteCount, sourceRowByteCount);
+                            PixelOperations<TPixel>.Instance.FromBgr24(configuration, workBuffer.GetSpan().Slice(0, w), row);
+                        }
                     }
                 }
             }
-
+            finally
+            {
+                bmp.UnlockBits(data);
+            }
             return image;
         }
 
@@ -131,27 +141,32 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
             var resultBitmap = new Bitmap(w, h, PixelFormat.Format32bppArgb);
             var fullRect = new Rectangle(0, 0, w, h);
             BitmapData data = resultBitmap.LockBits(fullRect, ImageLockMode.ReadWrite, resultBitmap.PixelFormat);
-            byte* destPtrBase = (byte*)data.Scan0;
-
-            long destRowByteCount = data.Stride;
-            long sourceRowByteCount = w * sizeof(Bgra32);
-
-            using (IMemoryOwner<Bgra32> workBuffer = image.GetConfiguration().MemoryAllocator.Allocate<Bgra32>(w))
+            try
             {
-                fixed (Bgra32* sourcePtr = &workBuffer.GetReference())
-                {
-                    for (int y = 0; y < h; y++)
-                    {
-                        Span<TPixel> row = image.Frames.RootFrame.GetPixelRowSpan(y);
-                        PixelOperations<TPixel>.Instance.ToBgra32(configuration, row, workBuffer.GetSpan());
-                        byte* destPtr = destPtrBase + (data.Stride * y);
+                byte* destPtrBase = (byte*)data.Scan0;
 
-                        Buffer.MemoryCopy(sourcePtr, destPtr, destRowByteCount, sourceRowByteCount);
+                long destRowByteCount = data.Stride;
+                long sourceRowByteCount = w * sizeof(Bgra32);
+
+                using (IMemoryOwner<Bgra32> workBuffer = image.GetConfiguration().MemoryAllocator.Allocate<Bgra32>(w))
+                {
+                    fixed (Bgra32* sourcePtr = &workBuffer.GetReference())
+                    {
+                        for (int y = 0; y < h; y++)
+                        {
+                            Span<TPixel> row = image.Frames.RootFrame.GetPixelRowSpan(y);
+                            PixelOperations<TPixel>.Instance.ToBgra32(configuration, row, workBuffer.GetSpan());
+                            byte* destPtr = destPtrBase + (data.Stride * y);
+
+                            Buffer.MemoryCopy(sourcePtr, destPtr, destRowByteCount, sourceRowByteCount);
+                        }
                     }
                 }
             }
-
-            resultBitmap.UnlockBits(data);
+            finally
+            {
+                resultBitmap.UnlockBits(data);
+            }
 
             return resultBitmap;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
Some changes to make the usages of GDI in benchmarks and tests more stable, this should hopefully prevent "a generic error occurred in GDI+". Hopefully I didn't miss one...

If you new Pen, Brush or Fonts, these need to be disposed.