### PR TITLE
Remove Enum Comparison Boxing

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -92,7 +92,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             ImageMetaData metaData = image.MetaData;
             this.gifMetaData = metaData.GetFormatMetaData(GifFormat.Instance);
             this.colorTableMode = this.colorTableMode ?? this.gifMetaData.ColorTableMode;
-            bool useGlobalTable = this.colorTableMode.Equals(GifColorTableMode.Global);
+            bool useGlobalTable = this.colorTableMode == GifColorTableMode.Global;
 
             // Quantize the image returning a palette.
             QuantizedFrame<TPixel> quantized =

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -185,7 +185,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             this.pngColorType = options.ColorType;
 
             // Specification recommends default filter method None for paletted images and Paeth for others.
-            this.pngFilterMethod = options.FilterMethod ?? (options.ColorType.Equals(PngColorType.Palette)
+            this.pngFilterMethod = options.FilterMethod ?? (options.ColorType == PngColorType.Palette
                 ? PngFilterMethod.None
                 : PngFilterMethod.Paeth);
             this.compressionLevel = options.CompressionLevel;
@@ -217,7 +217,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             this.writeGamma = this.gamma > 0;
             this.pngColorType = this.pngColorType ?? pngMetaData.ColorType;
             this.pngBitDepth = this.pngBitDepth ?? pngMetaData.BitDepth;
-            this.use16Bit = this.pngBitDepth.Equals(PngBitDepth.Bit16);
+            this.use16Bit = this.pngBitDepth == PngBitDepth.Bit16;
 
             // Ensure we are not allowing impossible combinations.
             if (!ColorTypes.ContainsKey(this.pngColorType.Value))
@@ -329,7 +329,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             Span<byte> rawScanlineSpan = this.rawScanline.GetSpan();
             ref byte rawScanlineSpanRef = ref MemoryMarshal.GetReference(rawScanlineSpan);
 
-            if (this.pngColorType.Equals(PngColorType.Grayscale))
+            if (this.pngColorType == PngColorType.Grayscale)
             {
                 if (this.use16Bit)
                 {
@@ -761,7 +761,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         private void WriteTransparencyChunk(Stream stream, PngMetaData pngMetaData)
         {
             Span<byte> alpha = this.chunkDataBuffer.AsSpan();
-            if (pngMetaData.ColorType.Equals(PngColorType.Rgb))
+            if (pngMetaData.ColorType == PngColorType.Rgb)
             {
                 if (pngMetaData.TransparentRgb48.HasValue && this.use16Bit)
                 {
@@ -782,7 +782,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                     this.WriteChunk(stream, PngChunkType.Transparency, this.chunkDataBuffer, 0, 6);
                 }
             }
-            else if (pngMetaData.ColorType.Equals(PngColorType.Grayscale))
+            else if (pngMetaData.ColorType == PngColorType.Grayscale)
             {
                 if (pngMetaData.TransparentGray16.HasValue && this.use16Bit)
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Replaces `enum.Equals(object)` with `enum == enum`. Fixes #862 
