### PR TITLE
Nits - Metadata

### DIFF
--- a/src/ImageSharp/Common/Helpers/UnitConverter.cs
+++ b/src/ImageSharp/Common/Helpers/UnitConverter.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Runtime.CompilerServices;
-using SixLabors.ImageSharp.MetaData;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 
 namespace SixLabors.ImageSharp.Common.Helpers
 {

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -9,7 +9,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.Common.Helpers;
 using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Memory;
 
@@ -66,12 +66,12 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <summary>
         /// The metadata.
         /// </summary>
-        private ImageMetaData metaData;
+        private ImageMetadata metadata;
 
         /// <summary>
         /// The bmp specific metadata.
         /// </summary>
-        private BmpMetaData bmpMetaData;
+        private BmpMetadata bmpMetadata;
 
         /// <summary>
         /// The file header containing general information.
@@ -116,7 +116,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             {
                 int bytesPerColorMapEntry = this.ReadImageHeaders(stream, out bool inverted, out byte[] palette);
 
-                var image = new Image<TPixel>(this.configuration, this.infoHeader.Width, this.infoHeader.Height, this.metaData);
+                var image = new Image<TPixel>(this.configuration, this.infoHeader.Width, this.infoHeader.Height, this.metadata);
 
                 Buffer2D<TPixel> pixels = image.GetRootFramePixelBuffer();
 
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
                     case BmpCompression.RGB:
                         if (this.infoHeader.BitsPerPixel == 32)
                         {
-                            if (this.bmpMetaData.InfoHeaderType == BmpInfoHeaderType.WinVersion3)
+                            if (this.bmpMetadata.InfoHeaderType == BmpInfoHeaderType.WinVersion3)
                             {
                                 this.ReadRgb32Slow(pixels, this.infoHeader.Width, this.infoHeader.Height, inverted);
                             }
@@ -188,7 +188,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         public IImageInfo Identify(Stream stream)
         {
             this.ReadImageHeaders(stream, out _, out _);
-            return new ImageInfo(new PixelTypeInfo(this.infoHeader.BitsPerPixel), this.infoHeader.Width, this.infoHeader.Height, this.metaData);
+            return new ImageInfo(new PixelTypeInfo(this.infoHeader.BitsPerPixel), this.infoHeader.Width, this.infoHeader.Height, this.metadata);
         }
 
         /// <summary>
@@ -999,7 +999,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             }
 
             // Resolution is stored in PPM.
-            var meta = new ImageMetaData
+            var meta = new ImageMetadata
             {
                 ResolutionUnits = PixelResolutionUnit.PixelsPerMeter
             };
@@ -1011,21 +1011,21 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             else
             {
                 // Convert default metadata values to PPM.
-                meta.HorizontalResolution = Math.Round(UnitConverter.InchToMeter(ImageMetaData.DefaultHorizontalResolution));
-                meta.VerticalResolution = Math.Round(UnitConverter.InchToMeter(ImageMetaData.DefaultVerticalResolution));
+                meta.HorizontalResolution = Math.Round(UnitConverter.InchToMeter(ImageMetadata.DefaultHorizontalResolution));
+                meta.VerticalResolution = Math.Round(UnitConverter.InchToMeter(ImageMetadata.DefaultVerticalResolution));
             }
 
-            this.metaData = meta;
+            this.metadata = meta;
 
             short bitsPerPixel = this.infoHeader.BitsPerPixel;
-            this.bmpMetaData = this.metaData.GetFormatMetaData(BmpFormat.Instance);
-            this.bmpMetaData.InfoHeaderType = infoHeaderType;
+            this.bmpMetadata = this.metadata.GetFormatMetadata(BmpFormat.Instance);
+            this.bmpMetadata.InfoHeaderType = infoHeaderType;
 
             // We can only encode at these bit rates so far.
             if (bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel24)
                 || bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel32))
             {
-                this.bmpMetaData.BitsPerPixel = (BmpBitsPerPixel)bitsPerPixel;
+                this.bmpMetadata.BitsPerPixel = (BmpBitsPerPixel)bitsPerPixel;
             }
 
             // skip the remaining header because we can't read those parts

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -7,7 +7,7 @@ using System.IO;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Common.Helpers;
 using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Memory;
 
@@ -73,9 +73,9 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             Guard.NotNull(stream, nameof(stream));
 
             this.configuration = image.GetConfiguration();
-            ImageMetaData metaData = image.MetaData;
-            BmpMetaData bmpMetaData = metaData.GetFormatMetaData(BmpFormat.Instance);
-            this.bitsPerPixel = this.bitsPerPixel ?? bmpMetaData.BitsPerPixel;
+            ImageMetadata metadata = image.Metadata;
+            BmpMetadata bmpMetadata = metadata.GetFormatMetadata(BmpFormat.Instance);
+            this.bitsPerPixel = this.bitsPerPixel ?? bmpMetadata.BitsPerPixel;
 
             short bpp = (short)this.bitsPerPixel;
             int bytesPerLine = 4 * (((image.Width * bpp) + 31) / 32);
@@ -85,27 +85,27 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             int hResolution = 0;
             int vResolution = 0;
 
-            if (metaData.ResolutionUnits != PixelResolutionUnit.AspectRatio)
+            if (metadata.ResolutionUnits != PixelResolutionUnit.AspectRatio)
             {
-                if (metaData.HorizontalResolution > 0 && metaData.VerticalResolution > 0)
+                if (metadata.HorizontalResolution > 0 && metadata.VerticalResolution > 0)
                 {
-                    switch (metaData.ResolutionUnits)
+                    switch (metadata.ResolutionUnits)
                     {
                         case PixelResolutionUnit.PixelsPerInch:
 
-                            hResolution = (int)Math.Round(UnitConverter.InchToMeter(metaData.HorizontalResolution));
-                            vResolution = (int)Math.Round(UnitConverter.InchToMeter(metaData.VerticalResolution));
+                            hResolution = (int)Math.Round(UnitConverter.InchToMeter(metadata.HorizontalResolution));
+                            vResolution = (int)Math.Round(UnitConverter.InchToMeter(metadata.VerticalResolution));
                             break;
 
                         case PixelResolutionUnit.PixelsPerCentimeter:
 
-                            hResolution = (int)Math.Round(UnitConverter.CmToMeter(metaData.HorizontalResolution));
-                            vResolution = (int)Math.Round(UnitConverter.CmToMeter(metaData.VerticalResolution));
+                            hResolution = (int)Math.Round(UnitConverter.CmToMeter(metadata.HorizontalResolution));
+                            vResolution = (int)Math.Round(UnitConverter.CmToMeter(metadata.VerticalResolution));
                             break;
 
                         case PixelResolutionUnit.PixelsPerMeter:
-                            hResolution = (int)Math.Round(metaData.HorizontalResolution);
-                            vResolution = (int)Math.Round(metaData.VerticalResolution);
+                            hResolution = (int)Math.Round(metadata.HorizontalResolution);
+                            vResolution = (int)Math.Round(metadata.VerticalResolution);
 
                             break;
                     }

--- a/src/ImageSharp/Formats/Bmp/BmpFormat.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpFormat.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
     /// <summary>
     /// Registers the image encoders, decoders and mime type detectors for the bmp format.
     /// </summary>
-    public sealed class BmpFormat : IImageFormat<BmpMetaData>
+    public sealed class BmpFormat : IImageFormat<BmpMetadata>
     {
         private BmpFormat()
         {
@@ -32,6 +32,6 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         public IEnumerable<string> FileExtensions => BmpConstants.FileExtensions;
 
         /// <inheritdoc/>
-        public BmpMetaData CreateDefaultFormatMetaData() => new BmpMetaData();
+        public BmpMetadata CreateDefaultFormatMetadata() => new BmpMetadata();
     }
 }

--- a/src/ImageSharp/Formats/Bmp/BmpMetaData.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpMetaData.cs
@@ -6,20 +6,20 @@ namespace SixLabors.ImageSharp.Formats.Bmp
     /// <summary>
     /// Provides Bmp specific metadata information for the image.
     /// </summary>
-    public class BmpMetaData : IDeepCloneable
+    public class BmpMetadata : IDeepCloneable
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="BmpMetaData"/> class.
+        /// Initializes a new instance of the <see cref="BmpMetadata"/> class.
         /// </summary>
-        public BmpMetaData()
+        public BmpMetadata()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="BmpMetaData"/> class.
+        /// Initializes a new instance of the <see cref="BmpMetadata"/> class.
         /// </summary>
         /// <param name="other">The metadata to create an instance from.</param>
-        private BmpMetaData(BmpMetaData other)
+        private BmpMetadata(BmpMetadata other)
         {
             this.BitsPerPixel = other.BitsPerPixel;
             this.InfoHeaderType = other.InfoHeaderType;
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         public BmpBitsPerPixel BitsPerPixel { get; set; } = BmpBitsPerPixel.Pixel24;
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new BmpMetaData(this);
+        public IDeepCloneable DeepClone() => new BmpMetadata(this);
 
         // TODO: Colors used once we support encoding palette bmps.
     }

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -3,7 +3,7 @@
 
 using System.IO;
 using System.Text;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Formats.Gif

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Memory;
 using SixLabors.Primitives;
@@ -63,12 +63,12 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <summary>
         /// The abstract metadata.
         /// </summary>
-        private ImageMetaData metaData;
+        private ImageMetadata metadata;
 
         /// <summary>
         /// The gif specific metadata.
         /// </summary>
-        private GifMetaData gifMetaData;
+        private GifMetadata gifMetadata;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GifDecoderCore"/> class.
@@ -223,7 +223,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 new PixelTypeInfo(this.logicalScreenDescriptor.BitsPerPixel),
                 this.logicalScreenDescriptor.Width,
                 this.logicalScreenDescriptor.Height,
-                this.metaData);
+                this.metadata);
         }
 
         /// <summary>
@@ -276,7 +276,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 if (subBlockSize == GifConstants.NetscapeLoopingSubBlockSize)
                 {
                     this.stream.Read(this.buffer, 0, GifConstants.NetscapeLoopingSubBlockSize);
-                    this.gifMetaData.RepeatCount = GifNetscapeLoopingApplicationExtension.Parse(this.buffer.AsSpan(1)).RepeatCount;
+                    this.gifMetadata.RepeatCount = GifNetscapeLoopingApplicationExtension.Parse(this.buffer.AsSpan(1)).RepeatCount;
                     this.stream.Skip(1); // Skip the terminator.
                     return;
                 }
@@ -334,7 +334,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 {
                     this.stream.Read(commentsBuffer.Array, 0, length);
                     string comments = this.TextEncoding.GetString(commentsBuffer.Array, 0, length);
-                    this.metaData.Properties.Add(new ImageProperty(GifConstants.Comments, comments));
+                    this.metadata.Properties.Add(new ImageProperty(GifConstants.Comments, comments));
                 }
             }
         }
@@ -416,9 +416,9 @@ namespace SixLabors.ImageSharp.Formats.Gif
             if (previousFrame is null)
             {
                 // This initializes the image to become fully transparent because the alpha channel is zero.
-                image = new Image<TPixel>(this.configuration, imageWidth, imageHeight, this.metaData);
+                image = new Image<TPixel>(this.configuration, imageWidth, imageHeight, this.metadata);
 
-                this.SetFrameMetaData(image.Frames.RootFrame.MetaData);
+                this.SetFrameMetadata(image.Frames.RootFrame.Metadata);
 
                 imageFrame = image.Frames.RootFrame;
             }
@@ -431,7 +431,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
                 currentFrame = image.Frames.AddFrame(previousFrame); // This clones the frame and adds it the collection
 
-                this.SetFrameMetaData(currentFrame.MetaData);
+                this.SetFrameMetadata(currentFrame.Metadata);
 
                 imageFrame = currentFrame;
 
@@ -549,11 +549,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <summary>
         /// Sets the frames metadata.
         /// </summary>
-        /// <param name="meta">The meta data.</param>
+        /// <param name="meta">The metadata.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetFrameMetaData(ImageFrameMetaData meta)
+        private void SetFrameMetadata(ImageFrameMetadata meta)
         {
-            GifFrameMetaData gifMeta = meta.GetFormatMetaData(GifFormat.Instance);
+            GifFrameMetadata gifMeta = meta.GetFormatMetadata(GifFormat.Instance);
             if (this.graphicsControlExtension.DelayTime > 0)
             {
                 gifMeta.FrameDelay = this.graphicsControlExtension.DelayTime;
@@ -586,7 +586,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             this.stream.Skip(6);
             this.ReadLogicalScreenDescriptor();
 
-            var meta = new ImageMetaData();
+            var meta = new ImageMetadata();
 
             // The Pixel Aspect Ratio is defined to be the quotient of the pixel's
             // width over its height.  The value range in this field allows
@@ -614,16 +614,16 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 }
             }
 
-            this.metaData = meta;
-            this.gifMetaData = meta.GetFormatMetaData(GifFormat.Instance);
-            this.gifMetaData.ColorTableMode = this.logicalScreenDescriptor.GlobalColorTableFlag
+            this.metadata = meta;
+            this.gifMetadata = meta.GetFormatMetadata(GifFormat.Instance);
+            this.gifMetadata.ColorTableMode = this.logicalScreenDescriptor.GlobalColorTableFlag
             ? GifColorTableMode.Global
             : GifColorTableMode.Local;
 
             if (this.logicalScreenDescriptor.GlobalColorTableFlag)
             {
                 int globalColorTableLength = this.logicalScreenDescriptor.GlobalColorTableSize * 3;
-                this.gifMetaData.GlobalColorTableLength = globalColorTableLength;
+                this.gifMetadata.GlobalColorTableLength = globalColorTableLength;
 
                 this.globalColorTable = this.MemoryAllocator.AllocateManagedByteBuffer(globalColorTableLength, AllocationOptions.Clean);
 

--- a/src/ImageSharp/Formats/Gif/GifFormat.cs
+++ b/src/ImageSharp/Formats/Gif/GifFormat.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
     /// <summary>
     /// Registers the image encoders, decoders and mime type detectors for the gif format.
     /// </summary>
-    public sealed class GifFormat : IImageFormat<GifMetaData, GifFrameMetaData>
+    public sealed class GifFormat : IImageFormat<GifMetadata, GifFrameMetadata>
     {
         private GifFormat()
         {
@@ -32,9 +32,9 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public IEnumerable<string> FileExtensions => GifConstants.FileExtensions;
 
         /// <inheritdoc/>
-        public GifMetaData CreateDefaultFormatMetaData() => new GifMetaData();
+        public GifMetadata CreateDefaultFormatMetadata() => new GifMetadata();
 
         /// <inheritdoc/>
-        public GifFrameMetaData CreateDefaultFormatFrameMetaData() => new GifFrameMetaData();
+        public GifFrameMetadata CreateDefaultFormatFrameMetadata() => new GifFrameMetadata();
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
+++ b/src/ImageSharp/Formats/Gif/GifFrameMetaData.cs
@@ -6,20 +6,20 @@ namespace SixLabors.ImageSharp.Formats.Gif
     /// <summary>
     /// Provides Gif specific metadata information for the image frame.
     /// </summary>
-    public class GifFrameMetaData : IDeepCloneable
+    public class GifFrameMetadata : IDeepCloneable
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="GifFrameMetaData"/> class.
+        /// Initializes a new instance of the <see cref="GifFrameMetadata"/> class.
         /// </summary>
-        public GifFrameMetaData()
+        public GifFrameMetadata()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="GifFrameMetaData"/> class.
+        /// Initializes a new instance of the <see cref="GifFrameMetadata"/> class.
         /// </summary>
         /// <param name="other">The metadata to create an instance from.</param>
-        private GifFrameMetaData(GifFrameMetaData other)
+        private GifFrameMetadata(GifFrameMetadata other)
         {
             this.ColorTableLength = other.ColorTableLength;
             this.FrameDelay = other.FrameDelay;
@@ -49,6 +49,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public GifDisposalMethod DisposalMethod { get; set; }
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new GifFrameMetaData(this);
+        public IDeepCloneable DeepClone() => new GifFrameMetadata(this);
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifMetaData.cs
+++ b/src/ImageSharp/Formats/Gif/GifMetaData.cs
@@ -6,20 +6,20 @@ namespace SixLabors.ImageSharp.Formats.Gif
     /// <summary>
     /// Provides Gif specific metadata information for the image.
     /// </summary>
-    public class GifMetaData : IDeepCloneable
+    public class GifMetadata : IDeepCloneable
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="GifMetaData"/> class.
+        /// Initializes a new instance of the <see cref="GifMetadata"/> class.
         /// </summary>
-        public GifMetaData()
+        public GifMetadata()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="GifMetaData"/> class.
+        /// Initializes a new instance of the <see cref="GifMetadata"/> class.
         /// </summary>
         /// <param name="other">The metadata to create an instance from.</param>
-        private GifMetaData(GifMetaData other)
+        private GifMetadata(GifMetadata other)
         {
             this.RepeatCount = other.RepeatCount;
             this.ColorTableMode = other.ColorTableMode;
@@ -45,6 +45,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public int GlobalColorTableLength { get; set; }
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new GifMetaData(this);
+        public IDeepCloneable DeepClone() => new GifMetadata(this);
     }
 }

--- a/src/ImageSharp/Formats/Gif/IGifDecoderOptions.cs
+++ b/src/ImageSharp/Formats/Gif/IGifDecoderOptions.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Text;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 
 namespace SixLabors.ImageSharp.Formats.Gif
 {

--- a/src/ImageSharp/Formats/IImageFormat.cs
+++ b/src/ImageSharp/Formats/IImageFormat.cs
@@ -34,30 +34,30 @@ namespace SixLabors.ImageSharp.Formats
     /// <summary>
     /// Defines the contract for an image format containing metadata.
     /// </summary>
-    /// <typeparam name="TFormatMetaData">The type of format metadata.</typeparam>
-    public interface IImageFormat<out TFormatMetaData> : IImageFormat
-        where TFormatMetaData : class
+    /// <typeparam name="TFormatMetadata">The type of format metadata.</typeparam>
+    public interface IImageFormat<out TFormatMetadata> : IImageFormat
+        where TFormatMetadata : class
     {
         /// <summary>
         /// Creates a default instance of the format metadata.
         /// </summary>
-        /// <returns>The <typeparamref name="TFormatMetaData"/>.</returns>
-        TFormatMetaData CreateDefaultFormatMetaData();
+        /// <returns>The <typeparamref name="TFormatMetadata"/>.</returns>
+        TFormatMetadata CreateDefaultFormatMetadata();
     }
 
     /// <summary>
     /// Defines the contract for an image format containing metadata with multiple frames.
     /// </summary>
-    /// <typeparam name="TFormatMetaData">The type of format metadata.</typeparam>
-    /// <typeparam name="TFormatFrameMetaData">The type of format frame metadata.</typeparam>
-    public interface IImageFormat<out TFormatMetaData, out TFormatFrameMetaData> : IImageFormat<TFormatMetaData>
-        where TFormatMetaData : class
-        where TFormatFrameMetaData : class
+    /// <typeparam name="TFormatMetadata">The type of format metadata.</typeparam>
+    /// <typeparam name="TFormatFrameMetadata">The type of format frame metadata.</typeparam>
+    public interface IImageFormat<out TFormatMetadata, out TFormatFrameMetadata> : IImageFormat<TFormatMetadata>
+        where TFormatMetadata : class
+        where TFormatFrameMetadata : class
     {
         /// <summary>
         /// Creates a default instance of the format frame metadata.
         /// </summary>
-        /// <returns>The <typeparamref name="TFormatFrameMetaData"/>.</returns>
-        TFormatFrameMetaData CreateDefaultFormatFrameMetaData();
+        /// <returns>The <typeparamref name="TFormatFrameMetadata"/>.</returns>
+        TFormatFrameMetadata CreateDefaultFormatFrameMetadata();
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 
 namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 {

--- a/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
@@ -10,9 +10,9 @@ using SixLabors.ImageSharp.Common.Helpers;
 using SixLabors.ImageSharp.Formats.Jpeg.Components;
 using SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
 using SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder;
-using SixLabors.ImageSharp.MetaData;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Formats.Jpeg
@@ -204,10 +204,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             }
 
             this.outputStream = stream;
-            ImageMetaData metaData = image.MetaData;
+            ImageMetadata metadata = image.Metadata;
 
             // System.Drawing produces identical output for jpegs with a quality parameter of 0 and 1.
-            int qlty = (this.quality ?? metaData.GetFormatMetaData(JpegFormat.Instance).Quality).Clamp(1, 100);
+            int qlty = (this.quality ?? metadata.GetFormatMetadata(JpegFormat.Instance).Quality).Clamp(1, 100);
             this.subsample = this.subsample ?? (qlty >= 91 ? JpegSubsample.Ratio444 : JpegSubsample.Ratio420);
 
             // Convert from a quality rating to a scaling factor.
@@ -229,10 +229,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             int componentCount = 3;
 
             // Write the Start Of Image marker.
-            this.WriteApplicationHeader(metaData);
+            this.WriteApplicationHeader(metadata);
 
             // Write Exif and ICC profiles
-            this.WriteProfiles(metaData);
+            this.WriteProfiles(metadata);
 
             // Write the quantization tables.
             this.WriteDefineQuantizationTables();
@@ -448,8 +448,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <summary>
         /// Writes the application header containing the JFIF identifier plus extra data.
         /// </summary>
-        /// <param name="meta">The image meta data.</param>
-        private void WriteApplicationHeader(ImageMetaData meta)
+        /// <param name="meta">The image metadata.</param>
+        private void WriteApplicationHeader(ImageMetadata meta)
         {
             // Write the start of image marker. Markers are always prefixed with 0xff.
             this.buffer[0] = JpegConstants.Markers.XFF;
@@ -791,17 +791,17 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <summary>
         /// Writes the metadata profiles to the image.
         /// </summary>
-        /// <param name="metaData">The image meta data.</param>
-        private void WriteProfiles(ImageMetaData metaData)
+        /// <param name="metadata">The image metadata.</param>
+        private void WriteProfiles(ImageMetadata metadata)
         {
-            if (metaData is null)
+            if (metadata is null)
             {
                 return;
             }
 
-            metaData.SyncProfiles();
-            this.WriteExifProfile(metaData.ExifProfile);
-            this.WriteIccProfile(metaData.IccProfile);
+            metadata.SyncProfiles();
+            this.WriteExifProfile(metadata.ExifProfile);
+            this.WriteIccProfile(metadata.IccProfile);
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/JpegFormat.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegFormat.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
     /// <summary>
     /// Registers the image encoders, decoders and mime type detectors for the jpeg format.
     /// </summary>
-    public sealed class JpegFormat : IImageFormat<JpegMetaData>
+    public sealed class JpegFormat : IImageFormat<JpegMetadata>
     {
         private JpegFormat()
         {
@@ -32,6 +32,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         public IEnumerable<string> FileExtensions => JpegConstants.FileExtensions;
 
         /// <inheritdoc/>
-        public JpegMetaData CreateDefaultFormatMetaData() => new JpegMetaData();
+        public JpegMetadata CreateDefaultFormatMetadata() => new JpegMetadata();
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/JpegMetaData.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegMetaData.cs
@@ -6,20 +6,20 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
     /// <summary>
     /// Provides Jpeg specific metadata information for the image.
     /// </summary>
-    public class JpegMetaData : IDeepCloneable
+    public class JpegMetadata : IDeepCloneable
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="JpegMetaData"/> class.
+        /// Initializes a new instance of the <see cref="JpegMetadata"/> class.
         /// </summary>
-        public JpegMetaData()
+        public JpegMetadata()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="JpegMetaData"/> class.
+        /// Initializes a new instance of the <see cref="JpegMetadata"/> class.
         /// </summary>
         /// <param name="other">The metadata to create an instance from.</param>
-        private JpegMetaData(JpegMetaData other) => this.Quality = other.Quality;
+        private JpegMetadata(JpegMetadata other) => this.Quality = other.Quality;
 
         /// <summary>
         /// Gets or sets the encoded quality.
@@ -27,6 +27,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         public int Quality { get; set; } = 75;
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new JpegMetaData(this);
+        public IDeepCloneable DeepClone() => new JpegMetadata(this);
     }
 }

--- a/src/ImageSharp/Formats/Png/Chunks/PhysicalChunkData.cs
+++ b/src/ImageSharp/Formats/Png/Chunks/PhysicalChunkData.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Buffers.Binary;
 using SixLabors.ImageSharp.Common.Helpers;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 
 namespace SixLabors.ImageSharp.Formats.Png.Chunks
 {
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Chunks
         /// </summary>
         /// <param name="meta">The metadata.</param>
         /// <returns>The constructed PngPhysicalChunkData instance.</returns>
-        public static PhysicalChunkData FromMetadata(ImageMetaData meta)
+        public static PhysicalChunkData FromMetadata(ImageMetadata meta)
         {
             byte unitSpecifier = 0;
             uint x;

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -12,8 +12,8 @@ using SixLabors.ImageSharp.Formats.Png.Chunks;
 using SixLabors.ImageSharp.Formats.Png.Filters;
 using SixLabors.ImageSharp.Formats.Png.Zlib;
 using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.MetaData;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Memory;
 
@@ -157,8 +157,8 @@ namespace SixLabors.ImageSharp.Formats.Png
         public Image<TPixel> Decode<TPixel>(Stream stream)
             where TPixel : struct, IPixel<TPixel>
         {
-            var metaData = new ImageMetaData();
-            PngMetaData pngMetaData = metaData.GetFormatMetaData(PngFormat.Instance);
+            var metadata = new ImageMetadata();
+            PngMetadata pngMetadata = metadata.GetFormatMetadata(PngFormat.Instance);
             this.currentStream = stream;
             this.currentStream.Skip(8);
             Image<TPixel> image = null;
@@ -171,24 +171,24 @@ namespace SixLabors.ImageSharp.Formats.Png
                         switch (chunk.Type)
                         {
                             case PngChunkType.Header:
-                                this.ReadHeaderChunk(pngMetaData, chunk.Data.Array);
+                                this.ReadHeaderChunk(pngMetadata, chunk.Data.Array);
                                 break;
                             case PngChunkType.Physical:
-                                this.ReadPhysicalChunk(metaData, chunk.Data.GetSpan());
+                                this.ReadPhysicalChunk(metadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.Gamma:
-                                this.ReadGammaChunk(pngMetaData, chunk.Data.GetSpan());
+                                this.ReadGammaChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.Data:
                                 if (image is null)
                                 {
-                                    this.InitializeImage(metaData, out image);
+                                    this.InitializeImage(metadata, out image);
                                 }
 
                                 using (var deframeStream = new ZlibInflateStream(this.currentStream, this.ReadNextDataChunk))
                                 {
                                     deframeStream.AllocateNewBytes(chunk.Length);
-                                    this.ReadScanlines(deframeStream.CompressedStream, image.Frames.RootFrame, pngMetaData);
+                                    this.ReadScanlines(deframeStream.CompressedStream, image.Frames.RootFrame, pngMetadata);
                                 }
 
                                 break;
@@ -201,17 +201,17 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 byte[] alpha = new byte[chunk.Length];
                                 Buffer.BlockCopy(chunk.Data.Array, 0, alpha, 0, chunk.Length);
                                 this.paletteAlpha = alpha;
-                                this.AssignTransparentMarkers(alpha, pngMetaData);
+                                this.AssignTransparentMarkers(alpha, pngMetadata);
                                 break;
                             case PngChunkType.Text:
-                                this.ReadTextChunk(metaData, chunk.Data.Array.AsSpan(0, chunk.Length));
+                                this.ReadTextChunk(metadata, chunk.Data.Array.AsSpan(0, chunk.Length));
                                 break;
                             case PngChunkType.Exif:
                                 if (!this.ignoreMetadata)
                                 {
                                     byte[] exifData = new byte[chunk.Length];
                                     Buffer.BlockCopy(chunk.Data.Array, 0, exifData, 0, chunk.Length);
-                                    metaData.ExifProfile = new ExifProfile(exifData);
+                                    metadata.ExifProfile = new ExifProfile(exifData);
                                 }
 
                                 break;
@@ -246,8 +246,8 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         public IImageInfo Identify(Stream stream)
         {
-            var metaData = new ImageMetaData();
-            PngMetaData pngMetaData = metaData.GetFormatMetaData(PngFormat.Instance);
+            var metadata = new ImageMetadata();
+            PngMetadata pngMetadata = metadata.GetFormatMetadata(PngFormat.Instance);
             this.currentStream = stream;
             this.currentStream.Skip(8);
             try
@@ -259,19 +259,19 @@ namespace SixLabors.ImageSharp.Formats.Png
                         switch (chunk.Type)
                         {
                             case PngChunkType.Header:
-                                this.ReadHeaderChunk(pngMetaData, chunk.Data.Array);
+                                this.ReadHeaderChunk(pngMetadata, chunk.Data.Array);
                                 break;
                             case PngChunkType.Physical:
-                                this.ReadPhysicalChunk(metaData, chunk.Data.GetSpan());
+                                this.ReadPhysicalChunk(metadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.Gamma:
-                                this.ReadGammaChunk(pngMetaData, chunk.Data.GetSpan());
+                                this.ReadGammaChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.Data:
                                 this.SkipChunkDataAndCrc(chunk);
                                 break;
                             case PngChunkType.Text:
-                                this.ReadTextChunk(metaData, chunk.Data.Array.AsSpan(0, chunk.Length));
+                                this.ReadTextChunk(metadata, chunk.Data.Array.AsSpan(0, chunk.Length));
                                 break;
                             case PngChunkType.End:
                                 this.isEndChunkReached = true;
@@ -295,7 +295,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                 throw new ImageFormatException("PNG Image does not contain a header chunk");
             }
 
-            return new ImageInfo(new PixelTypeInfo(this.CalculateBitsPerPixel()), this.header.Width, this.header.Height, metaData);
+            return new ImageInfo(new PixelTypeInfo(this.CalculateBitsPerPixel()), this.header.Width, this.header.Height, metadata);
         }
 
         /// <summary>
@@ -350,7 +350,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </summary>
         /// <param name="metadata">The metadata to read to.</param>
         /// <param name="data">The data containing physical data.</param>
-        private void ReadPhysicalChunk(ImageMetaData metadata, ReadOnlySpan<byte> data)
+        private void ReadPhysicalChunk(ImageMetadata metadata, ReadOnlySpan<byte> data)
         {
             var physicalChunk = PhysicalChunkData.Parse(data);
 
@@ -367,7 +367,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </summary>
         /// <param name="pngMetadata">The metadata to read to.</param>
         /// <param name="data">The data containing physical data.</param>
-        private void ReadGammaChunk(PngMetaData pngMetadata, ReadOnlySpan<byte> data)
+        private void ReadGammaChunk(PngMetadata pngMetadata, ReadOnlySpan<byte> data)
         {
             // The value is encoded as a 4-byte unsigned integer, representing gamma times 100000.
             // For example, a gamma of 1/2.2 would be stored as 45455.
@@ -380,7 +380,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <typeparam name="TPixel">The type the pixels will be</typeparam>
         /// <param name="metadata">The metadata information for the image</param>
         /// <param name="image">The image that we will populate</param>
-        private void InitializeImage<TPixel>(ImageMetaData metadata, out Image<TPixel> image)
+        private void InitializeImage<TPixel>(ImageMetadata metadata, out Image<TPixel> image)
             where TPixel : struct, IPixel<TPixel>
         {
             image = new Image<TPixel>(this.configuration, this.header.Width, this.header.Height, metadata);
@@ -471,17 +471,17 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="dataStream">The <see cref="MemoryStream"/> containing data.</param>
         /// <param name="image"> The pixel data.</param>
-        /// <param name="pngMetaData">The png meta data</param>
-        private void ReadScanlines<TPixel>(Stream dataStream, ImageFrame<TPixel> image, PngMetaData pngMetaData)
+        /// <param name="pngMetadata">The png metadata</param>
+        private void ReadScanlines<TPixel>(Stream dataStream, ImageFrame<TPixel> image, PngMetadata pngMetadata)
             where TPixel : struct, IPixel<TPixel>
         {
             if (this.header.InterlaceMethod == PngInterlaceMode.Adam7)
             {
-                this.DecodeInterlacedPixelData(dataStream, image, pngMetaData);
+                this.DecodeInterlacedPixelData(dataStream, image, pngMetadata);
             }
             else
             {
-                this.DecodePixelData(dataStream, image, pngMetaData);
+                this.DecodePixelData(dataStream, image, pngMetadata);
             }
         }
 
@@ -491,8 +491,8 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="compressedStream">The compressed pixel data stream.</param>
         /// <param name="image">The image to decode to.</param>
-        /// <param name="pngMetaData">The png meta data</param>
-        private void DecodePixelData<TPixel>(Stream compressedStream, ImageFrame<TPixel> image, PngMetaData pngMetaData)
+        /// <param name="pngMetadata">The png metadata</param>
+        private void DecodePixelData<TPixel>(Stream compressedStream, ImageFrame<TPixel> image, PngMetadata pngMetadata)
             where TPixel : struct, IPixel<TPixel>
         {
             while (this.currentRow < this.header.Height)
@@ -532,7 +532,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                         throw new ImageFormatException("Unknown filter type.");
                 }
 
-                this.ProcessDefilteredScanline(scanlineSpan, image, pngMetaData);
+                this.ProcessDefilteredScanline(scanlineSpan, image, pngMetadata);
 
                 this.SwapBuffers();
                 this.currentRow++;
@@ -546,8 +546,8 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="compressedStream">The compressed pixel data stream.</param>
         /// <param name="image">The current image.</param>
-        /// <param name="pngMetaData">The png meta data</param>
-        private void DecodeInterlacedPixelData<TPixel>(Stream compressedStream, ImageFrame<TPixel> image, PngMetaData pngMetaData)
+        /// <param name="pngMetadata">The png metadata.</param>
+        private void DecodeInterlacedPixelData<TPixel>(Stream compressedStream, ImageFrame<TPixel> image, PngMetadata pngMetadata)
             where TPixel : struct, IPixel<TPixel>
         {
             while (true)
@@ -604,7 +604,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                     }
 
                     Span<TPixel> rowSpan = image.GetPixelRowSpan(this.currentRow);
-                    this.ProcessInterlacedDefilteredScanline(this.scanline.GetSpan(), rowSpan, pngMetaData, Adam7.FirstColumn[this.pass], Adam7.ColumnIncrement[this.pass]);
+                    this.ProcessInterlacedDefilteredScanline(this.scanline.GetSpan(), rowSpan, pngMetadata, Adam7.FirstColumn[this.pass], Adam7.ColumnIncrement[this.pass]);
 
                     this.SwapBuffers();
 
@@ -632,8 +632,8 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="defilteredScanline">The de-filtered scanline</param>
         /// <param name="pixels">The image</param>
-        /// <param name="pngMetaData">The png meta data</param>
-        private void ProcessDefilteredScanline<TPixel>(ReadOnlySpan<byte> defilteredScanline, ImageFrame<TPixel> pixels, PngMetaData pngMetaData)
+        /// <param name="pngMetadata">The png metadata.</param>
+        private void ProcessDefilteredScanline<TPixel>(ReadOnlySpan<byte> defilteredScanline, ImageFrame<TPixel> pixels, PngMetadata pngMetadata)
             where TPixel : struct, IPixel<TPixel>
         {
             Span<TPixel> rowSpan = pixels.GetPixelRowSpan(this.currentRow);
@@ -653,9 +653,9 @@ namespace SixLabors.ImageSharp.Formats.Png
                         this.header,
                         scanlineSpan,
                         rowSpan,
-                        pngMetaData.HasTrans,
-                        pngMetaData.TransparentGray16.GetValueOrDefault(),
-                        pngMetaData.TransparentGray8.GetValueOrDefault());
+                        pngMetadata.HasTrans,
+                        pngMetadata.TransparentGray16.GetValueOrDefault(),
+                        pngMetadata.TransparentGray8.GetValueOrDefault());
 
                     break;
 
@@ -687,9 +687,9 @@ namespace SixLabors.ImageSharp.Formats.Png
                         rowSpan,
                         this.bytesPerPixel,
                         this.bytesPerSample,
-                        pngMetaData.HasTrans,
-                        pngMetaData.TransparentRgb48.GetValueOrDefault(),
-                        pngMetaData.TransparentRgb24.GetValueOrDefault());
+                        pngMetadata.HasTrans,
+                        pngMetadata.TransparentRgb48.GetValueOrDefault(),
+                        pngMetadata.TransparentRgb24.GetValueOrDefault());
 
                     break;
 
@@ -714,10 +714,10 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="defilteredScanline">The de-filtered scanline</param>
         /// <param name="rowSpan">The current image row.</param>
-        /// <param name="pngMetaData">The png meta data</param>
+        /// <param name="pngMetadata">The png metadata.</param>
         /// <param name="pixelOffset">The column start index. Always 0 for none interlaced images.</param>
         /// <param name="increment">The column increment. Always 1 for none interlaced images.</param>
-        private void ProcessInterlacedDefilteredScanline<TPixel>(ReadOnlySpan<byte> defilteredScanline, Span<TPixel> rowSpan, PngMetaData pngMetaData, int pixelOffset = 0, int increment = 1)
+        private void ProcessInterlacedDefilteredScanline<TPixel>(ReadOnlySpan<byte> defilteredScanline, Span<TPixel> rowSpan, PngMetadata pngMetadata, int pixelOffset = 0, int increment = 1)
             where TPixel : struct, IPixel<TPixel>
         {
             // Trim the first marker byte from the buffer
@@ -737,9 +737,9 @@ namespace SixLabors.ImageSharp.Formats.Png
                         rowSpan,
                         pixelOffset,
                         increment,
-                        pngMetaData.HasTrans,
-                        pngMetaData.TransparentGray16.GetValueOrDefault(),
-                        pngMetaData.TransparentGray8.GetValueOrDefault());
+                        pngMetadata.HasTrans,
+                        pngMetadata.TransparentGray16.GetValueOrDefault(),
+                        pngMetadata.TransparentGray8.GetValueOrDefault());
 
                     break;
 
@@ -776,9 +776,9 @@ namespace SixLabors.ImageSharp.Formats.Png
                         increment,
                         this.bytesPerPixel,
                         this.bytesPerSample,
-                        pngMetaData.HasTrans,
-                        pngMetaData.TransparentRgb48.GetValueOrDefault(),
-                        pngMetaData.TransparentRgb24.GetValueOrDefault());
+                        pngMetadata.HasTrans,
+                        pngMetadata.TransparentRgb48.GetValueOrDefault(),
+                        pngMetadata.TransparentRgb24.GetValueOrDefault());
 
                     break;
 
@@ -799,11 +799,11 @@ namespace SixLabors.ImageSharp.Formats.Png
         }
 
         /// <summary>
-        /// Decodes and assigns marker colors that identify transparent pixels in non indexed images
+        /// Decodes and assigns marker colors that identify transparent pixels in non indexed images.
         /// </summary>
-        /// <param name="alpha">The alpha tRNS array</param>
-        /// <param name="pngMetaData">The png meta data</param>
-        private void AssignTransparentMarkers(ReadOnlySpan<byte> alpha, PngMetaData pngMetaData)
+        /// <param name="alpha">The alpha tRNS array.</param>
+        /// <param name="pngMetadata">The png metadata.</param>
+        private void AssignTransparentMarkers(ReadOnlySpan<byte> alpha, PngMetadata pngMetadata)
         {
             if (this.pngColorType == PngColorType.Rgb)
             {
@@ -815,16 +815,16 @@ namespace SixLabors.ImageSharp.Formats.Png
                         ushort gc = BinaryPrimitives.ReadUInt16LittleEndian(alpha.Slice(2, 2));
                         ushort bc = BinaryPrimitives.ReadUInt16LittleEndian(alpha.Slice(4, 2));
 
-                        pngMetaData.TransparentRgb48 = new Rgb48(rc, gc, bc);
-                        pngMetaData.HasTrans = true;
+                        pngMetadata.TransparentRgb48 = new Rgb48(rc, gc, bc);
+                        pngMetadata.HasTrans = true;
                         return;
                     }
 
                     byte r = ReadByteLittleEndian(alpha, 0);
                     byte g = ReadByteLittleEndian(alpha, 2);
                     byte b = ReadByteLittleEndian(alpha, 4);
-                    pngMetaData.TransparentRgb24 = new Rgb24(r, g, b);
-                    pngMetaData.HasTrans = true;
+                    pngMetadata.TransparentRgb24 = new Rgb24(r, g, b);
+                    pngMetadata.HasTrans = true;
                 }
             }
             else if (this.pngColorType == PngColorType.Grayscale)
@@ -833,14 +833,14 @@ namespace SixLabors.ImageSharp.Formats.Png
                 {
                     if (this.header.BitDepth == 16)
                     {
-                        pngMetaData.TransparentGray16 = new Gray16(BinaryPrimitives.ReadUInt16LittleEndian(alpha.Slice(0, 2)));
+                        pngMetadata.TransparentGray16 = new Gray16(BinaryPrimitives.ReadUInt16LittleEndian(alpha.Slice(0, 2)));
                     }
                     else
                     {
-                        pngMetaData.TransparentGray8 = new Gray8(ReadByteLittleEndian(alpha, 0));
+                        pngMetadata.TransparentGray8 = new Gray8(ReadByteLittleEndian(alpha, 0));
                     }
 
-                    pngMetaData.HasTrans = true;
+                    pngMetadata.HasTrans = true;
                 }
             }
         }
@@ -848,16 +848,16 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <summary>
         /// Reads a header chunk from the data.
         /// </summary>
-        /// <param name="pngMetaData">The png metadata.</param>
+        /// <param name="pngMetadata">The png metadata.</param>
         /// <param name="data">The <see cref="T:ReadOnlySpan{byte}"/> containing data.</param>
-        private void ReadHeaderChunk(PngMetaData pngMetaData, ReadOnlySpan<byte> data)
+        private void ReadHeaderChunk(PngMetadata pngMetadata, ReadOnlySpan<byte> data)
         {
             this.header = PngHeader.Parse(data);
 
             this.header.Validate();
 
-            pngMetaData.BitDepth = (PngBitDepth)this.header.BitDepth;
-            pngMetaData.ColorType = this.header.ColorType;
+            pngMetadata.BitDepth = (PngBitDepth)this.header.BitDepth;
+            pngMetadata.ColorType = this.header.ColorType;
 
             this.pngColorType = this.header.ColorType;
         }
@@ -867,7 +867,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </summary>
         /// <param name="metadata">The metadata to decode to.</param>
         /// <param name="data">The <see cref="T:Span"/> containing the data.</param>
-        private void ReadTextChunk(ImageMetaData metadata, ReadOnlySpan<byte> data)
+        private void ReadTextChunk(ImageMetadata metadata, ReadOnlySpan<byte> data)
         {
             if (this.ignoreMetadata)
             {

--- a/src/ImageSharp/Formats/Png/PngFormat.cs
+++ b/src/ImageSharp/Formats/Png/PngFormat.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Formats.Png
     /// <summary>
     /// Registers the image encoders, decoders and mime type detectors for the png format.
     /// </summary>
-    public sealed class PngFormat : IImageFormat<PngMetaData>
+    public sealed class PngFormat : IImageFormat<PngMetadata>
     {
         private PngFormat()
         {
@@ -32,6 +32,6 @@ namespace SixLabors.ImageSharp.Formats.Png
         public IEnumerable<string> FileExtensions => PngConstants.FileExtensions;
 
         /// <inheritdoc/>
-        public PngMetaData CreateDefaultFormatMetaData() => new PngMetaData();
+        public PngMetadata CreateDefaultFormatMetadata() => new PngMetadata();
     }
 }

--- a/src/ImageSharp/Formats/Png/PngMetaData.cs
+++ b/src/ImageSharp/Formats/Png/PngMetaData.cs
@@ -8,20 +8,20 @@ namespace SixLabors.ImageSharp.Formats.Png
     /// <summary>
     /// Provides Png specific metadata information for the image.
     /// </summary>
-    public class PngMetaData : IDeepCloneable
+    public class PngMetadata : IDeepCloneable
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PngMetaData"/> class.
+        /// Initializes a new instance of the <see cref="PngMetadata"/> class.
         /// </summary>
-        public PngMetaData()
+        public PngMetadata()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PngMetaData"/> class.
+        /// Initializes a new instance of the <see cref="PngMetadata"/> class.
         /// </summary>
         /// <param name="other">The metadata to create an instance from.</param>
-        private PngMetaData(PngMetaData other)
+        private PngMetadata(PngMetadata other)
         {
             this.BitDepth = other.BitDepth;
             this.ColorType = other.ColorType;
@@ -75,6 +75,6 @@ namespace SixLabors.ImageSharp.Formats.Png
         public bool HasTrans { get; set; }
 
         /// <inheritdoc/>
-        public IDeepCloneable DeepClone() => new PngMetaData(this);
+        public IDeepCloneable DeepClone() => new PngMetadata(this);
     }
 }

--- a/src/ImageSharp/IImageInfo.cs
+++ b/src/ImageSharp/IImageInfo.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 
 namespace SixLabors.ImageSharp
 {
@@ -30,6 +30,6 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Gets the metadata of the image.
         /// </summary>
-        ImageMetaData MetaData { get; }
+        ImageMetadata Metadata { get; }
     }
 }

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Memory;
 
@@ -25,13 +25,13 @@ namespace SixLabors.ImageSharp
         /// <param name="configuration">The <see cref="Configuration"/></param>
         /// <param name="width">The width of the image</param>
         /// <param name="height">The height of the image</param>
-        /// <param name="metadata">The <see cref="ImageMetaData"/></param>
+        /// <param name="metadata">The <see cref="ImageMetadata"/></param>
         /// <returns>The result <see cref="Image{TPixel}"/></returns>
         internal static Image<TPixel> CreateUninitialized<TPixel>(
             Configuration configuration,
             int width,
             int height,
-            ImageMetaData metadata)
+            ImageMetadata metadata)
             where TPixel : struct, IPixel<TPixel>
         {
             Buffer2D<TPixel> uninitializedMemoryBuffer =

--- a/src/ImageSharp/Image.WrapMemory.cs
+++ b/src/ImageSharp/Image.WrapMemory.cs
@@ -5,7 +5,7 @@ using System;
 using System.Buffers;
 
 using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp
@@ -24,18 +24,18 @@ namespace SixLabors.ImageSharp
         /// <param name="pixelMemory">The pixel memory.</param>
         /// <param name="width">The width of the memory image.</param>
         /// <param name="height">The height of the memory image.</param>
-        /// <param name="metaData">The <see cref="ImageMetaData"/>.</param>
+        /// <param name="metadata">The <see cref="ImageMetadata"/>.</param>
         /// <returns>An <see cref="Image{TPixel}"/> instance</returns>
         public static Image<TPixel> WrapMemory<TPixel>(
             Configuration config,
             Memory<TPixel> pixelMemory,
             int width,
             int height,
-            ImageMetaData metaData)
+            ImageMetadata metadata)
             where TPixel : struct, IPixel<TPixel>
         {
             var memorySource = new MemorySource<TPixel>(pixelMemory);
-            return new Image<TPixel>(config, memorySource, width, height, metaData);
+            return new Image<TPixel>(config, memorySource, width, height, metadata);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace SixLabors.ImageSharp
             int height)
             where TPixel : struct, IPixel<TPixel>
         {
-            return WrapMemory(config, pixelMemory, width, height, new ImageMetaData());
+            return WrapMemory(config, pixelMemory, width, height, new ImageMetadata());
         }
 
         /// <summary>
@@ -89,18 +89,18 @@ namespace SixLabors.ImageSharp
         /// <param name="pixelMemoryOwner">The <see cref="IMemoryOwner{T}"/> that is being transferred to the image</param>
         /// <param name="width">The width of the memory image.</param>
         /// <param name="height">The height of the memory image.</param>
-        /// <param name="metaData">The <see cref="ImageMetaData"/></param>
+        /// <param name="metadata">The <see cref="ImageMetadata"/></param>
         /// <returns>An <see cref="Image{TPixel}"/> instance</returns>
         public static Image<TPixel> WrapMemory<TPixel>(
             Configuration config,
             IMemoryOwner<TPixel> pixelMemoryOwner,
             int width,
             int height,
-            ImageMetaData metaData)
+            ImageMetadata metadata)
             where TPixel : struct, IPixel<TPixel>
         {
             var memorySource = new MemorySource<TPixel>(pixelMemoryOwner, false);
-            return new Image<TPixel>(config, memorySource, width, height, metaData);
+            return new Image<TPixel>(config, memorySource, width, height, metadata);
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace SixLabors.ImageSharp
             int height)
             where TPixel : struct, IPixel<TPixel>
         {
-            return WrapMemory(config, pixelMemoryOwner, width, height, new ImageMetaData());
+            return WrapMemory(config, pixelMemoryOwner, width, height, new ImageMetadata());
         }
 
         /// <summary>

--- a/src/ImageSharp/ImageFrameCollection.cs
+++ b/src/ImageSharp/ImageFrameCollection.cs
@@ -192,7 +192,7 @@ namespace SixLabors.ImageSharp
 
             this.frames.Remove(frame);
 
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.DeepClone(), new[] { frame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.Metadata.DeepClone(), new[] { frame });
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace SixLabors.ImageSharp
         {
             ImageFrame<TPixel> frame = this[index];
             ImageFrame<TPixel> clonedFrame = frame.Clone();
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.MetaData.DeepClone(), new[] { clonedFrame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.Metadata.DeepClone(), new[] { clonedFrame });
         }
 
         /// <summary>

--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.ParallelUtils;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Memory;
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         internal ImageFrame(Configuration configuration, int width, int height)
-            : this(configuration, width, height, new ImageFrameMetaData())
+            : this(configuration, width, height, new ImageFrameMetadata())
         {
         }
 
@@ -39,9 +39,9 @@ namespace SixLabors.ImageSharp
         /// </summary>
         /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="size">The <see cref="Size"/> of the frame.</param>
-        /// <param name="metaData">The meta data.</param>
-        internal ImageFrame(Configuration configuration, Size size, ImageFrameMetaData metaData)
-            : this(configuration, size.Width, size.Height, metaData)
+        /// <param name="metadata">The metadata.</param>
+        internal ImageFrame(Configuration configuration, Size size, ImageFrameMetadata metadata)
+            : this(configuration, size.Width, size.Height, metadata)
         {
         }
 
@@ -51,9 +51,9 @@ namespace SixLabors.ImageSharp
         /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
-        /// <param name="metaData">The meta data.</param>
-        internal ImageFrame(Configuration configuration, int width, int height, ImageFrameMetaData metaData)
-            : this(configuration, width, height, default(TPixel), metaData)
+        /// <param name="metadata">The metadata.</param>
+        internal ImageFrame(Configuration configuration, int width, int height, ImageFrameMetadata metadata)
+            : this(configuration, width, height, default(TPixel), metadata)
         {
         }
 
@@ -65,7 +65,7 @@ namespace SixLabors.ImageSharp
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="backgroundColor">The color to clear the image with.</param>
         internal ImageFrame(Configuration configuration, int width, int height, TPixel backgroundColor)
-            : this(configuration, width, height, backgroundColor, new ImageFrameMetaData())
+            : this(configuration, width, height, backgroundColor, new ImageFrameMetadata())
         {
         }
 
@@ -76,8 +76,8 @@ namespace SixLabors.ImageSharp
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="backgroundColor">The color to clear the image with.</param>
-        /// <param name="metaData">The meta data.</param>
-        internal ImageFrame(Configuration configuration, int width, int height, TPixel backgroundColor, ImageFrameMetaData metaData)
+        /// <param name="metadata">The metadata.</param>
+        internal ImageFrame(Configuration configuration, int width, int height, TPixel backgroundColor, ImageFrameMetadata metadata)
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.MustBeGreaterThan(width, 0, nameof(width));
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp
             this.Configuration = configuration;
             this.MemoryAllocator = configuration.MemoryAllocator;
             this.PixelBuffer = this.MemoryAllocator.Allocate2D<TPixel>(width, height);
-            this.MetaData = metaData ?? new ImageFrameMetaData();
+            this.Metadata = metadata ?? new ImageFrameMetadata();
             this.Clear(configuration.GetParallelOptions(), backgroundColor);
         }
 
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="memorySource">The memory source.</param>
         internal ImageFrame(Configuration configuration, int width, int height, MemorySource<TPixel> memorySource)
-            : this(configuration, width, height, memorySource, new ImageFrameMetaData())
+            : this(configuration, width, height, memorySource, new ImageFrameMetadata())
         {
         }
 
@@ -109,18 +109,18 @@ namespace SixLabors.ImageSharp
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="memorySource">The memory source.</param>
-        /// <param name="metaData">The meta data.</param>
-        internal ImageFrame(Configuration configuration, int width, int height, MemorySource<TPixel> memorySource, ImageFrameMetaData metaData)
+        /// <param name="metadata">The metadata.</param>
+        internal ImageFrame(Configuration configuration, int width, int height, MemorySource<TPixel> memorySource, ImageFrameMetadata metadata)
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.MustBeGreaterThan(width, 0, nameof(width));
             Guard.MustBeGreaterThan(height, 0, nameof(height));
-            Guard.NotNull(metaData, nameof(metaData));
+            Guard.NotNull(metadata, nameof(metadata));
 
             this.Configuration = configuration;
             this.MemoryAllocator = configuration.MemoryAllocator;
             this.PixelBuffer = new Buffer2D<TPixel>(memorySource, width, height);
-            this.MetaData = metaData;
+            this.Metadata = metadata;
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace SixLabors.ImageSharp
             this.MemoryAllocator = configuration.MemoryAllocator;
             this.PixelBuffer = this.MemoryAllocator.Allocate2D<TPixel>(source.PixelBuffer.Width, source.PixelBuffer.Height);
             source.PixelBuffer.GetSpan().CopyTo(this.PixelBuffer.GetSpan());
-            this.MetaData = source.MetaData.DeepClone();
+            this.Metadata = source.Metadata.DeepClone();
         }
 
         /// <summary>
@@ -169,9 +169,9 @@ namespace SixLabors.ImageSharp
         public int Height => this.PixelBuffer.Height;
 
         /// <summary>
-        /// Gets the meta data of the frame.
+        /// Gets the metadata of the frame.
         /// </summary>
-        public ImageFrameMetaData MetaData { get; }
+        public ImageFrameMetadata Metadata { get; }
 
         /// <summary>
         /// Gets or sets the pixel at the specified position.
@@ -289,7 +289,7 @@ namespace SixLabors.ImageSharp
                 return this.Clone(configuration) as ImageFrame<TPixel2>;
             }
 
-            var target = new ImageFrame<TPixel2>(configuration, this.Width, this.Height, this.MetaData.DeepClone());
+            var target = new ImageFrame<TPixel2>(configuration, this.Width, this.Height, this.Metadata.DeepClone());
 
             ParallelHelper.IterateRows(
                 this.Bounds(),

--- a/src/ImageSharp/ImageInfo.cs
+++ b/src/ImageSharp/ImageInfo.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 
 namespace SixLabors.ImageSharp
 {
@@ -17,13 +17,13 @@ namespace SixLabors.ImageSharp
         /// <param name="pixelType">The image pixel type information.</param>
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
-        /// <param name="metaData">The images metadata.</param>
-        public ImageInfo(PixelTypeInfo pixelType, int width, int height, ImageMetaData metaData)
+        /// <param name="metadata">The images metadata.</param>
+        public ImageInfo(PixelTypeInfo pixelType, int width, int height, ImageMetadata metadata)
         {
             this.PixelType = pixelType;
             this.Width = width;
             this.Height = height;
-            this.MetaData = metaData;
+            this.Metadata = metadata;
         }
 
         /// <inheritdoc />
@@ -36,6 +36,6 @@ namespace SixLabors.ImageSharp
         public int Height { get; }
 
         /// <inheritdoc />
-        public ImageMetaData MetaData { get; }
+        public ImageMetadata Metadata { get; }
     }
 }

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp
@@ -31,7 +31,7 @@ namespace SixLabors.ImageSharp
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         public Image(Configuration configuration, int width, int height)
-            : this(configuration, width, height, new ImageMetaData())
+            : this(configuration, width, height, new ImageMetadata())
         {
         }
 
@@ -44,7 +44,7 @@ namespace SixLabors.ImageSharp
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="backgroundColor">The color to initialize the pixels with.</param>
         public Image(Configuration configuration, int width, int height, TPixel backgroundColor)
-            : this(configuration, width, height, backgroundColor, new ImageMetaData())
+            : this(configuration, width, height, backgroundColor, new ImageMetadata())
         {
         }
 
@@ -67,11 +67,11 @@ namespace SixLabors.ImageSharp
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="metadata">The images metadata.</param>
-        internal Image(Configuration configuration, int width, int height, ImageMetaData metadata)
+        internal Image(Configuration configuration, int width, int height, ImageMetadata metadata)
         {
             this.configuration = configuration ?? Configuration.Default;
             this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
-            this.MetaData = metadata ?? new ImageMetaData();
+            this.Metadata = metadata ?? new ImageMetadata();
             this.Frames = new ImageFrameCollection<TPixel>(this, width, height, default(TPixel));
         }
 
@@ -84,11 +84,11 @@ namespace SixLabors.ImageSharp
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="metadata">The images metadata.</param>
-        internal Image(Configuration configuration, MemorySource<TPixel> memorySource, int width, int height, ImageMetaData metadata)
+        internal Image(Configuration configuration, MemorySource<TPixel> memorySource, int width, int height, ImageMetadata metadata)
         {
             this.configuration = configuration;
             this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
-            this.MetaData = metadata;
+            this.Metadata = metadata;
             this.Frames = new ImageFrameCollection<TPixel>(this, width, height, memorySource);
         }
 
@@ -101,11 +101,11 @@ namespace SixLabors.ImageSharp
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="backgroundColor">The color to initialize the pixels with.</param>
         /// <param name="metadata">The images metadata.</param>
-        internal Image(Configuration configuration, int width, int height, TPixel backgroundColor, ImageMetaData metadata)
+        internal Image(Configuration configuration, int width, int height, TPixel backgroundColor, ImageMetadata metadata)
         {
             this.configuration = configuration ?? Configuration.Default;
             this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
-            this.MetaData = metadata ?? new ImageMetaData();
+            this.Metadata = metadata ?? new ImageMetadata();
             this.Frames = new ImageFrameCollection<TPixel>(this, width, height, backgroundColor);
         }
 
@@ -116,11 +116,11 @@ namespace SixLabors.ImageSharp
         /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
         /// <param name="metadata">The images metadata.</param>
         /// <param name="frames">The frames that will be owned by this image instance.</param>
-        internal Image(Configuration configuration, ImageMetaData metadata, IEnumerable<ImageFrame<TPixel>> frames)
+        internal Image(Configuration configuration, ImageMetadata metadata, IEnumerable<ImageFrame<TPixel>> frames)
         {
             this.configuration = configuration ?? Configuration.Default;
             this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
-            this.MetaData = metadata ?? new ImageMetaData();
+            this.Metadata = metadata ?? new ImageMetadata();
 
             this.Frames = new ImageFrameCollection<TPixel>(this, frames);
         }
@@ -140,7 +140,7 @@ namespace SixLabors.ImageSharp
         public int Height => this.Frames.RootFrame.Height;
 
         /// <inheritdoc/>
-        public ImageMetaData MetaData { get; }
+        public ImageMetadata Metadata { get; }
 
         /// <summary>
         /// Gets the frames.
@@ -193,7 +193,7 @@ namespace SixLabors.ImageSharp
         public Image<TPixel> Clone(Configuration configuration)
         {
             IEnumerable<ImageFrame<TPixel>> clonedFrames = this.Frames.Select(x => x.Clone(configuration));
-            return new Image<TPixel>(configuration, this.MetaData.DeepClone(), clonedFrames);
+            return new Image<TPixel>(configuration, this.Metadata.DeepClone(), clonedFrames);
         }
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace SixLabors.ImageSharp
             where TPixel2 : struct, IPixel<TPixel2>
         {
             IEnumerable<ImageFrame<TPixel2>> clonedFrames = this.Frames.Select(x => x.CloneAs<TPixel2>(configuration));
-            return new Image<TPixel2>(configuration, this.MetaData.DeepClone(), clonedFrames);
+            return new Image<TPixel2>(configuration, this.Metadata.DeepClone(), clonedFrames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/MetaData/FrameDecodingMode.cs
+++ b/src/ImageSharp/MetaData/FrameDecodingMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData
+namespace SixLabors.ImageSharp.Metadata
 {
     /// <summary>
     /// Enumerated frame process modes to apply to multi-frame images.

--- a/src/ImageSharp/MetaData/ImageFrameMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageFrameMetaData.cs
@@ -4,62 +4,62 @@
 using System.Collections.Generic;
 using SixLabors.ImageSharp.Formats;
 
-namespace SixLabors.ImageSharp.MetaData
+namespace SixLabors.ImageSharp.Metadata
 {
     /// <summary>
     /// Encapsulates the metadata of an image frame.
     /// </summary>
-    public sealed class ImageFrameMetaData : IDeepCloneable<ImageFrameMetaData>
+    public sealed class ImageFrameMetadata : IDeepCloneable<ImageFrameMetadata>
     {
-        private readonly Dictionary<IImageFormat, IDeepCloneable> formatMetaData = new Dictionary<IImageFormat, IDeepCloneable>();
+        private readonly Dictionary<IImageFormat, IDeepCloneable> formatMetadata = new Dictionary<IImageFormat, IDeepCloneable>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ImageFrameMetaData"/> class.
+        /// Initializes a new instance of the <see cref="ImageFrameMetadata"/> class.
         /// </summary>
-        internal ImageFrameMetaData()
+        internal ImageFrameMetadata()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ImageFrameMetaData"/> class
+        /// Initializes a new instance of the <see cref="ImageFrameMetadata"/> class
         /// by making a copy from other metadata.
         /// </summary>
         /// <param name="other">
-        /// The other <see cref="ImageFrameMetaData"/> to create this instance from.
+        /// The other <see cref="ImageFrameMetadata"/> to create this instance from.
         /// </param>
-        internal ImageFrameMetaData(ImageFrameMetaData other)
+        internal ImageFrameMetadata(ImageFrameMetadata other)
         {
             DebugGuard.NotNull(other, nameof(other));
 
-            foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetaData)
+            foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetadata)
             {
-                this.formatMetaData.Add(meta.Key, meta.Value.DeepClone());
+                this.formatMetadata.Add(meta.Key, meta.Value.DeepClone());
             }
         }
 
         /// <inheritdoc/>
-        public ImageFrameMetaData DeepClone() => new ImageFrameMetaData(this);
+        public ImageFrameMetadata DeepClone() => new ImageFrameMetadata(this);
 
         /// <summary>
         /// Gets the metadata value associated with the specified key.
         /// </summary>
-        /// <typeparam name="TFormatMetaData">The type of format metadata.</typeparam>
-        /// <typeparam name="TFormatFrameMetaData">The type of format frame metadata.</typeparam>
+        /// <typeparam name="TFormatMetadata">The type of format metadata.</typeparam>
+        /// <typeparam name="TFormatFrameMetadata">The type of format frame metadata.</typeparam>
         /// <param name="key">The key of the value to get.</param>
         /// <returns>
-        /// The <typeparamref name="TFormatFrameMetaData"/>.
+        /// The <typeparamref name="TFormatFrameMetadata"/>.
         /// </returns>
-        public TFormatFrameMetaData GetFormatMetaData<TFormatMetaData, TFormatFrameMetaData>(IImageFormat<TFormatMetaData, TFormatFrameMetaData> key)
-            where TFormatMetaData : class
-            where TFormatFrameMetaData : class, IDeepCloneable
+        public TFormatFrameMetadata GetFormatMetadata<TFormatMetadata, TFormatFrameMetadata>(IImageFormat<TFormatMetadata, TFormatFrameMetadata> key)
+            where TFormatMetadata : class
+            where TFormatFrameMetadata : class, IDeepCloneable
         {
-            if (this.formatMetaData.TryGetValue(key, out IDeepCloneable meta))
+            if (this.formatMetadata.TryGetValue(key, out IDeepCloneable meta))
             {
-                return (TFormatFrameMetaData)meta;
+                return (TFormatFrameMetadata)meta;
             }
 
-            TFormatFrameMetaData newMeta = key.CreateDefaultFormatFrameMetaData();
-            this.formatMetaData[key] = newMeta;
+            TFormatFrameMetadata newMeta = key.CreateDefaultFormatFrameMetadata();
+            this.formatMetadata[key] = newMeta;
             return newMeta;
         }
     }

--- a/src/ImageSharp/MetaData/ImageMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageMetaData.cs
@@ -3,15 +3,15 @@
 
 using System.Collections.Generic;
 using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 
-namespace SixLabors.ImageSharp.MetaData
+namespace SixLabors.ImageSharp.Metadata
 {
     /// <summary>
     /// Encapsulates the metadata of an image.
     /// </summary>
-    public sealed class ImageMetaData : IDeepCloneable<ImageMetaData>
+    public sealed class ImageMetadata : IDeepCloneable<ImageMetadata>
     {
         /// <summary>
         /// The default horizontal resolution value (dots per inch) in x direction.
@@ -31,14 +31,14 @@ namespace SixLabors.ImageSharp.MetaData
         /// </summary>
         public const PixelResolutionUnit DefaultPixelResolutionUnits = PixelResolutionUnit.PixelsPerInch;
 
-        private readonly Dictionary<IImageFormat, IDeepCloneable> formatMetaData = new Dictionary<IImageFormat, IDeepCloneable>();
+        private readonly Dictionary<IImageFormat, IDeepCloneable> formatMetadata = new Dictionary<IImageFormat, IDeepCloneable>();
         private double horizontalResolution;
         private double verticalResolution;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ImageMetaData"/> class.
+        /// Initializes a new instance of the <see cref="ImageMetadata"/> class.
         /// </summary>
-        internal ImageMetaData()
+        internal ImageMetadata()
         {
             this.horizontalResolution = DefaultHorizontalResolution;
             this.verticalResolution = DefaultVerticalResolution;
@@ -46,21 +46,21 @@ namespace SixLabors.ImageSharp.MetaData
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ImageMetaData"/> class
+        /// Initializes a new instance of the <see cref="ImageMetadata"/> class
         /// by making a copy from other metadata.
         /// </summary>
         /// <param name="other">
-        /// The other <see cref="ImageMetaData"/> to create this instance from.
+        /// The other <see cref="ImageMetadata"/> to create this instance from.
         /// </param>
-        private ImageMetaData(ImageMetaData other)
+        private ImageMetadata(ImageMetadata other)
         {
             this.HorizontalResolution = other.HorizontalResolution;
             this.VerticalResolution = other.VerticalResolution;
             this.ResolutionUnits = other.ResolutionUnits;
 
-            foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetaData)
+            foreach (KeyValuePair<IImageFormat, IDeepCloneable> meta in other.formatMetadata)
             {
-                this.formatMetaData.Add(meta.Key, meta.Value.DeepClone());
+                this.formatMetadata.Add(meta.Key, meta.Value.DeepClone());
             }
 
             foreach (ImageProperty property in other.Properties)
@@ -135,26 +135,26 @@ namespace SixLabors.ImageSharp.MetaData
         /// <summary>
         /// Gets the metadata value associated with the specified key.
         /// </summary>
-        /// <typeparam name="TFormatMetaData">The type of metadata.</typeparam>
+        /// <typeparam name="TFormatMetadata">The type of metadata.</typeparam>
         /// <param name="key">The key of the value to get.</param>
         /// <returns>
-        /// The <typeparamref name="TFormatMetaData"/>.
+        /// The <typeparamref name="TFormatMetadata"/>.
         /// </returns>
-        public TFormatMetaData GetFormatMetaData<TFormatMetaData>(IImageFormat<TFormatMetaData> key)
-             where TFormatMetaData : class, IDeepCloneable
+        public TFormatMetadata GetFormatMetadata<TFormatMetadata>(IImageFormat<TFormatMetadata> key)
+             where TFormatMetadata : class, IDeepCloneable
         {
-            if (this.formatMetaData.TryGetValue(key, out IDeepCloneable meta))
+            if (this.formatMetadata.TryGetValue(key, out IDeepCloneable meta))
             {
-                return (TFormatMetaData)meta;
+                return (TFormatMetadata)meta;
             }
 
-            TFormatMetaData newMeta = key.CreateDefaultFormatMetaData();
-            this.formatMetaData[key] = newMeta;
+            TFormatMetadata newMeta = key.CreateDefaultFormatMetadata();
+            this.formatMetadata[key] = newMeta;
             return newMeta;
         }
 
         /// <inheritdoc/>
-        public ImageMetaData DeepClone() => new ImageMetaData(this);
+        public ImageMetadata DeepClone() => new ImageMetadata(this);
 
         /// <summary>
         /// Looks up a property with the provided name.
@@ -180,7 +180,7 @@ namespace SixLabors.ImageSharp.MetaData
         }
 
         /// <summary>
-        /// Synchronizes the profiles with the current meta data.
+        /// Synchronizes the profiles with the current metadata.
         /// </summary>
         internal void SyncProfiles() => this.ExifProfile?.Sync(this);
     }

--- a/src/ImageSharp/MetaData/ImageProperty.cs
+++ b/src/ImageSharp/MetaData/ImageProperty.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData
+namespace SixLabors.ImageSharp.Metadata
 {
     /// <summary>
     /// Stores meta information about a image, like the name of the author,

--- a/src/ImageSharp/MetaData/PixelResolutionUnit.cs
+++ b/src/ImageSharp/MetaData/PixelResolutionUnit.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData
+namespace SixLabors.ImageSharp.Metadata
 {
     /// <summary>
     /// Provides enumeration of available pixel density units.

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifConstants.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifConstants.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     internal static class ExifConstants
     {

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifDataType.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifDataType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     /// <summary>
     /// Specifies exif data types.

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifParts.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifParts.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     /// <summary>
     /// Specifies which parts will be written when the profile is added to an image.

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
@@ -7,7 +7,7 @@ using System.IO;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Primitives;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     /// <summary>
     /// Represents an EXIF profile providing access to the collection of values.
@@ -249,13 +249,13 @@ namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
         public ExifProfile DeepClone() => new ExifProfile(this);
 
         /// <summary>
-        /// Synchronizes the profiles with the specified meta data.
+        /// Synchronizes the profiles with the specified metadata.
         /// </summary>
-        /// <param name="metaData">The meta data.</param>
-        internal void Sync(ImageMetaData metaData)
+        /// <param name="metadata">The metadata.</param>
+        internal void Sync(ImageMetadata metadata)
         {
-            this.SyncResolution(ExifTag.XResolution, metaData.HorizontalResolution);
-            this.SyncResolution(ExifTag.YResolution, metaData.VerticalResolution);
+            this.SyncResolution(ExifTag.XResolution, metadata.HorizontalResolution);
+            this.SyncResolution(ExifTag.YResolution, metadata.VerticalResolution);
         }
 
         private void SyncResolution(ExifTag tag, double resolution)

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifReader.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifReader.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using SixLabors.ImageSharp.Primitives;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     /// <summary>
     /// Reads and parses EXIF data from a byte array.

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifTag.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifTag.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     /// <summary>
     /// All exif tags from the Exif standard 2.2

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifTagDescriptionAttribute.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifTagDescriptionAttribute.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Reflection;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     /// <summary>
     /// Class that provides a description for an ExifTag value.

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifTags.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifTags.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using static SixLabors.ImageSharp.MetaData.Profiles.Exif.ExifTag;
+using static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     internal static class ExifTags
     {

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifValue.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifValue.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.Text;
 using SixLabors.ImageSharp.Primitives;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     /// <summary>
     /// Represent the value of the EXIF profile.

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifWriter.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Text;
 using SixLabors.ImageSharp.Primitives;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Exif
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     /// <summary>
     /// Contains methods for writing EXIF metadata.

--- a/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccCurveSegment.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccCurveSegment.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A segment of a curve

--- a/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccFormulaCurveElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccFormulaCurveElement.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A formula based curve segment

--- a/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccOneDimensionalCurve.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccOneDimensionalCurve.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A one dimensional ICC curve.

--- a/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccParametricCurve.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccParametricCurve.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A parametric curve

--- a/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccResponseCurve.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccResponseCurve.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A response curve

--- a/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccSampledCurveElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Curves/IccSampledCurveElement.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A sampled curve segment

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Curves.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Curves.cs
@@ -3,7 +3,7 @@
 
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to read ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Lut.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Lut.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to read ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Matrix.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Matrix.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to read ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.MultiProcessElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.MultiProcessElement.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to read ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.NonPrimitives.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.NonPrimitives.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to read ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Primitives.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.Primitives.cs
@@ -6,7 +6,7 @@ using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to read ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.TagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.TagDataEntry.cs
@@ -5,7 +5,7 @@ using System;
 using System.Globalization;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to read ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataReader/IccDataReader.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Text;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to read ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Curves.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Curves.cs
@@ -3,7 +3,7 @@
 
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <content>
     /// Provides methods to write ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Lut.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Lut.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <content>
     /// Provides methods to write ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Matrix.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Matrix.cs
@@ -4,7 +4,7 @@
 using System.Numerics;
 using SixLabors.ImageSharp.Primitives;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to write ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.MultiProcessElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.MultiProcessElement.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to write ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.NonPrimitives.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.NonPrimitives.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to write ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Primitives.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.Primitives.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Text;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to write ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.TagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.TagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to write ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/DataWriter/IccDataWriter.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Provides methods to write ICC data types

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccClutDataType.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccClutDataType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Color lookup table data type

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccColorSpaceType.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccColorSpaceType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Color Space Type

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccColorantEncoding.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccColorantEncoding.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Colorant Encoding

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccCurveMeasurementEncodings.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccCurveMeasurementEncodings.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Curve Measurement Encodings

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccCurveSegmentSignature.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccCurveSegmentSignature.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Curve Segment Signature

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccDataType.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccDataType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Enumerates the basic data types as defined in ICC.1:2010 version 4.3.0.0

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccDeviceAttribute.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccDeviceAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Device attributes. Can be combined with a logical OR

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccFormulaCurveType.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccFormulaCurveType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Formula curve segment type

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccMeasurementGeometry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccMeasurementGeometry.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Measurement Geometry

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccMultiProcessElementSignature.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccMultiProcessElementSignature.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Multi process element signature

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccParametricCurveType.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccParametricCurveType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Formula curve segment type

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccPrimaryPlatformType.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccPrimaryPlatformType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Enumerates the primary platform/operating system framework for which the profile was created

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileClass.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileClass.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Profile Class Name

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileFlag.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileFlag.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Profile flags. Can be combined with a logical OR.

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileTag.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccProfileTag.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 // ReSharper disable InconsistentNaming
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Enumerates the ICC Profile Tags as defined in ICC.1:2010 version 4.3.0.0

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccRenderingIntent.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccRenderingIntent.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Rendering intent

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccScreeningFlag.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccScreeningFlag.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Screening flags. Can be combined with a logical OR.

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccScreeningSpotType.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccScreeningSpotType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Enumerates the screening spot types

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccSignatureName.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccSignatureName.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Signature Name

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccStandardIlluminant.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccStandardIlluminant.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Standard Illuminant

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccStandardObserver.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccStandardObserver.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Standard Observer

--- a/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccTypeSignature.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Enums/IccTypeSignature.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Type Signature

--- a/src/ImageSharp/MetaData/Profiles/ICC/Exceptions/InvalidIccProfileException.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Exceptions/InvalidIccProfileException.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Represents an error that happened while reading or writing a corrupt/invalid ICC profile

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccProfile.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Security.Cryptography;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Represents an ICC profile

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccProfileHeader.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccProfileHeader.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Contains all values of an ICC profile header.

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccReader.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccReader.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Reads and parses ICC data from a byte array

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The data of an ICC tag entry

--- a/src/ImageSharp/MetaData/Profiles/ICC/IccWriter.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/IccWriter.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Contains methods for writing ICC profiles.

--- a/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccBAcsProcessElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccBAcsProcessElement.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A placeholder <see cref="IccMultiProcessElement"/> (might be used for future ICC versions)

--- a/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccClutProcessElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccClutProcessElement.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A CLUT (color lookup table) element to process data

--- a/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccCurveSetProcessElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccCurveSetProcessElement.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A set of curves to process data

--- a/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccEAcsProcessElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccEAcsProcessElement.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A placeholder <see cref="IccMultiProcessElement"/> (might be used for future ICC versions)

--- a/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccMatrixProcessElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccMatrixProcessElement.cs
@@ -5,7 +5,7 @@ using System;
 
 using SixLabors.ImageSharp.Primitives;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A matrix element to process data

--- a/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccMultiProcessElement.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/MultiProcessElements/IccMultiProcessElement.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// An element to process data

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccChromaticityTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccChromaticityTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The chromaticity tag type provides basic chromaticity data

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccColorantOrderTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccColorantOrderTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This tag specifies the laydown order in which colorants

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccColorantTableTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccColorantTableTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The purpose of this tag is to identify the colorants used in

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccCrdInfoTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccCrdInfoTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type contains the PostScript product name to which this profile

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccCurveTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccCurveTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The type contains a one-dimensional table of double values.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDataTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDataTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Text;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The dataType is a simple data structure that contains

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDateTimeTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccDateTimeTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type is a representation of the time and date.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccFix16ArrayTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccFix16ArrayTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type represents an array of doubles (from 32bit fixed point values).

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccLut16TagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccLut16TagDataEntry.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This structure represents a color transform using tables

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccLut8TagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccLut8TagDataEntry.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This structure represents a color transform using tables

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccLutAToBTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccLutAToBTagDataEntry.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This structure represents a color transform.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccLutBToATagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccLutBToATagDataEntry.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This structure represents a color transform.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccMeasurementTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccMeasurementTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The measurementType information refers only to the internal

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccMultiLocalizedUnicodeTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccMultiLocalizedUnicodeTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This tag structure contains a set of records each referencing

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccMultiProcessElementsTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccMultiProcessElementsTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This structure represents a color transform, containing

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccNamedColor2TagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccNamedColor2TagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The namedColor2Type is a count value and array of structures

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccParametricCurveTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccParametricCurveTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The parametricCurveType describes a one-dimensional curve by

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccProfileSequenceDescTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccProfileSequenceDescTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type is an array of structures, each of which contains information

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccProfileSequenceIdentifierTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccProfileSequenceIdentifierTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type is an array of structures, each of which contains information

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccResponseCurveSet16TagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccResponseCurveSet16TagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The purpose of this tag type is to provide a mechanism to relate physical

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccScreeningTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccScreeningTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type describes various screening parameters including

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccSignatureTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccSignatureTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Typically this type is used for registered tags that can

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccTextDescriptionTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccTextDescriptionTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Globalization;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The TextDescriptionType contains three types of text description.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccTextTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccTextTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This is a simple text structure that contains a text string.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUFix16ArrayTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUFix16ArrayTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type represents an array of doubles (from 32bit values).

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUInt16ArrayTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUInt16ArrayTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type represents an array of unsigned shorts.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUInt32ArrayTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUInt32ArrayTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type represents an array of unsigned 32bit integers.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUInt64ArrayTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUInt64ArrayTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type represents an array of unsigned 64bit integers.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUInt8ArrayTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUInt8ArrayTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type represents an array of bytes.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUcrBgTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUcrBgTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type contains curves representing the under color removal and black generation

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUnknownTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccUnknownTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This tag stores data of an unknown tag data entry

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccViewingConditionsTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccViewingConditionsTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// This type represents a set of viewing condition parameters.

--- a/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccXyzTagDataEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/TagDataEntries/IccXyzTagDataEntry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Numerics;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// The XYZType contains an array of XYZ values.

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccClut.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccClut.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Color Lookup Table

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccColorantTableEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccColorantTableEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Entry of ICC colorant table

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccLocalizedString.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccLocalizedString.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Globalization;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A string with a specific locale.

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccLut.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccLut.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Lookup Table

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccNamedColor.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccNamedColor.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A specific color with a name

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccPositionNumber.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccPositionNumber.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Position of an object within an ICC profile

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccProfileDescription.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccProfileDescription.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// ICC Profile description

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccProfileId.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccProfileId.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// ICC Profile ID

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccProfileSequenceIdentifier.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccProfileSequenceIdentifier.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Description of a profile within a sequence.

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccResponseNumber.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccResponseNumber.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Associates a normalized device code with a measurement value

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccScreeningChannel.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccScreeningChannel.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// A single channel of a <see cref="IccScreeningTagDataEntry"/>

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccTagTableEntry.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccTagTableEntry.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Entry of ICC tag table

--- a/src/ImageSharp/MetaData/Profiles/ICC/Various/IccVersion.cs
+++ b/src/ImageSharp/MetaData/Profiles/ICC/Various/IccVersion.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SixLabors.ImageSharp.MetaData.Profiles.Icc
+namespace SixLabors.ImageSharp.Metadata.Profiles.Icc
 {
     /// <summary>
     /// Represents the ICC profile version number.

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -53,10 +53,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
             IEnumerable<ImageFrame<TPixel>> frames =
-                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions, x.MetaData.DeepClone()));
+                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions, x.Metadata.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.Metadata.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors;
 using SixLabors.Primitives;
@@ -73,12 +73,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <returns>The <see cref="OrientationMode"/></returns>
         private static OrientationMode GetExifOrientation(Image<TPixel> source)
         {
-            if (source.MetaData.ExifProfile is null)
+            if (source.Metadata.ExifProfile is null)
             {
                 return OrientationMode.Unknown;
             }
 
-            ExifValue value = source.MetaData.ExifProfile.GetValue(ExifTag.Orientation);
+            ExifValue value = source.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
             if (value is null)
             {
                 return OrientationMode.Unknown;
@@ -92,10 +92,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             else
             {
                 orientation = (OrientationMode)Convert.ToUInt16(value.Value);
-                source.MetaData.ExifProfile.RemoveValue(ExifTag.Orientation);
+                source.Metadata.ExifProfile.RemoveValue(ExifTag.Orientation);
             }
 
-            source.MetaData.ExifProfile.SetValue(ExifTag.Orientation, (ushort)OrientationMode.TopLeft);
+            source.Metadata.ExifProfile.SetValue(ExifTag.Orientation, (ushort)OrientationMode.TopLeft);
 
             return orientation;
         }

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -39,10 +39,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.CropRectangle.Width, this.CropRectangle.Height, x.MetaData.DeepClone()));
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.CropRectangle.Width, this.CropRectangle.Height, x.Metadata.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.Metadata.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -53,10 +53,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
             IEnumerable<ImageFrame<TPixel>> frames =
-                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions.Width, this.TargetDimensions.Height, x.MetaData.DeepClone()));
+                source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.TargetDimensions.Width, this.TargetDimensions.Height, x.Metadata.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.Metadata.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
@@ -151,10 +151,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
         {
             // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.MetaData.DeepClone()));
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.Metadata.DeepClone()));
 
             // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.MetaData.DeepClone(), frames);
+            return new Image<TPixel>(source.GetConfiguration(), source.Metadata.DeepClone(), frames);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -5,7 +5,7 @@ using System;
 using System.Numerics;
 
 using SixLabors.ImageSharp.Advanced;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.ParallelUtils;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <inheritdoc/>
         protected override void AfterImageApply(Image<TPixel> source, Image<TPixel> destination, Rectangle sourceRectangle)
         {
-            ExifProfile profile = destination.MetaData.ExifProfile;
+            ExifProfile profile = destination.Metadata.ExifProfile;
             if (profile is null)
             {
                 return;

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorHelpers.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorHelpers.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public static void UpdateDimensionalMetData<TPixel>(Image<TPixel> image)
             where TPixel : struct, IPixel<TPixel>
         {
-            ExifProfile profile = image.MetaData.ExifProfile;
+            ExifProfile profile = image.Metadata.ExifProfile;
             if (profile is null)
             {
                 return;

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests
 {
-    using SixLabors.ImageSharp.MetaData;
+    using SixLabors.ImageSharp.Metadata;
     using static TestImages.Bmp;
 
     public class BmpDecoderTests
@@ -237,7 +237,7 @@ namespace SixLabors.ImageSharp.Tests
                 var decoder = new BmpDecoder();
                 using (Image<Rgba32> image = decoder.Decode<Rgba32>(Configuration.Default, stream))
                 {
-                    ImageMetaData meta = image.MetaData;
+                    ImageMetadata meta = image.Metadata;
                     Assert.Equal(xResolution, meta.HorizontalResolution);
                     Assert.Equal(yResolution, meta.VerticalResolution);
                     Assert.Equal(resolutionUnit, meta.ResolutionUnits);

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -3,7 +3,7 @@
 
 using System.IO;
 using SixLabors.ImageSharp.Formats.Bmp;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using Xunit;
@@ -55,7 +55,7 @@ namespace SixLabors.ImageSharp.Tests
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        ImageMetaData meta = output.MetaData;
+                        ImageMetadata meta = output.Metadata;
                         Assert.Equal(xResolution, meta.HorizontalResolution);
                         Assert.Equal(yResolution, meta.VerticalResolution);
                         Assert.Equal(resolutionUnit, meta.ResolutionUnits);
@@ -80,7 +80,7 @@ namespace SixLabors.ImageSharp.Tests
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        BmpMetaData meta = output.MetaData.GetFormatMetaData(BmpFormat.Instance);
+                        BmpMetadata meta = output.Metadata.GetFormatMetadata(BmpFormat.Instance);
 
                         Assert.Equal(bmpBitsPerPixel, meta.BitsPerPixel);
                     }

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpMetaDataTests.cs
@@ -11,8 +11,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Fact]
         public void CloneIsDeep()
         {
-            var meta = new BmpMetaData() { BitsPerPixel = BmpBitsPerPixel.Pixel24 };
-            var clone = (BmpMetaData)meta.DeepClone();
+            var meta = new BmpMetadata() { BitsPerPixel = BmpBitsPerPixel.Pixel24 };
+            var clone = (BmpMetadata)meta.DeepClone();
 
             clone.BitsPerPixel = BmpBitsPerPixel.Pixel32;
 

--- a/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
+++ b/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
@@ -27,8 +27,8 @@ namespace SixLabors.ImageSharp.Tests
         {
             using (Image<TPixel> image = provider.GetImage())
             {
-                image.MetaData.VerticalResolution = 150;
-                image.MetaData.HorizontalResolution = 150;
+                image.Metadata.VerticalResolution = 150;
+                image.Metadata.HorizontalResolution = 150;
                 image.DebugSave(provider);
             }
         }

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Text;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats.Gif;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 using Xunit;
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         public static readonly TheoryData<string, int, int, PixelResolutionUnit> RatioFiles =
         new TheoryData<string, int, int, PixelResolutionUnit>
         {
-            { TestImages.Gif.Rings, (int)ImageMetaData.DefaultHorizontalResolution, (int)ImageMetaData.DefaultVerticalResolution , PixelResolutionUnit.PixelsPerInch},
+            { TestImages.Gif.Rings, (int)ImageMetadata.DefaultHorizontalResolution, (int)ImageMetadata.DefaultVerticalResolution , PixelResolutionUnit.PixelsPerInch},
             { TestImages.Gif.Ratio1x4, 1, 4 , PixelResolutionUnit.AspectRatio},
             { TestImages.Gif.Ratio4x1, 4, 1, PixelResolutionUnit.AspectRatio }
         };
@@ -101,7 +101,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 var decoder = new GifDecoder();
                 using (Image<Rgba32> image = decoder.Decode<Rgba32>(Configuration.Default, stream))
                 {
-                    ImageMetaData meta = image.MetaData;
+                    ImageMetadata meta = image.Metadata;
                     Assert.Equal(xResolution, meta.HorizontalResolution);
                     Assert.Equal(yResolution, meta.VerticalResolution);
                     Assert.Equal(resolutionUnit, meta.ResolutionUnits);
@@ -118,7 +118,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
             {
                 var decoder = new GifDecoder();
                 IImageInfo image = decoder.Identify(Configuration.Default, stream);
-                ImageMetaData meta = image.MetaData;
+                ImageMetadata meta = image.Metadata;
                 Assert.Equal(xResolution, meta.HorizontalResolution);
                 Assert.Equal(yResolution, meta.VerticalResolution);
                 Assert.Equal(resolutionUnit, meta.ResolutionUnits);
@@ -167,9 +167,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
 
             using (Image<Rgba32> image = testFile.CreateImage(options))
             {
-                Assert.Equal(1, image.MetaData.Properties.Count);
-                Assert.Equal("Comments", image.MetaData.Properties[0].Name);
-                Assert.Equal("ImageSharp", image.MetaData.Properties[0].Value);
+                Assert.Equal(1, image.Metadata.Properties.Count);
+                Assert.Equal("Comments", image.Metadata.Properties[0].Name);
+                Assert.Equal("ImageSharp", image.Metadata.Properties[0].Value);
             }
         }
 
@@ -185,7 +185,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
 
             using (Image<Rgba32> image = testFile.CreateImage(options))
             {
-                Assert.Equal(0, image.MetaData.Properties.Count);
+                Assert.Equal(0, image.Metadata.Properties.Count);
             }
         }
 
@@ -201,8 +201,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
 
             using (Image<Rgba32> image = testFile.CreateImage(options))
             {
-                Assert.Equal(1, image.MetaData.Properties.Count);
-                Assert.Equal("浉条卥慨灲", image.MetaData.Properties[0].Value);
+                Assert.Equal(1, image.Metadata.Properties.Count);
+                Assert.Equal("浉条卥慨灲", image.Metadata.Properties[0].Value);
             }
         }
 

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -3,7 +3,7 @@
 
 using System.IO;
 using SixLabors.ImageSharp.Formats.Gif;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         public static readonly TheoryData<string, int, int, PixelResolutionUnit> RatioFiles =
         new TheoryData<string, int, int, PixelResolutionUnit>
         {
-            { TestImages.Gif.Rings, (int)ImageMetaData.DefaultHorizontalResolution, (int)ImageMetaData.DefaultVerticalResolution , PixelResolutionUnit.PixelsPerInch},
+            { TestImages.Gif.Rings, (int)ImageMetadata.DefaultHorizontalResolution, (int)ImageMetadata.DefaultVerticalResolution , PixelResolutionUnit.PixelsPerInch},
             { TestImages.Gif.Ratio1x4, 1, 4 , PixelResolutionUnit.AspectRatio},
             { TestImages.Gif.Ratio4x1, 4, 1, PixelResolutionUnit.AspectRatio }
         };
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        ImageMetaData meta = output.MetaData;
+                        ImageMetadata meta = output.Metadata;
                         Assert.Equal(xResolution, meta.HorizontalResolution);
                         Assert.Equal(yResolution, meta.VerticalResolution);
                         Assert.Equal(resolutionUnit, meta.ResolutionUnits);
@@ -92,9 +92,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        Assert.Equal(1, output.MetaData.Properties.Count);
-                        Assert.Equal("Comments", output.MetaData.Properties[0].Name);
-                        Assert.Equal("ImageSharp", output.MetaData.Properties[0].Value);
+                        Assert.Equal(1, output.Metadata.Properties.Count);
+                        Assert.Equal("Comments", output.Metadata.Properties[0].Name);
+                        Assert.Equal("ImageSharp", output.Metadata.Properties[0].Value);
                     }
                 }
             }
@@ -109,7 +109,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
 
             using (Image<Rgba32> input = testFile.CreateImage())
             {
-                input.MetaData.Properties.Clear();
+                input.Metadata.Properties.Clear();
                 using (var memStream = new MemoryStream())
                 {
                     input.SaveAsGif(memStream, options);
@@ -117,7 +117,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        Assert.Equal(0, output.MetaData.Properties.Count);
+                        Assert.Equal(0, output.Metadata.Properties.Count);
                     }
                 }
             }
@@ -129,7 +129,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
             using (var input = new Image<Rgba32>(1, 1))
             {
                 string comments = new string('c', 256);
-                input.MetaData.Properties.Add(new ImageProperty("Comments", comments));
+                input.Metadata.Properties.Add(new ImageProperty("Comments", comments));
 
                 using (var memStream = new MemoryStream())
                 {
@@ -138,9 +138,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        Assert.Equal(1, output.MetaData.Properties.Count);
-                        Assert.Equal("Comments", output.MetaData.Properties[0].Name);
-                        Assert.Equal(255, output.MetaData.Properties[0].Value.Length);
+                        Assert.Equal(1, output.Metadata.Properties.Count);
+                        Assert.Equal("Comments", output.Metadata.Properties[0].Name);
+                        Assert.Equal(255, output.Metadata.Properties[0].Value.Length);
                     }
                 }
             }
@@ -181,8 +181,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 inStream.Position = 0;
 
                 var image = Image.Load(inStream);
-                GifMetaData metaData = image.MetaData.GetFormatMetaData(GifFormat.Instance);
-                GifFrameMetaData frameMetaData = image.Frames.RootFrame.MetaData.GetFormatMetaData(GifFormat.Instance);
+                GifMetadata metaData = image.Metadata.GetFormatMetadata(GifFormat.Instance);
+                GifFrameMetadata frameMetaData = image.Frames.RootFrame.Metadata.GetFormatMetadata(GifFormat.Instance);
                 GifColorTableMode colorMode = metaData.ColorTableMode;
                 var encoder = new GifEncoder()
                 {
@@ -196,7 +196,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 outStream.Position = 0;
                 var clone = Image.Load(outStream);
 
-                GifMetaData cloneMetaData = clone.MetaData.GetFormatMetaData<GifMetaData>(GifFormat.Instance);
+                GifMetadata cloneMetaData = clone.Metadata.GetFormatMetadata<GifMetadata>(GifFormat.Instance);
                 Assert.Equal(metaData.ColorTableMode, cloneMetaData.ColorTableMode);
 
                 // Gifiddle and Cyotek GifInfo say this image has 64 colors.
@@ -204,8 +204,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
 
                 for (int i = 0; i < image.Frames.Count; i++)
                 {
-                    GifFrameMetaData ifm = image.Frames[i].MetaData.GetFormatMetaData(GifFormat.Instance);
-                    GifFrameMetaData cifm = clone.Frames[i].MetaData.GetFormatMetaData(GifFormat.Instance);
+                    GifFrameMetadata ifm = image.Frames[i].Metadata.GetFormatMetadata(GifFormat.Instance);
+                    GifFrameMetadata cifm = clone.Frames[i].Metadata.GetFormatMetadata(GifFormat.Instance);
 
                     Assert.Equal(ifm.ColorTableLength, cifm.ColorTableLength);
                     Assert.Equal(ifm.FrameDelay, cifm.FrameDelay);

--- a/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetaDataTests.cs
@@ -11,14 +11,14 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [Fact]
         public void CloneIsDeep()
         {
-            var meta = new GifFrameMetaData()
+            var meta = new GifFrameMetadata()
             {
                 FrameDelay = 1,
                 DisposalMethod = GifDisposalMethod.RestoreToBackground,
                 ColorTableLength = 2
             };
 
-            var clone = (GifFrameMetaData)meta.DeepClone();
+            var clone = (GifFrameMetadata)meta.DeepClone();
 
             clone.FrameDelay = 2;
             clone.DisposalMethod = GifDisposalMethod.RestoreToPrevious;

--- a/tests/ImageSharp.Tests/Formats/Gif/GifMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifMetaDataTests.cs
@@ -11,14 +11,14 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [Fact]
         public void CloneIsDeep()
         {
-            var meta = new GifMetaData()
+            var meta = new GifMetadata()
             {
                 RepeatCount = 1,
                 ColorTableMode = GifColorTableMode.Global,
                 GlobalColorTableLength = 2
             };
 
-            var clone = (GifMetaData)meta.DeepClone();
+            var clone = (GifMetadata)meta.DeepClone();
 
             clone.RepeatCount = 2;
             clone.ColorTableMode = GifColorTableMode.Local;

--- a/tests/ImageSharp.Tests/Formats/Jpg/JFifMarkerTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JFifMarkerTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.MetaData.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.MetaData.cs
@@ -3,8 +3,8 @@
 
 using System.IO;
 using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
     using System.Runtime.CompilerServices;
 
     using SixLabors.ImageSharp.Formats.Jpeg;
-    using SixLabors.ImageSharp.MetaData;
+    using SixLabors.ImageSharp.Metadata;
 
     public partial class JpegDecoderTests
     {
@@ -85,7 +85,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 var decoder = new JpegDecoder();
                 using (Image<Rgba32> image = decoder.Decode<Rgba32>(Configuration.Default, stream))
                 {
-                    ImageMetaData meta = image.MetaData;
+                    ImageMetadata meta = image.Metadata;
                     Assert.Equal(xResolution, meta.HorizontalResolution);
                     Assert.Equal(yResolution, meta.VerticalResolution);
                     Assert.Equal(resolutionUnit, meta.ResolutionUnits);
@@ -102,7 +102,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             {
                 var decoder = new JpegDecoder();
                 IImageInfo image = decoder.Identify(Configuration.Default, stream);
-                ImageMetaData meta = image.MetaData;
+                ImageMetadata meta = image.Metadata;
                 Assert.Equal(xResolution, meta.HorizontalResolution);
                 Assert.Equal(yResolution, meta.VerticalResolution);
                 Assert.Equal(resolutionUnit, meta.ResolutionUnits);
@@ -118,7 +118,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             {
                 var decoder = new JpegDecoder();
                 IImageInfo image = decoder.Identify(Configuration.Default, stream);
-                JpegMetaData meta = image.MetaData.GetFormatMetaData(JpegFormat.Instance);
+                JpegMetadata meta = image.Metadata.GetFormatMetadata(JpegFormat.Instance);
                 Assert.Equal(quality, meta.Quality);
             }
         }
@@ -133,7 +133,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 var decoder = new JpegDecoder();
                 using (Image<Rgba32> image = decoder.Decode<Rgba32>(Configuration.Default, stream))
                 {
-                    JpegMetaData meta = image.MetaData.GetFormatMetaData(JpegFormat.Instance);
+                    JpegMetadata meta = image.Metadata.GetFormatMetadata(JpegFormat.Instance);
                     Assert.Equal(quality, meta.Quality);
                 }
             }
@@ -180,7 +180,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                             Assert.Equal(bpp32, imageInfo.PixelType.BitsPerPixel);
                         }
 
-                        ExifProfile exifProfile = imageInfo.MetaData.ExifProfile;
+                        ExifProfile exifProfile = imageInfo.Metadata.ExifProfile;
 
                         if (exifProfilePresent)
                         {
@@ -192,7 +192,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                             Assert.Null(exifProfile);
                         }
 
-                        IccProfile iccProfile = imageInfo.MetaData.IccProfile;
+                        IccProfile iccProfile = imageInfo.Metadata.IccProfile;
 
                         if (iccProfilePresent)
                         {
@@ -220,13 +220,13 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             {
                 if (ignoreMetaData)
                 {
-                    Assert.Null(image.MetaData.ExifProfile);
-                    Assert.Null(image.MetaData.IccProfile);
+                    Assert.Null(image.Metadata.ExifProfile);
+                    Assert.Null(image.Metadata.IccProfile);
                 }
                 else
                 {
-                    Assert.NotNull(image.MetaData.ExifProfile);
-                    Assert.NotNull(image.MetaData.IccProfile);
+                    Assert.NotNull(image.Metadata.ExifProfile);
+                    Assert.NotNull(image.Metadata.IccProfile);
                 }
             }
         }
@@ -239,8 +239,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             TestImageInfo(TestImages.Jpeg.Baseline.Floorplan, JpegDecoder, useIdentify,
                 imageInfo =>
                     {
-                        Assert.Equal(300, imageInfo.MetaData.HorizontalResolution);
-                        Assert.Equal(300, imageInfo.MetaData.VerticalResolution);
+                        Assert.Equal(300, imageInfo.Metadata.HorizontalResolution);
+                        Assert.Equal(300, imageInfo.Metadata.VerticalResolution);
                     });
         }
 
@@ -252,8 +252,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             TestImageInfo(TestImages.Jpeg.Baseline.Jpeg420Exif, JpegDecoder, useIdentify,
                 imageInfo =>
                     {
-                        Assert.Equal(72, imageInfo.MetaData.HorizontalResolution);
-                        Assert.Equal(72, imageInfo.MetaData.VerticalResolution);
+                        Assert.Equal(72, imageInfo.Metadata.HorizontalResolution);
+                        Assert.Equal(72, imageInfo.Metadata.VerticalResolution);
                     });
         }
     }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
@@ -3,7 +3,7 @@
 
 using System.IO;
 using SixLabors.ImageSharp.Formats.Jpeg;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        JpegMetaData meta = output.MetaData.GetFormatMetaData(JpegFormat.Instance);
+                        JpegMetadata meta = output.Metadata.GetFormatMetadata(JpegFormat.Instance);
                         Assert.Equal(quality, meta.Quality);
                     }
                 }
@@ -189,7 +189,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        ImageMetaData meta = output.MetaData;
+                        ImageMetadata meta = output.Metadata;
                         Assert.Equal(xResolution, meta.HorizontalResolution);
                         Assert.Equal(yResolution, meta.VerticalResolution);
                         Assert.Equal(resolutionUnit, meta.ResolutionUnits);

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegMetaDataTests.cs
@@ -11,8 +11,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Fact]
         public void CloneIsDeep()
         {
-            var meta = new JpegMetaData() { Quality = 50 };
-            var clone = (JpegMetaData)meta.DeepClone();
+            var meta = new JpegMetadata() { Quality = 50 };
+            var clone = (JpegMetadata)meta.DeepClone();
 
             clone.Quality = 99;
 

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Text;
 
 using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 
@@ -204,9 +204,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             using (Image<Rgba32> image = testFile.CreateImage(options))
             {
-                Assert.Equal(1, image.MetaData.Properties.Count);
-                Assert.Equal("Software", image.MetaData.Properties[0].Name);
-                Assert.Equal("paint.net 4.0.6", image.MetaData.Properties[0].Value);
+                Assert.Equal(1, image.Metadata.Properties.Count);
+                Assert.Equal("Software", image.Metadata.Properties[0].Name);
+                Assert.Equal("paint.net 4.0.6", image.Metadata.Properties[0].Value);
             }
         }
 
@@ -222,7 +222,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             using (Image<Rgba32> image = testFile.CreateImage(options))
             {
-                Assert.Equal(0, image.MetaData.Properties.Count);
+                Assert.Equal(0, image.Metadata.Properties.Count);
             }
         }
 
@@ -238,8 +238,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             using (Image<Rgba32> image = testFile.CreateImage(options))
             {
-                Assert.Equal(1, image.MetaData.Properties.Count);
-                Assert.Equal("潓瑦慷敲", image.MetaData.Properties[0].Name);
+                Assert.Equal(1, image.Metadata.Properties.Count);
+                Assert.Equal("潓瑦慷敲", image.Metadata.Properties[0].Name);
             }
         }
 
@@ -270,7 +270,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 var decoder = new PngDecoder();
                 using (Image<Rgba32> image = decoder.Decode<Rgba32>(Configuration.Default, stream))
                 {
-                    ImageMetaData meta = image.MetaData;
+                    ImageMetadata meta = image.Metadata;
                     Assert.Equal(xResolution, meta.HorizontalResolution);
                     Assert.Equal(yResolution, meta.VerticalResolution);
                     Assert.Equal(resolutionUnit, meta.ResolutionUnits);
@@ -287,7 +287,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             {
                 var decoder = new PngDecoder();
                 IImageInfo image = decoder.Identify(Configuration.Default, stream);
-                ImageMetaData meta = image.MetaData;
+                ImageMetadata meta = image.Metadata;
                 Assert.Equal(xResolution, meta.HorizontalResolution);
                 Assert.Equal(yResolution, meta.VerticalResolution);
                 Assert.Equal(resolutionUnit, meta.ResolutionUnits);

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
@@ -228,7 +228,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        ImageMetaData meta = output.MetaData;
+                        ImageMetadata meta = output.Metadata;
                         Assert.Equal(xResolution, meta.HorizontalResolution);
                         Assert.Equal(yResolution, meta.VerticalResolution);
                         Assert.Equal(resolutionUnit, meta.ResolutionUnits);
@@ -253,7 +253,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        PngMetaData meta = output.MetaData.GetFormatMetaData(PngFormat.Instance);
+                        PngMetadata meta = output.Metadata.GetFormatMetadata(PngFormat.Instance);
 
                         Assert.Equal(pngBitDepth, meta.BitDepth);
                     }
@@ -270,7 +270,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             var testFile = TestFile.Create(imagePath);
             using (Image<Rgba32> input = testFile.CreateImage())
             {
-                PngMetaData inMeta = input.MetaData.GetFormatMetaData(PngFormat.Instance);
+                PngMetadata inMeta = input.Metadata.GetFormatMetadata(PngFormat.Instance);
                 Assert.True(inMeta.HasTrans);
 
                 using (var memStream = new MemoryStream())
@@ -279,7 +279,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                     memStream.Position = 0;
                     using (var output = Image.Load<Rgba32>(memStream))
                     {
-                        PngMetaData outMeta = output.MetaData.GetFormatMetaData(PngFormat.Instance);
+                        PngMetadata outMeta = output.Metadata.GetFormatMetadata(PngFormat.Instance);
                         Assert.True(outMeta.HasTrans);
 
                         switch (pngColorType)

--- a/tests/ImageSharp.Tests/Formats/Png/PngMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngMetaDataTests.cs
@@ -11,13 +11,13 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Fact]
         public void CloneIsDeep()
         {
-            var meta = new PngMetaData()
+            var meta = new PngMetadata()
             {
                 BitDepth = PngBitDepth.Bit16,
                 ColorType = PngColorType.GrayscaleWithAlpha,
                 Gamma = 2
             };
-            var clone = (PngMetaData)meta.DeepClone();
+            var clone = (PngMetadata)meta.DeepClone();
 
             clone.BitDepth = PngBitDepth.Bit2;
             clone.ColorType = PngColorType.Palette;

--- a/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Common.Helpers;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Shapes;
 using SixLabors.ImageSharp.Processing;
@@ -85,7 +85,7 @@ namespace SixLabors.ImageSharp.Tests
             public void WrapMemory_CreatedImageIsCorrect()
             {
                 Configuration cfg = Configuration.Default.Clone();
-                var metaData = new ImageMetaData();
+                var metaData = new ImageMetadata();
 
                 var array = new Rgba32[25];
                 var memory = new Memory<Rgba32>(array);
@@ -96,7 +96,7 @@ namespace SixLabors.ImageSharp.Tests
                     Assert.True(Unsafe.AreSame(ref array[0], ref pixel0));
 
                     Assert.Equal(cfg, image.GetConfiguration());
-                    Assert.Equal(metaData, image.MetaData);
+                    Assert.Equal(metaData, image.Metadata);
                 }
             }
 

--- a/tests/ImageSharp.Tests/Image/ImageTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Advanced;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests.Memory;
 
@@ -72,14 +72,14 @@ namespace SixLabors.ImageSharp.Tests
 
                 byte dirtyValue = 123;
                 configuration.MemoryAllocator = new TestMemoryAllocator(dirtyValue);
-                var metadata = new ImageMetaData();
+                var metadata = new ImageMetadata();
 
                 using (Image<Gray8> image = Image.CreateUninitialized<Gray8>(configuration, 21, 22, metadata))
                 {
                     Assert.Equal(21, image.Width);
                     Assert.Equal(22, image.Height);
                     Assert.Same(configuration, image.GetConfiguration());
-                    Assert.Same(metadata, image.MetaData);
+                    Assert.Same(metadata, image.Metadata);
 
                     Assert.Equal(dirtyValue, image[5, 5].PackedValue);
                 }

--- a/tests/ImageSharp.Tests/ImageInfoTests.cs
+++ b/tests/ImageSharp.Tests/ImageInfoTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.Primitives;
 
 using Xunit;
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Tests
             var size = new Size(Width, Height);
             var rectangle = new Rectangle(0, 0, Width, Height);
             var pixelType = new PixelTypeInfo(8);
-            var meta = new ImageMetaData();
+            var meta = new ImageMetadata();
 
             var info = new ImageInfo(pixelType, Width, Height, meta);
 
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Tests
             Assert.Equal(Height, info.Height);
             Assert.Equal(size, info.Size());
             Assert.Equal(rectangle, info.Bounds());
-            Assert.Equal(meta, info.MetaData);
+            Assert.Equal(meta, info.Metadata);
         }
     }
 }

--- a/tests/ImageSharp.Tests/MetaData/ImageFrameMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImageFrameMetaDataTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats.Gif;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests
@@ -19,14 +19,14 @@ namespace SixLabors.ImageSharp.Tests
             const int colorTableLength = 128;
             const GifDisposalMethod disposalMethod = GifDisposalMethod.RestoreToBackground;
 
-            var metaData = new ImageFrameMetaData();
-            GifFrameMetaData gifFrameMetaData = metaData.GetFormatMetaData(GifFormat.Instance);
+            var metaData = new ImageFrameMetadata();
+            GifFrameMetadata gifFrameMetaData = metaData.GetFormatMetadata(GifFormat.Instance);
             gifFrameMetaData.FrameDelay = frameDelay;
             gifFrameMetaData.ColorTableLength = colorTableLength;
             gifFrameMetaData.DisposalMethod = disposalMethod;
 
-            var clone = new ImageFrameMetaData(metaData);
-            GifFrameMetaData cloneGifFrameMetaData = clone.GetFormatMetaData(GifFormat.Instance);
+            var clone = new ImageFrameMetadata(metaData);
+            GifFrameMetadata cloneGifFrameMetaData = clone.GetFormatMetadata(GifFormat.Instance);
 
             Assert.Equal(frameDelay, cloneGifFrameMetaData.FrameDelay);
             Assert.Equal(colorTableLength, cloneGifFrameMetaData.ColorTableLength);
@@ -36,9 +36,9 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void CloneIsDeep()
         {
-            var metaData = new ImageFrameMetaData();
-            ImageFrameMetaData clone = metaData.DeepClone();
-            Assert.False(metaData.GetFormatMetaData(GifFormat.Instance).Equals(clone.GetFormatMetaData(GifFormat.Instance)));
+            var metaData = new ImageFrameMetadata();
+            ImageFrameMetadata clone = metaData.DeepClone();
+            Assert.False(metaData.GetFormatMetadata(GifFormat.Instance).Equals(clone.GetFormatMetadata(GifFormat.Instance)));
         }
     }
 }

--- a/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImageMetaDataTests.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats.Gif;
-using SixLabors.ImageSharp.MetaData;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Primitives;
 
@@ -12,14 +12,14 @@ using Xunit;
 namespace SixLabors.ImageSharp.Tests
 {
     /// <summary>
-    /// Tests the <see cref="ImageMetaData"/> class.
+    /// Tests the <see cref="ImageMetadata"/> class.
     /// </summary>
     public class ImageMetaDataTests
     {
         [Fact]
         public void ConstructorImageMetaData()
         {
-            var metaData = new ImageMetaData();
+            var metaData = new ImageMetadata();
 
             var exifProfile = new ExifProfile();
             var imageProperty = new ImageProperty("name", "value");
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Tests
             metaData.VerticalResolution = 2;
             metaData.Properties.Add(imageProperty);
 
-            ImageMetaData clone = metaData.DeepClone();
+            ImageMetadata clone = metaData.DeepClone();
 
             Assert.Equal(exifProfile.ToByteArray(), clone.ExifProfile.ToByteArray());
             Assert.Equal(4, clone.HorizontalResolution);
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void CloneIsDeep()
         {
-            var metaData = new ImageMetaData();
+            var metaData = new ImageMetadata();
 
             var exifProfile = new ExifProfile();
             var imageProperty = new ImageProperty("name", "value");
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Tests
             metaData.VerticalResolution = 2;
             metaData.Properties.Add(imageProperty);
 
-            ImageMetaData clone = metaData.DeepClone();
+            ImageMetadata clone = metaData.DeepClone();
             clone.HorizontalResolution = 2;
             clone.VerticalResolution = 4;
 
@@ -58,13 +58,13 @@ namespace SixLabors.ImageSharp.Tests
             Assert.False(metaData.HorizontalResolution.Equals(clone.HorizontalResolution));
             Assert.False(metaData.VerticalResolution.Equals(clone.VerticalResolution));
             Assert.False(metaData.Properties.Equals(clone.Properties));
-            Assert.False(metaData.GetFormatMetaData(GifFormat.Instance).Equals(clone.GetFormatMetaData(GifFormat.Instance)));
+            Assert.False(metaData.GetFormatMetadata(GifFormat.Instance).Equals(clone.GetFormatMetadata(GifFormat.Instance)));
         }
 
         [Fact]
         public void HorizontalResolution()
         {
-            var metaData = new ImageMetaData();
+            var metaData = new ImageMetadata();
             Assert.Equal(96, metaData.HorizontalResolution);
 
             metaData.HorizontalResolution = 0;
@@ -80,7 +80,7 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void VerticalResolution()
         {
-            var metaData = new ImageMetaData();
+            var metaData = new ImageMetadata();
             Assert.Equal(96, metaData.VerticalResolution);
 
             metaData.VerticalResolution = 0;
@@ -101,14 +101,14 @@ namespace SixLabors.ImageSharp.Tests
             exifProfile.SetValue(ExifTag.YResolution, new Rational(300));
 
             var image = new Image<Rgba32>(1, 1);
-            image.MetaData.ExifProfile = exifProfile;
-            image.MetaData.HorizontalResolution = 400;
-            image.MetaData.VerticalResolution = 500;
+            image.Metadata.ExifProfile = exifProfile;
+            image.Metadata.HorizontalResolution = 400;
+            image.Metadata.VerticalResolution = 500;
 
-            image.MetaData.SyncProfiles();
+            image.Metadata.SyncProfiles();
 
-            Assert.Equal(400, ((Rational)image.MetaData.ExifProfile.GetValue(ExifTag.XResolution).Value).ToDouble());
-            Assert.Equal(500, ((Rational)image.MetaData.ExifProfile.GetValue(ExifTag.YResolution).Value).ToDouble());
+            Assert.Equal(400, ((Rational)image.Metadata.ExifProfile.GetValue(ExifTag.XResolution).Value).ToDouble());
+            Assert.Equal(500, ((Rational)image.Metadata.ExifProfile.GetValue(ExifTag.YResolution).Value).ToDouble());
         }
     }
 }

--- a/tests/ImageSharp.Tests/MetaData/ImagePropertyTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/ImagePropertyTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests

--- a/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
@@ -8,8 +8,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
-using SixLabors.ImageSharp.MetaData;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Primitives;
 
@@ -43,17 +43,17 @@ namespace SixLabors.ImageSharp.Tests
         {
             Image<Rgba32> image = TestFile.Create(TestImages.Jpeg.Baseline.Calliphora).CreateImage();
 
-            Assert.Null(image.MetaData.ExifProfile);
+            Assert.Null(image.Metadata.ExifProfile);
 
-            image.MetaData.ExifProfile = new ExifProfile();
-            image.MetaData.ExifProfile.SetValue(ExifTag.Copyright, "Dirk Lemstra");
+            image.Metadata.ExifProfile = new ExifProfile();
+            image.Metadata.ExifProfile.SetValue(ExifTag.Copyright, "Dirk Lemstra");
 
             image = WriteAndRead(image, imageFormat);
 
-            Assert.NotNull(image.MetaData.ExifProfile);
-            Assert.Equal(1, image.MetaData.ExifProfile.Values.Count());
+            Assert.NotNull(image.Metadata.ExifProfile);
+            Assert.Equal(1, image.Metadata.ExifProfile.Values.Count());
 
-            ExifValue value = image.MetaData.ExifProfile.Values.FirstOrDefault(val => val.Tag == ExifTag.Copyright);
+            ExifValue value = image.Metadata.ExifProfile.Values.FirstOrDefault(val => val.Tag == ExifTag.Copyright);
             TestValue(value, "Dirk Lemstra");
         }
 
@@ -94,11 +94,11 @@ namespace SixLabors.ImageSharp.Tests
                 profile.SetValue(ExifTag.ExposureTime, new Rational(exposureTime));
 
                 var image = new Image<Rgba32>(1, 1);
-                image.MetaData.ExifProfile = profile;
+                image.Metadata.ExifProfile = profile;
 
                 image = WriteAndRead(image, imageFormat);
 
-                profile = image.MetaData.ExifProfile;
+                profile = image.Metadata.ExifProfile;
                 Assert.NotNull(profile);
 
                 ExifValue value = profile.GetValue(ExifTag.ExposureTime);
@@ -109,11 +109,11 @@ namespace SixLabors.ImageSharp.Tests
                 profile = GetExifProfile();
 
                 profile.SetValue(ExifTag.ExposureTime, new Rational(exposureTime, true));
-                image.MetaData.ExifProfile = profile;
+                image.Metadata.ExifProfile = profile;
 
                 image = WriteAndRead(image, imageFormat);
 
-                profile = image.MetaData.ExifProfile;
+                profile = image.Metadata.ExifProfile;
                 Assert.NotNull(profile);
 
                 value = profile.GetValue(ExifTag.ExposureTime);
@@ -127,24 +127,24 @@ namespace SixLabors.ImageSharp.Tests
         public void ReadWriteInfinity(TestImageWriteFormat imageFormat)
         {
             Image<Rgba32> image = TestFile.Create(TestImages.Jpeg.Baseline.Floorplan).CreateImage();
-            image.MetaData.ExifProfile.SetValue(ExifTag.ExposureBiasValue, new SignedRational(double.PositiveInfinity));
+            image.Metadata.ExifProfile.SetValue(ExifTag.ExposureBiasValue, new SignedRational(double.PositiveInfinity));
 
             image = WriteAndReadJpeg(image);
-            ExifValue value = image.MetaData.ExifProfile.GetValue(ExifTag.ExposureBiasValue);
+            ExifValue value = image.Metadata.ExifProfile.GetValue(ExifTag.ExposureBiasValue);
             Assert.NotNull(value);
             Assert.Equal(new SignedRational(double.PositiveInfinity), value.Value);
 
-            image.MetaData.ExifProfile.SetValue(ExifTag.ExposureBiasValue, new SignedRational(double.NegativeInfinity));
+            image.Metadata.ExifProfile.SetValue(ExifTag.ExposureBiasValue, new SignedRational(double.NegativeInfinity));
 
             image = WriteAndRead(image, imageFormat);
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.ExposureBiasValue);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.ExposureBiasValue);
             Assert.NotNull(value);
             Assert.Equal(new SignedRational(double.NegativeInfinity), value.Value);
 
-            image.MetaData.ExifProfile.SetValue(ExifTag.FlashEnergy, new Rational(double.NegativeInfinity));
+            image.Metadata.ExifProfile.SetValue(ExifTag.FlashEnergy, new Rational(double.NegativeInfinity));
 
             image = WriteAndRead(image, imageFormat);
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.FlashEnergy);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.FlashEnergy);
             Assert.NotNull(value);
             Assert.Equal(new Rational(double.PositiveInfinity), value.Value);
         }
@@ -157,74 +157,74 @@ namespace SixLabors.ImageSharp.Tests
             var latitude = new Rational[] { new Rational(12.3), new Rational(4.56), new Rational(789.0) };
 
             Image<Rgba32> image = TestFile.Create(TestImages.Jpeg.Baseline.Floorplan).CreateImage();
-            image.MetaData.ExifProfile.SetValue(ExifTag.Software, "ImageSharp");
+            image.Metadata.ExifProfile.SetValue(ExifTag.Software, "ImageSharp");
 
-            ExifValue value = image.MetaData.ExifProfile.GetValue(ExifTag.Software);
+            ExifValue value = image.Metadata.ExifProfile.GetValue(ExifTag.Software);
             TestValue(value, "ImageSharp");
 
             Assert.Throws<ArgumentException>(() => { value.WithValue(15); });
 
-            image.MetaData.ExifProfile.SetValue(ExifTag.ShutterSpeedValue, new SignedRational(75.55));
+            image.Metadata.ExifProfile.SetValue(ExifTag.ShutterSpeedValue, new SignedRational(75.55));
 
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.ShutterSpeedValue);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.ShutterSpeedValue);
 
             TestValue(value, new SignedRational(7555, 100));
 
             Assert.Throws<ArgumentException>(() => { value.WithValue(75); });
 
-            image.MetaData.ExifProfile.SetValue(ExifTag.XResolution, new Rational(150.0));
+            image.Metadata.ExifProfile.SetValue(ExifTag.XResolution, new Rational(150.0));
 
             // We also need to change this value because this overrides XResolution when the image is written.
-            image.MetaData.HorizontalResolution = 150.0;
+            image.Metadata.HorizontalResolution = 150.0;
 
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.XResolution);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.XResolution);
             TestValue(value, new Rational(150, 1));
 
             Assert.Throws<ArgumentException>(() => { value.WithValue("ImageSharp"); });
 
-            image.MetaData.ExifProfile.SetValue(ExifTag.ReferenceBlackWhite, null);
+            image.Metadata.ExifProfile.SetValue(ExifTag.ReferenceBlackWhite, null);
 
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.ReferenceBlackWhite);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.ReferenceBlackWhite);
             TestValue(value, (string)null);
 
-            image.MetaData.ExifProfile.SetValue(ExifTag.GPSLatitude, latitude);
+            image.Metadata.ExifProfile.SetValue(ExifTag.GPSLatitude, latitude);
 
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.GPSLatitude);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.GPSLatitude);
             TestValue(value, latitude);
 
             image = WriteAndRead(image, imageFormat);
 
-            Assert.NotNull(image.MetaData.ExifProfile);
-            Assert.Equal(17, image.MetaData.ExifProfile.Values.Count());
+            Assert.NotNull(image.Metadata.ExifProfile);
+            Assert.Equal(17, image.Metadata.ExifProfile.Values.Count());
 
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.Software);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.Software);
             TestValue(value, "ImageSharp");
 
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.ShutterSpeedValue);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.ShutterSpeedValue);
             TestValue(value, new SignedRational(75.55));
 
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.XResolution);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.XResolution);
             TestValue(value, new Rational(150.0));
 
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.ReferenceBlackWhite);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.ReferenceBlackWhite);
             Assert.Null(value);
 
-            value = image.MetaData.ExifProfile.GetValue(ExifTag.GPSLatitude);
+            value = image.Metadata.ExifProfile.GetValue(ExifTag.GPSLatitude);
             TestValue(value, latitude);
 
-            image.MetaData.ExifProfile.Parts = ExifParts.ExifTags;
+            image.Metadata.ExifProfile.Parts = ExifParts.ExifTags;
 
             image = WriteAndRead(image, imageFormat);
 
-            Assert.NotNull(image.MetaData.ExifProfile);
-            Assert.Equal(8, image.MetaData.ExifProfile.Values.Count());
+            Assert.NotNull(image.Metadata.ExifProfile);
+            Assert.Equal(8, image.Metadata.ExifProfile.Values.Count());
 
-            Assert.NotNull(image.MetaData.ExifProfile.GetValue(ExifTag.ColorSpace));
-            Assert.True(image.MetaData.ExifProfile.RemoveValue(ExifTag.ColorSpace));
-            Assert.False(image.MetaData.ExifProfile.RemoveValue(ExifTag.ColorSpace));
-            Assert.Null(image.MetaData.ExifProfile.GetValue(ExifTag.ColorSpace));
+            Assert.NotNull(image.Metadata.ExifProfile.GetValue(ExifTag.ColorSpace));
+            Assert.True(image.Metadata.ExifProfile.RemoveValue(ExifTag.ColorSpace));
+            Assert.False(image.Metadata.ExifProfile.RemoveValue(ExifTag.ColorSpace));
+            Assert.Null(image.Metadata.ExifProfile.GetValue(ExifTag.ColorSpace));
 
-            Assert.Equal(7, image.MetaData.ExifProfile.Values.Count());
+            Assert.Equal(7, image.Metadata.ExifProfile.Values.Count());
         }
 
         [Fact]
@@ -234,7 +234,7 @@ namespace SixLabors.ImageSharp.Tests
             exifProfile.SetValue(ExifTag.XResolution, new Rational(200));
             exifProfile.SetValue(ExifTag.YResolution, new Rational(300));
 
-            var metaData = new ImageMetaData
+            var metaData = new ImageMetadata
             {
                 ExifProfile = exifProfile,
                 HorizontalResolution = 200,
@@ -292,13 +292,13 @@ namespace SixLabors.ImageSharp.Tests
             ExifProfile expectedProfile = CreateExifProfile();
             var expectedProfileTags = expectedProfile.Values.Select(x => x.Tag).ToList();
             expectedProfile.SetValue(exifValueToChange, junk.ToString());
-            image.MetaData.ExifProfile = expectedProfile;
+            image.Metadata.ExifProfile = expectedProfile;
 
             // act
             Image<Rgba32> reloadedImage = WriteAndRead(image, TestImageWriteFormat.Jpeg);
 
             // assert
-            ExifProfile actualProfile = reloadedImage.MetaData.ExifProfile;
+            ExifProfile actualProfile = reloadedImage.Metadata.ExifProfile;
             Assert.NotNull(actualProfile);
             foreach (ExifTag expectedProfileTag in expectedProfileTags)
             {
@@ -317,7 +317,7 @@ namespace SixLabors.ImageSharp.Tests
             Image<Rgba32> image = TestFile.Create(TestImages.Jpeg.Progressive.Bad.ExifUndefType).CreateImage();
             Assert.NotNull(image);
 
-            ExifProfile profile = image.MetaData.ExifProfile;
+            ExifProfile profile = image.Metadata.ExifProfile;
             Assert.NotNull(profile);
 
             foreach (ExifValue value in profile.Values)
@@ -335,7 +335,7 @@ namespace SixLabors.ImageSharp.Tests
             // This images contains array in the exif profile that has zero components.
             Image<Rgba32> image = TestFile.Create(TestImages.Jpeg.Issues.InvalidCast520).CreateImage();
 
-            ExifProfile profile = image.MetaData.ExifProfile;
+            ExifProfile profile = image.Metadata.ExifProfile;
             Assert.NotNull(profile);
 
             // Force parsing of the profile.
@@ -353,13 +353,13 @@ namespace SixLabors.ImageSharp.Tests
             // arrange
             var image = new Image<Rgba32>(1, 1);
             ExifProfile expected = CreateExifProfile();
-            image.MetaData.ExifProfile = expected;
+            image.Metadata.ExifProfile = expected;
 
             // act
             Image<Rgba32> reloadedImage = WriteAndRead(image, imageFormat);
 
             // assert
-            ExifProfile actual = reloadedImage.MetaData.ExifProfile;
+            ExifProfile actual = reloadedImage.Metadata.ExifProfile;
             Assert.NotNull(actual);
             foreach (KeyValuePair<ExifTag, object> expectedProfileValue in TestProfileValues)
             {
@@ -410,7 +410,7 @@ namespace SixLabors.ImageSharp.Tests
         {
             Image<Rgba32> image = TestFile.Create(TestImages.Jpeg.Baseline.Floorplan).CreateImage();
 
-            ExifProfile profile = image.MetaData.ExifProfile;
+            ExifProfile profile = image.Metadata.ExifProfile;
             Assert.NotNull(profile);
 
             return profile;

--- a/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifReaderTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifReaderTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests

--- a/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifTagDescriptionAttributeTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifTagDescriptionAttributeTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests

--- a/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifValueTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifValueTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Linq;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests
             ExifProfile profile;
             using (Image<Rgba32> image = TestFile.Create(TestImages.Jpeg.Baseline.Floorplan).CreateImage())
             {
-                profile = image.MetaData.ExifProfile;
+                profile = image.Metadata.ExifProfile;
             }
 
             Assert.NotNull(profile);

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.CurvesTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.CurvesTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.LutTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.LutTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.MatrixTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.MatrixTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.MultiProcessElementTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.MultiProcessElementTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.NonPrimitivesTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.NonPrimitivesTests.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Numerics;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.PrimitivesTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.PrimitivesTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.TagDataEntryTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReader.TagDataEntryTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReaderTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataReader/IccDataReaderTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.CurvesTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.CurvesTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.LutTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.LutTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.MatrixTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.MatrixTests.cs
@@ -3,7 +3,7 @@
 
 using System.Numerics;
 using SixLabors.Memory;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.MultiProcessElementTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.MultiProcessElementTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.NonPrimitivesTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.NonPrimitivesTests.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Numerics;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.PrimitivesTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.PrimitivesTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.TagDataEntryTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriter.TagDataEntryTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriterTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/DataWriter/IccDataWriterTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccProfileTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccProfileTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccReaderTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccReaderTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccWriterTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/IccWriterTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/MetaData/Profiles/ICC/Various/IccProfileIdTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/ICC/Various/IccProfileIdTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Icc

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/AutoOrientTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/AutoOrientTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
@@ -45,8 +45,8 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         {
             using (Image<TPixel> image = provider.GetImage())
             {
-                image.MetaData.ExifProfile = new ExifProfile();
-                image.MetaData.ExifProfile.SetValue(ExifTag.Orientation, orientation);
+                image.Metadata.ExifProfile = new ExifProfile();
+                image.Metadata.ExifProfile.SetValue(ExifTag.Orientation, orientation);
 
                 image.Mutate(x => x.RotateFlip(rotateType, flipType));
                 image.DebugSave(provider, string.Join("_", rotateType, flipType, orientation, "1_before"));
@@ -75,7 +75,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
 
             using (Image<TPixel> image = provider.GetImage())
             {
-                image.MetaData.ExifProfile = new ExifProfile(bytes);
+                image.Metadata.ExifProfile = new ExifProfile(bytes);
                 image.Mutate(x => x.AutoOrient());
             }
         }

--- a/tests/ImageSharp.Tests/Processing/Transforms/TransformsHelpersTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/TransformsHelpersTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
 using Xunit;
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
             using (var img = new Image<Alpha8>(xy, xy))
             {
                 var profile = new ExifProfile();
-                img.MetaData.ExifProfile = profile;
+                img.Metadata.ExifProfile = profile;
                 profile.SetValue(ExifTag.PixelXDimension, (uint)xy);
                 profile.SetValue(ExifTag.PixelYDimension, (uint)xy);
 

--- a/tests/ImageSharp.Tests/TestDataIcc/IccTestDataCurves.cs
+++ b/tests/ImageSharp.Tests/TestDataIcc/IccTestDataCurves.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 
 namespace SixLabors.ImageSharp.Tests
 {

--- a/tests/ImageSharp.Tests/TestDataIcc/IccTestDataLut.cs
+++ b/tests/ImageSharp.Tests/TestDataIcc/IccTestDataLut.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 
 namespace SixLabors.ImageSharp.Tests
 {

--- a/tests/ImageSharp.Tests/TestDataIcc/IccTestDataMultiProcessElements.cs
+++ b/tests/ImageSharp.Tests/TestDataIcc/IccTestDataMultiProcessElements.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 
 namespace SixLabors.ImageSharp.Tests
 {

--- a/tests/ImageSharp.Tests/TestDataIcc/IccTestDataNonPrimitives.cs
+++ b/tests/ImageSharp.Tests/TestDataIcc/IccTestDataNonPrimitives.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Globalization;
 using System.Numerics;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 
 namespace SixLabors.ImageSharp.Tests
 {

--- a/tests/ImageSharp.Tests/TestDataIcc/IccTestDataProfiles.cs
+++ b/tests/ImageSharp.Tests/TestDataIcc/IccTestDataProfiles.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Numerics;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 
 namespace SixLabors.ImageSharp.Tests
 {

--- a/tests/ImageSharp.Tests/TestDataIcc/IccTestDataTagDataEntry.cs
+++ b/tests/ImageSharp.Tests/TestDataIcc/IccTestDataTagDataEntry.cs
@@ -3,7 +3,7 @@
 
 using System.Globalization;
 using System.Numerics;
-using SixLabors.ImageSharp.MetaData.Profiles.Icc;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 
 namespace SixLabors.ImageSharp.Tests
 {

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceDecoder.cs
@@ -4,7 +4,7 @@
 using System.IO;
 
 using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.MetaData;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
@@ -48,7 +48,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
             using (var sourceBitmap = new System.Drawing.Bitmap(stream))
             {
                 var pixelType = new PixelTypeInfo(System.Drawing.Image.GetPixelFormatSize(sourceBitmap.PixelFormat));
-                return new ImageInfo(pixelType, sourceBitmap.Width, sourceBitmap.Height, new ImageMetaData());
+                return new ImageInfo(pixelType, sourceBitmap.Width, sourceBitmap.Height, new ImageMetadata());
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

A longstanding nit. Metadata is one word and should not be space separated or camelCased.

See: 

https://github.com/dotnet/corefx/tree/master/src/System.Reflection.Metadata
https://github.com/dotnet/coreclr/commit/95d37e097086187692c770471d79810482971b34
https://en.wikipedia.org/wiki/Metadata


<!-- Thanks for contributing to ImageSharp! -->
