### PR TITLE
Pass correct output size source image is smaller than the Target in ResizeMode.Min

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeHelper.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeHelper.cs
@@ -296,7 +296,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             // Don't upscale
             if (width > sourceWidth || height > sourceHeight)
             {
-                return (new Size(sourceWidth, sourceWidth), new Rectangle(0, 0, sourceWidth, sourceHeight));
+                return (new Size(sourceWidth, sourceHeight), new Rectangle(0, 0, sourceWidth, sourceHeight));
             }
 
             // Find the shortest distance to go.

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeHelperTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeHelperTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
+using SixLabors.Primitives;
 
 using Xunit;
 
@@ -30,6 +32,25 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         {
             int actualCount = ResizeHelper.CalculateResizeWorkerHeightInWindowBands(windowDiameter, width, sizeLimitHintInBytes);
             Assert.Equal(expectedCount, actualCount);
+        }
+
+        [Fact]
+        public void CalculateMinRectangleWhenSourceIsSmallerThanTarget()
+        {
+            var sourceSize = new Size(200, 100);
+            var target = new Size(400, 200);
+
+            var actual = ResizeHelper.CalculateTargetLocationAndBounds(
+                sourceSize,
+                new ResizeOptions{
+                    Mode = ResizeMode.Min,
+                    Size = target
+                },
+                target.Width,
+                target.Height);
+            
+            Assert.Equal(sourceSize, actual.Item1);
+            Assert.Equal(new Rectangle(0, 0, sourceSize.Width, sourceSize.Height), actual.Item2);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [ ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #892 
When resizing an image that is smaller than the target image using Mode.Min, the resulting image is padded to be square instead of keeping the size of the original image.