### PR TITLE
API proposal: Pixel-agnostic Image base class

### DIFF
--- a/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
+++ b/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
@@ -21,8 +21,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// <typeparam name="TPixel">The Pixel format.</typeparam>
         /// <param name="source">The source image.</param>
         /// <returns>Returns the configuration.</returns>
-        public static Configuration GetConfiguration<TPixel>(this Image<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
+        public static Configuration GetConfiguration(this Image source)
             => GetConfiguration((IConfigurable)source);
 
         /// <summary>

--- a/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
@@ -30,6 +30,8 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             return new BmpDecoderCore(configuration, this).Decode<TPixel>(stream);
         }
 
+        public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
+
         /// <inheritdoc/>
         public IImageInfo Identify(Configuration configuration, Stream stream)
         {

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -44,5 +44,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             var decoder = new GifDecoderCore(configuration, this);
             return decoder.Identify(stream);
         }
+        
+        public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
     }
 }

--- a/src/ImageSharp/Formats/IImageDecoder.cs
+++ b/src/ImageSharp/Formats/IImageDecoder.cs
@@ -20,5 +20,7 @@ namespace SixLabors.ImageSharp.Formats
         /// <returns>The decoded image</returns>
         Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
             where TPixel : struct, IPixel<TPixel>;
+
+        Image Decode(Configuration configuration, Stream stream);
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
@@ -38,5 +38,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 return decoder.Identify(stream);
             }
         }
+        
+        public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
     }
 }

--- a/src/ImageSharp/Formats/PixelTypeInfo.cs
+++ b/src/ImageSharp/Formats/PixelTypeInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Runtime.CompilerServices;
+
 namespace SixLabors.ImageSharp.Formats
 {
     /// <summary>
@@ -21,5 +23,7 @@ namespace SixLabors.ImageSharp.Formats
         /// Gets color depth, in number of bits per pixel.
         /// </summary>
         public int BitsPerPixel { get; }
+        
+        internal static PixelTypeInfo Create<TPixel>() => new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
     }
 }

--- a/src/ImageSharp/Formats/Png/PngDecoder.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoder.cs
@@ -59,5 +59,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             var decoder = new PngDecoderCore(configuration, this);
             return decoder.Identify(stream);
         }
+        
+        public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
     }
 }

--- a/src/ImageSharp/IImage.cs
+++ b/src/ImageSharp/IImage.cs
@@ -4,7 +4,7 @@
 using System;
 
 namespace SixLabors.ImageSharp
-{
+{   
     /// <summary>
     /// Encapsulates the properties and methods that describe an image.
     /// </summary>

--- a/src/ImageSharp/IImage.cs
+++ b/src/ImageSharp/IImage.cs
@@ -4,7 +4,7 @@
 using System;
 
 namespace SixLabors.ImageSharp
-{   
+{
     /// <summary>
     /// Encapsulates the properties and methods that describe an image.
     /// </summary>

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp
     /// <content>
     /// Adds static methods allowing the decoding of new images.
     /// </content>
-    public static partial class Image
+    public abstract partial class Image
     {
         /// <summary>
         /// Creates an <see cref="Image{TPixel}"/> instance backed by an uninitialized memory buffer.

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -102,6 +102,18 @@ namespace SixLabors.ImageSharp
             Image<TPixel> img = decoder.Decode<TPixel>(config, stream);
             return (img, format);
         }
+        
+        private static (Image img, IImageFormat format) Decode(Stream stream, Configuration config)
+        {
+            IImageDecoder decoder = DiscoverDecoder(stream, config, out IImageFormat format);
+            if (decoder is null)
+            {
+                return (null, null);
+            }
+
+            Image img = decoder.Decode(config, stream);
+            return (img, format);
+        }
 
         /// <summary>
         /// Reads the raw image information from the specified stream.

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp
     /// <content>
     /// Adds static methods allowing the creation of new image from a byte array.
     /// </content>
-    public static partial class Image
+    public abstract partial class Image
     {
         /// <summary>
         /// By reading the header on the provided byte array this calculates the images format.

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp
     /// <content>
     /// Adds static methods allowing the creation of new image from a given file.
     /// </content>
-    public static partial class Image
+    public abstract partial class Image
     {
         /// <summary>
         /// By reading the header on the provided file this calculates the images mime type.

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -46,7 +46,7 @@ namespace SixLabors.ImageSharp
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>
-        public static Image<Rgba32> Load(string path) => Load<Rgba32>(path);
+        public static Image Load(string path) => Load(path);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{Rgba32}"/> class from the given file.
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>
-        public static Image<Rgba32> Load(string path, out IImageFormat format) => Load<Rgba32>(path, out format);
+        public static Image Load(string path, out IImageFormat format) => Load(path, out format);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{Rgba32}"/> class from the given file.
@@ -68,19 +68,7 @@ namespace SixLabors.ImageSharp
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>
-        public static Image<Rgba32> Load(Configuration config, string path) => Load<Rgba32>(config, path);
-
-        /// <summary>
-        /// Create a new instance of the <see cref="Image{Rgba32}"/> class from the given file.
-        /// </summary>
-        /// <param name="config">The config for the decoder.</param>
-        /// <param name="path">The file path to the image.</param>
-        /// <param name="format">The mime type of the decoded image.</param>
-        /// <exception cref="NotSupportedException">
-        /// Thrown if the stream is not readable nor seekable.
-        /// </exception>
-        /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>
-        public static Image<Rgba32> Load(Configuration config, string path, out IImageFormat format) => Load<Rgba32>(config, path, out format);
+        public static Image Load(Configuration config, string path) => Load(config, path);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{Rgba32}"/> class from the given file.
@@ -92,7 +80,7 @@ namespace SixLabors.ImageSharp
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>
-        public static Image<Rgba32> Load(Configuration config, string path, IImageDecoder decoder) => Load<Rgba32>(config, path, decoder);
+        public static Image Load(Configuration config, string path, IImageDecoder decoder) => Load(config, path, decoder);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{Rgba32}"/> class from the given file.
@@ -103,7 +91,7 @@ namespace SixLabors.ImageSharp
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>
-        public static Image<Rgba32> Load(string path, IImageDecoder decoder) => Load<Rgba32>(path, decoder);
+        public static Image Load(string path, IImageDecoder decoder) => Load(path, decoder);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given file.
@@ -172,6 +160,14 @@ namespace SixLabors.ImageSharp
             using (Stream stream = config.FileSystem.OpenRead(path))
             {
                 return Load<TPixel>(config, stream, out format);
+            }
+        }
+        
+        public static Image Load(Configuration config, string path, out IImageFormat format)
+        {
+            using (Stream stream = config.FileSystem.OpenRead(path))
+            {
+                return Load(config, stream, out format);
             }
         }
 

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp
     /// <content>
     /// Adds static methods allowing the creation of new image from a given stream.
     /// </content>
-    public static partial class Image
+    public abstract partial class Image
     {
         /// <summary>
         /// By reading the header on the provided stream this calculates the images mime type.

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp
         /// <param name="format">the mime type of the decoded image.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>>
-        public static Image<Rgba32> Load(Stream stream, out IImageFormat format) => Load<Rgba32>(stream, out format);
+        public static Image Load(Stream stream, out IImageFormat format) => Load(stream, out format);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{Rgba32}"/> class from the given stream.
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp
         /// <param name="stream">The stream containing image information.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>>
-        public static Image<Rgba32> Load(Stream stream) => Load<Rgba32>(stream);
+        public static Image Load(Stream stream) => Load(stream);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{Rgba32}"/> class from the given stream.
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp
         /// <param name="decoder">The decoder.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>>
-        public static Image<Rgba32> Load(Stream stream, IImageDecoder decoder) => Load<Rgba32>(stream, decoder);
+        public static Image Load(Stream stream, IImageDecoder decoder) => Load(stream, decoder);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{Rgba32}"/> class from the given stream.
@@ -88,18 +88,7 @@ namespace SixLabors.ImageSharp
         /// <param name="stream">The stream containing image information.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>>
-        public static Image<Rgba32> Load(Configuration config, Stream stream) => Load<Rgba32>(config, stream);
-
-        /// <summary>
-        /// Create a new instance of the <see cref="Image{Rgba32}"/> class from the given stream.
-        /// </summary>
-        /// <param name="config">The config for the decoder.</param>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="format">the mime type of the decoded image.</param>
-        /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
-        /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>>
-        public static Image<Rgba32> Load(Configuration config, Stream stream, out IImageFormat format)
-            => Load<Rgba32>(config, stream, out format);
+        public static Image Load(Configuration config, Stream stream) => Load(config, stream);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
@@ -175,6 +164,28 @@ namespace SixLabors.ImageSharp
         {
             config = config ?? Configuration.Default;
             (Image<TPixel> img, IImageFormat format) data = WithSeekableStream(config, stream, s => Decode<TPixel>(s, config));
+
+            format = data.format;
+
+            if (data.img != null)
+            {
+                return data.img;
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Image cannot be loaded. Available decoders:");
+
+            foreach (KeyValuePair<IImageFormat, IImageDecoder> val in config.ImageFormatsManager.ImageDecoders)
+            {
+                sb.AppendLine($" - {val.Key.Name} : {val.Value.GetType().Name}");
+            }
+
+            throw new NotSupportedException(sb.ToString());
+        }
+        private static Image Load(Configuration config, Stream stream, out IImageFormat format)
+        {
+            config = config ?? Configuration.Default;
+            (Image img, IImageFormat format) data = WithSeekableStream(config, stream, s => Decode(s, config));
 
             format = data.format;
 

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Metadata;
+
+namespace SixLabors.ImageSharp
+{
+    public abstract partial class Image : IImage
+    {
+        /// <inheritdoc/>
+        public PixelTypeInfo PixelType { get; }
+
+        public abstract int Width { get; }
+        
+        public abstract int Height { get; }
+        
+        /// <inheritdoc/>
+        public ImageMetadata Metadata { get; }
+
+        protected Image(PixelTypeInfo pixelType, ImageMetadata metadata)
+        {
+            this.PixelType = pixelType;
+            this.Metadata = metadata ?? new ImageMetadata();
+        }
+
+        public abstract void Dispose();
+    }
+}

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.IO;
+
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Metadata;
@@ -45,5 +47,39 @@ namespace SixLabors.ImageSharp
         public abstract void Dispose();
 
         internal abstract void AcceptVisitor(IImageVisitor visitor);
+
+        /// <summary>
+        /// Saves the image to the given stream using the given image encoder.
+        /// </summary>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream or encoder is null.</exception>
+        public void Save(Stream stream, IImageEncoder encoder)
+        {
+            Guard.NotNull(stream, nameof(stream));
+            Guard.NotNull(encoder, nameof(encoder));
+
+            EncodeVisitor visitor = new EncodeVisitor(encoder, stream);
+            this.AcceptVisitor(visitor);
+        }
+
+        class EncodeVisitor : IImageVisitor
+        {
+            private readonly IImageEncoder encoder;
+
+            private readonly Stream stream;
+
+            public EncodeVisitor(IImageEncoder encoder, Stream stream)
+            {
+                this.encoder = encoder;
+                this.stream = stream;
+            }
+
+            public void Visit<TPixel>(Image<TPixel> image)
+                where TPixel : struct, IPixel<TPixel>
+            {
+                this.encoder.Encode(image, this.stream);
+            }
+        }
     }
 }

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
@@ -13,8 +14,10 @@ namespace SixLabors.ImageSharp
             where TPixel : struct, IPixel<TPixel>;
     }
     
-    public abstract partial class Image : IImage
+    public abstract partial class Image : IImage, IConfigurable
     {
+        protected readonly Configuration configuration;
+
         /// <inheritdoc/>
         public PixelTypeInfo PixelType { get; }
 
@@ -27,14 +30,20 @@ namespace SixLabors.ImageSharp
         /// <inheritdoc/>
         public ImageMetadata Metadata { get; }
 
-        protected Image(PixelTypeInfo pixelType, ImageMetadata metadata)
+        /// <summary>
+        /// Gets the pixel buffer.
+        /// </summary>
+        Configuration IConfigurable.Configuration => this.configuration;
+
+        protected Image(Configuration configuration, PixelTypeInfo pixelType, ImageMetadata metadata)
         {
+            this.configuration = configuration ?? Configuration.Default;
             this.PixelType = pixelType;
             this.Metadata = metadata ?? new ImageMetadata();
         }
 
         public abstract void Dispose();
 
-        internal abstract void ApplyVisitor(IImageVisitor visitor);
+        internal abstract void AcceptVisitor(IImageVisitor visitor);
     }
 }

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -3,9 +3,16 @@
 
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp
 {
+    internal interface IImageVisitor
+    {
+        void Visit<TPixel>(Image<TPixel> image)
+            where TPixel : struct, IPixel<TPixel>;
+    }
+    
     public abstract partial class Image : IImage
     {
         /// <inheritdoc/>
@@ -27,5 +34,7 @@ namespace SixLabors.ImageSharp
         }
 
         public abstract void Dispose();
+
+        internal abstract void ApplyVisitor(IImageVisitor visitor);
     }
 }

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -11,8 +11,10 @@ namespace SixLabors.ImageSharp
         /// <inheritdoc/>
         public PixelTypeInfo PixelType { get; }
 
+        /// <inheritdoc />
         public abstract int Width { get; }
-        
+
+        /// <inheritdoc />
         public abstract int Height { get; }
         
         /// <inheritdoc/>

--- a/src/ImageSharp/ImageExtensions.cs
+++ b/src/ImageSharp/ImageExtensions.cs
@@ -23,8 +23,7 @@ namespace SixLabors.ImageSharp
         /// <param name="source">The source image.</param>
         /// <param name="filePath">The file path to save the image to.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void Save<TPixel>(this Image<TPixel> source, string filePath)
-            where TPixel : struct, IPixel<TPixel>
+        public static void Save(this Image source, string filePath)
         {
             Guard.NotNullOrWhiteSpace(filePath, nameof(filePath));
 
@@ -67,8 +66,7 @@ namespace SixLabors.ImageSharp
         /// <param name="filePath">The file path to save the image to.</param>
         /// <param name="encoder">The encoder to save the image with.</param>
         /// <exception cref="ArgumentNullException">Thrown if the encoder is null.</exception>
-        public static void Save<TPixel>(this Image<TPixel> source, string filePath, IImageEncoder encoder)
-            where TPixel : struct, IPixel<TPixel>
+        public static void Save(this Image source, string filePath, IImageEncoder encoder)
         {
             Guard.NotNull(encoder, nameof(encoder));
             using (Stream fs = source.GetConfiguration().FileSystem.Create(filePath))
@@ -85,8 +83,7 @@ namespace SixLabors.ImageSharp
         /// <param name="stream">The stream to save the image to.</param>
         /// <param name="format">The format to save the image in.</param>
         /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void Save<TPixel>(this Image<TPixel> source, Stream stream, IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+        public static void Save(this Image source, Stream stream, IImageFormat format)
         {
             Guard.NotNull(format, nameof(format));
             IImageEncoder encoder = source.GetConfiguration().ImageFormatsManager.FindEncoder(format);

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <AdditionalFiles Include="..\..\standards\stylecop.json" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.114" PrivateAssets="All" />
+    <!--<PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.114" PrivateAssets="All" />-->
     <PackageReference Include="SixLabors.Core" Version="1.0.0-dev000101" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
   </ItemGroup>

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -18,11 +18,9 @@ namespace SixLabors.ImageSharp
     /// Encapsulates an image, which consists of the pixel data for a graphics image and its attributes.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    public sealed class Image<TPixel> : Image, IConfigurable
+    public sealed class Image<TPixel> : Image
         where TPixel : struct, IPixel<TPixel>
     {
-        private readonly Configuration configuration;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Image{TPixel}"/> class
         /// with the height and the width of the image.
@@ -68,9 +66,8 @@ namespace SixLabors.ImageSharp
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="metadata">The images metadata.</param>
         internal Image(Configuration configuration, int width, int height, ImageMetadata metadata)
-            : base(PixelTypeInfo.Create<TPixel>(), metadata)
+            : base(configuration, PixelTypeInfo.Create<TPixel>(), metadata)
         {
-            this.configuration = configuration ?? Configuration.Default;
             this.Frames = new ImageFrameCollection<TPixel>(this, width, height, default(TPixel));
         }
 
@@ -84,9 +81,8 @@ namespace SixLabors.ImageSharp
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="metadata">The images metadata.</param>
         internal Image(Configuration configuration, MemorySource<TPixel> memorySource, int width, int height, ImageMetadata metadata)
-            : base(PixelTypeInfo.Create<TPixel>(), metadata)
+            : base(configuration, PixelTypeInfo.Create<TPixel>(), metadata)
         {
-            this.configuration = configuration;
             this.Frames = new ImageFrameCollection<TPixel>(this, width, height, memorySource);
         }
 
@@ -100,9 +96,8 @@ namespace SixLabors.ImageSharp
         /// <param name="backgroundColor">The color to initialize the pixels with.</param>
         /// <param name="metadata">The images metadata.</param>
         internal Image(Configuration configuration, int width, int height, TPixel backgroundColor, ImageMetadata metadata)
-            : base(PixelTypeInfo.Create<TPixel>(), metadata)
+            : base(configuration, PixelTypeInfo.Create<TPixel>(), metadata)
         {
-            this.configuration = configuration ?? Configuration.Default;
             this.Frames = new ImageFrameCollection<TPixel>(this, width, height, backgroundColor);
         }
 
@@ -114,16 +109,10 @@ namespace SixLabors.ImageSharp
         /// <param name="metadata">The images metadata.</param>
         /// <param name="frames">The frames that will be owned by this image instance.</param>
         internal Image(Configuration configuration, ImageMetadata metadata, IEnumerable<ImageFrame<TPixel>> frames)
-            : base(PixelTypeInfo.Create<TPixel>(), metadata)
+            : base(configuration,PixelTypeInfo.Create<TPixel>(), metadata)
         {
-            this.configuration = configuration ?? Configuration.Default;
             this.Frames = new ImageFrameCollection<TPixel>(this, frames);
         }
-
-        /// <summary>
-        /// Gets the pixel buffer.
-        /// </summary>
-        Configuration IConfigurable.Configuration => this.configuration;
 
         /// <summary>
         /// Gets the frames.
@@ -209,7 +198,7 @@ namespace SixLabors.ImageSharp
         /// <inheritdoc/>
         public override void Dispose() => this.Frames.Dispose();
 
-        internal override void ApplyVisitor(IImageVisitor visitor)
+        internal override void AcceptVisitor(IImageVisitor visitor)
         {
             visitor.Visit(this);
         }

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -209,6 +209,11 @@ namespace SixLabors.ImageSharp
         /// <inheritdoc/>
         public override void Dispose() => this.Frames.Dispose();
 
+        internal override void ApplyVisitor(IImageVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
         /// <inheritdoc/>
         public override string ToString() => $"Image<{typeof(TPixel).Name}>: {this.Width}x{this.Height}";
 

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -144,20 +144,6 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Saves the image to the given stream using the given image encoder.
-        /// </summary>
-        /// <param name="stream">The stream to save the image to.</param>
-        /// <param name="encoder">The encoder to save the image with.</param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the stream or encoder is null.</exception>
-        public void Save(Stream stream, IImageEncoder encoder)
-        {
-            Guard.NotNull(stream, nameof(stream));
-            Guard.NotNull(encoder, nameof(encoder));
-
-            encoder.Encode(this, stream);
-        }
-
-        /// <summary>
         /// Clones the current image
         /// </summary>
         /// <returns>Returns a new image with all the same metadata as the original.</returns>

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp
     /// Encapsulates an image, which consists of the pixel data for a graphics image and its attributes.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    public sealed class Image<TPixel> : IImage, IConfigurable
+    public sealed class Image<TPixel> : Image, IConfigurable
         where TPixel : struct, IPixel<TPixel>
     {
         private readonly Configuration configuration;
@@ -68,10 +68,9 @@ namespace SixLabors.ImageSharp
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="metadata">The images metadata.</param>
         internal Image(Configuration configuration, int width, int height, ImageMetadata metadata)
+            : base(PixelTypeInfo.Create<TPixel>(), metadata)
         {
             this.configuration = configuration ?? Configuration.Default;
-            this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
-            this.Metadata = metadata ?? new ImageMetadata();
             this.Frames = new ImageFrameCollection<TPixel>(this, width, height, default(TPixel));
         }
 
@@ -85,10 +84,9 @@ namespace SixLabors.ImageSharp
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="metadata">The images metadata.</param>
         internal Image(Configuration configuration, MemorySource<TPixel> memorySource, int width, int height, ImageMetadata metadata)
+            : base(PixelTypeInfo.Create<TPixel>(), metadata)
         {
             this.configuration = configuration;
-            this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
-            this.Metadata = metadata;
             this.Frames = new ImageFrameCollection<TPixel>(this, width, height, memorySource);
         }
 
@@ -102,10 +100,9 @@ namespace SixLabors.ImageSharp
         /// <param name="backgroundColor">The color to initialize the pixels with.</param>
         /// <param name="metadata">The images metadata.</param>
         internal Image(Configuration configuration, int width, int height, TPixel backgroundColor, ImageMetadata metadata)
+            : base(PixelTypeInfo.Create<TPixel>(), metadata)
         {
             this.configuration = configuration ?? Configuration.Default;
-            this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
-            this.Metadata = metadata ?? new ImageMetadata();
             this.Frames = new ImageFrameCollection<TPixel>(this, width, height, backgroundColor);
         }
 
@@ -117,11 +114,9 @@ namespace SixLabors.ImageSharp
         /// <param name="metadata">The images metadata.</param>
         /// <param name="frames">The frames that will be owned by this image instance.</param>
         internal Image(Configuration configuration, ImageMetadata metadata, IEnumerable<ImageFrame<TPixel>> frames)
+            : base(PixelTypeInfo.Create<TPixel>(), metadata)
         {
             this.configuration = configuration ?? Configuration.Default;
-            this.PixelType = new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
-            this.Metadata = metadata ?? new ImageMetadata();
-
             this.Frames = new ImageFrameCollection<TPixel>(this, frames);
         }
 
@@ -129,18 +124,6 @@ namespace SixLabors.ImageSharp
         /// Gets the pixel buffer.
         /// </summary>
         Configuration IConfigurable.Configuration => this.configuration;
-
-        /// <inheritdoc/>
-        public PixelTypeInfo PixelType { get; }
-
-        /// <inheritdoc/>
-        public int Width => this.Frames.RootFrame.Width;
-
-        /// <inheritdoc/>
-        public int Height => this.Frames.RootFrame.Height;
-
-        /// <inheritdoc/>
-        public ImageMetadata Metadata { get; }
 
         /// <summary>
         /// Gets the frames.
@@ -151,6 +134,12 @@ namespace SixLabors.ImageSharp
         /// Gets the root frame.
         /// </summary>
         private IPixelSource<TPixel> PixelSource => this.Frames?.RootFrame ?? throw new ObjectDisposedException(nameof(Image<TPixel>));
+
+        /// <inheritdoc/>
+        public override int Width => this.Frames.RootFrame.Width;
+
+        /// <inheritdoc/>
+        public override int Height => this.Frames.RootFrame.Height;
 
         /// <summary>
         /// Gets or sets the pixel at the specified position.
@@ -218,7 +207,7 @@ namespace SixLabors.ImageSharp
         }
 
         /// <inheritdoc/>
-        public void Dispose() => this.Frames.Dispose();
+        public override void Dispose() => this.Frames.Dispose();
 
         /// <inheritdoc/>
         public override string ToString() => $"Image<{typeof(TPixel).Name}>: {this.Width}x{this.Height}";

--- a/src/ImageSharp/Processing/BlackWhiteExtensions.cs
+++ b/src/ImageSharp/Processing/BlackWhiteExtensions.cs
@@ -15,24 +15,20 @@ namespace SixLabors.ImageSharp.Processing
         /// <summary>
         /// Applies black and white toning to the image.
         /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="source">The image this method extends.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> BlackWhite<TPixel>(this IImageProcessingContext<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
-            => source.ApplyProcessor(new BlackWhiteProcessor<TPixel>());
+        public static IImageProcessingContext BlackWhite(this IImageProcessingContext source)
+            => source.ApplyProcessor(new BlackWhiteProcessor());
 
         /// <summary>
         /// Applies black and white toning to the image.
         /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="source">The image this method extends.</param>
         /// <param name="rectangle">
         /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to alter.
         /// </param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> BlackWhite<TPixel>(this IImageProcessingContext<TPixel> source, Rectangle rectangle)
-            where TPixel : struct, IPixel<TPixel>
-            => source.ApplyProcessor(new BlackWhiteProcessor<TPixel>(), rectangle);
+        public static IImageProcessingContext BlackWhite(this IImageProcessingContext source, Rectangle rectangle)
+            => source.ApplyProcessor(new BlackWhiteProcessor(), rectangle);
     }
 }

--- a/src/ImageSharp/Processing/DefaultInternalImageProcessorContext.cs
+++ b/src/ImageSharp/Processing/DefaultInternalImageProcessorContext.cs
@@ -53,6 +53,18 @@ namespace SixLabors.ImageSharp.Processing
         /// <inheritdoc/>
         public Size GetCurrentSize() => this.GetCurrentBounds().Size;
 
+        public IImageProcessingContext ApplyProcessor(IImageProcessor processor, Rectangle rectangle)
+        {
+            var processorImplementation = processor.CreatePixelSpecificProcessor<TPixel>();
+            return this.ApplyProcessor(processorImplementation, rectangle);
+        }
+
+        public IImageProcessingContext ApplyProcessor(IImageProcessor processor)
+        {
+            var processorImplementation = processor.CreatePixelSpecificProcessor<TPixel>();
+            return this.ApplyProcessor(processorImplementation);
+        }
+
         /// <inheritdoc/>
         public IImageProcessingContext<TPixel> ApplyProcessor(IImageProcessor<TPixel> processor, Rectangle rectangle)
         {

--- a/src/ImageSharp/Processing/FilterExtensions.cs
+++ b/src/ImageSharp/Processing/FilterExtensions.cs
@@ -16,26 +16,22 @@ namespace SixLabors.ImageSharp.Processing
         /// <summary>
         /// Filters an image but the given color matrix
         /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="source">The image this method extends.</param>
         /// <param name="matrix">The filter color matrix</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> Filter<TPixel>(this IImageProcessingContext<TPixel> source, ColorMatrix matrix)
-            where TPixel : struct, IPixel<TPixel>
-            => source.ApplyProcessor(new FilterProcessor<TPixel>(matrix));
+        public static IImageProcessingContext Filter(this IImageProcessingContext source, ColorMatrix matrix)
+            => source.ApplyProcessor(new FilterProcessor(matrix));
 
         /// <summary>
         /// Filters an image but the given color matrix
         /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="source">The image this method extends.</param>
         /// <param name="matrix">The filter color matrix</param>
         /// <param name="rectangle">
         /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to alter.
         /// </param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> Filter<TPixel>(this IImageProcessingContext<TPixel> source, ColorMatrix matrix, Rectangle rectangle)
-            where TPixel : struct, IPixel<TPixel>
-            => source.ApplyProcessor(new FilterProcessor<TPixel>(matrix), rectangle);
+        public static IImageProcessingContext Filter(this IImageProcessingContext source, ColorMatrix matrix, Rectangle rectangle)
+            => source.ApplyProcessor(new FilterProcessor(matrix), rectangle);
     }
 }

--- a/src/ImageSharp/Processing/IImageProcessingContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/IImageProcessingContext{TPixel}.cs
@@ -10,16 +10,6 @@ namespace SixLabors.ImageSharp.Processing
 {
     public interface IImageProcessingContext
     {
-        
-    }
-    
-    /// <summary>
-    /// An interface to queue up image operations to apply to an image.
-    /// </summary>
-    /// <typeparam name="TPixel">The pixel format</typeparam>
-    public interface IImageProcessingContext<TPixel>
-        where TPixel : struct, IPixel<TPixel>
-    {
         /// <summary>
         /// Gets a reference to the <see cref="MemoryAllocator" /> used to allocate buffers
         /// for this context.
@@ -31,7 +21,15 @@ namespace SixLabors.ImageSharp.Processing
         /// </summary>
         /// <returns>The <see cref="Rectangle"/></returns>
         Size GetCurrentSize();
-
+    }
+    
+    /// <summary>
+    /// An interface to queue up image operations to apply to an image.
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format</typeparam>
+    public interface IImageProcessingContext<TPixel> : IImageProcessingContext
+        where TPixel : struct, IPixel<TPixel>
+    {
         /// <summary>
         /// Adds the processor to the current set of image operations to be applied.
         /// </summary>

--- a/src/ImageSharp/Processing/IImageProcessingContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/IImageProcessingContext{TPixel}.cs
@@ -21,8 +21,12 @@ namespace SixLabors.ImageSharp.Processing
         /// </summary>
         /// <returns>The <see cref="Rectangle"/></returns>
         Size GetCurrentSize();
+
+        IImageProcessingContext ApplyProcessor(IImageProcessor processor, Rectangle rectangle);
+
+        IImageProcessingContext ApplyProcessor(IImageProcessor processor);
     }
-    
+
     /// <summary>
     /// An interface to queue up image operations to apply to an image.
     /// </summary>

--- a/src/ImageSharp/Processing/IImageProcessingContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/IImageProcessingContext{TPixel}.cs
@@ -8,6 +8,11 @@ using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing
 {
+    public interface IImageProcessingContext
+    {
+        
+    }
+    
     /// <summary>
     /// An interface to queue up image operations to apply to an image.
     /// </summary>

--- a/src/ImageSharp/Processing/OpacityExtensions.cs
+++ b/src/ImageSharp/Processing/OpacityExtensions.cs
@@ -15,26 +15,22 @@ namespace SixLabors.ImageSharp.Processing
         /// <summary>
         /// Multiplies the alpha component of the image.
         /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="source">The image this method extends.</param>
         /// <param name="amount">The proportion of the conversion. Must be between 0 and 1.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> Opacity<TPixel>(this IImageProcessingContext<TPixel> source, float amount)
-            where TPixel : struct, IPixel<TPixel>
-            => source.ApplyProcessor(new OpacityProcessor<TPixel>(amount));
+        public static IImageProcessingContext Opacity(this IImageProcessingContext source, float amount)
+            => source.ApplyProcessor(new OpacityProcessor(amount));
 
         /// <summary>
         /// Multiplies the alpha component of the image.
         /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="source">The image this method extends.</param>
         /// <param name="amount">The proportion of the conversion. Must be between 0 and 1.</param>
         /// <param name="rectangle">
         /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to alter.
         /// </param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> Opacity<TPixel>(this IImageProcessingContext<TPixel> source, float amount, Rectangle rectangle)
-            where TPixel : struct, IPixel<TPixel>
-            => source.ApplyProcessor(new OpacityProcessor<TPixel>(amount), rectangle);
+        public static IImageProcessingContext Opacity(this IImageProcessingContext source, float amount, Rectangle rectangle)
+            => source.ApplyProcessor(new OpacityProcessor(amount), rectangle);
     }
 }

--- a/src/ImageSharp/Processing/PadExtensions.cs
+++ b/src/ImageSharp/Processing/PadExtensions.cs
@@ -19,8 +19,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="width">The new width.</param>
         /// <param name="height">The new height.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
-        public static IImageProcessingContext<TPixel> Pad<TPixel>(this IImageProcessingContext<TPixel> source, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+        public static IImageProcessingContext Pad(this IImageProcessingContext source, int width, int height)
         {
             var options = new ResizeOptions
             {

--- a/src/ImageSharp/Processing/ProcessingExtensions.cs
+++ b/src/ImageSharp/Processing/ProcessingExtensions.cs
@@ -13,6 +13,11 @@ namespace SixLabors.ImageSharp.Processing
     /// </summary>
     public static class ProcessingExtensions
     {
+        public static void Mutate(this Image source, Action<IImageProcessingContext> operation)
+        {
+            
+        }
+        
         /// <summary>
         /// Applies the given operation to the mutable image.
         /// Useful when we need to extract information like Width/Height to parametrize the next operation working on the <see cref="IImageProcessingContext{TPixel}"/> chain.

--- a/src/ImageSharp/Processing/Processors/Filters/BlackWhiteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/BlackWhiteProcessor.cs
@@ -9,8 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies a black and white filter matrix to the image
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class BlackWhiteProcessor<TPixel> : FilterProcessor<TPixel>
-          where TPixel : struct, IPixel<TPixel>
+    internal class BlackWhiteProcessor : FilterProcessor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BlackWhiteProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
@@ -1,5 +1,5 @@
-// // Copyright (c) Six Labors and contributors.
-// // Licensed under the Apache License, Version 2.0.
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Primitives;
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     public class FilterProcessor : IImageProcessor
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FilterProcessorImplementation{TPixel}"/> class.
+        /// Initializes a new instance of the <see cref="FilterProcessor"/> class.
         /// </summary>
         /// <param name="matrix">The matrix used to apply the image filter</param>
         public FilterProcessor(ColorMatrix matrix) => this.Matrix = matrix;

--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessorImplementation.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessorImplementation.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Numerics;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.ParallelUtils;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Primitives;
+using SixLabors.Primitives;
+
+namespace SixLabors.ImageSharp.Processing.Processors.Filters
+{
+    /// <summary>
+    /// Provides methods that accept a <see cref="ColorMatrix"/> matrix to apply free-form filters to images.
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format.</typeparam>
+    internal class FilterProcessorImplementation<TPixel> : ImageProcessor<TPixel>
+        where TPixel : struct, IPixel<TPixel>
+    {
+        private readonly FilterProcessor paramterSource;
+
+        public FilterProcessorImplementation(FilterProcessor paramterSource)
+        {
+            this.paramterSource = paramterSource;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnFrameApply(ImageFrame<TPixel> source, Rectangle sourceRectangle, Configuration configuration)
+        {
+            var interest = Rectangle.Intersect(sourceRectangle, source.Bounds());
+            int startX = interest.X;
+
+            ColorMatrix matrix = this.paramterSource.Matrix;
+
+            ParallelHelper.IterateRowsWithTempBuffer<Vector4>(
+                interest,
+                configuration,
+                (rows, vectorBuffer) =>
+                    {
+                        for (int y = rows.Min; y < rows.Max; y++)
+                        {
+                            Span<Vector4> vectorSpan = vectorBuffer.Span;
+                            int length = vectorSpan.Length;
+                            Span<TPixel> rowSpan = source.GetPixelRowSpan(y).Slice(startX, length);
+                            PixelOperations<TPixel>.Instance.ToVector4(configuration, rowSpan, vectorSpan);
+
+                            Vector4Utils.Transform(vectorSpan, ref matrix);
+
+                            PixelOperations<TPixel>.Instance.FromVector4Destructive(configuration, vectorSpan, rowSpan);
+                        }
+                    });
+        }
+    }
+}

--- a/src/ImageSharp/Processing/Processors/Filters/OpacityProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/OpacityProcessor.cs
@@ -9,8 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Applies an opacity filter matrix using the given amount.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class OpacityProcessor<TPixel> : FilterProcessor<TPixel>
-         where TPixel : struct, IPixel<TPixel>
+    internal class OpacityProcessor : FilterProcessor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OpacityProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/IImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/IImageProcessor.cs
@@ -6,6 +6,12 @@ using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors
 {
+    public interface IImageProcessor
+    {
+        IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>()
+            where TPixel : struct, IPixel<TPixel>;
+    }
+    
     /// <summary>
     /// Encapsulates methods to alter the pixels of an image.
     /// </summary>

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
@@ -1,5 +1,5 @@
-// // Copyright (c) Six Labors and contributors.
-// // Licensed under the Apache License, Version 2.0.
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 using System;
 
@@ -8,6 +8,9 @@ using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 {
+    // The non-generic processor is responsible for:
+    // - Encapsulating the parameters of the processor
+    // - Implementing a factory method to create the pixel-specific processor that contains the implementation
     public class ResizeProcessor : IImageProcessor
     {
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
@@ -1,37 +1,72 @@
-﻿// Copyright (c) Six Labors and contributors.
-// Licensed under the Apache License, Version 2.0.
+// // Copyright (c) Six Labors and contributors.
+// // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-using SixLabors.ImageSharp.Advanced;
-using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.ParallelUtils;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.Memory;
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 {
-    /// <summary>
-    /// Provides methods that allow the resizing of images using various algorithms.
-    /// Adapted from <see href="http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/filter_rcg.c"/>
-    /// </summary>
-    /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal class ResizeProcessor<TPixel> : TransformProcessorBase<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+    public class ResizeProcessor : IImageProcessor
     {
-        // The following fields are not immutable but are optionally created on demand.
-        private ResizeKernelMap horizontalKernelMap;
-        private ResizeKernelMap verticalKernelMap;
+        /// <summary>
+        /// Gets the sampler to perform the resize operation.
+        /// </summary>
+        public IResampler Sampler { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResizeProcessor{TPixel}"/> class.
+        /// Gets the target width.
+        /// </summary>
+        public int Width { get; }
+
+        /// <summary>
+        /// Gets the target height.
+        /// </summary>
+        public int Height { get; }
+
+        /// <summary>
+        /// Gets the resize rectangle.
+        /// </summary>
+        public Rectangle TargetRectangle { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether to compress or expand individual pixel color values on processing.
+        /// </summary>
+        public bool Compand { get; }
+        
+        public ResizeProcessor(IResampler sampler, int width, int height, Size sourceSize, Rectangle targetRectangle, bool compand)
+        {
+            Guard.NotNull(sampler, nameof(sampler));
+
+            // Ensure size is populated across both dimensions.
+            // If only one of the incoming dimensions is 0, it will be modified here to maintain aspect ratio.
+            // If it is not possible to keep aspect ratio, make sure at least the minimum is is kept.
+            const int min = 1;
+            if (width == 0 && height > 0)
+            {
+                width = (int)MathF.Max(min, MathF.Round(sourceSize.Width * height / (float)sourceSize.Height));
+                targetRectangle.Width = width;
+            }
+
+            if (height == 0 && width > 0)
+            {
+                height = (int)MathF.Max(min, MathF.Round(sourceSize.Height * width / (float)sourceSize.Width));
+                targetRectangle.Height = height;
+            }
+
+            Guard.MustBeGreaterThan(width, 0, nameof(width));
+            Guard.MustBeGreaterThan(height, 0, nameof(height));
+
+            this.Sampler = sampler;
+            this.Width = width;
+            this.Height = height;
+            this.TargetRectangle = targetRectangle;
+            this.Compand = compand;
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResizeProcessorImplementation{TPixel}"/> class.
         /// </summary>
         /// <param name="options">The resize options</param>
         /// <param name="sourceSize">The source image size</param>
@@ -71,7 +106,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResizeProcessor{TPixel}"/> class.
+        /// Initializes a new instance of the <see cref="ResizeProcessorImplementation{TPixel}"/> class.
         /// </summary>
         /// <param name="sampler">The sampler to perform the resize operation.</param>
         /// <param name="width">The target width.</param>
@@ -82,189 +117,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ResizeProcessor{TPixel}"/> class.
-        /// </summary>
-        /// <param name="sampler">The sampler to perform the resize operation.</param>
-        /// <param name="width">The target width.</param>
-        /// <param name="height">The target height.</param>
-        /// <param name="sourceSize">The source image size</param>
-        /// <param name="targetRectangle">
-        /// The <see cref="Rectangle"/> structure that specifies the portion of the target image object to draw to.
-        /// </param>
-        /// <param name="compand">Whether to compress or expand individual pixel color values on processing.</param>
-        public ResizeProcessor(IResampler sampler, int width, int height, Size sourceSize, Rectangle targetRectangle, bool compand)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>()
+            where TPixel : struct, IPixel<TPixel>
         {
-            Guard.NotNull(sampler, nameof(sampler));
-
-            // Ensure size is populated across both dimensions.
-            // If only one of the incoming dimensions is 0, it will be modified here to maintain aspect ratio.
-            // If it is not possible to keep aspect ratio, make sure at least the minimum is is kept.
-            const int min = 1;
-            if (width == 0 && height > 0)
-            {
-                width = (int)MathF.Max(min, MathF.Round(sourceSize.Width * height / (float)sourceSize.Height));
-                targetRectangle.Width = width;
-            }
-
-            if (height == 0 && width > 0)
-            {
-                height = (int)MathF.Max(min, MathF.Round(sourceSize.Height * width / (float)sourceSize.Width));
-                targetRectangle.Height = height;
-            }
-
-            Guard.MustBeGreaterThan(width, 0, nameof(width));
-            Guard.MustBeGreaterThan(height, 0, nameof(height));
-
-            this.Sampler = sampler;
-            this.Width = width;
-            this.Height = height;
-            this.TargetRectangle = targetRectangle;
-            this.Compand = compand;
-        }
-
-        /// <summary>
-        /// Gets the sampler to perform the resize operation.
-        /// </summary>
-        public IResampler Sampler { get; }
-
-        /// <summary>
-        /// Gets the target width.
-        /// </summary>
-        public int Width { get; }
-
-        /// <summary>
-        /// Gets the target height.
-        /// </summary>
-        public int Height { get; }
-
-        /// <summary>
-        /// Gets the resize rectangle.
-        /// </summary>
-        public Rectangle TargetRectangle { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether to compress or expand individual pixel color values on processing.
-        /// </summary>
-        public bool Compand { get; }
-
-        /// <inheritdoc/>
-        protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.Metadata.DeepClone()));
-
-            // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(source.GetConfiguration(), source.Metadata.DeepClone(), frames);
-        }
-
-        /// <inheritdoc/>
-        protected override void BeforeImageApply(Image<TPixel> source, Image<TPixel> destination, Rectangle sourceRectangle)
-        {
-            if (!(this.Sampler is NearestNeighborResampler))
-            {
-                // Since all image frame dimensions have to be the same we can calculate this for all frames.
-                MemoryAllocator memoryAllocator = source.GetMemoryAllocator();
-                this.horizontalKernelMap = ResizeKernelMap.Calculate(
-                    this.Sampler,
-                    this.TargetRectangle.Width,
-                    sourceRectangle.Width,
-                    memoryAllocator);
-
-                this.verticalKernelMap = ResizeKernelMap.Calculate(
-                    this.Sampler,
-                    this.TargetRectangle.Height,
-                    sourceRectangle.Height,
-                    memoryAllocator);
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override void OnFrameApply(ImageFrame<TPixel> source, ImageFrame<TPixel> destination, Rectangle sourceRectangle, Configuration configuration)
-        {
-            // Handle resize dimensions identical to the original
-            if (source.Width == destination.Width && source.Height == destination.Height && sourceRectangle == this.TargetRectangle)
-            {
-                // The cloned will be blank here copy all the pixel data over
-                source.GetPixelSpan().CopyTo(destination.GetPixelSpan());
-                return;
-            }
-
-            int width = this.Width;
-            int height = this.Height;
-            int sourceX = sourceRectangle.X;
-            int sourceY = sourceRectangle.Y;
-            int startY = this.TargetRectangle.Y;
-            int startX = this.TargetRectangle.X;
-
-            var targetWorkingRect = Rectangle.Intersect(
-                this.TargetRectangle,
-                new Rectangle(0, 0, width, height));
-
-            if (this.Sampler is NearestNeighborResampler)
-            {
-                // Scaling factors
-                float widthFactor = sourceRectangle.Width / (float)this.TargetRectangle.Width;
-                float heightFactor = sourceRectangle.Height / (float)this.TargetRectangle.Height;
-
-                ParallelHelper.IterateRows(
-                    targetWorkingRect,
-                    configuration,
-                    rows =>
-                    {
-                        for (int y = rows.Min; y < rows.Max; y++)
-                        {
-                            // Y coordinates of source points
-                            Span<TPixel> sourceRow =
-                                source.GetPixelRowSpan((int)(((y - startY) * heightFactor) + sourceY));
-                            Span<TPixel> targetRow = destination.GetPixelRowSpan(y);
-
-                            for (int x = targetWorkingRect.Left; x < targetWorkingRect.Right; x++)
-                            {
-                                // X coordinates of source points
-                                targetRow[x] = sourceRow[(int)(((x - startX) * widthFactor) + sourceX)];
-                            }
-                        }
-                    });
-
-                return;
-            }
-
-            int sourceHeight = source.Height;
-
-            PixelConversionModifiers conversionModifiers =
-                PixelConversionModifiers.Premultiply.ApplyCompanding(this.Compand);
-
-            BufferArea<TPixel> sourceArea = source.PixelBuffer.GetArea(sourceRectangle);
-
-            // To reintroduce parallel processing, we to launch multiple workers
-            // for different row intervals of the image.
-            using (var worker = new ResizeWorker<TPixel>(
-                configuration,
-                sourceArea,
-                conversionModifiers,
-                this.horizontalKernelMap,
-                this.verticalKernelMap,
-                width,
-                targetWorkingRect,
-                this.TargetRectangle.Location))
-            {
-                worker.Initialize();
-
-                var workingInterval = new RowInterval(targetWorkingRect.Top, targetWorkingRect.Bottom);
-                worker.FillDestinationPixels(workingInterval, destination.PixelBuffer);
-            }
-        }
-
-        protected override void AfterImageApply(Image<TPixel> source, Image<TPixel> destination, Rectangle sourceRectangle)
-        {
-            base.AfterImageApply(source, destination, sourceRectangle);
-
-            // TODO: An exception in the processing chain can leave these buffers undisposed. We should consider making image processors IDisposable!
-            this.horizontalKernelMap?.Dispose();
-            this.horizontalKernelMap = null;
-            this.verticalKernelMap?.Dispose();
-            this.verticalKernelMap = null;
+            return new ResizeProcessorImplementation<TPixel>(this);
         }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessorImplementation.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessorImplementation.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.ParallelUtils;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.Memory;
+using SixLabors.Primitives;
+
+namespace SixLabors.ImageSharp.Processing.Processors.Transforms
+{
+    // The non-generic processor is responsible for:
+    // - Encapsulating the parameters of the processor
+    // - Implementing a factory method to create the pixel-specific processor that contains the implementation
+
+    /// <summary>
+    /// Provides methods that allow the resizing of images using various algorithms.
+    /// Adapted from <see href="http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/filter_rcg.c"/>
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format.</typeparam>
+    internal class ResizeProcessorImplementation<TPixel> : TransformProcessorBase<TPixel>
+        where TPixel : struct, IPixel<TPixel>
+    {
+        // The following fields are not immutable but are optionally created on demand.
+        private ResizeKernelMap horizontalKernelMap;
+        private ResizeKernelMap verticalKernelMap;
+
+        private readonly ResizeProcessor parameterSource;
+
+        public ResizeProcessorImplementation(ResizeProcessor parameterSource)
+        {
+            this.parameterSource = parameterSource;
+        }
+
+        /// <summary>
+        /// Gets the sampler to perform the resize operation.
+        /// </summary>
+        public IResampler Sampler => this.parameterSource.Sampler;
+
+        /// <summary>
+        /// Gets the target width.
+        /// </summary>
+        public int Width => this.parameterSource.Width;
+
+        /// <summary>
+        /// Gets the target height.
+        /// </summary>
+        public int Height => this.parameterSource.Height;
+
+        /// <summary>
+        /// Gets the resize rectangle.
+        /// </summary>
+        public Rectangle TargetRectangle => this.parameterSource.TargetRectangle;
+
+        /// <summary>
+        /// Gets a value indicating whether to compress or expand individual pixel color values on processing.
+        /// </summary>
+        public bool Compand => this.parameterSource.Compand;
+
+        /// <inheritdoc/>
+        protected override Image<TPixel> CreateDestination(Image<TPixel> source, Rectangle sourceRectangle)
+        {
+            // We will always be creating the clone even for mutate because we may need to resize the canvas
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select(x => new ImageFrame<TPixel>(source.GetConfiguration(), this.Width, this.Height, x.Metadata.DeepClone()));
+
+            // Use the overload to prevent an extra frame being added
+            return new Image<TPixel>(source.GetConfiguration(), source.Metadata.DeepClone(), frames);
+        }
+
+        /// <inheritdoc/>
+        protected override void BeforeImageApply(Image<TPixel> source, Image<TPixel> destination, Rectangle sourceRectangle)
+        {
+            if (!(this.Sampler is NearestNeighborResampler))
+            {
+                // Since all image frame dimensions have to be the same we can calculate this for all frames.
+                MemoryAllocator memoryAllocator = source.GetMemoryAllocator();
+                this.horizontalKernelMap = ResizeKernelMap.Calculate(
+                    this.Sampler,
+                    this.TargetRectangle.Width,
+                    sourceRectangle.Width,
+                    memoryAllocator);
+
+                this.verticalKernelMap = ResizeKernelMap.Calculate(
+                    this.Sampler,
+                    this.TargetRectangle.Height,
+                    sourceRectangle.Height,
+                    memoryAllocator);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnFrameApply(ImageFrame<TPixel> source, ImageFrame<TPixel> destination, Rectangle sourceRectangle, Configuration configuration)
+        {
+            // Handle resize dimensions identical to the original
+            if (source.Width == destination.Width && source.Height == destination.Height && sourceRectangle == this.TargetRectangle)
+            {
+                // The cloned will be blank here copy all the pixel data over
+                source.GetPixelSpan().CopyTo(destination.GetPixelSpan());
+                return;
+            }
+
+            int width = this.Width;
+            int height = this.Height;
+            int sourceX = sourceRectangle.X;
+            int sourceY = sourceRectangle.Y;
+            int startY = this.TargetRectangle.Y;
+            int startX = this.TargetRectangle.X;
+
+            var targetWorkingRect = Rectangle.Intersect(
+                this.TargetRectangle,
+                new Rectangle(0, 0, width, height));
+
+            if (this.Sampler is NearestNeighborResampler)
+            {
+                // Scaling factors
+                float widthFactor = sourceRectangle.Width / (float)this.TargetRectangle.Width;
+                float heightFactor = sourceRectangle.Height / (float)this.TargetRectangle.Height;
+
+                ParallelHelper.IterateRows(
+                    targetWorkingRect,
+                    configuration,
+                    rows =>
+                    {
+                        for (int y = rows.Min; y < rows.Max; y++)
+                        {
+                            // Y coordinates of source points
+                            Span<TPixel> sourceRow =
+                                source.GetPixelRowSpan((int)(((y - startY) * heightFactor) + sourceY));
+                            Span<TPixel> targetRow = destination.GetPixelRowSpan(y);
+
+                            for (int x = targetWorkingRect.Left; x < targetWorkingRect.Right; x++)
+                            {
+                                // X coordinates of source points
+                                targetRow[x] = sourceRow[(int)(((x - startX) * widthFactor) + sourceX)];
+                            }
+                        }
+                    });
+
+                return;
+            }
+
+            int sourceHeight = source.Height;
+
+            PixelConversionModifiers conversionModifiers =
+                PixelConversionModifiers.Premultiply.ApplyCompanding(this.Compand);
+
+            BufferArea<TPixel> sourceArea = source.PixelBuffer.GetArea(sourceRectangle);
+
+            // To reintroduce parallel processing, we to launch multiple workers
+            // for different row intervals of the image.
+            using (var worker = new ResizeWorker<TPixel>(
+                configuration,
+                sourceArea,
+                conversionModifiers,
+                this.horizontalKernelMap,
+                this.verticalKernelMap,
+                width,
+                targetWorkingRect,
+                this.TargetRectangle.Location))
+            {
+                worker.Initialize();
+
+                var workingInterval = new RowInterval(targetWorkingRect.Top, targetWorkingRect.Bottom);
+                worker.FillDestinationPixels(workingInterval, destination.PixelBuffer);
+            }
+        }
+
+        protected override void AfterImageApply(Image<TPixel> source, Image<TPixel> destination, Rectangle sourceRectangle)
+        {
+            base.AfterImageApply(source, destination, sourceRectangle);
+
+            // TODO: An exception in the processing chain can leave these buffers undisposed. We should consider making image processors IDisposable!
+            this.horizontalKernelMap?.Dispose();
+            this.horizontalKernelMap = null;
+            this.verticalKernelMap?.Dispose();
+            this.verticalKernelMap = null;
+        }
+    }
+}

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessorImplementation.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessorImplementation.cs
@@ -18,10 +18,6 @@ using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 {
-    // The non-generic processor is responsible for:
-    // - Encapsulating the parameters of the processor
-    // - Implementing a factory method to create the pixel-specific processor that contains the implementation
-
     /// <summary>
     /// Provides methods that allow the resizing of images using various algorithms.
     /// Adapted from <see href="http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/filter_rcg.c"/>

--- a/src/ImageSharp/Processing/ResizeExtensions.cs
+++ b/src/ImageSharp/Processing/ResizeExtensions.cs
@@ -20,9 +20,8 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="options">The resize options.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width within the resize options will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(this IImageProcessingContext<TPixel> source, ResizeOptions options)
-            where TPixel : struct, IPixel<TPixel>
-            => source.ApplyProcessor(new ResizeProcessor<TPixel>(options, source.GetCurrentSize()));
+        public static IImageProcessingContext Resize(this IImageProcessingContext source, ResizeOptions options)
+            => source.ApplyProcessor(new ResizeProcessor(options, source.GetCurrentSize()));
 
         /// <summary>
         /// Resizes an image to the given <see cref="Size"/>.
@@ -32,8 +31,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="size">The target image size.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(this IImageProcessingContext<TPixel> source, Size size)
-            where TPixel : struct, IPixel<TPixel>
+        public static IImageProcessingContext Resize(this IImageProcessingContext source, Size size)
             => Resize(source, size.Width, size.Height, KnownResamplers.Bicubic, false);
 
         /// <summary>
@@ -45,8 +43,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="compand">Whether to compress and expand the image color-space to gamma correct the image during processing.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(this IImageProcessingContext<TPixel> source, Size size, bool compand)
-            where TPixel : struct, IPixel<TPixel>
+        public static IImageProcessingContext Resize(this IImageProcessingContext source, Size size, bool compand)
             => Resize(source, size.Width, size.Height, KnownResamplers.Bicubic, compand);
 
         /// <summary>
@@ -58,8 +55,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="height">The target image height.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(this IImageProcessingContext<TPixel> source, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+        public static IImageProcessingContext Resize(this IImageProcessingContext source, int width, int height)
             => Resize(source, width, height, KnownResamplers.Bicubic, false);
 
         /// <summary>
@@ -72,8 +68,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="compand">Whether to compress and expand the image color-space to gamma correct the image during processing.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(this IImageProcessingContext<TPixel> source, int width, int height, bool compand)
-            where TPixel : struct, IPixel<TPixel>
+        public static IImageProcessingContext Resize(this IImageProcessingContext source, int width, int height, bool compand)
             => Resize(source, width, height, KnownResamplers.Bicubic, compand);
 
         /// <summary>
@@ -86,8 +81,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="sampler">The <see cref="IResampler"/> to perform the resampling.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(this IImageProcessingContext<TPixel> source, int width, int height, IResampler sampler)
-            where TPixel : struct, IPixel<TPixel>
+        public static IImageProcessingContext Resize(this IImageProcessingContext source, int width, int height, IResampler sampler)
             => Resize(source, width, height, sampler, false);
 
         /// <summary>
@@ -100,8 +94,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="compand">Whether to compress and expand the image color-space to gamma correct the image during processing.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(this IImageProcessingContext<TPixel> source, Size size, IResampler sampler, bool compand)
-            where TPixel : struct, IPixel<TPixel>
+        public static IImageProcessingContext Resize(this IImageProcessingContext source, Size size, IResampler sampler, bool compand)
             => Resize(source, size.Width, size.Height, sampler, new Rectangle(0, 0, size.Width, size.Height), compand);
 
         /// <summary>
@@ -115,8 +108,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="compand">Whether to compress and expand the image color-space to gamma correct the image during processing.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(this IImageProcessingContext<TPixel> source, int width, int height, IResampler sampler, bool compand)
-            where TPixel : struct, IPixel<TPixel>
+        public static IImageProcessingContext Resize(this IImageProcessingContext source, int width, int height, IResampler sampler, bool compand)
             => Resize(source, width, height, sampler, new Rectangle(0, 0, width, height), compand);
 
         /// <summary>
@@ -137,16 +129,15 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="compand">Whether to compress and expand the image color-space to gamma correct the image during processing.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(
-            this IImageProcessingContext<TPixel> source,
+        public static IImageProcessingContext Resize(
+            this IImageProcessingContext source,
             int width,
             int height,
             IResampler sampler,
             Rectangle sourceRectangle,
             Rectangle targetRectangle,
             bool compand)
-            where TPixel : struct, IPixel<TPixel>
-            => source.ApplyProcessor(new ResizeProcessor<TPixel>(sampler, width, height, source.GetCurrentSize(), targetRectangle, compand), sourceRectangle);
+            => source.ApplyProcessor(new ResizeProcessor(sampler, width, height, source.GetCurrentSize(), targetRectangle, compand), sourceRectangle);
 
         /// <summary>
         /// Resizes an image to the given width and height with the given sampler and source rectangle.
@@ -162,14 +153,13 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="compand">Whether to compress and expand the image color-space to gamma correct the image during processing.</param>
         /// <returns>The <see cref="Image{TPixel}"/></returns>
         /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image or the nearest possible ratio.</remarks>
-        public static IImageProcessingContext<TPixel> Resize<TPixel>(
-            this IImageProcessingContext<TPixel> source,
+        public static IImageProcessingContext Resize(
+            this IImageProcessingContext source,
             int width,
             int height,
             IResampler sampler,
             Rectangle targetRectangle,
             bool compand)
-            where TPixel : struct, IPixel<TPixel>
-            => source.ApplyProcessor(new ResizeProcessor<TPixel>(sampler, width, height, source.GetCurrentSize(), targetRectangle, compand));
+            => source.ApplyProcessor(new ResizeProcessor(sampler, width, height, source.GetCurrentSize(), targetRectangle, compand));
     }
 }

--- a/tests/ImageSharp.Tests/FakeImageOperationsProvider.cs
+++ b/tests/ImageSharp.Tests/FakeImageOperationsProvider.cs
@@ -67,6 +67,16 @@ namespace SixLabors.ImageSharp.Tests
                 return this.Source.Size();
             }
 
+            public IImageProcessingContext ApplyProcessor(IImageProcessor processor, Rectangle rectangle)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public IImageProcessingContext ApplyProcessor(IImageProcessor processor)
+            {
+                throw new System.NotImplementedException();
+            }
+
             public IImageProcessingContext<TPixel> ApplyProcessor(IImageProcessor<TPixel> processor, Rectangle rectangle)
             {
                 this.Applied.Add(new AppliedOperation

--- a/tests/ImageSharp.Tests/Image/ImageProcessingContextTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageProcessingContextTests.cs
@@ -10,43 +10,43 @@ namespace SixLabors.ImageSharp.Tests
 {
     public class ImageProcessingContextTests
     {
-        [Fact]
-        public void MutatedSizeIsAccuratePerOperation()
-        {
-            var x500 = new Size(500, 500);
-            var x400 = new Size(400, 400);
-            var x300 = new Size(300, 300);
-            var x200 = new Size(200, 200);
-            var x100 = new Size(100, 100);
-            using (var image = new Image<Rgba32>(500, 500))
-            {
-                image.Mutate(x =>
-                    x.AssertSize(x500)
-                        .Resize(x400).AssertSize(x400)
-                        .Resize(x300).AssertSize(x300)
-                        .Resize(x200).AssertSize(x200)
-                        .Resize(x100).AssertSize(x100));
-            }
-        }
-
-        [Fact]
-        public void ClonedSizeIsAccuratePerOperation()
-        {
-            var x500 = new Size(500, 500);
-            var x400 = new Size(400, 400);
-            var x300 = new Size(300, 300);
-            var x200 = new Size(200, 200);
-            var x100 = new Size(100, 100);
-            using (var image = new Image<Rgba32>(500, 500))
-            {
-                image.Clone(x =>
-                    x.AssertSize(x500)
-                        .Resize(x400).AssertSize(x400)
-                        .Resize(x300).AssertSize(x300)
-                        .Resize(x200).AssertSize(x200)
-                        .Resize(x100).AssertSize(x100));
-            }
-        }
+        // [Fact]
+        // public void MutatedSizeIsAccuratePerOperation()
+        // {
+        //     var x500 = new Size(500, 500);
+        //     var x400 = new Size(400, 400);
+        //     var x300 = new Size(300, 300);
+        //     var x200 = new Size(200, 200);
+        //     var x100 = new Size(100, 100);
+        //     using (var image = new Image<Rgba32>(500, 500))
+        //     {
+        //         image.Mutate(x =>
+        //             x.AssertSize(x500)
+        //                 .Resize(x400).AssertSize(x400)
+        //                 .Resize(x300).AssertSize(x300)
+        //                 .Resize(x200).AssertSize(x200)
+        //                 .Resize(x100).AssertSize(x100));
+        //     }
+        // }
+        //
+        // [Fact]
+        // public void ClonedSizeIsAccuratePerOperation()
+        // {
+        //     var x500 = new Size(500, 500);
+        //     var x400 = new Size(400, 400);
+        //     var x300 = new Size(300, 300);
+        //     var x200 = new Size(200, 200);
+        //     var x100 = new Size(100, 100);
+        //     using (var image = new Image<Rgba32>(500, 500))
+        //     {
+        //         image.Clone(x =>
+        //             x.AssertSize(x500)
+        //                 .Resize(x400).AssertSize(x400)
+        //                 .Resize(x300).AssertSize(x300)
+        //                 .Resize(x200).AssertSize(x200)
+        //                 .Resize(x100).AssertSize(x100));
+        //     }
+        // }
     }
 
     public static class SizeAssertationExtensions

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -40,6 +40,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
                 nameof(KnownResamplers.Lanczos5),
             };
 
+
         private static readonly ImageComparer ValidatorComparer = ImageComparer.TolerantPercentage(0.07F);
 
         [Fact]

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -42,6 +42,22 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
 
         private static readonly ImageComparer ValidatorComparer = ImageComparer.TolerantPercentage(0.07F);
 
+        [Fact]
+        public void Resize_PixelAgnostic()
+        {
+            var filePath = TestFile.GetInputFileFullPath(TestImages.Jpeg.Baseline.Calliphora);
+            
+            using (Image image = Image.Load(filePath))
+            {
+                image.Mutate(x => x.Resize(image.Size() / 2));
+                string path = System.IO.Path.Combine(
+                    TestEnvironment.CreateOutputDirectory(nameof(ResizeTests)),
+                    nameof(this.Resize_PixelAgnostic) + ".png");
+                
+                image.Save(path);
+            }
+        }
+        
         [Theory(
             Skip = "Debug only, enable manually"
             )]

--- a/tests/ImageSharp.Tests/TestFormat.cs
+++ b/tests/ImageSharp.Tests/TestFormat.cs
@@ -199,6 +199,8 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             public bool IsSupportedFileFormat(Span<byte> header) => testFormat.IsSupportedFileFormat(header);
+            
+            public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
         }
 
         public class TestEncoder : ImageSharp.Formats.IImageEncoder

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -57,5 +57,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
                 return result;
             }
         }
+        
+        public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceDecoder.cs
@@ -51,5 +51,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
                 return new ImageInfo(pixelType, sourceBitmap.Width, sourceBitmap.Height, new ImageMetadata());
             }
         }
+        
+        public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageProviderTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageProviderTests.cs
@@ -379,6 +379,8 @@ namespace SixLabors.ImageSharp.Tests
                 this.callerName = name;
                 invocationCounts[name] = 0;
             }
+            
+            public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
         }
 
         private class TestDecoderWithParameters : IImageDecoder
@@ -416,6 +418,8 @@ namespace SixLabors.ImageSharp.Tests
                 this.callerName = name;
                 invocationCounts[name] = 0;
             }
+            
+            public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
         }
     }
 }


### PR DESCRIPTION
This is an API proposal (+POC), communicated in the form of a pull request, not intended for merging. The target branch contains stripped ImageSharp source code, so we can focus on the important changes.

Please, feel free to review it, any feedback is welcome!

## The problem
This proposal aims to solve the following issues with the current API:
- The majority of our users (eg. thumbnail makers) are not interested in the pixel type backing the `Image<TPixel>` instance. They just want to apply a processor, and resave the image. `TPixel`, `Rgba32` is only a noise for them.
- `Image.Load(...)` is decoding images into into `Image<Rgba32>` in an arbitrary manner. This is sub-optimal in many cases. Eg. jpegs do not have an alpha-channel, therefore it's better to decode them into `Image<Rgb24>`. It would be benefitical to solve this in a way that's transparent to the user.
- It's not possible to make the current ImageProcessor implementations public without exposing a bunch of implementation details. This means that any refactor and optimization could introduce breaking changes in the future.
- From API perspective, it's not necessary for ImageProcessors and extension methods to be pixel-type specific.

## The solution
- Making `Image` an abstract, pixel-agnostic base class for `Image<TPixel>`
- `Image.Load(....)` overloads return an `Image` instead of `Image<Rgba32>`
- `Image.Load<TPixel>(....)` overloads keep returning `Image<TPixel>`
- Introcuce a pixel-agnostic `IImageProcessor` and `IImageProcessingContext` interfaces
- Separate API from implementation in Image Processors. The "definition" class implements `IImageProcessor`, it's only responsible to encapsulate the parameters, and create the pixel specific `IImageProcessor<TPixel>` implementation.
- The majority of the extension methods could operate on the pixel-agnostic `Image` and `IImageProcessingContext` (See `ResizeExtensions` in the PR changes).
- For stuff like drawing, users should be aware of the pixel type.
- The "trick" is done by [Double Dispatch](https://en.wikipedia.org/wiki/Double_dispatch), but it makes sense to follow the terminology defined by by the [Visitor Pattern](https://en.wikipedia.org/wiki/Visitor_pattern).

## Impact
This is a breaking change, however it's scope is very limited, most of the users should be able to adapt the new API with minimal or no code changes:

- All users should recompile their project after package update
- Code using specific pixel types when loading an image should be unaffected:
```C#
using (Image<Rgb24> image = Image.Load<Rgb24>("foo.jpg"))
{
    image.Mutate(x => x
         .Resize(image.Width / 2, image.Height / 2);
    image.Save("bar.jpg");
}
```

- Processing code using `var` should be unaffected:
```C#
using (var image = Image.Load("foo.jpg"))
{
    image.Mutate(x => x
         .Resize(image.Width / 2, image.Height / 2);
    image.Save("bar.jpg");
}
```

- Code which used to specify the `Image<Rgba32>` class when using `Image.Load(...)` could be easily adapted by replacing `Image<Rgba32>` with `Image`:
```C#
using (Image image = Image.Load("foo.jpg"))
{
    image.Mutate(x => x
         .Resize(image.Width / 2, image.Height / 2);
    image.Save("bar.jpg");
}
```