### PR TITLE
Add Color overload to Pad method.

### DIFF
--- a/src/ImageSharp/Processing/Extensions/PadExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/PadExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing
@@ -20,6 +19,17 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="height">The new height.</param>
         /// <returns>The <see cref="IImageProcessingContext"/> to allow chaining of operations.</returns>
         public static IImageProcessingContext Pad(this IImageProcessingContext source, int width, int height)
+            => source.Pad(width, height, default);
+
+        /// <summary>
+        /// Evenly pads an image to fit the new dimensions with the given background color.
+        /// </summary>
+        /// <param name="source">The source image to pad.</param>
+        /// <param name="width">The new width.</param>
+        /// <param name="height">The new height.</param>
+        /// <param name="color">The background color with which to pad the image.</param>
+        /// <returns>The <see cref="IImageProcessingContext"/> to allow chaining of operations.</returns>
+        public static IImageProcessingContext Pad(this IImageProcessingContext source, int width, int height, Color color)
         {
             var options = new ResizeOptions
             {
@@ -28,7 +38,7 @@ namespace SixLabors.ImageSharp.Processing
                 Sampler = KnownResamplers.NearestNeighbor,
             };
 
-            return source.Resize(options);
+            return color.Equals(default) ? source.Resize(options) : source.Resize(options).BackgroundColor(color);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/PadTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/PadTest.cs
@@ -10,10 +10,10 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
     public class PadTest
     {
         public static readonly string[] CommonTestImages =
-            {
-                TestImages.Png.CalliphoraPartial, TestImages.Png.Bike
-            };
-        
+        {
+            TestImages.Png.CalliphoraPartial, TestImages.Png.Bike
+        };
+
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), PixelTypes.Rgba32)]
         public void ImageShouldPad<TPixel>(TestImageProvider<TPixel> provider)
@@ -29,7 +29,30 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
                 {
                     for (int x = 0; x < 25; x++)
                     {
-                        Assert.Equal(default(TPixel), image[x, y]);
+                        Assert.Equal(default, image[x, y]);
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [WithFileCollection(nameof(CommonTestImages), PixelTypes.Rgba32)]
+        public void ImageShouldPadWithBackgroundColor<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            Color color = Color.Red;
+            TPixel expected = color.ToPixel<TPixel>();
+            using (Image<TPixel> image = provider.GetImage())
+            {
+                image.Mutate(x => x.Pad(image.Width + 50, image.Height + 50, color));
+                image.DebugSave(provider);
+
+                // Check pixels are filled
+                for (int y = 0; y < 25; y++)
+                {
+                    for (int x = 0; x < 25; x++)
+                    {
+                        Assert.Equal(expected, image[x, y]);
                     }
                 }
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #466

<!-- Thanks for contributing to ImageSharp! -->
