### PR TITLE
Fix IndexOutOfRangeException in FillRegionProcessor

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor{TPixel}.cs
@@ -105,7 +105,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
 
                             QuickSort.Sort(buffer.Slice(0, pointsFound));
 
-                            for (int point = 0; point < pointsFound; point += 2)
+                            for (int point = 0; point < pointsFound && point < buffer.Length - 1; point += 2)
                             {
                                 // points will be paired up
                                 float scanStart = buffer[point] - minX;

--- a/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
@@ -70,6 +70,32 @@ namespace SixLabors.ImageSharp.Tests.Drawing
         }
 
         [Fact]
+        public void DoesNotThrowForIssue928()
+        {
+            var rectText = new RectangleF(0, 0, 2000, 2000);
+            using (Image<Rgba32> img = new Image<Rgba32>((int)rectText.Width, (int)rectText.Height))
+            {
+                img.Mutate(x => x.Fill(Rgba32.Transparent));
+
+                img.Mutate(ctx => {
+                    ctx.DrawLines(
+                        Rgba32.Red,
+                        0.984252f,
+                        new PointF(104.762581f, 1074.99365f),
+                        new PointF(104.758667f, 1075.01721f),
+                        new PointF(104.757675f, 1075.04114f),
+                        new PointF(104.759628f, 1075.065f),
+                        new PointF(104.764488f, 1075.08838f),
+                        new PointF(104.772186f, 1075.111f),
+                        new PointF(104.782608f, 1075.13245f),
+                        new PointF(104.782608f, 1075.13245f)
+                        );
+                    }
+                );
+            }
+        }
+
+        [Fact]
         public void DoesNotThrowFillingTriangle()
         {
             using(var image = new Image<Rgba32>(28, 28))

--- a/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
@@ -12,6 +12,7 @@ using SixLabors.ImageSharp.Processing.Processors;
 using SixLabors.Primitives;
 using Xunit;
 using SixLabors.ImageSharp.Processing.Processors.Drawing;
+using SixLabors.Shapes;
 
 namespace SixLabors.ImageSharp.Tests.Drawing
 {
@@ -65,6 +66,24 @@ namespace SixLabors.ImageSharp.Tests.Drawing
                 img.Mutate(x => x.DrawLines(new Pen(Rgba32.Black, 10),
                     new Vector2(-10, 5),
                     new Vector2(20, 5)));
+            }
+        }
+
+        [Fact]
+        public void DoesNotThrowFillingTriangle()
+        {
+            using(var image = new Image<Rgba32>(28, 28))
+            {
+                var path = new Polygon(
+                    new LinearLineSegment(new PointF(17.11f, 13.99659f), new PointF(14.01433f, 27.06201f)),
+                    new LinearLineSegment(new PointF(14.01433f, 27.06201f), new PointF(13.79267f, 14.00023f)),
+                    new LinearLineSegment(new PointF(13.79267f, 14.00023f), new PointF(17.11f, 13.99659f))
+                );
+
+                image.Mutate(ctx =>
+                {
+                    ctx.Fill(Rgba32.White, path);
+                });
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description

This is a fix for an issue that I have discovered as well as the reported issue #928.  I have added two tests to illustrate the issue that fail on `master` as well as a possible fix.

The issue arises due to this code:

https://github.com/SixLabors/ImageSharp/blob/aac8eae64aab06ecd8aa0210e49fb0ba67e9a4ea/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor%7BTPixel%7D.cs#L99-L112

If `pointsFound` is odd (such as 3) and equal to the size of the buffer, the loop will go up to `buffer.Length - 1`, but that means that `buffer[point + 1]` will be out of bounds and cause an exception.

My solution was to add a second condition to the loop: `point < buffer.Length - 1`  Unfortunately, I don't know enough about the algorithm to know if this will result in an incorrect result.