### PR TITLE
Patch MemoryOwnerExtensions to workaround #987

### DIFF
--- a/src/ImageSharp/Memory/MemoryOwnerExtensions.cs
+++ b/src/ImageSharp/Memory/MemoryOwnerExtensions.cs
@@ -13,7 +13,6 @@ namespace SixLabors.ImageSharp.Memory
     /// </summary>
     internal static class MemoryOwnerExtensions
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Span<T> GetSpan<T>(this IMemoryOwner<T> buffer)
             => buffer.Memory.Span;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
See [this issue comment](https://github.com/SixLabors/ImageSharp/issues/987#issuecomment-525491787) for explanation. May workaround #987 for (some? all?) users.
