### PR TITLE
Prevent PathGradientBrush from throwing an error with corner cases

### DIFF
--- a/src/ImageSharp.Drawing/Processing/PathGradientBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/PathGradientBrush.cs
@@ -231,11 +231,6 @@ namespace SixLabors.ImageSharp.Processing
                         return new Color(this.centerColor).ToPixel<TPixel>();
                     }
 
-                    if (!this.path.Contains(point))
-                    {
-                        return Color.Transparent.ToPixel<TPixel>();
-                    }
-
                     Vector2 direction = Vector2.Normalize(point - this.center);
 
                     PointF end = point + (PointF)(direction * this.maxDistance);

--- a/src/ImageSharp.Drawing/Processing/PathGradientBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/PathGradientBrush.cs
@@ -237,6 +237,11 @@ namespace SixLabors.ImageSharp.Processing
 
                     (Edge edge, Intersection? info) = this.FindIntersection(point, end);
 
+                    if (!info.HasValue)
+                    {
+                        return Color.Transparent.ToPixel<TPixel>();
+                    }
+
                     PointF intersection = info.Value.Point;
 
                     Vector4 edgeColor = edge.ColorAt(intersection);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

While testing the initial implementation of `PathGradientBrush` with a more complex scenario, I found that there are such cases where it fails to find intersection points for a given position.

The previous code assumed it would be always possible to calculate an intersecting point of a line between the center position and an arbitrary point within the paint area. But it seems that the assumption was wrong for very small polygons, for a reason that I have yet to understand perfectly.

So, I just made a small correction to ignore such corner cases which prevents an error from halting the paint process. And it looks like ignoring them doesn't affect the output image noticeably.

As such, I think we could address this problem with the proposed change without breaking any existing code (that is, if anyone beside me is already using the new gradient brush), although further investigation might be needed in future.