### PR TITLE
Fix horizontally out-of-bounds error when drawing text

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
@@ -90,26 +90,31 @@ namespace SixLabors.ImageSharp.Processing.Processors.Text
                             Buffer2D<float> buffer = operation.Map;
                             int startY = operation.Location.Y;
                             int startX = operation.Location.X;
-                            int offSetSpan = 0;
+                            int offsetSpan = 0;
                             if (startX < 0)
                             {
-                                offSetSpan = -startX;
+                                offsetSpan = -startX;
                                 startX = 0;
                             }
 
-                            int fistRow = 0;
+                            if (startX >= source.Width)
+                            {
+                                continue;
+                            }
+
+                            int firstRow = 0;
                             if (startY < 0)
                             {
-                                fistRow = -startY;
+                                firstRow = -startY;
                             }
 
                             int maxHeight = source.Height - startY;
                             int end = Math.Min(operation.Map.Height, maxHeight);
 
-                            for (int row = fistRow; row < end; row++)
+                            for (int row = firstRow; row < end; row++)
                             {
                                 int y = startY + row;
-                                Span<float> span = buffer.GetRowSpan(row).Slice(offSetSpan);
+                                Span<float> span = buffer.GetRowSpan(row).Slice(offsetSpan);
                                 app.Apply(span, startX, y);
                             }
                         }

--- a/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -66,6 +66,24 @@ namespace SixLabors.ImageSharp.Tests.Drawing.Text
         }
 
         [Theory]
+        [WithSolidFilledImages(1500, 500, "White", PixelTypes.Rgba32)]
+        public void DoesntThrowExceptionWhenOverlappingRightEdge_Issue688_2<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (Image<TPixel> img = provider.GetImage())
+            {
+                Font font = SystemFonts.CreateFont("Arial", 39, FontStyle.Regular);
+                string text = new string('a', 10000); // exception
+                                                      // string text = "Hello"; // no exception
+                Rgba32 color = Rgba32.Black;
+                var point = new PointF(100, 100);
+
+                img.Mutate(ctx => ctx.DrawText(text, font, color, point));
+            }
+        }
+
+
+        [Theory]
         [WithSolidFilledImages(200, 100, "White", PixelTypes.Rgba32, 50, 0, 0, "SixLaborsSampleAB.woff", AB)]
         [WithSolidFilledImages(900, 100, "White", PixelTypes.Rgba32, 50, 0, 0, "OpenSans-Regular.ttf", TestText)]
         [WithSolidFilledImages(400, 40, "White", PixelTypes.Rgba32, 20, 0, 0, "OpenSans-Regular.ttf", TestText)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This addresses the horizontal out-of-bounds error raised in #688. The error was confirmed using [the code sample provided in one of the comments](https://github.com/SixLabors/ImageSharp/issues/688#issuecomment-451537085).

<!-- Thanks for contributing to ImageSharp! -->
