### PR TITLE
Refactor IDisposable pattern

### DIFF
--- a/src/ImageSharp/IImage.cs
+++ b/src/ImageSharp/IImage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.IO;
 
 using SixLabors.ImageSharp.Advanced;
@@ -80,21 +81,11 @@ namespace SixLabors.ImageSharp
         /// </summary>
         Configuration IConfigurable.Configuration => this.Configuration;
 
-        /// <summary>
-        /// Gets a value indicating whether the image instance is disposed.
-        /// </summary>
-        public bool IsDisposed { get; private set; }
-
         /// <inheritdoc />
         public void Dispose()
         {
-            if (this.IsDisposed)
-            {
-                return;
-            }
-
-            this.IsDisposed = true;
-            this.DisposeImpl();
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -109,7 +100,7 @@ namespace SixLabors.ImageSharp
             Guard.NotNull(encoder, nameof(encoder));
             this.EnsureNotDisposed();
 
-            EncodeVisitor visitor = new EncodeVisitor(encoder, stream);
+            var visitor = new EncodeVisitor(encoder, stream);
             this.AcceptVisitor(visitor);
         }
 
@@ -144,9 +135,15 @@ namespace SixLabors.ImageSharp
         protected void UpdateSize(Size size) => this.size = size;
 
         /// <summary>
-        /// Implements the Dispose logic.
+        /// Disposes the object and frees resources for the Garbage Collector.
         /// </summary>
-        protected abstract void DisposeImpl();
+        /// <param name="disposing">Whether to dispose of managed and unmanaged objects.</param>
+        protected abstract void Dispose(bool disposing);
+
+        /// <summary>
+        /// Throws <see cref="ObjectDisposedException"/> if the image is disposed.
+        /// </summary>
+        internal abstract void EnsureNotDisposed();
 
         private class EncodeVisitor : IImageVisitor
         {

--- a/src/ImageSharp/ImageExtensions.cs
+++ b/src/ImageSharp/ImageExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -117,17 +117,6 @@ namespace SixLabors.ImageSharp
                 source.Save(stream, format);
                 stream.Flush();
                 return $"data:{format.DefaultMimeType};base64,{Convert.ToBase64String(stream.ToArray())}";
-            }
-        }
-
-        /// <summary>
-        /// Throws <see cref="ObjectDisposedException"/> if the image is disposed.
-        /// </summary>
-        internal static void EnsureNotDisposed(this Image image)
-        {
-            if (image.IsDisposed)
-            {
-                throw new ObjectDisposedException(nameof(image), "Trying to execute an operation on a disposed image.");
             }
         }
     }

--- a/src/ImageSharp/ImageFrame.cs
+++ b/src/ImageSharp/ImageFrame.cs
@@ -74,7 +74,17 @@ namespace SixLabors.ImageSharp
         public Rectangle Bounds() => new Rectangle(0, 0, this.Width, this.Height);
 
         /// <inheritdoc />
-        public abstract void Dispose();
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes the object and frees resources for the Garbage Collector.
+        /// </summary>
+        /// <param name="disposing">Whether to dispose of managed and unmanaged objects.</param>
+        protected abstract void Dispose(bool disposing);
 
         internal abstract void CopyPixelsTo<TDestinationPixel>(Span<TDestinationPixel> destination)
             where TDestinationPixel : struct, IPixel<TDestinationPixel>;

--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp
     /// In all other cases it is the only frame of the image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    public sealed class ImageFrame<TPixel> : ImageFrame, IPixelSource<TPixel>, IDisposable
+    public sealed class ImageFrame<TPixel> : ImageFrame, IPixelSource<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         private bool isDisposed;
@@ -196,20 +196,20 @@ namespace SixLabors.ImageSharp
             this.UpdateSize(this.PixelBuffer.Size());
         }
 
-        /// <summary>
-        /// Disposes the object and frees resources for the Garbage Collector.
-        /// </summary>
-        public override void Dispose()
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
         {
             if (this.isDisposed)
             {
                 return;
             }
 
-            this.PixelBuffer?.Dispose();
-            this.PixelBuffer = null;
+            if (disposing)
+            {
+                this.PixelBuffer?.Dispose();
+                this.PixelBuffer = null;
+            }
 
-            // Note disposing is done.
             this.isDisposed = true;
         }
 

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp
     /// For generic <see cref="Image{TPixel}"/>-s the pixel type is known at compile time.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    public class Image<TPixel> : Image
+    public sealed class Image<TPixel> : Image
         where TPixel : struct, IPixel<TPixel>
     {
         private bool isDisposed;

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -18,9 +18,11 @@ namespace SixLabors.ImageSharp
     /// For generic <see cref="Image{TPixel}"/>-s the pixel type is known at compile time.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    public sealed class Image<TPixel> : Image
+    public class Image<TPixel> : Image
         where TPixel : struct, IPixel<TPixel>
     {
+        private bool isDisposed;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Image{TPixel}"/> class
         /// with the height and the width of the image.
@@ -185,7 +187,29 @@ namespace SixLabors.ImageSharp
         }
 
         /// <inheritdoc/>
-        protected override void DisposeImpl() => this.Frames.Dispose();
+        protected override void Dispose(bool disposing)
+        {
+            if (this.isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                this.Frames.Dispose();
+            }
+
+            this.isDisposed = true;
+        }
+
+        /// <inheritdoc/>
+        internal override void EnsureNotDisposed()
+        {
+            if (this.isDisposed)
+            {
+                throw new ObjectDisposedException("Trying to execute an operation on a disposed image.");
+            }
+        }
 
         /// <inheritdoc />
         internal override void AcceptVisitor(IImageVisitor visitor)

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
@@ -15,8 +15,6 @@ namespace SixLabors.ImageSharp.Processing.Processors
     internal abstract class CloningImageProcessor<TPixel> : ICloningImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
-        private bool isDisposed;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CloningImageProcessor{TPixel}"/> class.
         /// </summary>
@@ -104,6 +102,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
         public void Dispose()
         {
             this.Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -160,10 +159,6 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// <param name="disposing">Whether to dispose managed and unmanaged objects.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!this.isDisposed)
-            {
-                this.isDisposed = true;
-            }
         }
     }
 }

--- a/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
@@ -15,8 +15,6 @@ namespace SixLabors.ImageSharp.Processing.Processors
     internal abstract class ImageProcessor<TPixel> : IImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
-        private bool isDisposed;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageProcessor{TPixel}"/> class.
         /// </summary>
@@ -97,6 +95,8 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// <inheritdoc/>
         public virtual void Dispose()
         {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -142,10 +142,6 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// <param name="disposing">Whether to dispose managed and unmanaged objects.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!this.isDisposed)
-            {
-                this.isDisposed = true;
-            }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Touches #967 

- Refactor of `IDisposable` pattern for images, frames, and processors to work better with inheritance and ensure finalizer suppression.
- `Image<TPixel>` is no longer sealed as that prevents extending for potential types like `IntegralImage<TPixel>`. `ImageFrame<TPixel>` is left sealed as inheritance should not be required.

<!-- Thanks for contributing to ImageSharp! -->
