### PR TITLE
Expose visitor through advanced namespace.

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 

--- a/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
+++ b/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
@@ -16,6 +16,15 @@ namespace SixLabors.ImageSharp.Advanced
     public static class AdvancedImageExtensions
     {
         /// <summary>
+        /// Accepts a <see cref="IImageVisitor"/> to implement a double-dispatch pattern in order to
+        /// apply pixel-specific operations on non-generic <see cref="Image"/> instances
+        /// </summary>
+        /// <param name="source">The source.</param>
+        /// <param name="visitor">The visitor.</param>
+        public static void AcceptVisitor(this Image source, IImageVisitor visitor)
+            => source.Accept(visitor);
+
+        /// <summary>
         /// Gets the configuration for the image.
         /// </summary>
         /// <param name="source">The source image.</param>

--- a/src/ImageSharp/Advanced/IImageVisitor.cs
+++ b/src/ImageSharp/Advanced/IImageVisitor.cs
@@ -3,13 +3,13 @@
 
 using SixLabors.ImageSharp.PixelFormats;
 
-namespace SixLabors.ImageSharp
+namespace SixLabors.ImageSharp.Advanced
 {
     /// <summary>
-    /// A visitor to implement double-dispatch pattern in order to apply pixel-specific operations
-    /// on non-generic <see cref="Image"/> instances. The operation is dispatched by <see cref="Image.AcceptVisitor"/>.
+    /// A visitor to implement a double-dispatch pattern in order to apply pixel-specific operations
+    /// on non-generic <see cref="Image"/> instances.
     /// </summary>
-    internal interface IImageVisitor
+    public interface IImageVisitor
     {
         /// <summary>
         /// Provides a pixel-specific implementation for a given operation.

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -109,8 +109,7 @@ namespace SixLabors.ImageSharp
             Guard.NotNull(encoder, nameof(encoder));
             this.EnsureNotDisposed();
 
-            EncodeVisitor visitor = new EncodeVisitor(encoder, stream);
-            this.AcceptVisitor(visitor);
+            this.AcceptVisitor(new EncodeVisitor(encoder, stream));
         }
 
         /// <summary>
@@ -131,11 +130,12 @@ namespace SixLabors.ImageSharp
             where TPixel2 : struct, IPixel<TPixel2>;
 
         /// <summary>
-        /// Accept a <see cref="IImageVisitor"/>.
+        /// Accepts a <see cref="IImageVisitor"/>.
         /// Implemented by <see cref="Image{TPixel}"/> invoking <see cref="IImageVisitor.Visit{TPixel}"/>
         /// with the pixel type of the image.
         /// </summary>
-        internal abstract void AcceptVisitor(IImageVisitor visitor);
+        /// <param name="visitor">The visitor.</param>
+        protected internal abstract void Accept(IImageVisitor visitor);
 
         /// <summary>
         /// Update the size of the image after mutation.

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -130,14 +130,6 @@ namespace SixLabors.ImageSharp
             where TPixel2 : struct, IPixel<TPixel2>;
 
         /// <summary>
-        /// Accepts a <see cref="IImageVisitor"/>.
-        /// Implemented by <see cref="Image{TPixel}"/> invoking <see cref="IImageVisitor.Visit{TPixel}"/>
-        /// with the pixel type of the image.
-        /// </summary>
-        /// <param name="visitor">The visitor.</param>
-        protected internal abstract void Accept(IImageVisitor visitor);
-
-        /// <summary>
         /// Update the size of the image after mutation.
         /// </summary>
         /// <param name="size">The <see cref="Size"/>.</param>
@@ -147,6 +139,14 @@ namespace SixLabors.ImageSharp
         /// Implements the Dispose logic.
         /// </summary>
         protected abstract void DisposeImpl();
+
+        /// <summary>
+        /// Accepts a <see cref="IImageVisitor"/>.
+        /// Implemented by <see cref="Image{TPixel}"/> invoking <see cref="IImageVisitor.Visit{TPixel}"/>
+        /// with the pixel type of the image.
+        /// </summary>
+        /// <param name="visitor">The visitor.</param>
+        internal abstract void Accept(IImageVisitor visitor);
 
         private class EncodeVisitor : IImageVisitor
         {

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -188,7 +188,7 @@ namespace SixLabors.ImageSharp
         protected override void DisposeImpl() => this.Frames.Dispose();
 
         /// <inheritdoc />
-        internal override void AcceptVisitor(IImageVisitor visitor)
+        protected internal override void Accept(IImageVisitor visitor)
         {
             this.EnsureNotDisposed();
 

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -187,16 +187,16 @@ namespace SixLabors.ImageSharp
         /// <inheritdoc/>
         protected override void DisposeImpl() => this.Frames.Dispose();
 
+        /// <inheritdoc/>
+        public override string ToString() => $"Image<{typeof(TPixel).Name}>: {this.Width}x{this.Height}";
+
         /// <inheritdoc />
-        protected internal override void Accept(IImageVisitor visitor)
+        internal override void Accept(IImageVisitor visitor)
         {
             this.EnsureNotDisposed();
 
             visitor.Visit(this);
         }
-
-        /// <inheritdoc/>
-        public override string ToString() => $"Image<{typeof(TPixel).Name}>: {this.Width}x{this.Height}";
 
         /// <summary>
         /// Switches the buffers used by the image and the pixelSource meaning that the Image will "own" the buffer from the pixelSource and the pixelSource will now own the Images buffer.

--- a/src/ImageSharp/Processing/Extensions/ProcessingExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/ProcessingExtensions.cs
@@ -25,8 +25,7 @@ namespace SixLabors.ImageSharp.Processing
             Guard.NotNull(operation, nameof(operation));
             source.EnsureNotDisposed();
 
-            var visitor = new ProcessingVisitor(operation, true);
-            source.AcceptVisitor(visitor);
+            source.AcceptVisitor(new ProcessingVisitor(operation, true));
         }
 
         /// <summary>
@@ -42,8 +41,10 @@ namespace SixLabors.ImageSharp.Processing
             Guard.NotNull(operation, nameof(operation));
             source.EnsureNotDisposed();
 
-            IInternalImageProcessingContext<TPixel> operationsRunner = source.GetConfiguration().ImageOperationsProvider
-                .CreateImageProcessingContext(source, true);
+            IInternalImageProcessingContext<TPixel> operationsRunner
+                = source.GetConfiguration()
+                        .ImageOperationsProvider.CreateImageProcessingContext(source, true);
+
             operation(operationsRunner);
         }
 
@@ -60,8 +61,10 @@ namespace SixLabors.ImageSharp.Processing
             Guard.NotNull(operations, nameof(operations));
             source.EnsureNotDisposed();
 
-            IInternalImageProcessingContext<TPixel> operationsRunner = source.GetConfiguration().ImageOperationsProvider
-                .CreateImageProcessingContext(source, true);
+            IInternalImageProcessingContext<TPixel> operationsRunner
+                = source.GetConfiguration()
+                        .ImageOperationsProvider.CreateImageProcessingContext(source, true);
+
             operationsRunner.ApplyProcessors(operations);
         }
 
@@ -96,8 +99,10 @@ namespace SixLabors.ImageSharp.Processing
             Guard.NotNull(operation, nameof(operation));
             source.EnsureNotDisposed();
 
-            IInternalImageProcessingContext<TPixel> operationsRunner = source.GetConfiguration().ImageOperationsProvider
-                .CreateImageProcessingContext(source, false);
+            IInternalImageProcessingContext<TPixel> operationsRunner
+                = source.GetConfiguration()
+                        .ImageOperationsProvider.CreateImageProcessingContext(source, false);
+
             operation(operationsRunner);
             return operationsRunner.GetResultImage();
         }
@@ -116,8 +121,10 @@ namespace SixLabors.ImageSharp.Processing
             Guard.NotNull(operations, nameof(operations));
             source.EnsureNotDisposed();
 
-            IInternalImageProcessingContext<TPixel> operationsRunner = source.GetConfiguration().ImageOperationsProvider
-                .CreateImageProcessingContext(source, false);
+            IInternalImageProcessingContext<TPixel> operationsRunner
+                = source.GetConfiguration()
+                        .ImageOperationsProvider.CreateImageProcessingContext(source, false);
+
             operationsRunner.ApplyProcessors(operations);
             return operationsRunner.GetResultImage();
         }
@@ -157,8 +164,10 @@ namespace SixLabors.ImageSharp.Processing
             public void Visit<TPixel>(Image<TPixel> image)
                 where TPixel : struct, IPixel<TPixel>
             {
-                IInternalImageProcessingContext<TPixel> operationsRunner = image.GetConfiguration()
-                    .ImageOperationsProvider.CreateImageProcessingContext(image, this.mutate);
+                IInternalImageProcessingContext<TPixel> operationsRunner =
+                    image.GetConfiguration()
+                         .ImageOperationsProvider.CreateImageProcessingContext(image, this.mutate);
+
                 this.operation(operationsRunner);
                 this.ResultImage = operationsRunner.GetResultImage();
             }

--- a/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
- Adds new `AcceptVisitor` extension method to the `Advanced` namespace and redirects all calls to that method.

<!-- Thanks for contributing to ImageSharp! -->
