### PR TITLE
Make processors public, refactor cloning.

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
 
             var workingRect = Rectangle.FromLTRB(minX, minY, maxX, maxY);
 
-            // not a valid operation because rectangle does not overlap with this image.
+            // Not a valid operation because rectangle does not overlap with this image.
             if (workingRect.Width <= 0 || workingRect.Height <= 0)
             {
                 throw new ImageProcessingException(
@@ -102,14 +102,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
                 workingRect,
                 configuration,
                 rows =>
+                {
+                    for (int y = rows.Min; y < rows.Max; y++)
                     {
-                        for (int y = rows.Min; y < rows.Max; y++)
-                        {
-                            Span<TPixelBg> background = source.GetPixelRowSpan(y).Slice(minX, width);
-                            Span<TPixelFg> foreground = targetImage.GetPixelRowSpan(y - locationY).Slice(targetX, width);
-                            blender.Blend<TPixelFg>(configuration, background, background, foreground, this.Opacity);
-                        }
-                    });
+                        Span<TPixelBg> background = source.GetPixelRowSpan(y).Slice(minX, width);
+                        Span<TPixelFg> foreground = targetImage.GetPixelRowSpan(y - locationY).Slice(targetX, width);
+                        blender.Blend<TPixelFg>(configuration, background, background, foreground, this.Opacity);
+                    }
+                });
         }
     }
 }

--- a/src/ImageSharp/Advanced/AotCompilerTools.cs
+++ b/src/ImageSharp/Advanced/AotCompilerTools.cs
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Jpeg.Components;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Dithering;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
-using SixLabors.ImageSharp.Processing.Processors.Transforms;
 
 namespace SixLabors.ImageSharp.Advanced
 {
@@ -81,9 +80,8 @@ namespace SixLabors.ImageSharp.Advanced
             AotCompileWuQuantizer<TPixel>();
             AotCompileDithering<TPixel>();
             AotCompilePixelOperations<TPixel>();
-            AotCompileResizeOperations<TPixel>();
 
-            System.Runtime.CompilerServices.Unsafe.SizeOf<TPixel>();
+            Unsafe.SizeOf<TPixel>();
 
             AotCodec<TPixel>(new Formats.Png.PngDecoder(), new Formats.Png.PngEncoder());
             AotCodec<TPixel>(new Formats.Bmp.BmpDecoder(), new Formats.Bmp.BmpEncoder());
@@ -107,8 +105,10 @@ namespace SixLabors.ImageSharp.Advanced
         private static void AotCompileOctreeQuantizer<TPixel>()
             where TPixel : struct, IPixel<TPixel>
         {
-            var test = new OctreeFrameQuantizer<TPixel>(new OctreeQuantizer(false));
-            test.AotGetPalette();
+            using (var test = new OctreeFrameQuantizer<TPixel>(new OctreeQuantizer(false)))
+            {
+                test.AotGetPalette();
+            }
         }
 
         /// <summary>
@@ -118,9 +118,11 @@ namespace SixLabors.ImageSharp.Advanced
         private static void AotCompileWuQuantizer<TPixel>()
             where TPixel : struct, IPixel<TPixel>
         {
-            var test = new WuFrameQuantizer<TPixel>(Configuration.Default.MemoryAllocator, new WuQuantizer(false));
-            test.QuantizeFrame(new ImageFrame<TPixel>(Configuration.Default, 1, 1));
-            test.AotGetPalette();
+            using (var test = new WuFrameQuantizer<TPixel>(Configuration.Default.MemoryAllocator, new WuQuantizer(false)))
+            {
+                test.QuantizeFrame(new ImageFrame<TPixel>(Configuration.Default, 1, 1));
+                test.AotGetPalette();
+            }
         }
 
         /// <summary>
@@ -132,7 +134,10 @@ namespace SixLabors.ImageSharp.Advanced
         {
             var test = new FloydSteinbergDiffuser();
             TPixel pixel = default;
-            test.Dither(new ImageFrame<TPixel>(Configuration.Default, 1, 1), pixel, pixel, 0, 0, 0, 0, 0, 0);
+            using (var image = new ImageFrame<TPixel>(Configuration.Default, 1, 1))
+            {
+                test.Dither(image, pixel, pixel, 0, 0, 0, 0, 0, 0);
+            }
         }
 
         /// <summary>
@@ -170,17 +175,6 @@ namespace SixLabors.ImageSharp.Advanced
         {
             var pixelOp = new PixelOperations<TPixel>();
             pixelOp.GetPixelBlender(PixelColorBlendingMode.Normal, PixelAlphaCompositionMode.Clear);
-        }
-
-        /// <summary>
-        /// This method pre-seeds the ResizeProcessor for the AoT compiler on iOS.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        private static void AotCompileResizeOperations<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
-        {
-            var genericResizeProcessor = (ResizeProcessor<TPixel>)new ResizeProcessor(new ResizeOptions(), default).CreatePixelSpecificProcessor(new Image<TPixel>(0, 0), default);
-            genericResizeProcessor.AotCreateDestination();
         }
     }
 }

--- a/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
@@ -69,9 +69,9 @@ namespace SixLabors.ImageSharp.Processing
             {
                 // When cloning an image we can optimize the processing pipeline by avoiding an unnecessary
                 // interim clone if the first processor in the pipeline is a cloning processor.
-                if (processor is CloningImageProcessor cloningImageProcessor)
+                if (processor is ICloningImageProcessor cloningImageProcessor)
                 {
-                    using (ICloningImageProcessor<TPixel> pixelProcessor = cloningImageProcessor.CreatePixelSpecificProcessor(this.source, rectangle))
+                    using (ICloningImageProcessor<TPixel> pixelProcessor = cloningImageProcessor.CreatePixelSpecificCloningProcessor(this.source, rectangle))
                     {
                         this.destination = pixelProcessor.CloneAndExecute();
                         return this;

--- a/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
@@ -29,6 +29,8 @@ namespace SixLabors.ImageSharp.Processing
         {
             this.mutate = mutate;
             this.source = source;
+
+            // Mutate acts upon the source image only.
             if (this.mutate)
             {
                 this.destination = source;
@@ -43,7 +45,8 @@ namespace SixLabors.ImageSharp.Processing
         {
             if (!this.mutate && this.destination is null)
             {
-                // Ensure we have cloned it if we are not mutating as we might have failed to register any processors
+                // Ensure we have cloned the source if we are not mutating as we might have failed
+                // to register any processors.
                 this.destination = this.source.Clone();
             }
 
@@ -64,26 +67,25 @@ namespace SixLabors.ImageSharp.Processing
         {
             if (!this.mutate && this.destination is null)
             {
-                // This will only work if the first processor applied is the cloning one thus
-                // realistically for this optimization to work the resize must the first processor
-                // applied any only up processors will take the double data path.
-                using (IImageProcessor<TPixel> specificProcessor = processor.CreatePixelSpecificProcessor(this.source, rectangle))
+                // When cloning an image we can optimize the processing pipeline by avoiding an unnecessary
+                // interim clone if the first processor in the pipeline is a cloning processor.
+                if (processor is CloningImageProcessor cloningImageProcessor)
                 {
-                    // TODO: if 'specificProcessor' is not an ICloningImageProcessor<TPixel> we are unnecessarily disposing and recreating it.
-                    // This should be solved in a future refactor.
-                    if (specificProcessor is ICloningImageProcessor<TPixel> cloningImageProcessor)
+                    using (ICloningImageProcessor<TPixel> pixelProcessor = cloningImageProcessor.CreatePixelSpecificProcessor(this.source, rectangle))
                     {
-                        this.destination = cloningImageProcessor.CloneAndApply();
+                        this.destination = pixelProcessor.CloneAndExecute();
                         return this;
                     }
                 }
 
+                // Not a cloning processor? We need to create a clone to operate on.
                 this.destination = this.source.Clone();
             }
 
+            // Standard processing pipeline.
             using (IImageProcessor<TPixel> specificProcessor = processor.CreatePixelSpecificProcessor(this.destination, rectangle))
             {
-                specificProcessor.Apply();
+                specificProcessor.Execute();
             }
 
             return this;

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
@@ -7,15 +7,12 @@ using SixLabors.Primitives;
 namespace SixLabors.ImageSharp.Processing.Processors
 {
     /// <summary>
-    /// Defines an algorithm to alter the pixels of an image.
-    /// Non-generic <see cref="IImageProcessor"/> implementations are responsible for:
-    /// 1. Encapsulating the parameters of the algorithm.
-    /// 2. Creating the generic <see cref="IImageProcessor{TPixel}"/> instance to execute the algorithm.
+    /// The base class for all cloning image processors.
     /// </summary>
-    public interface IImageProcessor
+    public abstract class CloningImageProcessor : IImageProcessor
     {
         /// <summary>
-        /// Creates a pixel specific <see cref="IImageProcessor{TPixel}"/> that is capable of executing
+        /// Creates a pixel specific <see cref="ICloningImageProcessor{TPixel}"/> that is capable of executing
         /// the processing algorithm on an <see cref="Image{TPixel}"/>.
         /// </summary>
         /// <typeparam name="TPixel">The pixel type.</typeparam>
@@ -23,8 +20,12 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// <param name="sourceRectangle">
         /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to draw.
         /// </param>
-        /// <returns>The <see cref="IImageProcessor{TPixel}"/></returns>
-        IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        /// <returns>The <see cref="ICloningImageProcessor{TPixel}"/></returns>
+        public abstract ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>;
+
+        /// <inheritdoc/>
+        IImageProcessor<TPixel> IImageProcessor.CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+            => this.CreatePixelSpecificProcessor(source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
@@ -9,23 +9,14 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// <summary>
     /// The base class for all cloning image processors.
     /// </summary>
-    public abstract class CloningImageProcessor : IImageProcessor
+    public abstract class CloningImageProcessor : ICloningImageProcessor
     {
-        /// <summary>
-        /// Creates a pixel specific <see cref="ICloningImageProcessor{TPixel}"/> that is capable of executing
-        /// the processing algorithm on an <see cref="Image{TPixel}"/>.
-        /// </summary>
-        /// <typeparam name="TPixel">The pixel type.</typeparam>
-        /// <param name="source">The source image. Cannot be null.</param>
-        /// <param name="sourceRectangle">
-        /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to draw.
-        /// </param>
-        /// <returns>The <see cref="ICloningImageProcessor{TPixel}"/></returns>
-        public abstract ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        /// <inheritdoc/>
+        public abstract ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>;
 
         /// <inheritdoc/>
         IImageProcessor<TPixel> IImageProcessor.CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            => this.CreatePixelSpecificProcessor(source, sourceRectangle);
+            => this.CreatePixelSpecificCloningProcessor(source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
@@ -40,16 +42,16 @@ namespace SixLabors.ImageSharp.Processing.Processors
         protected Rectangle SourceRectangle { get; }
 
         /// <summary>
-        /// Gets the <see cref="ImageSharp.Configuration"/> instance to use when performing operations.
+        /// Gets the <see cref="Configuration"/> instance to use when performing operations.
         /// </summary>
         protected Configuration Configuration { get; }
 
         /// <inheritdoc/>
-        public Image<TPixel> CloneAndExecute()
+        Image<TPixel> ICloningImageProcessor<TPixel>.CloneAndExecute()
         {
             try
             {
-                Image<TPixel> clone = this.CreateDestination();
+                Image<TPixel> clone = this.CreateTarget();
                 this.CheckFrameCount(this.Source, clone);
 
                 Configuration configuration = this.Source.GetConfiguration();
@@ -82,7 +84,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
         }
 
         /// <inheritdoc/>
-        public void Execute()
+        void IImageProcessor<TPixel>.Execute()
         {
             // Create an interim clone of the source image to operate on.
             // Doing this allows for the application of transforms that will alter
@@ -90,7 +92,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
             Image<TPixel> clone = default;
             try
             {
-                clone = this.CloneAndExecute();
+                clone = ((ICloningImageProcessor<TPixel>)this).CloneAndExecute();
 
                 // We now need to move the pixel data/size data from the clone to the source.
                 this.CheckFrameCount(this.Source, clone);
@@ -111,10 +113,10 @@ namespace SixLabors.ImageSharp.Processing.Processors
         }
 
         /// <summary>
-        /// Generates a deep clone of the source image that operations should be applied to.
+        /// Gets the size of the target image.
         /// </summary>
-        /// <returns>The cloned image.</returns>
-        protected virtual Image<TPixel> CreateDestination() => this.Source.Clone();
+        /// <returns>The <see cref="Size"/>.</returns>
+        protected abstract Size GetTargetSize();
 
         /// <summary>
         /// This method is called before the process is applied to prepare the processor.
@@ -164,6 +166,23 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// <param name="disposing">Whether to dispose managed and unmanaged objects.</param>
         protected virtual void Dispose(bool disposing)
         {
+        }
+
+        private Image<TPixel> CreateTarget()
+        {
+            Image<TPixel> source = this.Source;
+            Size targetSize = this.GetTargetSize();
+
+            // We will always be creating the clone even for mutate because we may need to resize the canvas
+            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select<ImageFrame<TPixel>, ImageFrame<TPixel>>(
+                x => new ImageFrame<TPixel>(
+                    source.GetConfiguration(),
+                    targetSize.Width,
+                    targetSize.Height,
+                    x.Metadata.DeepClone()));
+
+            // Use the overload to prevent an extra frame being added
+            return new Image<TPixel>(this.Configuration, source.Metadata.DeepClone(), frames);
         }
 
         private void CheckFrameCount(Image<TPixel> a, Image<TPixel> b)

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor{TPixel}.cs
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         {
             if (this.Grayscale)
             {
-                new GrayscaleBt709Processor(1F).Apply(this.Source, this.SourceRectangle);
+                new GrayscaleBt709Processor(1F).Execute(this.Source, this.SourceRectangle);
             }
 
             base.BeforeImageApply();

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
@@ -45,7 +45,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         {
             if (this.Grayscale)
             {
-                new GrayscaleBt709Processor(1F).Apply(this.Source, this.SourceRectangle);
+                new GrayscaleBt709Processor(1F).Execute(this.Source, this.SourceRectangle);
             }
 
             base.BeforeImageApply();

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         {
             if (this.Grayscale)
             {
-                new GrayscaleBt709Processor(1F).Apply(this.Source, this.SourceRectangle);
+                new GrayscaleBt709Processor(1F).Execute(this.Source, this.SourceRectangle);
             }
 
             base.BeforeImageApply();

--- a/src/ImageSharp/Processing/Processors/Filters/LomographProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/LomographProcessor{TPixel}.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
         /// <inheritdoc/>
         protected override void AfterImageApply()
         {
-            new VignetteProcessor(VeryDarkGreen).Apply(this.Source, this.SourceRectangle);
+            new VignetteProcessor(VeryDarkGreen).Execute(this.Source, this.SourceRectangle);
             base.AfterImageApply();
         }
     }

--- a/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor{TPixel}.cs
@@ -31,8 +31,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
         /// <inheritdoc/>
         protected override void AfterImageApply()
         {
-            new VignetteProcessor(VeryDarkOrange).Apply(this.Source, this.SourceRectangle);
-            new GlowProcessor(LightOrange, this.Source.Width / 4F).Apply(this.Source, this.SourceRectangle);
+            new VignetteProcessor(VeryDarkOrange).Execute(this.Source, this.SourceRectangle);
+            new GlowProcessor(LightOrange, this.Source.Width / 4F).Execute(this.Source, this.SourceRectangle);
             base.AfterImageApply();
         }
     }

--- a/src/ImageSharp/Processing/Processors/ICloningImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/ICloningImageProcessor.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.Primitives;
+
+namespace SixLabors.ImageSharp.Processing.Processors
+{
+    /// <summary>
+    /// Defines an algorithm to alter the pixels of a cloned image.
+    /// </summary>
+    public interface ICloningImageProcessor : IImageProcessor
+    {
+        /// <summary>
+        /// Creates a pixel specific <see cref="ICloningImageProcessor{TPixel}"/> that is capable of executing
+        /// the processing algorithm on an <see cref="Image{TPixel}"/>.
+        /// </summary>
+        /// <typeparam name="TPixel">The pixel type.</typeparam>
+        /// <param name="source">The source image. Cannot be null.</param>
+        /// <param name="sourceRectangle">
+        /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to draw.
+        /// </param>
+        /// <returns>The <see cref="ICloningImageProcessor{TPixel}"/></returns>
+        ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+            where TPixel : struct, IPixel<TPixel>;
+    }
+}

--- a/src/ImageSharp/Processing/Processors/ICloningImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/ICloningImageProcessor{TPixel}.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors
 {
@@ -10,19 +9,13 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// Encapsulates methods to alter the pixels of a new image, cloned from the original image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal interface ICloningImageProcessor<TPixel> : IImageProcessor<TPixel>
+    public interface ICloningImageProcessor<TPixel> : IImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>
-        /// Applies the process to the specified portion of the specified <see cref="ImageFrame{TPixel}"/>.
+        /// Clones the specified <see cref="Image{TPixel}"/> and executes the process against the clone.
         /// </summary>
-        /// <exception cref="System.ArgumentNullException">
-        /// The target <see cref="Image{TPixel}"/> is null.
-        /// </exception>
-        /// <exception cref="System.ArgumentException">
-        /// The target <see cref="Rectangle"/> doesn't fit the dimension of the image.
-        /// </exception>
-        /// <returns>Returns the cloned image after there processor has been applied to it.</returns>
-        Image<TPixel> CloneAndApply();
+        /// <returns>The <see cref="Image{TPixel}"/>.</returns>
+        Image<TPixel> CloneAndExecute();
     }
 }

--- a/src/ImageSharp/Processing/Processors/ICloningImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/ICloningImageProcessor{TPixel}.cs
@@ -6,7 +6,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace SixLabors.ImageSharp.Processing.Processors
 {
     /// <summary>
-    /// Encapsulates methods to alter the pixels of a new image, cloned from the original image.
+    /// Implements an algorithm to alter the pixels of a cloned image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public interface ICloningImageProcessor<TPixel> : IImageProcessor<TPixel>

--- a/src/ImageSharp/Processing/Processors/IImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/IImageProcessor{TPixel}.cs
@@ -3,7 +3,6 @@
 
 using System;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors
 {
@@ -15,14 +14,8 @@ namespace SixLabors.ImageSharp.Processing.Processors
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>
-        /// Applies the process to the specified portion of the specified <see cref="Image{TPixel}"/>.
+        /// Executes the process against the specified <see cref="Image{TPixel}"/>.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// The target <see cref="Image{TPixel}"/> is null.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// The target <see cref="Rectangle"/> doesn't fit the dimension of the image.
-        /// </exception>
-        void Apply();
+        void Execute();
     }
 }

--- a/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
@@ -9,18 +9,21 @@ namespace SixLabors.ImageSharp.Processing.Processors
 {
     internal static class ImageProcessorExtensions
     {
-        public static void Apply(this IImageProcessor processor, Image source, Rectangle sourceRectangle)
-        {
-            source.AcceptVisitor(new ApplyVisitor(processor, sourceRectangle));
-        }
+        /// <summary>
+        /// Executes the processor against the given source image and rectangle bounds.
+        /// </summary>
+        /// <param name="processor">The processor.</param>
+        /// <param name="source">The source image.</param>
+        /// <param name="sourceRectangle">The source bounds.</param>
+        public static void Execute(this IImageProcessor processor, Image source, Rectangle sourceRectangle)
+            => source.AcceptVisitor(new ExecuteVisitor(processor, sourceRectangle));
 
-        private class ApplyVisitor : IImageVisitor
+        private class ExecuteVisitor : IImageVisitor
         {
             private readonly IImageProcessor processor;
-
             private readonly Rectangle sourceRectangle;
 
-            public ApplyVisitor(IImageProcessor processor, Rectangle sourceRectangle)
+            public ExecuteVisitor(IImageProcessor processor, Rectangle sourceRectangle)
             {
                 this.processor = processor;
                 this.sourceRectangle = sourceRectangle;

--- a/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
             {
                 using (IImageProcessor<TPixel> processorImpl = this.processor.CreatePixelSpecificProcessor(image, this.sourceRectangle))
                 {
-                    processorImpl.Apply();
+                    processorImpl.Execute();
                 }
             }
         }

--- a/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
@@ -9,10 +9,11 @@ using SixLabors.Primitives;
 namespace SixLabors.ImageSharp.Processing.Processors
 {
     /// <summary>
-    /// Allows the application of processors to images.
+    /// The base class for all pixel specific image processors.
+    /// Allows the application of processing algorithms to the image.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    internal abstract class ImageProcessor<TPixel> : IImageProcessor<TPixel>
+    public abstract class ImageProcessor<TPixel> : IImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         private bool isDisposed;
@@ -45,7 +46,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
         protected Configuration Configuration { get; }
 
         /// <inheritdoc/>
-        public void Apply()
+        public void Execute()
         {
             try
             {
@@ -71,7 +72,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
         }
 
         /// <summary>
-        /// Applies the processor to just a single ImageBase.
+        /// Applies the processor to a single image frame.
         /// </summary>
         /// <param name="source">the source image.</param>
         public void Apply(ImageFrame<TPixel> source)

--- a/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
@@ -44,7 +44,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
         protected Configuration Configuration { get; }
 
         /// <inheritdoc/>
-        public void Execute()
+        void IImageProcessor<TPixel>.Execute()
         {
             try
             {

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
-
-using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms
@@ -11,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// <summary>
     /// Defines an affine transformation applicable on an <see cref="Image"/>.
     /// </summary>
-    public class AffineTransformProcessor : IImageProcessor
+    public class AffineTransformProcessor : CloningImageProcessor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AffineTransformProcessor"/> class.
@@ -42,11 +40,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// </summary>
         public Size TargetDimensions { get; }
 
-        /// <inheritdoc />
-        public virtual IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
-        {
-            return new AffineTransformProcessor<TPixel>(this, source, sourceRectangle);
-        }
+        /// <inheritdoc/>
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+            => new AffineTransformProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Size TargetDimensions { get; }
 
         /// <inheritdoc/>
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
             => new AffineTransformProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor{TPixel}.cs
@@ -34,33 +34,33 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             switch (orientation)
             {
                 case OrientationMode.TopRight:
-                    new FlipProcessor(FlipMode.Horizontal).Apply(this.Source, this.SourceRectangle);
+                    new FlipProcessor(FlipMode.Horizontal).Execute(this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.BottomRight:
-                    new RotateProcessor((int)RotateMode.Rotate180, size).Apply(this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate180, size).Execute(this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.BottomLeft:
-                    new FlipProcessor(FlipMode.Vertical).Apply(this.Source, this.SourceRectangle);
+                    new FlipProcessor(FlipMode.Vertical).Execute(this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.LeftTop:
-                    new RotateProcessor((int)RotateMode.Rotate90, size).Apply(this.Source, this.SourceRectangle);
-                    new FlipProcessor(FlipMode.Horizontal).Apply(this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate90, size).Execute(this.Source, this.SourceRectangle);
+                    new FlipProcessor(FlipMode.Horizontal).Execute(this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.RightTop:
-                    new RotateProcessor((int)RotateMode.Rotate90, size).Apply(this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate90, size).Execute(this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.RightBottom:
-                    new FlipProcessor(FlipMode.Vertical).Apply(this.Source, this.SourceRectangle);
-                    new RotateProcessor((int)RotateMode.Rotate270, size).Apply(this.Source, this.SourceRectangle);
+                    new FlipProcessor(FlipMode.Vertical).Execute(this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate270, size).Execute(this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.LeftBottom:
-                    new RotateProcessor((int)RotateMode.Rotate270, size).Apply(this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate270, size).Execute(this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.Unknown:

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Rectangle CropRectangle { get; }
 
         /// <inheritdoc />
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
             => new CropProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms
@@ -9,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// <summary>
     /// Defines a crop operation on an image.
     /// </summary>
-    public sealed class CropProcessor : IImageProcessor
+    public sealed class CropProcessor : CloningImageProcessor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CropProcessor"/> class.
@@ -23,6 +22,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 new Rectangle(Point.Empty, sourceSize).Contains(cropRectangle),
                 nameof(cropRectangle),
                 "Crop rectangle should be smaller than the source bounds.");
+
             this.CropRectangle = cropRectangle;
         }
 
@@ -32,10 +32,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Rectangle CropRectangle { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
-        {
-            return new CropProcessor<TPixel>(this, source, sourceRectangle);
-        }
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+            => new CropProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
@@ -42,16 +42,16 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 Configuration configuration = this.Source.GetConfiguration();
 
                 // Detect the edges.
-                new SobelProcessor(false).Apply(temp, this.SourceRectangle);
+                new SobelProcessor(false).Execute(temp, this.SourceRectangle);
 
                 // Apply threshold binarization filter.
-                new BinaryThresholdProcessor(this.definition.Threshold).Apply(temp, this.SourceRectangle);
+                new BinaryThresholdProcessor(this.definition.Threshold).Execute(temp, this.SourceRectangle);
 
                 // Search for the first white pixels
                 rectangle = ImageMaths.GetFilteredBoundingRectangle(temp.Frames.RootFrame, 0);
             }
 
-            new CropProcessor(rectangle, this.Source.Size()).Apply(this.Source, this.SourceRectangle);
+            new CropProcessor(rectangle, this.Source.Size()).Execute(this.Source, this.SourceRectangle);
 
             base.BeforeImageApply();
         }

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Size TargetDimensions { get; }
 
         /// <inheritdoc />
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
             => new ProjectiveTransformProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
-
-using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms
@@ -11,7 +9,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// <summary>
     /// Defines a projective transformation applicable to an <see cref="Image"/>.
     /// </summary>
-    public sealed class ProjectiveTransformProcessor : IImageProcessor
+    public sealed class ProjectiveTransformProcessor : CloningImageProcessor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ProjectiveTransformProcessor"/> class.
@@ -43,10 +41,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Size TargetDimensions { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
-        {
-            return new ProjectiveTransformProcessor<TPixel>(this, source, sourceRectangle);
-        }
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+            => new ProjectiveTransformProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-
-using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms
@@ -11,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// <summary>
     /// Defines an image resizing operation with the given <see cref="IResampler"/> and dimensional parameters.
     /// </summary>
-    public class ResizeProcessor : IImageProcessor
+    public class ResizeProcessor : CloningImageProcessor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ResizeProcessor"/> class.
@@ -58,8 +55,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public bool Compand { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
             => new ResizeProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
@@ -55,7 +55,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public bool Compand { get; }
 
         /// <inheritdoc />
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
             => new ResizeProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Memory;
@@ -24,74 +22,34 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     internal class ResizeProcessor<TPixel> : TransformProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
-        private readonly ResizeProcessor parameterSource;
         private bool isDisposed;
+        private readonly int targetWidth;
+        private readonly int targetHeight;
+        private readonly IResampler resampler;
+        private Rectangle targetRectangle;
+        private readonly bool compand;
 
         // The following fields are not immutable but are optionally created on demand.
         private ResizeKernelMap horizontalKernelMap;
         private ResizeKernelMap verticalKernelMap;
 
-        public ResizeProcessor(ResizeProcessor parameterSource, Image<TPixel> source, Rectangle sourceRectangle)
+        public ResizeProcessor(ResizeProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
             : base(source, sourceRectangle)
         {
-            this.parameterSource = parameterSource;
+            this.targetWidth = definition.TargetWidth;
+            this.targetHeight = definition.TargetHeight;
+            this.targetRectangle = definition.TargetRectangle;
+            this.resampler = definition.Sampler;
+            this.compand = definition.Compand;
         }
-
-        /// <summary>
-        /// Gets the sampler to perform the resize operation.
-        /// </summary>
-        public IResampler Sampler => this.parameterSource.Sampler;
-
-        /// <summary>
-        /// Gets the target width.
-        /// </summary>
-        public int TargetWidth => this.parameterSource.TargetWidth;
-
-        /// <summary>
-        /// Gets the target height.
-        /// </summary>
-        public int TargetHeight => this.parameterSource.TargetHeight;
-
-        /// <summary>
-        /// Gets the target resize rectangle.
-        /// </summary>
-        public Rectangle TargetRectangle => this.parameterSource.TargetRectangle;
-
-        /// <summary>
-        /// Gets a value indicating whether to compress or expand individual pixel color values on processing.
-        /// </summary>
-        public bool Compand => this.parameterSource.Compand;
-
-        /// <summary>
-        /// This is a shim for tagging the CreateDestination virtual generic method for the AoT iOS compiler.
-        /// This method should never be referenced outside of the AotCompiler code.
-        /// </summary>
-        /// <returns>The result returned from <see cref="M:CreateDestination"/>.</returns>
-        internal Image<TPixel> AotCreateDestination()
-            => this.CreateDestination();
 
         /// <inheritdoc/>
-        protected override Image<TPixel> CreateDestination()
-        {
-            Image<TPixel> source = this.Source;
-            Configuration configuration = this.Configuration;
-
-            // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select<ImageFrame<TPixel>, ImageFrame<TPixel>>(
-                x => new ImageFrame<TPixel>(
-                    configuration,
-                    this.TargetWidth,
-                    this.TargetHeight,
-                    x.Metadata.DeepClone()));
-
-            // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(configuration, source.Metadata.DeepClone(), frames);
-        }
+        protected override Size GetTargetSize() => new Size(this.targetWidth, this.targetHeight);
 
         /// <inheritdoc/>
         protected override void BeforeImageApply(Image<TPixel> destination)
         {
-            if (!(this.Sampler is NearestNeighborResampler))
+            if (!(this.resampler is NearestNeighborResampler))
             {
                 Image<TPixel> source = this.Source;
                 Rectangle sourceRectangle = this.SourceRectangle;
@@ -99,14 +57,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 // Since all image frame dimensions have to be the same we can calculate this for all frames.
                 MemoryAllocator memoryAllocator = source.GetMemoryAllocator();
                 this.horizontalKernelMap = ResizeKernelMap.Calculate(
-                    this.Sampler,
-                    this.TargetRectangle.Width,
+                    this.resampler,
+                    this.targetRectangle.Width,
                     sourceRectangle.Width,
                     memoryAllocator);
 
                 this.verticalKernelMap = ResizeKernelMap.Calculate(
-                    this.Sampler,
-                    this.TargetRectangle.Height,
+                    this.resampler,
+                    this.targetRectangle.Height,
                     sourceRectangle.Height,
                     memoryAllocator);
             }
@@ -121,29 +79,29 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             Configuration configuration = this.Configuration;
 
             // Handle resize dimensions identical to the original
-            if (source.Width == destination.Width && source.Height == destination.Height && sourceRectangle == this.TargetRectangle)
+            if (source.Width == destination.Width && source.Height == destination.Height && sourceRectangle == this.targetRectangle)
             {
                 // The cloned will be blank here copy all the pixel data over
                 source.GetPixelSpan().CopyTo(destination.GetPixelSpan());
                 return;
             }
 
-            int width = this.TargetWidth;
-            int height = this.TargetHeight;
+            int width = this.targetWidth;
+            int height = this.targetHeight;
             int sourceX = sourceRectangle.X;
             int sourceY = sourceRectangle.Y;
-            int startY = this.TargetRectangle.Y;
-            int startX = this.TargetRectangle.X;
+            int startY = this.targetRectangle.Y;
+            int startX = this.targetRectangle.X;
 
             var targetWorkingRect = Rectangle.Intersect(
-                this.TargetRectangle,
+                this.targetRectangle,
                 new Rectangle(0, 0, width, height));
 
-            if (this.Sampler is NearestNeighborResampler)
+            if (this.resampler is NearestNeighborResampler)
             {
                 // Scaling factors
-                float widthFactor = sourceRectangle.Width / (float)this.TargetRectangle.Width;
-                float heightFactor = sourceRectangle.Height / (float)this.TargetRectangle.Height;
+                float widthFactor = sourceRectangle.Width / (float)this.targetRectangle.Width;
+                float heightFactor = sourceRectangle.Height / (float)this.targetRectangle.Height;
 
                 ParallelHelper.IterateRows(
                     targetWorkingRect,
@@ -153,8 +111,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                         for (int y = rows.Min; y < rows.Max; y++)
                         {
                             // Y coordinates of source points
-                            Span<TPixel> sourceRow =
-                                source.GetPixelRowSpan((int)(((y - startY) * heightFactor) + sourceY));
+                            Span<TPixel> sourceRow = source.GetPixelRowSpan((int)(((y - startY) * heightFactor) + sourceY));
                             Span<TPixel> targetRow = destination.GetPixelRowSpan(y);
 
                             for (int x = targetWorkingRect.Left; x < targetWorkingRect.Right; x++)
@@ -169,7 +126,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             }
 
             PixelConversionModifiers conversionModifiers =
-                PixelConversionModifiers.Premultiply.ApplyCompanding(this.Compand);
+                PixelConversionModifiers.Premultiply.ApplyCompanding(this.compand);
 
             BufferArea<TPixel> sourceArea = source.PixelBuffer.GetArea(sourceRectangle);
 
@@ -183,7 +140,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 this.verticalKernelMap,
                 width,
                 targetWorkingRect,
-                this.TargetRectangle.Location))
+                this.targetRectangle.Location))
             {
                 worker.Initialize();
 

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -46,7 +46,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public float Degrees { get; }
 
         /// <inheritdoc />
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
             => new RotateProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
-
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms
@@ -47,9 +46,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public float Degrees { get; }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new RotateProcessor<TPixel>(this, source, sourceRectangle);
-        }
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+            => new RotateProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/SkewProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/SkewProcessor.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
-
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Transforms

--- a/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             };
             var processor = new FillRegionProcessor(brush.Object, region, options);
             var img = new Image<Rgba32>(1, 1);
-            processor.Apply(img, bounds);
+            processor.Execute(img, bounds);
 
             Assert.Equal(4, region.ScanInvocationCounter);
         }
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             var options = new GraphicsOptions(true);
             var processor = new FillRegionProcessor(brush.Object, new MockRegion1(), options);
             var img = new Image<Rgba32>(10, 10);
-            processor.Apply(img, bounds);
+            processor.Execute(img, bounds);
         }
 
         [Fact]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Touches. #967 

- Refactors the image processors to make the interfaces and base classes public. 
- Removes double pixel processor creation.
- Simplified cloned target image creation.

<strike>I've marked this as draft as I want to do something more extreme and remove `ICloningImageProcessor<TPixel>` moving the interface method into the base class. This makes additional methods impossible to test against though via mocking. </strike>

Changed my mind and figured out a better way to create contracts for cloned/regular processors.

Thoughts please!
<!-- Thanks for contributing to ImageSharp! -->
