### PR TITLE
Update the hex value for DarkSeaGreen color

### DIFF
--- a/src/ImageSharp/Color/Color.NamedColors.cs
+++ b/src/ImageSharp/Color/Color.NamedColors.cs
@@ -174,9 +174,9 @@ namespace SixLabors.ImageSharp
         public static readonly Color DarkSalmon = FromRgba(233, 150, 122, 255);
 
         /// <summary>
-        /// Represents a <see paramref="Color"/> matching the W3C definition that has an hex value of #8FBC8B.
+        /// Represents a <see paramref="Color"/> matching the W3C definition that has an hex value of #8FBC8F.
         /// </summary>
-        public static readonly Color DarkSeaGreen = FromRgba(143, 188, 139, 255);
+        public static readonly Color DarkSeaGreen = FromRgba(143, 188, 143, 255);
 
         /// <summary>
         /// Represents a <see paramref="Color"/> matching the W3C definition that has an hex value of #483D8B.


### PR DESCRIPTION
Update the hex value for DarkSeaGreen color to 0xFF8FBC8F.

Based on W3 definition, the hex value for DarkSeaGreen color needs to be fixed:
https://www.w3.org/wiki/CSS/Properties/color/keywords

Fix issue: https://github.com/SixLabors/ImageSharp/issues/1015

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
