### PR TITLE
Huffman decode optimizations

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         [MethodImpl(InliningOptions.ShortMethod)]
         public void CheckBits()
         {
-            if (this.remainingBits < 16)
+            if (this.remainingBits < JpegConstants.Huffman.MinBits)
             {
                 this.FillBuffer();
             }
@@ -85,8 +85,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         {
             // Attempt to load at least the minimum number of required bits into the buffer.
             // We fail to do so only if we hit a marker or reach the end of the input stream.
-            this.remainingBits += JpegConstants.Huffman.MinBits;
-            this.data = (this.data << JpegConstants.Huffman.MinBits) | this.GetBytes();
+            this.remainingBits += JpegConstants.Huffman.FetchBits;
+            this.data = (this.data << JpegConstants.Huffman.FetchBits) | this.GetBytes();
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
@@ -85,8 +85,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         {
             // Attempt to load at least the minimum number of required bits into the buffer.
             // We fail to do so only if we hit a marker or reach the end of the input stream.
-            this.remainingBits += 48;
-            this.data = (this.data << 48) | this.GetBytes();
+            this.remainingBits += JpegConstants.Huffman.MinBits;
+            this.data = (this.data << JpegConstants.Huffman.MinBits) | this.GetBytes();
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
@@ -141,7 +141,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         private ulong GetBytes()
         {
             ulong temp = 0;
-            for (int i = 0; i < 6; i++)
+            for (int i = 0; i < JpegConstants.Huffman.FetchLoop; i++)
             {
                 int b = this.ReadStream();
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -82,12 +82,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 
             // Figure C.1: make table of Huffman code length for each symbol
             int p = 0;
-            for (int l = 1; l <= 16; l++)
+            for (int j = 1; j <= 16; j++)
             {
-                int i = this.Sizes[l];
+                int i = this.Sizes[j];
                 while (i-- != 0)
                 {
-                    huffSize[p++] = (char)l;
+                    huffSize[p++] = (char)j;
                 }
             }
 
@@ -111,20 +111,19 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 
             // Figure F.15: generate decoding tables for bit-sequential decoding
             p = 0;
-            for (int l = 1; l <= 16; l++)
+            for (int j = 1; j <= 16; j++)
             {
-                if (this.Sizes[l] != 0)
+                if (this.Sizes[j] != 0)
                 {
-                    int offset = p - (int)huffCode[p];
-                    this.ValOffset[l] = offset;
-                    p += this.Sizes[l];
-                    this.MaxCode[l] = huffCode[p - 1]; // Maximum code of length l
-                    this.MaxCode[l] <<= 64 - l; // Left justify
-                    this.MaxCode[l] |= (1ul << (64 - l)) - 1;
+                    this.ValOffset[j] = p - (int)huffCode[p];
+                    p += this.Sizes[j];
+                    this.MaxCode[j] = huffCode[p - 1]; // Maximum code of length l
+                    this.MaxCode[j] <<= JpegConstants.Huffman.RegisterSize - j; // Left justify
+                    this.MaxCode[j] |= (1ul << (JpegConstants.Huffman.RegisterSize - j)) - 1;
                 }
                 else
                 {
-                    this.MaxCode[l] = 0;
+                    this.MaxCode[j] = 0;
                 }
             }
 
@@ -142,11 +141,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             p = 0;
             for (int length = 1; length <= JpegConstants.Huffman.LookupBits; length++)
             {
+                int jShift = JpegConstants.Huffman.LookupBits - length;
                 for (int i = 1; i <= this.Sizes[length]; i++, p++)
                 {
                     // length = current code's length, p = its index in huffCode[] & Values[].
                     // Generate left-justified code followed by all possible bit sequences
-                    int lookBits = (int)(huffCode[p] << (JpegConstants.Huffman.LookupBits - length));
+                    int lookBits = (int)(huffCode[p] << jShift);
                     for (int ctr = 1 << (JpegConstants.Huffman.LookupBits - length); ctr > 0; ctr--)
                     {
                         this.LookaheadSize[lookBits] = (byte)length;

--- a/src/ImageSharp/Formats/Jpeg/JpegConstants.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegConstants.cs
@@ -251,9 +251,14 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             public const int RegisterSize = 64;
 
             /// <summary>
-            /// The minimum number of bits required by the <see cref="HuffmanScanBuffer"/>.
+            /// The number of bits to fetch when filling the <see cref="HuffmanScanBuffer"/> buffer.
             /// </summary>
-            public const int MinBits = 48;
+            public const int FetchBits = 48;
+
+            /// <summary>
+            /// The minimum number of bits allowed before by the <see cref="HuffmanScanBuffer"/> before fetching.
+            /// </summary>
+            public const int MinBits = RegisterSize - FetchBits;
 
             /// <summary>
             /// If the next Huffman code is no more than this number of bits, we can obtain its length

--- a/src/ImageSharp/Formats/Jpeg/JpegConstants.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegConstants.cs
@@ -256,6 +256,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             public const int FetchBits = 48;
 
             /// <summary>
+            /// The number of times to read the input stream when filling the <see cref="HuffmanScanBuffer"/> buffer.
+            /// </summary>
+            public const int FetchLoop = FetchBits / 8;
+
+            /// <summary>
             /// The minimum number of bits allowed before by the <see cref="HuffmanScanBuffer"/> before fetching.
             /// </summary>
             public const int MinBits = RegisterSize - FetchBits;

--- a/src/ImageSharp/Formats/Jpeg/JpegConstants.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegConstants.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
+using SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
 
 namespace SixLabors.ImageSharp.Formats.Jpeg
 {
@@ -248,6 +249,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             /// The size of the huffman decoder register.
             /// </summary>
             public const int RegisterSize = 64;
+
+            /// <summary>
+            /// The minimum number of bits required by the <see cref="HuffmanScanBuffer"/>.
+            /// </summary>
+            public const int MinBits = 48;
 
             /// <summary>
             /// If the next Huffman code is no more than this number of bits, we can obtain its length

--- a/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
@@ -94,7 +94,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
         }
 
         /// <inheritdoc/>
-        public virtual void Dispose()
+        public void Dispose()
         {
             this.Dispose(true);
             GC.SuppressFinalize(this);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Some minor optimizations to the HuffmanScanDecoder plus a little cleanup. For baseline jpegs we're sitting at around 25-30% for the total processing time.

``` bash
Full decoder

|                         Method |            TestImage |       Mean |      Error |     StdDev | Ratio | RatioSD |     Gen 0 | Gen 1 | Gen 2 |   Allocated |
|------------------------------- |--------------------- |-----------:|-----------:|-----------:|------:|--------:|----------:|------:|------:|------------:|
| 'Decode Jpeg - System.Drawing' | Jpg/b(...)e.jpg [21] |   6.121 ms |   3.134 ms |  0.1718 ms |  1.00 |    0.00 |   46.8750 |     - |     - |   205.83 KB |
|     'Decode Jpeg - ImageSharp' | Jpg/b(...)e.jpg [21] |  16.796 ms |   9.187 ms |  0.5036 ms |  2.74 |    0.03 |         - |     - |     - |    14.37 KB |
|                                |                      |            |            |            |       |         |           |       |       |             |
| 'Decode Jpeg - System.Drawing' | Jpg/b(...)f.jpg [28] |  16.034 ms |  19.142 ms |  1.0492 ms |  1.00 |    0.00 |  171.8750 |     - |     - |   757.04 KB |
|     'Decode Jpeg - ImageSharp' | Jpg/b(...)f.jpg [28] |  38.926 ms |   4.144 ms |  0.2271 ms |  2.43 |    0.15 |         - |     - |     - |    15.35 KB |
|                                |                      |            |            |            |       |         |           |       |       |             |
| 'Decode Jpeg - System.Drawing' | Jpg/i(...)e.jpg [43] | 408.578 ms | 202.366 ms | 11.0924 ms |  1.00 |    0.00 | 1000.0000 |     - |     - |  7403.76 KB |
|     'Decode Jpeg - ImageSharp' | Jpg/i(...)e.jpg [43] | 348.491 ms | 103.983 ms |  5.6997 ms |  0.85 |    0.04 |         - |     - |     - | 35177.02 KB |


The below benchmark is the result of returning an empty image before any iDCT or Color conversion. It appears those operations now take ~75%
of the decoding process.

|                         Method |            TestImage |       Mean |      Error |    StdDev | Ratio | RatioSD |     Gen 0 | Gen 1 | Gen 2 |  Allocated |
|------------------------------- |--------------------- |-----------:|-----------:|----------:|------:|--------:|----------:|------:|------:|-----------:|
| 'Decode Jpeg - System.Drawing' | Jpg/b(...)e.jpg [21] |   6.775 ms |   8.296 ms | 0.4547 ms |  1.00 |    0.00 |   46.8750 |     - |     - |  205.83 KB |
|     'Decode Jpeg - ImageSharp' | Jpg/b(...)e.jpg [21] |   4.689 ms |   1.700 ms | 0.0932 ms |  0.69 |    0.06 |         - |     - |     - |   12.29 KB |
|                                |                      |            |            |           |       |         |           |       |       |            |
| 'Decode Jpeg - System.Drawing' | Jpg/b(...)f.jpg [28] |  18.201 ms |   3.556 ms | 0.1949 ms |  1.00 |    0.00 |  156.2500 |     - |     - |  757.04 KB |
|     'Decode Jpeg - ImageSharp' | Jpg/b(...)f.jpg [28] |  14.439 ms |   4.345 ms | 0.2382 ms |  0.79 |    0.00 |         - |     - |     - |   12.29 KB |
|                                |                      |            |            |           |       |         |           |       |       |            |
| 'Decode Jpeg - System.Drawing' | Jpg/i(...)e.jpg [43] | 438.533 ms |  55.331 ms | 3.0329 ms |  1.00 |    0.00 | 1000.0000 |     - |     - | 7403.76 KB |
|     'Decode Jpeg - ImageSharp' | Jpg/i(...)e.jpg [43] | 229.262 ms | 100.169 ms | 5.4906 ms |  0.52 |    0.01 |         - |     - |     - | 35171.8 KB |
```

<!-- Thanks for contributing to ImageSharp! -->
