### PR TITLE
small improvements on the PorterDuff functions

### DIFF
--- a/src/ImageSharp/PixelFormats/PixelBlenders/PorterDuffFunctions.cs
+++ b/src/ImageSharp/PixelFormats/PixelBlenders/PorterDuffFunctions.cs
@@ -164,7 +164,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             float srcW = source.W - blendW;
 
             // calculate final alpha
-            float alpha = dstW + srcW + blendW;
+            float alpha = dstW + source.W;
 
             // calculate final color
             Vector4 color = (destination * dstW) + (source * srcW) + (blend * blendW);
@@ -191,7 +191,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             float dstW = destination.W - blendW;
 
             // calculate final alpha
-            float alpha = dstW + blendW;
+            float alpha = destination.W;
 
             // calculate final color
             Vector4 color = (destination * dstW) + (blend * blendW);


### PR DESCRIPTION
Explanation of the changes:










line 167:
    dstW + srcW + blendW
= dstW + (source.W - blendW) + blendW
= dstW + source.W - blendW + blendW
= dstW + source.W

line 194:
   dstW + blendW
= (destination.W - blendW) + blendW
= destination.W - blendW + blendW
= destination.W

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
removes two additions that are not necessary.