### PR TITLE
#1040 - Alpha blending incorrect for Gradients with relevant alpha component: Test and first fix

### DIFF
--- a/src/ImageSharp.Drawing/Processing/GradientBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/GradientBrush.cs
@@ -125,11 +125,12 @@ namespace SixLabors.ImageSharp.Processing
                         var toAsVector = to.Color.ToVector4();
                         float onLocalGradient = (positionOnCompleteGradient - from.Ratio) / (to.Ratio - from.Ratio);
 
-                        // TODO: this should be changeble for different gradienting functions
                         Vector4 result = PorterDuffFunctions.NormalSrcOver(
                             fromAsVector,
                             toAsVector,
                             onLocalGradient);
+
+                        result.W = fromAsVector.W + ((toAsVector.W - fromAsVector.W) * onLocalGradient);
 
                         TPixel resultColor = default;
                         resultColor.FromVector4(result);


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Gradients did not properly morph the alpha channel when that was different between start and end.
This was reported by @equinox2k in #1040.

There may be a matching PorterDuff-Function that does this correctly, but I didn't find one. Therefore this PR instead re-calculates the Alpha-Value after PorterDuff has been applied.

I checked the unit test myself, the reference output image must be added as well.
