### PR TITLE
Allow returning the image format with the info.

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpImageFormatDetector.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpImageFormatDetector.cs
@@ -22,9 +22,13 @@ namespace SixLabors.ImageSharp.Formats.Bmp
 
         private bool IsSupportedFileFormat(ReadOnlySpan<byte> header)
         {
-            short fileTypeMarker = BinaryPrimitives.ReadInt16LittleEndian(header);
-            return header.Length >= this.HeaderSize &&
-                   (fileTypeMarker == BmpConstants.TypeMarkers.Bitmap || fileTypeMarker == BmpConstants.TypeMarkers.BitmapArray);
+            if (header.Length >= this.HeaderSize)
+            {
+                short fileTypeMarker = BinaryPrimitives.ReadInt16LittleEndian(header);
+                return fileTypeMarker == BmpConstants.TypeMarkers.Bitmap || fileTypeMarker == BmpConstants.TypeMarkers.BitmapArray;
+            }
+
+            return false;
         }
     }
 }

--- a/src/ImageSharp/Formats/Tga/TgaImageFormatDetector.cs
+++ b/src/ImageSharp/Formats/Tga/TgaImageFormatDetector.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         {
             if (header.Length >= this.HeaderSize)
             {
-                // There is no magick bytes in a tga file, so at least the image type
+                // There are no magic bytes in a tga file, so at least the image type
                 // and the colormap type in the header will be checked for a valid value.
                 if (header[1] != 0 && header[1] != 1)
                 {
@@ -34,7 +34,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
                 return imageType.IsValid();
             }
 
-            return true;
+            return false;
         }
     }
 }

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.IO;
 using System.Linq;
 using SixLabors.ImageSharp.Formats;
@@ -47,19 +48,26 @@ namespace SixLabors.ImageSharp
         /// <returns>The mime type or null if none found.</returns>
         private static IImageFormat InternalDetectFormat(Stream stream, Configuration config)
         {
-            // This is probably a candidate for making into a public API in the future!
-            int maxHeaderSize = config.MaxHeaderSize;
-            if (maxHeaderSize <= 0)
+            // We take a minimum of the stream length vs the max header size and always check below
+            // to ensure that only formats that headers fit within the given buffer length are tested.
+            int headerSize = (int)Math.Min(config.MaxHeaderSize, stream.Length);
+            if (headerSize <= 0)
             {
                 return null;
             }
 
-            using (IManagedByteBuffer buffer = config.MemoryAllocator.AllocateManagedByteBuffer(maxHeaderSize, AllocationOptions.Clean))
+            using (IManagedByteBuffer buffer = config.MemoryAllocator.AllocateManagedByteBuffer(headerSize, AllocationOptions.Clean))
             {
                 long startPosition = stream.Position;
-                stream.Read(buffer.Array, 0, maxHeaderSize);
+                stream.Read(buffer.Array, 0, headerSize);
                 stream.Position = startPosition;
-                return config.ImageFormatsManager.FormatDetectors.Select(x => x.DetectFormat(buffer.GetSpan())).LastOrDefault(x => x != null);
+
+                // Does the given stream contain enough data to fit in the header for the format
+                // and does that data match the format specification?
+                // Individual formats should still check since they are public.
+                return config.ImageFormatsManager.FormatDetectors
+                    .Where(x => x.HeaderSize <= headerSize)
+                    .Select(x => x.DetectFormat(buffer.GetSpan())).LastOrDefault(x => x != null);
             }
         }
 

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
@@ -123,10 +123,14 @@ namespace SixLabors.ImageSharp
         /// <returns>
         /// The <see cref="IImageInfo"/> or null if suitable info detector not found.
         /// </returns>
-        private static IImageInfo InternalIdentity(Stream stream, Configuration config)
+        private static (IImageInfo info, IImageFormat format) InternalIdentity(Stream stream, Configuration config)
         {
-            var detector = DiscoverDecoder(stream, config, out IImageFormat _) as IImageInfoDetector;
-            return detector?.Identify(config, stream);
+            if (!(DiscoverDecoder(stream, config, out IImageFormat format) is IImageInfoDetector detector))
+            {
+                return (null, null);
+            }
+
+            return (detector?.Identify(config, stream), format);
         }
     }
 }

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -16,20 +16,20 @@ namespace SixLabors.ImageSharp
     public abstract partial class Image
     {
         /// <summary>
-        /// By reading the header on the provided stream this calculates the images mime type.
+        /// By reading the header on the provided stream this calculates the images format type.
         /// </summary>
         /// <param name="stream">The image stream to read the header from.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
-        /// <returns>The mime type or null if none found.</returns>
+        /// <returns>The format type or null if none found.</returns>
         public static IImageFormat DetectFormat(Stream stream) => DetectFormat(Configuration.Default, stream);
 
         /// <summary>
-        /// By reading the header on the provided stream this calculates the images mime type.
+        /// By reading the header on the provided stream this calculates the images format type.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="stream">The image stream to read the header from.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
-        /// <returns>The mime type or null if none found.</returns>
+        /// <returns>The format type or null if none found.</returns>
         public static IImageFormat DetectFormat(Configuration config, Stream stream)
             => WithSeekableStream(config, stream, s => InternalDetectFormat(s, config));
 
@@ -41,26 +41,43 @@ namespace SixLabors.ImageSharp
         /// <returns>
         /// The <see cref="IImageInfo"/> or null if suitable info detector not found.
         /// </returns>
-        public static IImageInfo Identify(Stream stream) => Identify(Configuration.Default, stream);
+        public static IImageInfo Identify(Stream stream) => Identify(stream, out IImageFormat _);
+
+        /// <summary>
+        /// By reading the header on the provided stream this reads the raw image information.
+        /// </summary>
+        /// <param name="stream">The image stream to read the header from.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
+        /// <returns>
+        /// The <see cref="IImageInfo"/> or null if suitable info detector not found.
+        /// </returns>
+        public static IImageInfo Identify(Stream stream, out IImageFormat format) => Identify(Configuration.Default, stream, out format);
 
         /// <summary>
         /// Reads the raw image information from the specified stream without fully decoding it.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="stream">The image stream to read the information from.</param>
+        /// <param name="format">The format type of the decoded image.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
         /// <returns>
         /// The <see cref="IImageInfo"/> or null if suitable info detector is not found.
         /// </returns>
-        public static IImageInfo Identify(Configuration config, Stream stream)
-            => WithSeekableStream(config, stream, s => InternalIdentity(s, config ?? Configuration.Default));
+        public static IImageInfo Identify(Configuration config, Stream stream, out IImageFormat format)
+        {
+            (IImageInfo info, IImageFormat format) data = WithSeekableStream(config, stream, s => InternalIdentity(s, config ?? Configuration.Default));
+
+            format = data.format;
+            return data.info;
+        }
 
         /// <summary>
         /// Decode a new instance of the <see cref="Image"/> class from the given stream.
         /// The pixel format is selected by the decoder.
         /// </summary>
         /// <param name="stream">The stream containing image information.</param>
-        /// <param name="format">the mime type of the decoded image.</param>
+        /// <param name="format">The format type of the decoded image.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
         /// <exception cref="UnknownImageFormatException">Image cannot be loaded.</exception>
         /// <returns>A new <see cref="Image"/>.</returns>>
@@ -126,7 +143,7 @@ namespace SixLabors.ImageSharp
         /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
         /// </summary>
         /// <param name="stream">The stream containing image information.</param>
-        /// <param name="format">the mime type of the decoded image.</param>
+        /// <param name="format">The format type of the decoded image.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
         /// <exception cref="UnknownImageFormatException">Image cannot be loaded.</exception>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
@@ -180,7 +197,7 @@ namespace SixLabors.ImageSharp
         /// </summary>
         /// <param name="config">The configuration options.</param>
         /// <param name="stream">The stream containing image information.</param>
-        /// <param name="format">the mime type of the decoded image.</param>
+        /// <param name="format">The format type of the decoded image.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
         /// <exception cref="UnknownImageFormatException">Image cannot be loaded.</exception>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
@@ -215,7 +232,7 @@ namespace SixLabors.ImageSharp
         /// </summary>
         /// <param name="config">The configuration options.</param>
         /// <param name="stream">The stream containing image information.</param>
-        /// <param name="format">the mime type of the decoded image.</param>
+        /// <param name="format">The format type of the decoded image.</param>
         /// <exception cref="NotSupportedException">Thrown if the stream is not readable.</exception>
         /// <exception cref="UnknownImageFormatException">Image cannot be loaded.</exception>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>

--- a/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
+++ b/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
@@ -191,6 +191,20 @@ namespace SixLabors.ImageSharp.Tests
             }
         }
 
+        [Fact]
+        public void IdentifyReturnsNullWithInvalidStream()
+        {
+            byte[] invalid = new byte[10];
+
+            using (var memoryStream = new MemoryStream(invalid))
+            {
+                IImageInfo imageInfo = Image.Identify(memoryStream, out IImageFormat format);
+
+                Assert.Null(imageInfo);
+                Assert.Null(format);
+            }
+        }
+
         private static IImageFormat GetFormat(string format)
         {
             return Configuration.Default.ImageFormats.FirstOrDefault(x => x.FileExtensions.Contains(format));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR adds the following method:

```c#
IImageInfo Image.Identify(stream, out IImageFormat format);
```

Which mirrors the `Image.Load` method. I spotted a need for it when writing a PR for PeachPie. 

It also fixes the issue identified here. Where it was possible to misidentify an image as TGA.

https://github.com/SixLabors/ImageSharp/pull/1026#issuecomment-546713541

<!-- Thanks for contributing to ImageSharp! -->
