### PR TITLE
Allow passing custom Configuration instances to processors

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor.cs
@@ -60,10 +60,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         public float Opacity { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixelBg> CreatePixelSpecificProcessor<TPixelBg>(Image<TPixelBg> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixelBg> CreatePixelSpecificProcessor<TPixelBg>(Configuration configuration, Image<TPixelBg> source, Rectangle sourceRectangle)
             where TPixelBg : struct, IPixel<TPixelBg>
         {
-            var visitor = new ProcessorFactoryVisitor<TPixelBg>(this, source, sourceRectangle);
+            var visitor = new ProcessorFactoryVisitor<TPixelBg>(configuration, this, source, sourceRectangle);
             this.Image.AcceptVisitor(visitor);
             return visitor.Result;
         }
@@ -71,12 +71,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         private class ProcessorFactoryVisitor<TPixelBg> : IImageVisitor
             where TPixelBg : struct, IPixel<TPixelBg>
         {
+            private readonly Configuration configuration;
             private readonly DrawImageProcessor definition;
             private readonly Image<TPixelBg> source;
             private readonly Rectangle sourceRectangle;
 
-            public ProcessorFactoryVisitor(DrawImageProcessor definition, Image<TPixelBg> source, Rectangle sourceRectangle)
+            public ProcessorFactoryVisitor(Configuration configuration, DrawImageProcessor definition, Image<TPixelBg> source, Rectangle sourceRectangle)
             {
+                this.configuration = configuration;
                 this.definition = definition;
                 this.source = source;
                 this.sourceRectangle = sourceRectangle;
@@ -88,6 +90,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
                 where TPixelFg : struct, IPixel<TPixelFg>
             {
                 this.Result = new DrawImageProcessor<TPixelBg, TPixelFg>(
+                    this.configuration,
                     image,
                     this.source,
                     this.sourceRectangle,

--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
@@ -22,6 +22,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         /// <summary>
         /// Initializes a new instance of the <see cref="DrawImageProcessor{TPixelBg, TPixelFg}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="image">The foreground <see cref="Image{TPixelFg}"/> to blend with the currently processing image.</param>
         /// <param name="source">The source <see cref="Image{TPixelBg}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
@@ -30,6 +31,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         /// <param name="alphaCompositionMode">The Alpha blending mode to use when drawing the image.</param>
         /// <param name="opacity">The opacity of the image to blend. Must be between 0 and 1.</param>
         public DrawImageProcessor(
+            Configuration configuration,
             Image<TPixelFg> image,
             Image<TPixelBg> source,
             Rectangle sourceRectangle,
@@ -37,7 +39,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
             PixelColorBlendingMode colorBlendingMode,
             PixelAlphaCompositionMode alphaCompositionMode,
             float opacity)
-            : base(source, sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             Guard.MustBeBetweenOrEqualTo(opacity, 0, 1, nameof(opacity));
 

--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor.cs
@@ -34,10 +34,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         public GraphicsOptions Options { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new FillProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new FillProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor{TPixel}.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Advanced.ParallelUtils;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 
@@ -21,8 +20,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
     {
         private readonly FillProcessor definition;
 
-        public FillProcessor(FillProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public FillProcessor(Configuration configuration, FillProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }
@@ -112,7 +111,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         {
             solidBrush = this.definition.Brush as SolidBrush;
 
-            if (solidBrush == null)
+            if (solidBrush is null)
             {
                 return false;
             }

--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor.cs
@@ -42,10 +42,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         public GraphicsOptions Options { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new FillRegionProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new FillRegionProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor{TPixel}.cs
@@ -23,8 +23,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
     {
         private readonly FillRegionProcessor definition;
 
-        public FillRegionProcessor(FillRegionProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public FillRegionProcessor(Configuration configuration, FillRegionProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor.cs
@@ -72,10 +72,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Text
         public PointF Location { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new DrawTextProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new DrawTextProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
@@ -27,8 +27,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Text
 
         private readonly DrawTextProcessor definition;
 
-        public DrawTextProcessor(DrawTextProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public DrawTextProcessor(Configuration configuration, DrawTextProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors;
-using SixLabors.Memory;
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing
@@ -23,10 +21,12 @@ namespace SixLabors.ImageSharp.Processing
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultImageProcessorContext{TPixel}"/> class.
         /// </summary>
-        /// <param name="source">The image.</param>
-        /// <param name="mutate">The mutate.</param>
-        public DefaultImageProcessorContext(Image<TPixel> source, bool mutate)
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+        /// <param name="source">The source image.</param>
+        /// <param name="mutate">Whether to mutate the image.</param>
+        public DefaultImageProcessorContext(Configuration configuration, Image<TPixel> source, bool mutate)
         {
+            this.Configuration = configuration;
             this.mutate = mutate;
             this.source = source;
 
@@ -38,7 +38,7 @@ namespace SixLabors.ImageSharp.Processing
         }
 
         /// <inheritdoc/>
-        public MemoryAllocator MemoryAllocator => this.source.GetConfiguration().MemoryAllocator;
+        public Configuration Configuration { get; }
 
         /// <inheritdoc/>
         public Image<TPixel> GetResultImage()
@@ -71,7 +71,7 @@ namespace SixLabors.ImageSharp.Processing
                 // interim clone if the first processor in the pipeline is a cloning processor.
                 if (processor is ICloningImageProcessor cloningImageProcessor)
                 {
-                    using (ICloningImageProcessor<TPixel> pixelProcessor = cloningImageProcessor.CreatePixelSpecificCloningProcessor(this.source, rectangle))
+                    using (ICloningImageProcessor<TPixel> pixelProcessor = cloningImageProcessor.CreatePixelSpecificCloningProcessor(this.Configuration, this.source, rectangle))
                     {
                         this.destination = pixelProcessor.CloneAndExecute();
                         return this;
@@ -83,7 +83,7 @@ namespace SixLabors.ImageSharp.Processing
             }
 
             // Standard processing pipeline.
-            using (IImageProcessor<TPixel> specificProcessor = processor.CreatePixelSpecificProcessor(this.destination, rectangle))
+            using (IImageProcessor<TPixel> specificProcessor = processor.CreatePixelSpecificProcessor(this.Configuration, this.destination, rectangle))
             {
                 specificProcessor.Execute();
             }

--- a/src/ImageSharp/Processing/Extensions/ProcessingExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/ProcessingExtensions.cs
@@ -20,12 +20,22 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="source">The image to mutate.</param>
         /// <param name="operation">The operation to perform on the source.</param>
         public static void Mutate(this Image source, Action<IImageProcessingContext> operation)
+            => Mutate(source, source.GetConfiguration(), operation);
+
+        /// <summary>
+        /// Mutates the source image by applying the image operation to it.
+        /// </summary>
+        /// <param name="source">The image to mutate.</param>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+        /// <param name="operation">The operation to perform on the source.</param>
+        public static void Mutate(this Image source, Configuration configuration, Action<IImageProcessingContext> operation)
         {
+            Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(source, nameof(source));
             Guard.NotNull(operation, nameof(operation));
             source.EnsureNotDisposed();
 
-            source.AcceptVisitor(new ProcessingVisitor(operation, true));
+            source.AcceptVisitor(new ProcessingVisitor(configuration, operation, true));
         }
 
         /// <summary>
@@ -36,14 +46,25 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="operation">The operation to perform on the source.</param>
         public static void Mutate<TPixel>(this Image<TPixel> source, Action<IImageProcessingContext> operation)
             where TPixel : struct, IPixel<TPixel>
+            => Mutate(source, source.GetConfiguration(), operation);
+
+        /// <summary>
+        /// Mutates the source image by applying the image operation to it.
+        /// </summary>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <param name="source">The image to mutate.</param>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+        /// <param name="operation">The operation to perform on the source.</param>
+        public static void Mutate<TPixel>(this Image<TPixel> source, Configuration configuration, Action<IImageProcessingContext> operation)
+        where TPixel : struct, IPixel<TPixel>
         {
+            Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(source, nameof(source));
             Guard.NotNull(operation, nameof(operation));
             source.EnsureNotDisposed();
 
             IInternalImageProcessingContext<TPixel> operationsRunner
-                = source.GetConfiguration()
-                        .ImageOperationsProvider.CreateImageProcessingContext(source, true);
+                = configuration.ImageOperationsProvider.CreateImageProcessingContext(configuration, source, true);
 
             operation(operationsRunner);
         }
@@ -56,14 +77,24 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="operations">The operations to perform on the source.</param>
         public static void Mutate<TPixel>(this Image<TPixel> source, params IImageProcessor[] operations)
             where TPixel : struct, IPixel<TPixel>
+            => Mutate(source, source.GetConfiguration(), operations);
+
+        /// <summary>
+        /// Mutates the source image by applying the operations to it.
+        /// </summary>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <param name="source">The image to mutate.</param>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+        /// <param name="operations">The operations to perform on the source.</param>
+        public static void Mutate<TPixel>(this Image<TPixel> source, Configuration configuration, params IImageProcessor[] operations)
+            where TPixel : struct, IPixel<TPixel>
         {
             Guard.NotNull(source, nameof(source));
             Guard.NotNull(operations, nameof(operations));
             source.EnsureNotDisposed();
 
             IInternalImageProcessingContext<TPixel> operationsRunner
-                = source.GetConfiguration()
-                        .ImageOperationsProvider.CreateImageProcessingContext(source, true);
+                = configuration.ImageOperationsProvider.CreateImageProcessingContext(configuration, source, true);
 
             operationsRunner.ApplyProcessors(operations);
         }
@@ -75,12 +106,23 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="operation">The operation to perform on the clone.</param>
         /// <returns>The new <see cref="SixLabors.ImageSharp.Image"/>.</returns>
         public static Image Clone(this Image source, Action<IImageProcessingContext> operation)
+            => Clone(source, source.GetConfiguration(), operation);
+
+        /// <summary>
+        /// Creates a deep clone of the current image. The clone is then mutated by the given operation.
+        /// </summary>
+        /// <param name="source">The image to clone.</param>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+        /// <param name="operation">The operation to perform on the clone.</param>
+        /// <returns>The new <see cref="SixLabors.ImageSharp.Image"/>.</returns>
+        public static Image Clone(this Image source, Configuration configuration, Action<IImageProcessingContext> operation)
         {
+            Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(source, nameof(source));
             Guard.NotNull(operation, nameof(operation));
             source.EnsureNotDisposed();
 
-            var visitor = new ProcessingVisitor(operation, false);
+            var visitor = new ProcessingVisitor(configuration, operation, false);
             source.AcceptVisitor(visitor);
             return visitor.ResultImage;
         }
@@ -94,14 +136,26 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The new <see cref="SixLabors.ImageSharp.Image{TPixel}"/></returns>
         public static Image<TPixel> Clone<TPixel>(this Image<TPixel> source, Action<IImageProcessingContext> operation)
             where TPixel : struct, IPixel<TPixel>
+            => Clone(source, source.GetConfiguration(), operation);
+
+        /// <summary>
+        /// Creates a deep clone of the current image. The clone is then mutated by the given operation.
+        /// </summary>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <param name="source">The image to clone.</param>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+        /// <param name="operation">The operation to perform on the clone.</param>
+        /// <returns>The new <see cref="SixLabors.ImageSharp.Image{TPixel}"/></returns>
+        public static Image<TPixel> Clone<TPixel>(this Image<TPixel> source, Configuration configuration, Action<IImageProcessingContext> operation)
+        where TPixel : struct, IPixel<TPixel>
         {
+            Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(source, nameof(source));
             Guard.NotNull(operation, nameof(operation));
             source.EnsureNotDisposed();
 
             IInternalImageProcessingContext<TPixel> operationsRunner
-                = source.GetConfiguration()
-                        .ImageOperationsProvider.CreateImageProcessingContext(source, false);
+                = configuration.ImageOperationsProvider.CreateImageProcessingContext(configuration, source, false);
 
             operation(operationsRunner);
             return operationsRunner.GetResultImage();
@@ -116,14 +170,26 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The new <see cref="SixLabors.ImageSharp.Image{TPixel}"/></returns>
         public static Image<TPixel> Clone<TPixel>(this Image<TPixel> source, params IImageProcessor[] operations)
             where TPixel : struct, IPixel<TPixel>
+            => Clone(source, source.GetConfiguration(), operations);
+
+        /// <summary>
+        /// Creates a deep clone of the current image. The clone is then mutated by the given operations.
+        /// </summary>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <param name="source">The image to clone.</param>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+        /// <param name="operations">The operations to perform on the clone.</param>
+        /// <returns>The new <see cref="SixLabors.ImageSharp.Image{TPixel}"/></returns>
+        public static Image<TPixel> Clone<TPixel>(this Image<TPixel> source, Configuration configuration, params IImageProcessor[] operations)
+        where TPixel : struct, IPixel<TPixel>
         {
+            Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(source, nameof(source));
             Guard.NotNull(operations, nameof(operations));
             source.EnsureNotDisposed();
 
             IInternalImageProcessingContext<TPixel> operationsRunner
-                = source.GetConfiguration()
-                        .ImageOperationsProvider.CreateImageProcessingContext(source, false);
+                = configuration.ImageOperationsProvider.CreateImageProcessingContext(configuration, source, false);
 
             operationsRunner.ApplyProcessors(operations);
             return operationsRunner.GetResultImage();
@@ -149,12 +215,15 @@ namespace SixLabors.ImageSharp.Processing
 
         private class ProcessingVisitor : IImageVisitor
         {
+            private readonly Configuration configuration;
+
             private readonly Action<IImageProcessingContext> operation;
 
             private readonly bool mutate;
 
-            public ProcessingVisitor(Action<IImageProcessingContext> operation, bool mutate)
+            public ProcessingVisitor(Configuration configuration, Action<IImageProcessingContext> operation, bool mutate)
             {
+                this.configuration = configuration;
                 this.operation = operation;
                 this.mutate = mutate;
             }
@@ -165,8 +234,7 @@ namespace SixLabors.ImageSharp.Processing
                 where TPixel : struct, IPixel<TPixel>
             {
                 IInternalImageProcessingContext<TPixel> operationsRunner =
-                    image.GetConfiguration()
-                         .ImageOperationsProvider.CreateImageProcessingContext(image, this.mutate);
+                    this.configuration.ImageOperationsProvider.CreateImageProcessingContext(this.configuration, image, this.mutate);
 
                 this.operation(operationsRunner);
                 this.ResultImage = operationsRunner.GetResultImage();

--- a/src/ImageSharp/Processing/IImageProcessingContext.cs
+++ b/src/ImageSharp/Processing/IImageProcessingContext.cs
@@ -13,10 +13,9 @@ namespace SixLabors.ImageSharp.Processing
     public interface IImageProcessingContext
     {
         /// <summary>
-        /// Gets a reference to the <see cref="MemoryAllocator" /> used to allocate buffers
-        /// for this context.
+        /// Gets the configuration which allows altering default behaviour or extending the library.
         /// </summary>
-        MemoryAllocator MemoryAllocator { get; }
+        Configuration Configuration { get; }
 
         /// <summary>
         /// Gets the image dimensions at the current point in the processing pipeline.

--- a/src/ImageSharp/Processing/IImageProcessingContextFactory.cs
+++ b/src/ImageSharp/Processing/IImageProcessingContextFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.PixelFormats;
@@ -14,10 +14,11 @@ namespace SixLabors.ImageSharp.Processing
         /// Called during mutate operations to generate the image operations provider.
         /// </summary>
         /// <typeparam name="TPixel">The pixel format</typeparam>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="source">The source image.</param>
         /// <param name="mutate">A flag to determine whether image operations are allowed to mutate the source image.</param>
         /// <returns>A new <see cref="IInternalImageProcessingContext{TPixel}"/></returns>
-        IInternalImageProcessingContext<TPixel> CreateImageProcessingContext<TPixel>(Image<TPixel> source, bool mutate)
+        IInternalImageProcessingContext<TPixel> CreateImageProcessingContext<TPixel>(Configuration configuration, Image<TPixel> source, bool mutate)
             where TPixel : struct, IPixel<TPixel>;
     }
 
@@ -27,10 +28,10 @@ namespace SixLabors.ImageSharp.Processing
     internal class DefaultImageOperationsProviderFactory : IImageProcessingContextFactory
     {
         /// <inheritdoc/>
-        public IInternalImageProcessingContext<TPixel> CreateImageProcessingContext<TPixel>(Image<TPixel> source, bool mutate)
+        public IInternalImageProcessingContext<TPixel> CreateImageProcessingContext<TPixel>(Configuration configuration, Image<TPixel> source, bool mutate)
             where TPixel : struct, IPixel<TPixel>
         {
-            return new DefaultImageProcessorContext<TPixel>(source, mutate);
+            return new DefaultImageProcessorContext<TPixel>(configuration, source, mutate);
         }
     }
 }

--- a/src/ImageSharp/Processing/IInternalImageProcessingContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/IInternalImageProcessingContext{TPixel}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.PixelFormats;
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>
-        /// Returns the result image to return by <see cref="ProcessingExtensions.Clone"/>
+        /// Returns the result image to return by <see cref="ProcessingExtensions.Clone(Image, Configuration, System.Action{IImageProcessingContext})"/>
         /// (and other overloads).
         /// </summary>
         /// <returns>The current image or a new image depending on whether it is requested to mutate the source image.</returns>

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryErrorDiffusionProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryErrorDiffusionProcessor.cs
@@ -70,8 +70,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
         public Color LowerColor { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-            => new BinaryErrorDiffusionProcessor<TPixel>(this, source, sourceRectangle);
+            => new BinaryErrorDiffusionProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryErrorDiffusionProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryErrorDiffusionProcessor{TPixel}.cs
@@ -22,11 +22,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryErrorDiffusionProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="BinaryErrorDiffusionProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public BinaryErrorDiffusionProcessor(BinaryErrorDiffusionProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public BinaryErrorDiffusionProcessor(Configuration configuration, BinaryErrorDiffusionProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryOrderedDitherProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryOrderedDitherProcessor.cs
@@ -52,8 +52,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
         public Color LowerColor { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-            => new BinaryOrderedDitherProcessor<TPixel>(this, source, sourceRectangle);
+            => new BinaryOrderedDitherProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryOrderedDitherProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryOrderedDitherProcessor{TPixel}.cs
@@ -22,11 +22,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryOrderedDitherProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="BinaryErrorDiffusionProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public BinaryOrderedDitherProcessor(BinaryOrderedDitherProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public BinaryOrderedDitherProcessor(Configuration configuration, BinaryOrderedDitherProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
@@ -50,8 +50,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
         public Color LowerColor { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-            => new BinaryThresholdProcessor<TPixel>(this, source, sourceRectangle);
+            => new BinaryThresholdProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor{TPixel}.cs
@@ -22,11 +22,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryThresholdProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="BinaryThresholdProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public BinaryThresholdProcessor(BinaryThresholdProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public BinaryThresholdProcessor(Configuration configuration, BinaryThresholdProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
@@ -12,11 +12,11 @@ namespace SixLabors.ImageSharp.Processing.Processors
     public abstract class CloningImageProcessor : ICloningImageProcessor
     {
         /// <inheritdoc/>
-        public abstract ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public abstract ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>;
 
         /// <inheritdoc/>
-        IImageProcessor<TPixel> IImageProcessor.CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            => this.CreatePixelSpecificCloningProcessor(source, sourceRectangle);
+        IImageProcessor<TPixel> IImageProcessor.CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => this.CreatePixelSpecificCloningProcessor(configuration, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.Primitives;
 
@@ -22,13 +21,14 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="CloningImageProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        protected CloningImageProcessor(Image<TPixel> source, Rectangle sourceRectangle)
+        protected CloningImageProcessor(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
         {
+            this.Configuration = configuration;
             this.Source = source;
             this.SourceRectangle = sourceRectangle;
-            this.Configuration = this.Source.GetConfiguration();
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
                 Image<TPixel> clone = this.CreateTarget();
                 this.CheckFrameCount(this.Source, clone);
 
-                Configuration configuration = this.Source.GetConfiguration();
+                Configuration configuration = this.Configuration;
                 this.BeforeImageApply(clone);
 
                 for (int i = 0; i < this.Source.Frames.Count; i++)
@@ -176,7 +176,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
             // We will always be creating the clone even for mutate because we may need to resize the canvas
             IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select<ImageFrame<TPixel>, ImageFrame<TPixel>>(
                 x => new ImageFrame<TPixel>(
-                    source.GetConfiguration(),
+                    this.Configuration,
                     targetSize.Width,
                     targetSize.Height,
                     x.Metadata.DeepClone()));

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
@@ -71,10 +71,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         public float Gamma { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new BokehBlurProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new BokehBlurProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
@@ -69,11 +69,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <summary>
         /// Initializes a new instance of the <see cref="BokehBlurProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="BoxBlurProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public BokehBlurProcessor(BokehBlurProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public BokehBlurProcessor(Configuration configuration, BokehBlurProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.radius = definition.Radius;
             this.kernelSize = (this.radius * 2) + 1;

--- a/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor.cs
@@ -7,7 +7,7 @@ using SixLabors.Primitives;
 namespace SixLabors.ImageSharp.Processing.Processors.Convolution
 {
     /// <summary>
-    /// Defines a box blur processor of a given Radius.
+    /// Defines a box blur processor of a given radius.
     /// </summary>
     public sealed class BoxBlurProcessor : IImageProcessor
     {
@@ -41,10 +41,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         public int Radius { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new BoxBlurProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new BoxBlurProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor{TPixel}.cs
@@ -14,18 +14,16 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     internal class BoxBlurProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
-        private readonly BoxBlurProcessor definition;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="BoxBlurProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="BoxBlurProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public BoxBlurProcessor(BoxBlurProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public BoxBlurProcessor(Configuration configuration, BoxBlurProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
-            this.definition = definition;
             int kernelSize = (definition.Radius * 2) + 1;
             this.KernelX = CreateBoxKernel(kernelSize);
             this.KernelY = this.KernelX.Transpose();
@@ -44,7 +42,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <inheritdoc/>
         protected override void OnFrameApply(ImageFrame<TPixel> source)
         {
-            using (var processor = new Convolution2PassProcessor<TPixel>(this.KernelX, this.KernelY, false, this.Source, this.SourceRectangle))
+            using (var processor = new Convolution2PassProcessor<TPixel>(this.Configuration, this.KernelX, this.KernelY, false, this.Source, this.SourceRectangle))
             {
                 processor.Apply(source);
             }

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor{TPixel}.cs
@@ -23,18 +23,20 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <summary>
         /// Initializes a new instance of the <see cref="Convolution2DProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="kernelX">The horizontal gradient operator.</param>
         /// <param name="kernelY">The vertical gradient operator.</param>
         /// <param name="preserveAlpha">Whether the convolution filter is applied to alpha as well as the color channels.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         public Convolution2DProcessor(
+            Configuration configuration,
             in DenseMatrix<float> kernelX,
             in DenseMatrix<float> kernelY,
             bool preserveAlpha,
             Image<TPixel> source,
             Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             Guard.IsTrue(kernelX.Size.Equals(kernelY.Size), $"{nameof(kernelX)} {nameof(kernelY)}", "Kernel sizes must be the same.");
             this.KernelX = kernelX;

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
@@ -23,18 +23,20 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <summary>
         /// Initializes a new instance of the <see cref="Convolution2PassProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="kernelX">The horizontal gradient operator.</param>
         /// <param name="kernelY">The vertical gradient operator.</param>
         /// <param name="preserveAlpha">Whether the convolution filter is applied to alpha as well as the color channels.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         public Convolution2PassProcessor(
+            Configuration configuration,
             in DenseMatrix<float> kernelX,
             in DenseMatrix<float> kernelY,
             bool preserveAlpha,
             Image<TPixel> source,
             Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.KernelX = kernelX;
             this.KernelY = kernelY;

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
@@ -23,16 +23,18 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <summary>
         /// Initializes a new instance of the <see cref="ConvolutionProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="kernelXY">The 2d gradient operator.</param>
         /// <param name="preserveAlpha">Whether the convolution filter is applied to alpha as well as the color channels.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         public ConvolutionProcessor(
+            Configuration configuration,
             in DenseMatrix<float> kernelXY,
             bool preserveAlpha,
             Image<TPixel> source,
             Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.KernelXY = kernelXY;
             this.PreserveAlpha = preserveAlpha;

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor{TPixel}.cs
@@ -18,18 +18,20 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <summary>
         /// Initializes a new instance of the <see cref="EdgeDetector2DProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="kernelX">The horizontal gradient operator.</param>
         /// <param name="kernelY">The vertical gradient operator.</param>
         /// <param name="grayscale">Whether to convert the image to grayscale before performing edge detection.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         internal EdgeDetector2DProcessor(
+            Configuration configuration,
             in DenseMatrix<float> kernelX,
             in DenseMatrix<float> kernelY,
             bool grayscale,
             Image<TPixel> source,
             Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             Guard.IsTrue(kernelX.Size.Equals(kernelY.Size), $"{nameof(kernelX)} {nameof(kernelY)}", "Kernel sizes must be the same.");
             this.KernelX = kernelX;
@@ -54,7 +56,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         {
             if (this.Grayscale)
             {
-                new GrayscaleBt709Processor(1F).Execute(this.Source, this.SourceRectangle);
+                new GrayscaleBt709Processor(1F).Execute(this.Configuration, this.Source, this.SourceRectangle);
             }
 
             base.BeforeImageApply();
@@ -63,7 +65,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <inheritdoc />
         protected override void OnFrameApply(ImageFrame<TPixel> source)
         {
-            using (var processor = new Convolution2DProcessor<TPixel>(this.KernelX, this.KernelY, true, this.Source, this.SourceRectangle))
+            using (var processor = new Convolution2DProcessor<TPixel>(this.Configuration, this.KernelX, this.KernelY, true, this.Source, this.SourceRectangle))
             {
                 processor.Apply(source);
             }

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
@@ -25,12 +25,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <summary>
         /// Initializes a new instance of the <see cref="EdgeDetectorCompassProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="kernels">Gets the kernels to use.</param>
         /// <param name="grayscale">Whether to convert the image to grayscale before performing edge detection.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        internal EdgeDetectorCompassProcessor(CompassKernels kernels, bool grayscale, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        internal EdgeDetectorCompassProcessor(Configuration configuration, CompassKernels kernels, bool grayscale, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.Grayscale = grayscale;
             this.Kernels = kernels;
@@ -45,7 +46,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         {
             if (this.Grayscale)
             {
-                new GrayscaleBt709Processor(1F).Execute(this.Source, this.SourceRectangle);
+                new GrayscaleBt709Processor(1F).Execute(this.Configuration, this.Source, this.SourceRectangle);
             }
 
             base.BeforeImageApply();
@@ -70,7 +71,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
             // we need a clean copy for each pass to start from
             using (ImageFrame<TPixel> cleanCopy = source.Clone())
             {
-                using (var processor = new ConvolutionProcessor<TPixel>(kernels[0], true, this.Source, this.SourceRectangle))
+                using (var processor = new ConvolutionProcessor<TPixel>(this.Configuration, kernels[0], true, this.Source, this.SourceRectangle))
                 {
                     processor.Apply(source);
                 }
@@ -102,7 +103,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
                 {
                     using (ImageFrame<TPixel> pass = cleanCopy.Clone())
                     {
-                        using (var processor = new ConvolutionProcessor<TPixel>(kernels[i], true, this.Source, this.SourceRectangle))
+                        using (var processor = new ConvolutionProcessor<TPixel>(this.Configuration, kernels[i], true, this.Source, this.SourceRectangle))
                         {
                             processor.Apply(pass);
                         }

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         public bool Grayscale { get; }
 
         /// <inheritdoc />
-        public abstract IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public abstract IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
@@ -18,12 +18,18 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <summary>
         /// Initializes a new instance of the <see cref="EdgeDetectorProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="kernelXY">The 2d gradient operator.</param>
         /// <param name="grayscale">Whether to convert the image to grayscale before performing edge detection.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The target area to process for the current processor instance.</param>
-        public EdgeDetectorProcessor(in DenseMatrix<float> kernelXY, bool grayscale, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public EdgeDetectorProcessor(
+            Configuration configuration,
+            in DenseMatrix<float> kernelXY,
+            bool grayscale,
+            Image<TPixel> source,
+            Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.KernelXY = kernelXY;
             this.Grayscale = grayscale;
@@ -41,7 +47,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         {
             if (this.Grayscale)
             {
-                new GrayscaleBt709Processor(1F).Execute(this.Source, this.SourceRectangle);
+                new GrayscaleBt709Processor(1F).Execute(this.Configuration, this.Source, this.SourceRectangle);
             }
 
             base.BeforeImageApply();
@@ -50,7 +56,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <inheritdoc/>
         protected override void OnFrameApply(ImageFrame<TPixel> source)
         {
-            using (var processor = new ConvolutionProcessor<TPixel>(this.KernelXY, true, this.Source, this.SourceRectangle))
+            using (var processor = new ConvolutionProcessor<TPixel>(this.Configuration, this.KernelXY, true, this.Source, this.SourceRectangle))
             {
                 processor.Apply(source);
             }

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor.cs
@@ -71,10 +71,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         public int Radius { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new GaussianBlurProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new GaussianBlurProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor{TPixel}.cs
@@ -17,11 +17,16 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianBlurProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="GaussianBlurProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public GaussianBlurProcessor(GaussianBlurProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public GaussianBlurProcessor(
+            Configuration configuration,
+            GaussianBlurProcessor definition,
+            Image<TPixel> source,
+            Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             int kernelSize = (definition.Radius * 2) + 1;
             this.KernelX = ConvolutionProcessorHelpers.CreateGaussianBlurKernel(kernelSize, definition.Sigma);
@@ -41,7 +46,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <inheritdoc/>
         protected override void OnFrameApply(ImageFrame<TPixel> source)
         {
-            using (var processor = new Convolution2PassProcessor<TPixel>(this.KernelX, this.KernelY, false, this.Source, this.SourceRectangle))
+            using (var processor = new Convolution2PassProcessor<TPixel>(this.Configuration, this.KernelX, this.KernelY, false, this.Source, this.SourceRectangle))
             {
                 processor.Apply(source);
             }

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     public sealed class GaussianSharpenProcessor : IImageProcessor
     {
-         /// <summary>
+        /// <summary>
         /// The default value for <see cref="Sigma"/>.
         /// </summary>
         public const float DefaultSigma = 3f;
@@ -71,10 +71,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         public int Radius { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new GaussianSharpenProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new GaussianSharpenProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor{TPixel}.cs
@@ -17,11 +17,16 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianSharpenProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="GaussianBlurProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public GaussianSharpenProcessor(GaussianSharpenProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public GaussianSharpenProcessor(
+            Configuration configuration,
+            GaussianSharpenProcessor definition,
+            Image<TPixel> source,
+            Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             int kernelSize = (definition.Radius * 2) + 1;
             this.KernelX = ConvolutionProcessorHelpers.CreateGaussianSharpenKernel(kernelSize, definition.Sigma);
@@ -41,7 +46,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <inheritdoc/>
         protected override void OnFrameApply(ImageFrame<TPixel> source)
         {
-            using (var processor = new Convolution2PassProcessor<TPixel>(this.KernelX, this.KernelY, false, this.Source, this.SourceRectangle))
+            using (var processor = new Convolution2PassProcessor<TPixel>(this.Configuration, this.KernelX, this.KernelY, false, this.Source, this.SourceRectangle))
             {
                 processor.Apply(source);
             }

--- a/src/ImageSharp/Processing/Processors/Convolution/KayyaliProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KayyaliProcessor.cs
@@ -21,14 +21,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetector2DProcessor<TPixel>(
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetector2DProcessor<TPixel>(
+                configuration,
                 KayyaliKernels.KayyaliX,
                 KayyaliKernels.KayyaliY,
                 this.Grayscale,
                 source,
                 sourceRectangle);
-        }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/KirschProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KirschProcessor.cs
@@ -21,9 +21,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetectorCompassProcessor<TPixel>(new KirschKernels(), this.Grayscale, source, sourceRectangle);
-        }
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetectorCompassProcessor<TPixel>(configuration, new KirschKernels(), this.Grayscale, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/Laplacian3x3Processor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Laplacian3x3Processor.cs
@@ -21,9 +21,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetectorProcessor<TPixel>(LaplacianKernels.Laplacian3x3, this.Grayscale, source, sourceRectangle);
-        }
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetectorProcessor<TPixel>(configuration, LaplacianKernels.Laplacian3x3, this.Grayscale, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/Laplacian5x5Processor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Laplacian5x5Processor.cs
@@ -21,9 +21,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetectorProcessor<TPixel>(LaplacianKernels.Laplacian5x5, this.Grayscale, source, sourceRectangle);
-        }
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetectorProcessor<TPixel>(configuration, LaplacianKernels.Laplacian5x5, this.Grayscale, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/LaplacianOfGaussianProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/LaplacianOfGaussianProcessor.cs
@@ -21,9 +21,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetectorProcessor<TPixel>(LaplacianKernels.LaplacianOfGaussianXY, this.Grayscale, source, sourceRectangle);
-        }
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetectorProcessor<TPixel>(configuration, LaplacianKernels.LaplacianOfGaussianXY, this.Grayscale, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/PrewittProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/PrewittProcessor.cs
@@ -21,9 +21,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetector2DProcessor<TPixel>(PrewittKernels.PrewittX, PrewittKernels.PrewittY, this.Grayscale, source, sourceRectangle);
-        }
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetector2DProcessor<TPixel>(
+                configuration,
+                PrewittKernels.PrewittX,
+                PrewittKernels.PrewittY,
+                this.Grayscale,
+                source,
+                sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/RobertsCrossProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/RobertsCrossProcessor.cs
@@ -21,14 +21,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetector2DProcessor<TPixel>(
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetector2DProcessor<TPixel>(
+                configuration,
                 RobertsCrossKernels.RobertsCrossX,
                 RobertsCrossKernels.RobertsCrossY,
                 this.Grayscale,
                 source,
                 sourceRectangle);
-        }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/RobinsonProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/RobinsonProcessor.cs
@@ -21,9 +21,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetectorCompassProcessor<TPixel>(new RobinsonKernels(), this.Grayscale, source, sourceRectangle);
-        }
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetectorCompassProcessor<TPixel>(configuration, new RobinsonKernels(), this.Grayscale, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/ScharrProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ScharrProcessor.cs
@@ -21,9 +21,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetector2DProcessor<TPixel>(ScharrKernels.ScharrX, ScharrKernels.ScharrY, this.Grayscale, source, sourceRectangle);
-        }
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetector2DProcessor<TPixel>(
+                configuration,
+                ScharrKernels.ScharrX,
+                ScharrKernels.ScharrY,
+                this.Grayscale,
+                source,
+                sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/SobelProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/SobelProcessor.cs
@@ -21,9 +21,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new EdgeDetector2DProcessor<TPixel>(SobelKernels.SobelX, SobelKernels.SobelY, this.Grayscale, source, sourceRectangle);
-        }
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new EdgeDetector2DProcessor<TPixel>(
+                configuration,
+                SobelKernels.SobelX,
+                SobelKernels.SobelY,
+                this.Grayscale,
+                source,
+                sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Dithering/ErrorDiffusionPaletteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/ErrorDiffusionPaletteProcessor.cs
@@ -58,9 +58,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         public float Threshold { get; }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
         {
-            return new ErrorDiffusionPaletteProcessor<TPixel>(this, source, sourceRectangle);
+            return new ErrorDiffusionPaletteProcessor<TPixel>(configuration, this, source, sourceRectangle);
         }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Dithering/ErrorDiffusionPaletteProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/ErrorDiffusionPaletteProcessor{TPixel}.cs
@@ -19,11 +19,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         /// <summary>
         /// Initializes a new instance of the <see cref="ErrorDiffusionPaletteProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="ErrorDiffusionPaletteProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public ErrorDiffusionPaletteProcessor(ErrorDiffusionPaletteProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(definition, source, sourceRectangle)
+        public ErrorDiffusionPaletteProcessor(Configuration configuration, ErrorDiffusionPaletteProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, definition, source, sourceRectangle)
         {
         }
 

--- a/src/ImageSharp/Processing/Processors/Dithering/OrderedDitherPaletteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/OrderedDitherPaletteProcessor.cs
@@ -35,9 +35,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         public IOrderedDither Dither { get; }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new OrderedDitherPaletteProcessor<TPixel>(this, source, sourceRectangle);
-        }
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new OrderedDitherPaletteProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Dithering/OrderedDitherPaletteProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/OrderedDitherPaletteProcessor{TPixel}.cs
@@ -19,11 +19,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         /// <summary>
         /// Initializes a new instance of the <see cref="OrderedDitherPaletteProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="OrderedDitherPaletteProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public OrderedDitherPaletteProcessor(OrderedDitherPaletteProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(definition, source, sourceRectangle)
+        public OrderedDitherPaletteProcessor(Configuration configuration, OrderedDitherPaletteProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, definition, source, sourceRectangle)
         {
         }
 

--- a/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessor.cs
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         public ReadOnlyMemory<Color> Palette { get; }
 
         /// <inheritdoc />
-        public abstract IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public abstract IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessor{TPixel}.cs
@@ -8,7 +8,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.Memory;
 using SixLabors.Primitives;
 
 namespace SixLabors.ImageSharp.Processing.Processors.Dithering
@@ -29,11 +28,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         /// <summary>
         /// Initializes a new instance of the <see cref="PaletteDitherProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="PaletteDitherProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        protected PaletteDitherProcessor(PaletteDitherProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        protected PaletteDitherProcessor(Configuration configuration, PaletteDitherProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.Definition = definition;
             this.palette = this.Configuration.MemoryAllocator.Allocate<TPixel>(definition.Palette.Length);

--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
@@ -40,10 +40,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
         public int BrushSize { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new OilPaintingProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new OilPaintingProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
@@ -25,11 +25,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
         /// <summary>
         /// Initializes a new instance of the <see cref="OilPaintingProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="OilPaintingProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public OilPaintingProcessor(OilPaintingProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public OilPaintingProcessor(Configuration configuration, OilPaintingProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp/Processing/Processors/Effects/PixelShaderProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelShaderProcessor.cs
@@ -52,10 +52,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
         public PixelConversionModifiers Modifiers { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new PixelShaderProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new PixelShaderProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Effects/PixelShaderProcessorBase.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelShaderProcessorBase.cs
@@ -26,11 +26,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
         /// <summary>
         /// Initializes a new instance of the <see cref="PixelShaderProcessorBase{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="modifiers">The <see cref="PixelConversionModifiers"/> to apply during the pixel conversions.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        protected PixelShaderProcessorBase(PixelConversionModifiers modifiers, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        protected PixelShaderProcessorBase(Configuration configuration, PixelConversionModifiers modifiers, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.modifiers = modifiers;
         }

--- a/src/ImageSharp/Processing/Processors/Effects/PixelShaderProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelShaderProcessor{TPixel}.cs
@@ -24,11 +24,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
         /// <summary>
         /// Initializes a new instance of the <see cref="PixelShaderProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="PixelShaderProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public PixelShaderProcessor(PixelShaderProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(definition.Modifiers, source, sourceRectangle)
+        public PixelShaderProcessor(Configuration configuration, PixelShaderProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, definition.Modifiers, source, sourceRectangle)
         {
             this.pixelShader = definition.PixelShader;
         }

--- a/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor.cs
@@ -30,10 +30,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
         public int Size { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new PixelateProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new PixelateProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor{TPixel}.cs
@@ -24,11 +24,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
         /// <summary>
         /// Initializes a new instance of the <see cref="PixelateProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="PixelateProcessor"/>.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public PixelateProcessor(PixelateProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public PixelateProcessor(Configuration configuration, PixelateProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp/Processing/Processors/Effects/PositionAwarePixelShaderProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PositionAwarePixelShaderProcessor.cs
@@ -52,10 +52,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
         public PixelConversionModifiers Modifiers { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new PositionAwarePixelShaderProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new PositionAwarePixelShaderProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Effects/PositionAwarePixelShaderProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PositionAwarePixelShaderProcessor{TPixel}.cs
@@ -24,11 +24,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
         /// <summary>
         /// Initializes a new instance of the <see cref="PositionAwarePixelShaderProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="PositionAwarePixelShaderProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public PositionAwarePixelShaderProcessor(PositionAwarePixelShaderProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(definition.Modifiers, source, sourceRectangle)
+        public PositionAwarePixelShaderProcessor(Configuration configuration, PositionAwarePixelShaderProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, definition.Modifiers, source, sourceRectangle)
         {
             this.pixelShader = definition.PixelShader;
         }

--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
@@ -24,10 +24,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
         public ColorMatrix Matrix { get; }
 
         /// <inheritdoc />
-        public virtual IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public virtual IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new FilterProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new FilterProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessor{TPixel}.cs
@@ -23,11 +23,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
         /// <summary>
         /// Initializes a new instance of the <see cref="FilterProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="FilterProcessor"/>.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public FilterProcessor(FilterProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public FilterProcessor(Configuration configuration, FilterProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp/Processing/Processors/Filters/LomographProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/LomographProcessor.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle) =>
-            new LomographProcessor<TPixel>(this, source, sourceRectangle);
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle) =>
+            new LomographProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Filters/LomographProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/LomographProcessor{TPixel}.cs
@@ -18,18 +18,19 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
         /// <summary>
         /// Initializes a new instance of the <see cref="LomographProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="LomographProcessor"/> defining the parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public LomographProcessor(LomographProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(definition, source, sourceRectangle)
+        public LomographProcessor(Configuration configuration, LomographProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, definition, source, sourceRectangle)
         {
         }
 
         /// <inheritdoc/>
         protected override void AfterImageApply()
         {
-            new VignetteProcessor(VeryDarkGreen).Execute(this.Source, this.SourceRectangle);
+            new VignetteProcessor(VeryDarkGreen).Execute(this.Configuration, this.Source, this.SourceRectangle);
             base.AfterImageApply();
         }
     }

--- a/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle) =>
-            new PolaroidProcessor<TPixel>(this, source, sourceRectangle);
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle) =>
+            new PolaroidProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor{TPixel}.cs
@@ -14,25 +14,25 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
         where TPixel : struct, IPixel<TPixel>
     {
         private static readonly Color LightOrange = Color.FromRgba(255, 153, 102, 128);
-
         private static readonly Color VeryDarkOrange = Color.FromRgb(102, 34, 0);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolaroidProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="PolaroidProcessor"/> defining the parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public PolaroidProcessor(PolaroidProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(definition, source, sourceRectangle)
+        public PolaroidProcessor(Configuration configuration, PolaroidProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, definition, source, sourceRectangle)
         {
         }
 
         /// <inheritdoc/>
         protected override void AfterImageApply()
         {
-            new VignetteProcessor(VeryDarkOrange).Execute(this.Source, this.SourceRectangle);
-            new GlowProcessor(LightOrange, this.Source.Width / 4F).Execute(this.Source, this.SourceRectangle);
+            new VignetteProcessor(VeryDarkOrange).Execute(this.Configuration, this.Source, this.SourceRectangle);
+            new GlowProcessor(LightOrange, this.Source.Width / 4F).Execute(this.Configuration, this.Source, this.SourceRectangle);
             base.AfterImageApply();
         }
     }

--- a/src/ImageSharp/Processing/Processors/ICloningImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/ICloningImageProcessor.cs
@@ -16,12 +16,13 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// the processing algorithm on an <see cref="Image{TPixel}"/>.
         /// </summary>
         /// <typeparam name="TPixel">The pixel type.</typeparam>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="source">The source image. Cannot be null.</param>
         /// <param name="sourceRectangle">
         /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to draw.
         /// </param>
         /// <returns>The <see cref="ICloningImageProcessor{TPixel}"/></returns>
-        ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Processing/Processors/IImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/IImageProcessor.cs
@@ -19,12 +19,13 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// the processing algorithm on an <see cref="Image{TPixel}"/>.
         /// </summary>
         /// <typeparam name="TPixel">The pixel type.</typeparam>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="source">The source image. Cannot be null.</param>
         /// <param name="sourceRectangle">
         /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to draw.
         /// </param>
         /// <returns>The <see cref="IImageProcessor{TPixel}"/></returns>
-        IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
@@ -13,18 +13,21 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// Executes the processor against the given source image and rectangle bounds.
         /// </summary>
         /// <param name="processor">The processor.</param>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="source">The source image.</param>
         /// <param name="sourceRectangle">The source bounds.</param>
-        public static void Execute(this IImageProcessor processor, Image source, Rectangle sourceRectangle)
-            => source.AcceptVisitor(new ExecuteVisitor(processor, sourceRectangle));
+        public static void Execute(this IImageProcessor processor, Configuration configuration, Image source, Rectangle sourceRectangle)
+            => source.AcceptVisitor(new ExecuteVisitor(configuration, processor, sourceRectangle));
 
         private class ExecuteVisitor : IImageVisitor
         {
+            private readonly Configuration configuration;
             private readonly IImageProcessor processor;
             private readonly Rectangle sourceRectangle;
 
-            public ExecuteVisitor(IImageProcessor processor, Rectangle sourceRectangle)
+            public ExecuteVisitor(Configuration configuration, IImageProcessor processor, Rectangle sourceRectangle)
             {
+                this.configuration = configuration;
                 this.processor = processor;
                 this.sourceRectangle = sourceRectangle;
             }
@@ -32,7 +35,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
             public void Visit<TPixel>(Image<TPixel> image)
                 where TPixel : struct, IPixel<TPixel>
             {
-                using (IImageProcessor<TPixel> processorImpl = this.processor.CreatePixelSpecificProcessor(image, this.sourceRectangle))
+                using (IImageProcessor<TPixel> processorImpl = this.processor.CreatePixelSpecificProcessor(this.configuration, image, this.sourceRectangle))
                 {
                     processorImpl.Execute();
                 }

--- a/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
@@ -19,13 +19,14 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        protected ImageProcessor(Image<TPixel> source, Rectangle sourceRectangle)
+        protected ImageProcessor(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
         {
+            this.Configuration = configuration;
             this.Source = source;
             this.SourceRectangle = sourceRectangle;
-            this.Configuration = this.Source.GetConfiguration();
         }
 
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationProcessor.cs
@@ -35,9 +35,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         public int NumberOfTiles { get; }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
         {
             return new AdaptiveHistogramEqualizationProcessor<TPixel>(
+                configuration,
                 this.LuminanceLevels,
                 this.ClipHistogram,
                 this.ClipLimit,

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationProcessor{TPixel}.cs
@@ -27,6 +27,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveHistogramEqualizationProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="luminanceLevels">The number of different luminance levels. Typical values are 256 for 8-bit grayscale images
         /// or 65536 for 16-bit grayscale images.</param>
         /// <param name="clipHistogram">Indicating whether to clip the histogram bins at a specific value.</param>
@@ -35,13 +36,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         public AdaptiveHistogramEqualizationProcessor(
+            Configuration configuration,
             int luminanceLevels,
             bool clipHistogram,
             int clipLimit,
             int tiles,
             Image<TPixel> source,
             Rectangle sourceRectangle)
-            : base(luminanceLevels, clipHistogram, clipLimit, source, sourceRectangle)
+            : base(configuration, luminanceLevels, clipHistogram, clipLimit, source, sourceRectangle)
         {
             Guard.MustBeGreaterThanOrEqualTo(tiles, 2, nameof(tiles));
             Guard.MustBeLessThanOrEqualTo(tiles, 100, nameof(tiles));

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor.cs
@@ -34,15 +34,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         public int NumberOfTiles { get; }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new AdaptiveHistogramEqualizationSlidingWindowProcessor<TPixel>(
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new AdaptiveHistogramEqualizationSlidingWindowProcessor<TPixel>(
+                configuration,
                 this.LuminanceLevels,
                 this.ClipHistogram,
                 this.ClipLimit,
                 this.NumberOfTiles,
                 source,
                 sourceRectangle);
-        }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
@@ -26,6 +26,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="luminanceLevels">The number of different luminance levels. Typical values are 256 for 8-bit grayscale images
         /// or 65536 for 16-bit grayscale images.</param>
         /// <param name="clipHistogram">Indicating whether to clip the histogram bins at a specific value.</param>
@@ -34,13 +35,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         public AdaptiveHistogramEqualizationSlidingWindowProcessor(
+            Configuration configuration,
             int luminanceLevels,
             bool clipHistogram,
             int clipLimit,
             int tiles,
             Image<TPixel> source,
             Rectangle sourceRectangle)
-            : base(luminanceLevels, clipHistogram, clipLimit, source, sourceRectangle)
+            : base(configuration, luminanceLevels, clipHistogram, clipLimit, source, sourceRectangle)
         {
             Guard.MustBeGreaterThanOrEqualTo(tiles, 2, nameof(tiles));
             Guard.MustBeLessThanOrEqualTo(tiles, 100, nameof(tiles));

--- a/src/ImageSharp/Processing/Processors/Normalization/GlobalHistogramEqualizationProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/GlobalHistogramEqualizationProcessor.cs
@@ -22,14 +22,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         }
 
         /// <inheritdoc />
-        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-        {
-            return new GlobalHistogramEqualizationProcessor<TPixel>(
+        public override IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new GlobalHistogramEqualizationProcessor<TPixel>(
+                configuration,
                 this.LuminanceLevels,
                 this.ClipHistogram,
                 this.ClipLimit,
                 source,
                 sourceRectangle);
-        }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Normalization/GlobalHistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/GlobalHistogramEqualizationProcessor{TPixel}.cs
@@ -26,6 +26,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         /// <summary>
         /// Initializes a new instance of the <see cref="GlobalHistogramEqualizationProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="luminanceLevels">
         /// The number of different luminance levels. Typical values are 256 for 8-bit grayscale images
         /// or 65536 for 16-bit grayscale images.
@@ -35,12 +36,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         public GlobalHistogramEqualizationProcessor(
+            Configuration configuration,
             int luminanceLevels,
             bool clipHistogram,
             int clipLimit,
             Image<TPixel> source,
             Rectangle sourceRectangle)
-            : base(luminanceLevels, clipHistogram, clipLimit, source, sourceRectangle)
+            : base(configuration, luminanceLevels, clipHistogram, clipLimit, source, sourceRectangle)
         {
         }
 

--- a/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         public int ClipLimit { get; }
 
         /// <inheritdoc />
-        public abstract IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public abstract IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>;
 
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor{TPixel}.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -23,6 +22,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         /// <summary>
         /// Initializes a new instance of the <see cref="HistogramEqualizationProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="luminanceLevels">The number of different luminance levels. Typical values are 256 for 8-bit grayscale images
         /// or 65536 for 16-bit grayscale images.</param>
         /// <param name="clipHistogram">Indicates, if histogram bins should be clipped.</param>
@@ -30,12 +30,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         protected HistogramEqualizationProcessor(
+            Configuration configuration,
             int luminanceLevels,
             bool clipHistogram,
             int clipLimit,
             Image<TPixel> source,
             Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             Guard.MustBeGreaterThan(luminanceLevels, 0, nameof(luminanceLevels));
             Guard.MustBeGreaterThan(clipLimit, 1, nameof(clipLimit));

--- a/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor.cs
@@ -33,10 +33,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
         public Color Color { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new BackgroundColorProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new BackgroundColorProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor{TPixel}.cs
@@ -24,11 +24,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
         /// <summary>
         /// Initializes a new instance of the <see cref="BackgroundColorProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="BackgroundColorProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public BackgroundColorProcessor(BackgroundColorProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public BackgroundColorProcessor(Configuration configuration, BackgroundColorProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
@@ -70,10 +70,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
         internal ValueSize Radius { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new GlowProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new GlowProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor{TPixel}.cs
@@ -21,17 +21,17 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
         where TPixel : struct, IPixel<TPixel>
     {
         private readonly PixelBlender<TPixel> blender;
-
         private readonly GlowProcessor definition;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GlowProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="GlowProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public GlowProcessor(GlowProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public GlowProcessor(Configuration configuration, GlowProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
             this.blender = PixelOperations<TPixel>.Instance.GetPixelBlender(definition.GraphicsOptions);

--- a/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
@@ -68,10 +68,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
         internal ValueSize RadiusY { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new VignetteProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new VignetteProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor{TPixel}.cs
@@ -27,11 +27,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
         /// <summary>
         /// Initializes a new instance of the <see cref="VignetteProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="VignetteProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public VignetteProcessor(VignetteProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public VignetteProcessor(Configuration configuration, VignetteProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
             this.blender = PixelOperations<TPixel>.Instance.GetPixelBlender(definition.GraphicsOptions);

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor.cs
@@ -26,10 +26,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         public IQuantizer Quantizer { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new QuantizeProcessor<TPixel>(this.Quantizer, source, sourceRectangle);
-        }
+            => new QuantizeProcessor<TPixel>(configuration, this.Quantizer, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor{TPixel}.cs
@@ -21,11 +21,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         /// <summary>
         /// Initializes a new instance of the <see cref="QuantizeProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="quantizer">The quantizer used to reduce the color palette.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public QuantizeProcessor(IQuantizer quantizer, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public QuantizeProcessor(Configuration configuration, IQuantizer quantizer, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             Guard.NotNull(quantizer, nameof(quantizer));
             this.quantizer = quantizer;

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Size TargetDimensions { get; }
 
         /// <inheritdoc/>
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            => new AffineTransformProcessor<TPixel>(this, source, sourceRectangle);
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new AffineTransformProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor{TPixel}.cs
@@ -24,11 +24,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <summary>
         /// Initializes a new instance of the <see cref="AffineTransformProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="AffineTransformProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public AffineTransformProcessor(AffineTransformProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public AffineTransformProcessor(Configuration configuration, AffineTransformProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.targetSize = definition.TargetDimensions;
             this.transformMatrix = definition.TransformMatrix;

--- a/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor.cs
@@ -12,10 +12,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     public sealed class AutoOrientProcessor : IImageProcessor
     {
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new AutoOrientProcessor<TPixel>(source, sourceRectangle);
-        }
+            => new AutoOrientProcessor<TPixel>(configuration, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor{TPixel}.cs
@@ -19,10 +19,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoOrientProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public AutoOrientProcessor(Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public AutoOrientProcessor(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
         }
 
@@ -34,33 +35,33 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             switch (orientation)
             {
                 case OrientationMode.TopRight:
-                    new FlipProcessor(FlipMode.Horizontal).Execute(this.Source, this.SourceRectangle);
+                    new FlipProcessor(FlipMode.Horizontal).Execute(this.Configuration, this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.BottomRight:
-                    new RotateProcessor((int)RotateMode.Rotate180, size).Execute(this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate180, size).Execute(this.Configuration, this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.BottomLeft:
-                    new FlipProcessor(FlipMode.Vertical).Execute(this.Source, this.SourceRectangle);
+                    new FlipProcessor(FlipMode.Vertical).Execute(this.Configuration, this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.LeftTop:
-                    new RotateProcessor((int)RotateMode.Rotate90, size).Execute(this.Source, this.SourceRectangle);
-                    new FlipProcessor(FlipMode.Horizontal).Execute(this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate90, size).Execute(this.Configuration, this.Source, this.SourceRectangle);
+                    new FlipProcessor(FlipMode.Horizontal).Execute(this.Configuration, this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.RightTop:
-                    new RotateProcessor((int)RotateMode.Rotate90, size).Execute(this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate90, size).Execute(this.Configuration, this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.RightBottom:
-                    new FlipProcessor(FlipMode.Vertical).Execute(this.Source, this.SourceRectangle);
-                    new RotateProcessor((int)RotateMode.Rotate270, size).Execute(this.Source, this.SourceRectangle);
+                    new FlipProcessor(FlipMode.Vertical).Execute(this.Configuration, this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate270, size).Execute(this.Configuration, this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.LeftBottom:
-                    new RotateProcessor((int)RotateMode.Rotate270, size).Execute(this.Source, this.SourceRectangle);
+                    new RotateProcessor((int)RotateMode.Rotate270, size).Execute(this.Configuration, this.Source, this.SourceRectangle);
                     break;
 
                 case OrientationMode.Unknown:

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Rectangle CropRectangle { get; }
 
         /// <inheritdoc />
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            => new CropProcessor<TPixel>(this, source, sourceRectangle);
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new CropProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor{TPixel}.cs
@@ -21,11 +21,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <summary>
         /// Initializes a new instance of the <see cref="CropProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="CropProcessor"/>.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public CropProcessor(CropProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public CropProcessor(Configuration configuration, CropProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
             => this.cropRectangle = definition.CropRectangle;
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor.cs
@@ -38,10 +38,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public float Threshold { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new EntropyCropProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new EntropyCropProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
@@ -21,11 +21,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <summary>
         /// Initializes a new instance of the <see cref="EntropyCropProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="EntropyCropProcessor"/>.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public EntropyCropProcessor(EntropyCropProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public EntropyCropProcessor(Configuration configuration, EntropyCropProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }
@@ -42,16 +43,16 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 Configuration configuration = this.Source.GetConfiguration();
 
                 // Detect the edges.
-                new SobelProcessor(false).Execute(temp, this.SourceRectangle);
+                new SobelProcessor(false).Execute(this.Configuration, temp, this.SourceRectangle);
 
                 // Apply threshold binarization filter.
-                new BinaryThresholdProcessor(this.definition.Threshold).Execute(temp, this.SourceRectangle);
+                new BinaryThresholdProcessor(this.definition.Threshold).Execute(this.Configuration, temp, this.SourceRectangle);
 
                 // Search for the first white pixels
                 rectangle = ImageMaths.GetFilteredBoundingRectangle(temp.Frames.RootFrame, 0);
             }
 
-            new CropProcessor(rectangle, this.Source.Size()).Execute(this.Source, this.SourceRectangle);
+            new CropProcessor(rectangle, this.Source.Size()).Execute(this.Configuration, this.Source, this.SourceRectangle);
 
             base.BeforeImageApply();
         }

--- a/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor.cs
@@ -15,10 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// Initializes a new instance of the <see cref="FlipProcessor"/> class.
         /// </summary>
         /// <param name="flipMode">The <see cref="FlipMode"/> used to perform flipping.</param>
-        public FlipProcessor(FlipMode flipMode)
-        {
-            this.FlipMode = flipMode;
-        }
+        public FlipProcessor(FlipMode flipMode) => this.FlipMode = flipMode;
 
         /// <summary>
         /// Gets the <see cref="FlipMode"/> used to perform flipping.
@@ -26,10 +23,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public FlipMode FlipMode { get; }
 
         /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : struct, IPixel<TPixel>
-        {
-            return new FlipProcessor<TPixel>(this, source, sourceRectangle);
-        }
+            => new FlipProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor{TPixel}.cs
@@ -23,11 +23,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <summary>
         /// Initializes a new instance of the <see cref="FlipProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="FlipProcessor"/>.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public FlipProcessor(FlipProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public FlipProcessor(Configuration configuration, FlipProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.definition = definition;
         }

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Size TargetDimensions { get; }
 
         /// <inheritdoc />
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            => new ProjectiveTransformProcessor<TPixel>(this, source, sourceRectangle);
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new ProjectiveTransformProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor{TPixel}.cs
@@ -25,11 +25,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <summary>
         /// Initializes a new instance of the <see cref="ProjectiveTransformProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="ProjectiveTransformProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public ProjectiveTransformProcessor(ProjectiveTransformProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public ProjectiveTransformProcessor(Configuration configuration, ProjectiveTransformProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.targetSize = definition.TargetDimensions;
             this.transformMatrix = definition.TransformMatrix;

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
@@ -55,7 +55,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public bool Compand { get; }
 
         /// <inheritdoc />
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            => new ResizeProcessor<TPixel>(this, source, sourceRectangle);
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new ResizeProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
@@ -33,8 +33,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         private ResizeKernelMap horizontalKernelMap;
         private ResizeKernelMap verticalKernelMap;
 
-        public ResizeProcessor(ResizeProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        public ResizeProcessor(Configuration configuration, ResizeProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
             this.targetWidth = definition.TargetWidth;
             this.targetHeight = definition.TargetHeight;

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -46,7 +46,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public float Degrees { get; }
 
         /// <inheritdoc />
-        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
-            => new RotateProcessor<TPixel>(this, source, sourceRectangle);
+        public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            => new RotateProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor{TPixel}.cs
@@ -21,11 +21,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <summary>
         /// Initializes a new instance of the <see cref="RotateProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="definition">The <see cref="RotateProcessor"/> defining the processor parameters.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        public RotateProcessor(RotateProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
-            : base(definition, source, sourceRectangle)
+        public RotateProcessor(Configuration configuration, RotateProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, definition, source, sourceRectangle)
         {
             this.Degrees = definition.Degrees;
         }

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformProcessor.cs
@@ -16,10 +16,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <summary>
         /// Initializes a new instance of the <see cref="TransformProcessor{TPixel}"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-        protected TransformProcessor(Image<TPixel> source, Rectangle sourceRectangle)
-            : base(source, sourceRectangle)
+        protected TransformProcessor(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
         {
         }
 

--- a/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
@@ -13,6 +13,7 @@ using SixLabors.Primitives;
 using Xunit;
 using SixLabors.ImageSharp.Processing.Processors.Drawing;
 using SixLabors.Shapes;
+using SixLabors.ImageSharp.Advanced;
 
 namespace SixLabors.ImageSharp.Tests.Drawing
 {
@@ -40,7 +41,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             };
             var processor = new FillRegionProcessor(options, brush.Object, region);
             var img = new Image<Rgba32>(1, 1);
-            processor.Execute(img, bounds);
+            processor.Execute(img.GetConfiguration(), img, bounds);
 
             Assert.Equal(4, region.ScanInvocationCounter);
         }
@@ -53,7 +54,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             var options = new GraphicsOptions { Antialias = true };
             var processor = new FillRegionProcessor(options, brush.Object, new MockRegion1());
             var img = new Image<Rgba32>(10, 10);
-            processor.Execute(img, bounds);
+            processor.Execute(img.GetConfiguration(), img, bounds);
         }
 
         [Fact]

--- a/tests/ImageSharp.Tests/Processing/BaseImageOperationsExtensionTest.cs
+++ b/tests/ImageSharp.Tests/Processing/BaseImageOperationsExtensionTest.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.Primitives;
@@ -24,7 +25,7 @@ namespace SixLabors.ImageSharp.Tests.Processing
             this.options = new GraphicsOptions { Antialias = false };
             this.source = new Image<Rgba32>(91 + 324, 123 + 56);
             this.rect = new Rectangle(91, 123, 324, 56); // make this random?
-            this.internalOperations = new FakeImageOperationsProvider.FakeImageOperations<Rgba32>(this.source, false);
+            this.internalOperations = new FakeImageOperationsProvider.FakeImageOperations<Rgba32>(this.source.GetConfiguration(), this.source, false);
             this.operations = this.internalOperations;
         }
 
@@ -38,7 +39,7 @@ namespace SixLabors.ImageSharp.Tests.Processing
             {
                 return Assert.IsType<T>(operation.NonGenericProcessor);
             }
-            
+
             return Assert.IsType<T>(operation.GenericProcessor);
         }
 
@@ -49,12 +50,12 @@ namespace SixLabors.ImageSharp.Tests.Processing
             FakeImageOperationsProvider.FakeImageOperations<Rgba32>.AppliedOperation operation = this.internalOperations.Applied[index];
 
             Assert.Equal(rect, operation.Rectangle);
-            
+
             if (operation.NonGenericProcessor != null)
             {
                 return Assert.IsType<T>(operation.NonGenericProcessor);
             }
-            
+
             return Assert.IsType<T>(operation.GenericProcessor);
         }
     }

--- a/tests/ImageSharp.Tests/Processing/ImageOperationTests.cs
+++ b/tests/ImageSharp.Tests/Processing/ImageOperationTests.cs
@@ -106,7 +106,7 @@ namespace SixLabors.ImageSharp.Tests.Processing
         [Fact]
         public void ApplyProcessors_ListOfProcessors_AppliesAllProcessorsToOperation()
         {
-            var operations = new FakeImageOperationsProvider.FakeImageOperations<Rgba32>(null, false);
+            var operations = new FakeImageOperationsProvider.FakeImageOperations<Rgba32>(Configuration.Default, null, false);
             operations.ApplyProcessors(this.processorDefinition);
             Assert.Contains(this.processorDefinition, operations.Applied.Select(x => x.NonGenericProcessor));
         }

--- a/tests/ImageSharp.Tests/Processing/ImageProcessingContextTests.cs
+++ b/tests/ImageSharp.Tests/Processing/ImageProcessingContextTests.cs
@@ -176,7 +176,7 @@ namespace SixLabors.ImageSharp.Tests.Processing
             }
 
             this.processorDefinition
-                .Setup(p => p.CreatePixelSpecificProcessor(It.IsAny<Image<Rgba32>>(), It.IsAny<Rectangle>()))
+                .Setup(p => p.CreatePixelSpecificProcessor(Configuration.Default, It.IsAny<Image<Rgba32>>(), It.IsAny<Rectangle>()))
                 .Returns(this.regularProcessorImpl.Object);
         }
 
@@ -189,11 +189,11 @@ namespace SixLabors.ImageSharp.Tests.Processing
             }
 
             this.cloningProcessorDefinition
-                .Setup(p => p.CreatePixelSpecificCloningProcessor(It.IsAny<Image<Rgba32>>(), It.IsAny<Rectangle>()))
+                .Setup(p => p.CreatePixelSpecificCloningProcessor(Configuration.Default, It.IsAny<Image<Rgba32>>(), It.IsAny<Rectangle>()))
                 .Returns(this.cloningProcessorImpl.Object);
 
             this.cloningProcessorDefinition
-                .Setup(p => p.CreatePixelSpecificProcessor(It.IsAny<Image<Rgba32>>(), It.IsAny<Rectangle>()))
+                .Setup(p => p.CreatePixelSpecificProcessor(Configuration.Default, It.IsAny<Image<Rgba32>>(), It.IsAny<Rectangle>()))
                 .Returns(this.cloningProcessorImpl.Object);
         }
     }

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/BokehBlurTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/BokehBlurTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
-
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Primitives;
 using SixLabors.ImageSharp.Processing;
@@ -58,8 +58,9 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
             // Make sure the kernel components are the same
             using (var image = new Image<Rgb24>(1, 1))
             {
+                Configuration configuration = image.GetConfiguration();
                 var definition = new BokehBlurProcessor(10, BokehBlurProcessor.DefaultComponents, BokehBlurProcessor.DefaultGamma);
-                using (var processor = (BokehBlurProcessor<Rgb24>)definition.CreatePixelSpecificProcessor(image, image.Bounds()))
+                using (var processor = (BokehBlurProcessor<Rgb24>)definition.CreatePixelSpecificProcessor(configuration, image, image.Bounds()))
                 {
                     Assert.Equal(components.Count, processor.Kernels.Count);
                     foreach ((Complex64[] a, Complex64[] b) in components.Zip(processor.Kernels, (a, b) => (a, b)))

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -678,16 +678,16 @@ namespace SixLabors.ImageSharp.Tests
 
         private class MakeOpaqueProcessor : IImageProcessor
         {
-            public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+            public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
                 where TPixel : struct, IPixel<TPixel>
-                => new MakeOpaqueProcessor<TPixel>(source, sourceRectangle);
+                => new MakeOpaqueProcessor<TPixel>(configuration, source, sourceRectangle);
         }
 
         private class MakeOpaqueProcessor<TPixel> : ImageProcessor<TPixel>
             where TPixel : struct, IPixel<TPixel>
         {
-            public MakeOpaqueProcessor(Image<TPixel> source, Rectangle sourceRectangle)
-                : base(source, sourceRectangle)
+            public MakeOpaqueProcessor(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+                : base(configuration, source, sourceRectangle)
             {
 
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR replaces #857 and fixes #650 by adding the ability to pass custom configuration to all processing operations.

<!-- Thanks for contributing to ImageSharp! -->
