### PR TITLE
Enumerate once on clone. Fix #1073

### DIFF
--- a/src/ImageSharp/ImageFrameCollection.cs
+++ b/src/ImageSharp/ImageFrameCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -122,7 +122,7 @@ namespace SixLabors.ImageSharp
         public IEnumerator<ImageFrame> GetEnumerator() => this.NonGenericGetEnumerator();
 
         /// <inheritdoc/>
-        IEnumerator IEnumerable.GetEnumerator() => this.NonGenericGetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
         /// <summary>
         /// Implements <see cref="GetEnumerator"/>.

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -130,7 +130,7 @@ namespace SixLabors.ImageSharp
         protected override ImageFrameCollection NonGenericFrameCollection => this.Frames;
 
         /// <summary>
-        /// Gets the frames.
+        /// Gets the collection of image frames.
         /// </summary>
         public new ImageFrameCollection<TPixel> Frames { get; }
 
@@ -166,8 +166,12 @@ namespace SixLabors.ImageSharp
         {
             this.EnsureNotDisposed();
 
-            IEnumerable<ImageFrame<TPixel>> clonedFrames =
-                this.Frames.Select<ImageFrame<TPixel>, ImageFrame<TPixel>>(x => x.Clone(configuration));
+            var clonedFrames = new ImageFrame<TPixel>[this.Frames.Count];
+            for (int i = 0; i < clonedFrames.Length; i++)
+            {
+                clonedFrames[i] = this.Frames[i].Clone(configuration);
+            }
+
             return new Image<TPixel>(configuration, this.Metadata.DeepClone(), clonedFrames);
         }
 
@@ -181,8 +185,12 @@ namespace SixLabors.ImageSharp
         {
             this.EnsureNotDisposed();
 
-            IEnumerable<ImageFrame<TPixel2>> clonedFrames =
-                this.Frames.Select<ImageFrame<TPixel>, ImageFrame<TPixel2>>(x => x.CloneAs<TPixel2>(configuration));
+            var clonedFrames = new ImageFrame<TPixel2>[this.Frames.Count];
+            for (int i = 0; i < clonedFrames.Length; i++)
+            {
+                clonedFrames[i] = this.Frames[i].CloneAs<TPixel2>(configuration);
+            }
+
             return new Image<TPixel2>(configuration, this.Metadata.DeepClone(), clonedFrames);
         }
 

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
@@ -173,16 +173,19 @@ namespace SixLabors.ImageSharp.Processing.Processors
             Image<TPixel> source = this.Source;
             Size targetSize = this.GetTargetSize();
 
-            // We will always be creating the clone even for mutate because we may need to resize the canvas
-            IEnumerable<ImageFrame<TPixel>> frames = source.Frames.Select<ImageFrame<TPixel>, ImageFrame<TPixel>>(
-                x => new ImageFrame<TPixel>(
+            // We will always be creating the clone even for mutate because we may need to resize the canvas.
+            var targetFrames = new ImageFrame<TPixel>[source.Frames.Count];
+            for (int i = 0; i < targetFrames.Length; i++)
+            {
+                targetFrames[i] = new ImageFrame<TPixel>(
                     this.Configuration,
                     targetSize.Width,
                     targetSize.Height,
-                    x.Metadata.DeepClone()));
+                    source.Frames[i].Metadata.DeepClone());
+            }
 
-            // Use the overload to prevent an extra frame being added
-            return new Image<TPixel>(this.Configuration, source.Metadata.DeepClone(), frames);
+            // Use the overload to prevent an extra frame being added.
+            return new Image<TPixel>(this.Configuration, source.Metadata.DeepClone(), targetFrames);
         }
 
         private void CheckFrameCount(Image<TPixel> a, Image<TPixel> b)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
We were allowing enumerating our source `ImageFrame<TPixel>` collection more than once on clone causing memory leaks so I've switched the code to explicitly enumerate once and pass an array to the new image constructor.

Fixes #1073  

<!-- Thanks for contributing to ImageSharp! -->
