### PR TITLE
Simplify and cleanup build constants

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -89,13 +89,22 @@
 ###############################################################################
 *.bmp               binary
 *.dll               binary
+*.eot               binary
 *.exe               binary
 *.gif               binary
 *.jpg               binary
+*.pdf               binary
 *.png               binary
-*.tga               binary
+*.ppt               binary
+*.pptx              binary
 *.ttf               binary
 *.snk               binary
+*.ttf               binary
+*.woff              binary
+*.woff2             binary
+*.xls               binary
+*.xlsx              binary
+
 
 ###############################################################################
 # Set explicit file behavior to:
@@ -107,3 +116,4 @@
 *.pdf               diff=astextplain
 *.pptx              diff=astextplain
 *.rtf               diff=astextplain
+*.svg               diff=astextplain

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,10 +29,42 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
+  <!--
+    https://apisof.net/
+    +===================+================+===================+==============================+======================+==========================+
+    | Target Framework  | SUPPORTS_MATHF | SUPPORTS_HASHCODE | SUPPORTS_EXTENDED_INTRINSICS | SUPPORTS_SPAN_STREAM | SUPPORTS_ENCODING_STRING |
+    +===================+================+===================+==============================+======================+==========================+
+    | netcoreapp3.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
+    | netcoreapp2.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
+    | netcoreapp2.0     |       Y        |         N         |               N              |          N           |            N             |
+    | netstandard2.1    |       Y        |         N         |               N              |          Y           |            Y             |
+    | netstandard2.0    |       N        |         N         |               N              |          N           |            N             |
+    | netstandard1.3    |       N        |         N         |               N              |          N           |            N             |
+    | net472            |       N        |         N         |               Y              |          N           |            N             |
+    +===================+================+===================+==============================+======================+==========================+
+    -->
+
+  <!-- TODO: Include additional targets to TargetFrameworks -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  
+
   <!--TODO: Check what this is testing for and why does it fail?-->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>

--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -8,16 +8,40 @@
     <PackageId>SixLabors.ImageSharp.Drawing</PackageId>
     <PackageTags>Image Draw Shape Path Font</PackageTags>
     <RootNamespace>SixLabors.ImageSharp</RootNamespace>
-    <TargetFrameworks>netcoreapp2.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- TODO: Include .NETSTANDARD2.1 when released-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2')) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
-  </PropertyGroup>
+  <!--
+    https://apisof.net/
+    +===================+================+===================+==============================+======================+==========================+
+    | Target Framework  | SUPPORTS_MATHF | SUPPORTS_HASHCODE | SUPPORTS_EXTENDED_INTRINSICS | SUPPORTS_SPAN_STREAM | SUPPORTS_ENCODING_STRING |
+    +===================+================+===================+==============================+======================+==========================+
+    | netcoreapp3.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
+    | netcoreapp2.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
+    | netcoreapp2.0     |       Y        |         N         |               N              |          N           |            N             |
+    | netstandard2.1    |       Y        |         N         |               N              |          Y           |            Y             |
+    | netstandard2.0    |       N        |         N         |               N              |          N           |            N             |
+    | netstandard1.3    |       N        |         N         |               N              |          N           |            N             |
+    | net472            |       N        |         N         |               Y              |          N           |            N             |
+    +===================+================+===================+==============================+======================+==========================+
+    -->
 
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2.1')) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+  <!-- TODO: Include additional targets to TargetFrameworks -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -12,38 +12,6 @@
     <TargetFrameworks>netcoreapp2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
-  <!--
-    https://apisof.net/
-    +===================+================+===================+==============================+======================+==========================+
-    | Target Framework  | SUPPORTS_MATHF | SUPPORTS_HASHCODE | SUPPORTS_EXTENDED_INTRINSICS | SUPPORTS_SPAN_STREAM | SUPPORTS_ENCODING_STRING |
-    +===================+================+===================+==============================+======================+==========================+
-    | netcoreapp3.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
-    | netcoreapp2.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
-    | netcoreapp2.0     |       Y        |         N         |               N              |          N           |            N             |
-    | netstandard2.1    |       Y        |         N         |               N              |          Y           |            Y             |
-    | netstandard2.0    |       N        |         N         |               N              |          N           |            N             |
-    | netstandard1.3    |       N        |         N         |               N              |          N           |            N             |
-    | net472            |       N        |         N         |               Y              |          N           |            N             |
-    +===================+================+===================+==============================+======================+==========================+
-    -->
-
-  <!-- TODO: Include additional targets to TargetFrameworks -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
-  </PropertyGroup>
-  
   <ItemGroup>
     <PackageReference Include="SixLabors.Fonts" />
     <PackageReference Include="SixLabors.Shapes" />

--- a/src/ImageSharp/Common/Extensions/EncoderExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/EncoderExtensions.cs
@@ -1,7 +1,7 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-#if !NETCOREAPP2_1
+#if !SUPPORTS_ENCODING_STRING
 using System;
 using System.Text;
 

--- a/src/ImageSharp/Common/Extensions/StreamExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/StreamExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Buffers;
 using System.IO;
-
 using SixLabors.ImageSharp.Memory;
 using SixLabors.Memory;
 
@@ -15,7 +14,6 @@ namespace SixLabors.ImageSharp
     /// </summary>
     internal static class StreamExtensions
     {
-#if NETCOREAPP2_1
         /// <summary>
         /// Writes data from a stream into the provided buffer.
         /// </summary>
@@ -24,23 +22,18 @@ namespace SixLabors.ImageSharp
         /// <param name="offset">The offset within the buffer to begin writing.</param>
         /// <param name="count">The number of bytes to write to the stream.</param>
         public static void Write(this Stream stream, Span<byte> buffer, int offset, int count)
-        {
-            stream.Write(buffer.Slice(offset, count));
-        }
+            => stream.Write(buffer.Slice(offset, count));
 
         /// <summary>
         /// Reads data from a stream into the provided buffer.
         /// </summary>
         /// <param name="stream">The stream.</param>
-        /// <param name="buffer">The buffer..</param>
+        /// <param name="buffer">The buffer.</param>
         /// <param name="offset">The offset within the buffer where the bytes are read into.</param>
         /// <param name="count">The number of bytes, if available, to read.</param>
         /// <returns>The actual number of bytes read.</returns>
         public static int Read(this Stream stream, Span<byte> buffer, int offset, int count)
-        {
-            return stream.Read(buffer.Slice(offset, count));
-        }
-#endif
+            => stream.Read(buffer.Slice(offset, count));
 
         /// <summary>
         /// Skips the number of bytes in the given stream.
@@ -75,17 +68,39 @@ namespace SixLabors.ImageSharp
         }
 
         public static void Read(this Stream stream, IManagedByteBuffer buffer)
-        {
-            stream.Read(buffer.Array, 0, buffer.Length());
-        }
+            => stream.Read(buffer.Array, 0, buffer.Length());
 
         public static void Write(this Stream stream, IManagedByteBuffer buffer)
+            => stream.Write(buffer.Array, 0, buffer.Length());
+
+#if !SUPPORTS_SPAN_STREAM
+        // This is a port of the CoreFX implementation and is MIT Licensed:
+        // https://github.com/dotnet/corefx/blob/17300169760c61a90cab8d913636c1058a30a8c1/src/Common/src/CoreLib/System/IO/Stream.cs#L742
+        public static int Read(this Stream stream, Span<byte> buffer)
         {
-            stream.Write(buffer.Array, 0, buffer.Length());
+            // This uses ArrayPool<byte>.Shared, rather than taking a MemoryAllocator,
+            // in order to match the signature of the framework method that exists in
+            // .NET Core.
+            byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                int numRead = stream.Read(sharedBuffer, 0, buffer.Length);
+                if ((uint)numRead > (uint)buffer.Length)
+                {
+                    throw new IOException("Stream was too long.");
+                }
+
+                new Span<byte>(sharedBuffer, 0, numRead).CopyTo(buffer);
+                return numRead;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(sharedBuffer);
+            }
         }
 
-#if NET472 || NETSTANDARD1_3 || NETSTANDARD2_0
-        // This is a port of the CoreFX implementation and is MIT Licensed: https://github.com/dotnet/coreclr/blob/c4dca1072d15bdda64c754ad1ea474b1580fa554/src/System.Private.CoreLib/shared/System/IO/Stream.cs#L770
+        // This is a port of the CoreFX implementation and is MIT Licensed:
+        // https://github.com/dotnet/corefx/blob/17300169760c61a90cab8d913636c1058a30a8c1/src/Common/src/CoreLib/System/IO/Stream.cs#L775
         public static void Write(this Stream stream, ReadOnlySpan<byte> buffer)
         {
             // This uses ArrayPool<byte>.Shared, rather than taking a MemoryAllocator,

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -445,11 +445,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="rowsWithUndefinedPixels">Keeps track of rows, which have undefined pixels.</param>
         private void UncompressRle4(int w, Span<byte> buffer, Span<bool> undefinedPixels, Span<bool> rowsWithUndefinedPixels)
         {
-#if NETCOREAPP2_1
             Span<byte> cmd = stackalloc byte[2];
-#else
-            var cmd = new byte[2];
-#endif
             int count = 0;
 
             while (count < buffer.Length)
@@ -556,11 +552,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="rowsWithUndefinedPixels">Keeps track of rows, which have undefined pixels.</param>
         private void UncompressRle8(int w, Span<byte> buffer, Span<bool> undefinedPixels, Span<bool> rowsWithUndefinedPixels)
         {
-#if NETCOREAPP2_1
             Span<byte> cmd = stackalloc byte[2];
-#else
-            var cmd = new byte[2];
-#endif
             int count = 0;
 
             while (count < buffer.Length)
@@ -639,11 +631,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="rowsWithUndefinedPixels">Keeps track of rows, which have undefined pixels.</param>
         private void UncompressRle24(int w, Span<byte> buffer, Span<bool> undefinedPixels, Span<bool> rowsWithUndefinedPixels)
         {
-#if NETCOREAPP2_1
             Span<byte> cmd = stackalloc byte[2];
-#else
-            var cmd = new byte[2];
-#endif
             int uncompressedPixels = 0;
 
             while (uncompressedPixels < buffer.Length)
@@ -1213,11 +1201,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// </summary>
         private void ReadInfoHeader()
         {
-#if NETCOREAPP2_1
             Span<byte> buffer = stackalloc byte[BmpInfoHeader.MaxHeaderSize];
-#else
-            var buffer = new byte[BmpInfoHeader.MaxHeaderSize];
-#endif
 
             // Read the header size.
             this.stream.Read(buffer, 0, BmpInfoHeader.HeaderSizeSize);
@@ -1339,11 +1323,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// </summary>
         private void ReadFileHeader()
         {
-#if NETCOREAPP2_1
             Span<byte> buffer = stackalloc byte[BmpFileHeader.Size];
-#else
-            var buffer = new byte[BmpFileHeader.Size];
-#endif
             this.stream.Read(buffer, 0, BmpFileHeader.Size);
 
             short fileTypeMarker = BinaryPrimitives.ReadInt16LittleEndian(buffer);

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -173,11 +173,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
                 reserved: 0,
                 offset: BmpFileHeader.Size + infoHeaderSize + colorPaletteSize);
 
-#if NETCOREAPP2_1
             Span<byte> buffer = stackalloc byte[infoHeaderSize];
-#else
-            var buffer = new byte[infoHeaderSize];
-#endif
             fileHeader.WriteTo(buffer);
 
             stream.Write(buffer, 0, BmpFileHeader.Size);

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -113,11 +113,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 Unsafe.Add(ref suffixRef, code) = (byte)code;
             }
 
-#if NETCOREAPP2_1
             Span<byte> buffer = stackalloc byte[255];
-#else
-            var buffer = new byte[255];
-#endif
 
             while (xyz < length)
             {
@@ -227,11 +223,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// The <see cref="int"/>.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if NETCOREAPP2_1
         private int ReadBlock(Span<byte> buffer)
-#else
-        private int ReadBlock(byte[] buffer)
-#endif
         {
             int bufferSize = this.stream.ReadByte();
 

--- a/src/ImageSharp/Formats/Tga/TgaDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tga/TgaDecoderCore.cs
@@ -565,11 +565,8 @@ namespace SixLabors.ImageSharp.Formats.Tga
         {
             this.currentStream = stream;
 
-#if NETCOREAPP2_1
             Span<byte> buffer = stackalloc byte[TgaFileHeader.Size];
-#else
-            var buffer = new byte[TgaFileHeader.Size];
-#endif
+
             this.currentStream.Read(buffer, 0, TgaFileHeader.Size);
             this.fileHeader = TgaFileHeader.Parse(buffer);
             this.metadata = new ImageMetadata();

--- a/src/ImageSharp/Formats/Tga/TgaEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tga/TgaEncoderCore.cs
@@ -97,11 +97,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
                 pixelDepth: (byte)this.bitsPerPixel.Value,
                 imageDescriptor: imageDescriptor);
 
-#if NETCOREAPP2_1
             Span<byte> buffer = stackalloc byte[TgaFileHeader.Size];
-#else
-            byte[] buffer = new byte[TgaFileHeader.Size];
-#endif
             fileHeader.WriteTo(buffer);
 
             stream.Write(buffer, 0, TgaFileHeader.Size);

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -19,38 +19,6 @@
     <RootNamespace>SixLabors.ImageSharp</RootNamespace>
   </PropertyGroup>
 
-  <!--
-    https://apisof.net/
-    +===================+================+===================+==============================+======================+==========================+
-    | Target Framework  | SUPPORTS_MATHF | SUPPORTS_HASHCODE | SUPPORTS_EXTENDED_INTRINSICS | SUPPORTS_SPAN_STREAM | SUPPORTS_ENCODING_STRING |
-    +===================+================+===================+==============================+======================+==========================+
-    | netcoreapp3.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
-    | netcoreapp2.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
-    | netcoreapp2.0     |       Y        |         N         |               N              |          N           |            N             |
-    | netstandard2.1    |       Y        |         N         |               N              |          Y           |            Y             |
-    | netstandard2.0    |       N        |         N         |               N              |          N           |            N             |
-    | netstandard1.3    |       N        |         N         |               N              |          N           |            N             |
-    | net472            |       N        |         N         |               Y              |          N           |            N             |
-    +===================+================+===================+==============================+======================+==========================+
-    -->
-  
-  <!-- TODO: Include additional targets to TargetFrameworks -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\..\shared-infrastructure\**\*.cs" />
   </ItemGroup>

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -10,7 +10,7 @@
     <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
     <VersionPrefix Condition="$(packageversion) == ''">0.0.1</VersionPrefix>
 
-    <TargetFrameworks>netcoreapp2.1;netstandard1.3;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;netstandard1.3;net472</TargetFrameworks>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -19,22 +19,37 @@
     <RootNamespace>SixLabors.ImageSharp</RootNamespace>
   </PropertyGroup>
 
-  <!-- TODO: Include .NETSTANDARD2.1 when released-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2')) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2.1')) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
-  </PropertyGroup>
+  <!--
+    https://apisof.net/
+    +===================+================+===================+==============================+======================+==========================+
+    | Target Framework  | SUPPORTS_MATHF | SUPPORTS_HASHCODE | SUPPORTS_EXTENDED_INTRINSICS | SUPPORTS_SPAN_STREAM | SUPPORTS_ENCODING_STRING |
+    +===================+================+===================+==============================+======================+==========================+
+    | netcoreapp3.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
+    | netcoreapp2.1     |       Y        |         Y         |               Y              |          Y           |            Y             |
+    | netcoreapp2.0     |       Y        |         N         |               N              |          N           |            N             |
+    | netstandard2.1    |       Y        |         N         |               N              |          Y           |            Y             |
+    | netstandard2.0    |       N        |         N         |               N              |          N           |            N             |
+    | netstandard1.3    |       N        |         N         |               N              |          N           |            N             |
+    | net472            |       N        |         N         |               Y              |          N           |            N             |
+    +===================+================+===================+==============================+======================+==========================+
+    -->
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net472' ">
+  <!-- TODO: Include additional targets to TargetFrameworks -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
     <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="..\Shared\*.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\..\shared-infrastructure\**\*.cs" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
As part of the move to externalize ImageSharp.Drawing and import Core I thought it wise to simplify and normalize our use of #ifdefs throughout the library.

Once we have a CI build environment that works on .NET Core 3.1 we can easily add additional target frameworks.

Touch #1002

<!-- Thanks for contributing to ImageSharp! -->
