### PR TITLE
Use per-edge buffer + minor optimizations.

### DIFF
--- a/src/ImageSharp.Drawing/Processing/BrushApplicator.cs
+++ b/src/ImageSharp.Drawing/Processing/BrushApplicator.cs
@@ -90,19 +90,23 @@ namespace SixLabors.ImageSharp.Processing
             {
                 Span<float> amountSpan = amountBuffer.Memory.Span;
                 Span<TPixel> overlaySpan = overlay.Memory.Span;
+                float blendPercentage = this.Options.BlendPercentage;
 
-                for (int i = 0; i < scanline.Length; i++)
+                if (blendPercentage < 1)
                 {
-                    if (this.Options.BlendPercentage < 1)
+                    for (int i = 0; i < scanline.Length; i++)
                     {
-                        amountSpan[i] = scanline[i] * this.Options.BlendPercentage;
+                        amountSpan[i] = scanline[i] * blendPercentage;
+                        overlaySpan[i] = this[x + i, y];
                     }
-                    else
+                }
+                else
+                {
+                    for (int i = 0; i < scanline.Length; i++)
                     {
                         amountSpan[i] = scanline[i];
+                        overlaySpan[i] = this[x + i, y];
                     }
-
-                    overlaySpan[i] = this[x + i, y];
                 }
 
                 Span<TPixel> destinationRow = this.Target.GetPixelRowSpan(y).Slice(x, scanline.Length);

--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor{TPixel}.cs
@@ -88,7 +88,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
                     source,
                     sourceRectangle))
                 {
-                    amount.Memory.Span.Fill(1f);
+                    amount.Memory.Span.Fill(1F);
 
                     ParallelHelper.IterateRows(
                         workingRect,

--- a/tests/ImageSharp.Tests/Drawing/FillLinearGradientBrushTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillLinearGradientBrushTests.cs
@@ -433,5 +433,20 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             }
         }
 
+        [Theory]
+        [WithBlankImages(200, 200, PixelTypes.Rgb24)]
+        public void BrushApplicatorIsThreadSafeIssue1044<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            provider.VerifyOperation(
+                img =>
+                {
+                    var brush = new PathGradientBrush(
+                        new[] { new PointF(0, 0), new PointF(200, 0), new PointF(200, 200), new PointF(0, 200), new PointF(0, 0) },
+                        new[] { Color.Red, Color.Yellow, Color.Green, Color.DarkCyan, Color.Red });
+
+                    img.Mutate(m => m.Fill(brush));
+                }, false, false);
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Drawing/FillLinearGradientBrushTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillLinearGradientBrushTests.cs
@@ -439,6 +439,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             where TPixel : struct, IPixel<TPixel>
         {
             provider.VerifyOperation(
+                TolerantComparer,
                 img =>
                 {
                     var brush = new PathGradientBrush(


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Added pooled buffer generation to the edge class to make it threadsafe. Also did some very low hanging optimization fruit. Fix #1044 

@jongleur1983 can you also have a look at the fix please to confirm. Thanks!

<!-- Thanks for contributing to ImageSharp! -->
