### PR TITLE
Fix build number

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 continuous-delivery-fallback-tag: ci
 branches:
     master:
-        tag: dev
+        tag: unstable
     pull-request:
         tag: pr


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Replaces `dev` nightly prefix with `unstable` fixing Nuget ordering. Also means that `rc` can be overwritten also.

<!-- Thanks for contributing to ImageSharp! -->
