### PR TITLE
Removed unnecessary MemoryMarshal.Cast call

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8.cs
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
         public Block8x8(Span<short> coefficients)
         {
             ref byte selfRef = ref Unsafe.As<Block8x8, byte>(ref this);
-            ref byte sourceRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<short, byte>(coefficients));
+            ref byte sourceRef = ref Unsafe.As<short, byte>(ref MemoryMarshal.GetReference(coefficients));
             Unsafe.CopyBlock(ref selfRef, ref sourceRef, Size * sizeof(short));
         }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Optimization to the `Block8x8` constructor, as discussed with @JimBobSquarePants.

**Before (Release x64):**
```asm
SixLabors.ImageSharp.Formats.Jpeg.Components.Block8x8..ctor(System.Span`1<Int16>)
    L0000: sub rsp, 0x28
    L0004: mov r8, [rdx]
    L0007: mov edx, [rdx+0x8]
    L000a: shl rdx, 1
    L000d: cmp rdx, 0x7fffffff
    L0014: ja L002a
    L0016: mov rdx, r8
    L0019: mov r8d, 0x80
    L001f: call 0x7ffa28883850
    L0024: nop
    L0025: add rsp, 0x28
    L0029: ret
    L002a: call 0x7ffa289aed50
    L002f: int3
```

**After:**
```asm
SixLabors.ImageSharp.Formats.Jpeg.Components.Block8x8..ctor(System.Span`1<Int16>)
    L0000: mov rdx, [rdx]
    L0003: mov r8d, 0x80
    L0009: call 0x7ffa28883850
    L000e: nop
    L000f: ret
```