### PR TITLE
Refactoring and tweaks

### DIFF
--- a/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
+++ b/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// therefore it's not recommended to mutate the image while holding a reference to it's <see cref="IMemoryGroup{T}"/>.
         /// </remarks>
         public static IMemoryGroup<TPixel> GetPixelMemoryGroup<TPixel>(this ImageFrame<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => source?.PixelBuffer.FastMemoryGroup.View ?? throw new ArgumentNullException(nameof(source));
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// therefore it's not recommended to mutate the image while holding a reference to it's <see cref="IMemoryGroup{T}"/>.
         /// </remarks>
         public static IMemoryGroup<TPixel> GetPixelMemoryGroup<TPixel>(this Image<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => source?.Frames.RootFrame.GetPixelMemoryGroup() ?? throw new ArgumentNullException(nameof(source));
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace SixLabors.ImageSharp.Advanced
         [Obsolete(
             @"GetPixelSpan might fail, because the backing buffer could be discontiguous for large images. Use GetPixelMemoryGroup or GetPixelRowSpan instead!")]
         public static Span<TPixel> GetPixelSpan<TPixel>(this ImageFrame<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(source, nameof(source));
 
@@ -113,7 +113,7 @@ namespace SixLabors.ImageSharp.Advanced
         [Obsolete(
             @"GetPixelSpan might fail, because the backing buffer could be discontiguous for large images. Use GetPixelMemoryGroup or GetPixelRowSpan instead!")]
         public static Span<TPixel> GetPixelSpan<TPixel>(this Image<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(source, nameof(source));
 
@@ -129,7 +129,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// <param name="rowIndex">The row.</param>
         /// <returns>The <see cref="Span{TPixel}"/></returns>
         public static Span<TPixel> GetPixelRowSpan<TPixel>(this ImageFrame<TPixel> source, int rowIndex)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(source, nameof(source));
             Guard.MustBeGreaterThanOrEqualTo(rowIndex, 0, nameof(rowIndex));
@@ -147,7 +147,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// <param name="rowIndex">The row.</param>
         /// <returns>The <see cref="Span{TPixel}"/></returns>
         public static Span<TPixel> GetPixelRowSpan<TPixel>(this Image<TPixel> source, int rowIndex)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(source, nameof(source));
             Guard.MustBeGreaterThanOrEqualTo(rowIndex, 0, nameof(rowIndex));
@@ -165,7 +165,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// <param name="rowIndex">The row.</param>
         /// <returns>The <see cref="Span{TPixel}"/></returns>
         public static Memory<TPixel> GetPixelRowMemory<TPixel>(this ImageFrame<TPixel> source, int rowIndex)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(source, nameof(source));
             Guard.MustBeGreaterThanOrEqualTo(rowIndex, 0, nameof(rowIndex));
@@ -183,7 +183,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// <param name="rowIndex">The row.</param>
         /// <returns>The <see cref="Span{TPixel}"/></returns>
         public static Memory<TPixel> GetPixelRowMemory<TPixel>(this Image<TPixel> source, int rowIndex)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(source, nameof(source));
             Guard.MustBeGreaterThanOrEqualTo(rowIndex, 0, nameof(rowIndex));

--- a/src/ImageSharp/Advanced/AotCompilerTools.cs
+++ b/src/ImageSharp/Advanced/AotCompilerTools.cs
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         private static void Seed<TPixel>()
-             where TPixel : struct, IPixel<TPixel>
+             where TPixel : unmanaged, IPixel<TPixel>
         {
             // This is we actually call all the individual methods you need to seed.
             AotCompileOctreeQuantizer<TPixel>();
@@ -110,7 +110,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         private static void AotCompileOctreeQuantizer<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var test = new OctreeFrameQuantizer<TPixel>(Configuration.Default, new OctreeQuantizer().Options))
             {
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         private static void AotCompileWuQuantizer<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var test = new WuFrameQuantizer<TPixel>(Configuration.Default, new WuQuantizer().Options))
             {
@@ -138,7 +138,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         private static void AotCompilePaletteQuantizer<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var test = (PaletteFrameQuantizer<TPixel>)new PaletteQuantizer(Array.Empty<Color>()).CreateFrameQuantizer<TPixel>(Configuration.Default))
             {
@@ -152,7 +152,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         private static void AotCompileDithering<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ErrorDither errorDither = ErrorDither.FloydSteinberg;
             OrderedDither orderedDither = OrderedDither.Bayer2x2;
@@ -171,7 +171,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// <param name="encoder">The image encoder to seed.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         private static void AotCodec<TPixel>(IImageDecoder decoder, IImageEncoder encoder)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             try
             {
@@ -195,7 +195,7 @@ namespace SixLabors.ImageSharp.Advanced
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         private static void AotCompilePixelOperations<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var pixelOp = new PixelOperations<TPixel>();
             pixelOp.GetPixelBlender(PixelColorBlendingMode.Normal, PixelAlphaCompositionMode.Clear);

--- a/src/ImageSharp/Advanced/IImageVisitor.cs
+++ b/src/ImageSharp/Advanced/IImageVisitor.cs
@@ -17,6 +17,6 @@ namespace SixLabors.ImageSharp.Advanced
         /// <param name="image">The image.</param>
         /// <typeparam name="TPixel">The pixel type.</typeparam>
         void Visit<TPixel>(Image<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Advanced/IPixelSource.cs
+++ b/src/ImageSharp/Advanced/IPixelSource.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Advanced
     /// </summary>
     /// <typeparam name="TPixel">The type of the pixel.</typeparam>
     internal interface IPixelSource<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Gets the pixel buffer.

--- a/src/ImageSharp/Color/Color.cs
+++ b/src/ImageSharp/Color/Color.cs
@@ -220,7 +220,7 @@ namespace SixLabors.ImageSharp
         /// <returns>The pixel value.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
         public TPixel ToPixel<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             pixel.FromRgba64(this.data);
@@ -239,7 +239,7 @@ namespace SixLabors.ImageSharp
             Configuration configuration,
             ReadOnlySpan<Color> source,
             Span<TPixel> destination)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ReadOnlySpan<Rgba64> rgba64Span = MemoryMarshal.Cast<Color, Rgba64>(source);
             PixelOperations<TPixel>.Instance.FromRgba64(configuration, rgba64Span, destination);

--- a/src/ImageSharp/Common/Helpers/Buffer2DUtils.cs
+++ b/src/ImageSharp/Common/Helpers/Buffer2DUtils.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp
             int maxRow,
             int minColumn,
             int maxColumn)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ComplexVector4 vector = default;
             int kernelLength = kernel.Length;

--- a/src/ImageSharp/Common/Helpers/DenseMatrixUtils.cs
+++ b/src/ImageSharp/Common/Helpers/DenseMatrixUtils.cs
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp
             int maxRow,
             int minColumn,
             int maxColumn)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Convolve2DImpl(
                 in matrixY,
@@ -90,7 +90,7 @@ namespace SixLabors.ImageSharp
             int maxRow,
             int minColumn,
             int maxColumn)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Convolve2DImpl(
                 in matrixY,
@@ -121,7 +121,7 @@ namespace SixLabors.ImageSharp
             int minColumn,
             int maxColumn,
             out Vector4 vector)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Vector4 vectorY = default;
             Vector4 vectorX = default;
@@ -175,7 +175,7 @@ namespace SixLabors.ImageSharp
             int maxRow,
             int minColumn,
             int maxColumn)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Vector4 vector = default;
 
@@ -222,7 +222,7 @@ namespace SixLabors.ImageSharp
             int maxRow,
             int minColumn,
             int maxColumn)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Vector4 vector = default;
 
@@ -253,7 +253,7 @@ namespace SixLabors.ImageSharp
             int minColumn,
             int maxColumn,
             ref Vector4 vector)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int matrixHeight = matrix.Rows;
             int matrixWidth = matrix.Columns;

--- a/src/ImageSharp/Common/Helpers/ImageMaths.cs
+++ b/src/ImageSharp/Common/Helpers/ImageMaths.cs
@@ -303,7 +303,7 @@ namespace SixLabors.ImageSharp
         /// The <see cref="Rectangle"/>.
         /// </returns>
         public static Rectangle GetFilteredBoundingRectangle<TPixel>(ImageFrame<TPixel> bitmap, float componentValue, RgbaComponent channel = RgbaComponent.B)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int width = bitmap.Width;
             int height = bitmap.Height;

--- a/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
 
         /// <inheritdoc/>
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(stream, nameof(stream));
 

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -131,7 +131,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// </exception>
         /// <returns>The decoded image.</returns>
         public Image<TPixel> Decode<TPixel>(Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             try
             {
@@ -256,7 +256,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="pixels">The output pixel buffer containing the decoded image.</param>
         /// <param name="inverted">Whether the bitmap is inverted.</param>
         private void ReadBitFields<TPixel>(Buffer2D<TPixel> pixels, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (this.infoHeader.BitsPerPixel == 16)
             {
@@ -296,7 +296,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="height">The height of the bitmap.</param>
         /// <param name="inverted">Whether the bitmap is inverted.</param>
         private void ReadRle<TPixel>(BmpCompression compression, Buffer2D<TPixel> pixels, byte[] colors, int width, int height, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel color = default;
             using (IMemoryOwner<byte> buffer = this.memoryAllocator.Allocate<byte>(width * height, AllocationOptions.Clean))
@@ -376,7 +376,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="height">The height of the bitmap.</param>
         /// <param name="inverted">Whether the bitmap is inverted.</param>
         private void ReadRle24<TPixel>(Buffer2D<TPixel> pixels, int width, int height, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel color = default;
             using (IMemoryOwner<byte> buffer = this.memoryAllocator.Allocate<byte>(width * height * 3, AllocationOptions.Clean))
@@ -814,7 +814,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// the bytes per color palette entry's can be 3 bytes instead of 4.</param>
         /// <param name="inverted">Whether the bitmap is inverted.</param>
         private void ReadRgbPalette<TPixel>(Buffer2D<TPixel> pixels, byte[] colors, int width, int height, int bitsPerPixel, int bytesPerColorMapEntry, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Pixels per byte (bits per pixel).
             int ppb = 8 / bitsPerPixel;
@@ -872,7 +872,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="greenMask">The bitmask for the green channel.</param>
         /// <param name="blueMask">The bitmask for the blue channel.</param>
         private void ReadRgb16<TPixel>(Buffer2D<TPixel> pixels, int width, int height, bool inverted, int redMask = DefaultRgb16RMask, int greenMask = DefaultRgb16GMask, int blueMask = DefaultRgb16BMask)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int padding = CalculatePadding(width, 2);
             int stride = (width * 2) + padding;
@@ -939,7 +939,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="height">The height of the bitmap.</param>
         /// <param name="inverted">Whether the bitmap is inverted.</param>
         private void ReadRgb24<TPixel>(Buffer2D<TPixel> pixels, int width, int height, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int padding = CalculatePadding(width, 3);
 
@@ -968,7 +968,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="height">The height of the bitmap.</param>
         /// <param name="inverted">Whether the bitmap is inverted.</param>
         private void ReadRgb32Fast<TPixel>(Buffer2D<TPixel> pixels, int width, int height, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int padding = CalculatePadding(width, 4);
 
@@ -998,7 +998,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="height">The height of the bitmap.</param>
         /// <param name="inverted">Whether the bitmap is inverted.</param>
         private void ReadRgb32Slow<TPixel>(Buffer2D<TPixel> pixels, int width, int height, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int padding = CalculatePadding(width, 4);
 
@@ -1099,7 +1099,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="blueMask">The bitmask for the blue channel.</param>
         /// <param name="alphaMask">The bitmask for the alpha channel.</param>
         private void ReadRgb32BitFields<TPixel>(Buffer2D<TPixel> pixels, int width, int height, bool inverted, int redMask, int greenMask, int blueMask, int alphaMask)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel color = default;
             int padding = CalculatePadding(width, 4);

--- a/src/ImageSharp/Formats/Bmp/BmpEncoder.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoder.cs
@@ -34,7 +34,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
 
         /// <inheritdoc/>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var encoder = new BmpEncoderCore(this, image.GetMemoryAllocator());
             encoder.Encode(image, stream);

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="image">The <see cref="ImageFrame{TPixel}"/> to encode from.</param>
         /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(image, nameof(image));
             Guard.NotNull(stream, nameof(stream));
@@ -203,7 +203,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// The <see cref="ImageFrame{TPixel}"/> containing pixel data.
         /// </param>
         private void WriteImage<TPixel>(Stream stream, ImageFrame<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Buffer2D<TPixel> pixels = image.PixelBuffer;
             switch (this.bitsPerPixel)
@@ -235,7 +235,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="stream">The <see cref="Stream"/> to write to.</param>
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> containing pixel data.</param>
         private void Write32Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 4))
             {
@@ -259,7 +259,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="stream">The <see cref="Stream"/> to write to.</param>
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> containing pixel data.</param>
         private void Write24Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 3))
             {
@@ -283,7 +283,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="stream">The <see cref="Stream"/> to write to.</param>
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> containing pixel data.</param>
         private void Write16Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 2))
             {
@@ -309,7 +309,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="stream">The <see cref="Stream"/> to write to.</param>
         /// <param name="image"> The <see cref="ImageFrame{TPixel}"/> containing pixel data.</param>
         private void Write8Bit<TPixel>(Stream stream, ImageFrame<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             bool isL8 = typeof(TPixel) == typeof(L8);
             using (IMemoryOwner<byte> colorPaletteBuffer = this.memoryAllocator.AllocateManagedByteBuffer(ColorPaletteSize8Bit, AllocationOptions.Clean))
@@ -334,7 +334,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="image"> The <see cref="ImageFrame{TPixel}"/> containing pixel data.</param>
         /// <param name="colorPalette">A byte span of size 1024 for the color palette.</param>
         private void Write8BitColor<TPixel>(Stream stream, ImageFrame<TPixel> image, Span<byte> colorPalette)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using IFrameQuantizer<TPixel> quantizer = this.quantizer.CreateFrameQuantizer<TPixel>(this.configuration);
             using QuantizedFrame<TPixel> quantized = quantizer.QuantizeFrame(image, image.Bounds());
@@ -378,7 +378,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="image"> The <see cref="ImageFrame{TPixel}"/> containing pixel data.</param>
         /// <param name="colorPalette">A byte span of size 1024 for the color palette.</param>
         private void Write8BitGray<TPixel>(Stream stream, ImageFrame<TPixel> image, Span<byte> colorPalette)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Create a color palette with 256 different gray values.
             for (int i = 0; i <= 255; i++)

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
         /// <inheritdoc/>
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var decoder = new GifDecoderCore(configuration, this);
 

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -104,7 +104,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="stream">The stream containing image data. </param>
         /// <returns>The decoded image</returns>
         public Image<TPixel> Decode<TPixel>(Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Image<TPixel> image = null;
             ImageFrame<TPixel> previousFrame = null;
@@ -348,7 +348,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="image">The image to decode the information to.</param>
         /// <param name="previousFrame">The previous frame.</param>
         private void ReadFrame<TPixel>(ref Image<TPixel> image, ref ImageFrame<TPixel> previousFrame)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.ReadImageDescriptor();
 
@@ -405,7 +405,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="colorTable">The color table containing the available colors.</param>
         /// <param name="descriptor">The <see cref="GifImageDescriptor"/></param>
         private void ReadFrameColors<TPixel>(ref Image<TPixel> image, ref ImageFrame<TPixel> previousFrame, Span<byte> indices, ReadOnlySpan<Rgb24> colorTable, in GifImageDescriptor descriptor)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ref byte indicesRef = ref MemoryMarshal.GetReference(indices);
             int imageWidth = this.logicalScreenDescriptor.Width;
@@ -535,7 +535,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="frame">The frame.</param>
         private void RestoreToBackground<TPixel>(ImageFrame<TPixel> frame)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (this.restoreArea is null)
             {

--- a/src/ImageSharp/Formats/Gif/GifEncoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoder.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
         /// <inheritdoc/>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var encoder = new GifEncoderCore(image.GetConfiguration(), this);
             encoder.Encode(image, stream);

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -68,7 +68,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="image">The <see cref="Image{TPixel}"/> to encode from.</param>
         /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(image, nameof(image));
             Guard.NotNull(stream, nameof(stream));
@@ -126,7 +126,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         }
 
         private void EncodeGlobal<TPixel>(Image<TPixel> image, QuantizedFrame<TPixel> quantized, int transparencyIndex, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             for (int i = 0; i < image.Frames.Count; i++)
             {
@@ -152,7 +152,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         }
 
         private void EncodeLocal<TPixel>(Image<TPixel> image, QuantizedFrame<TPixel> quantized, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ImageFrame<TPixel> previousFrame = null;
             GifFrameMetadata previousMeta = null;
@@ -209,7 +209,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// The <see cref="int"/>.
         /// </returns>
         private int GetTransparentIndex<TPixel>(QuantizedFrame<TPixel> quantized)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Transparent pixels are much more likely to be found at the end of a palette
             int index = -1;
@@ -411,7 +411,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="hasColorTable">Whether to use the global color table.</param>
         /// <param name="stream">The stream to write to.</param>
         private void WriteImageDescriptor<TPixel>(ImageFrame<TPixel> image, bool hasColorTable, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             byte packedValue = GifImageDescriptor.GetPackedValue(
                 localColorTableFlag: hasColorTable,
@@ -438,7 +438,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="image">The <see cref="ImageFrame{TPixel}"/> to encode.</param>
         /// <param name="stream">The stream to write to.</param>
         private void WriteColorTable<TPixel>(QuantizedFrame<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // The maximum number of colors for the bit depth
             int colorTableLength = ImageMaths.GetColorCountForBitDepth(this.bitDepth) * 3;
@@ -462,7 +462,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="image">The <see cref="QuantizedFrame{TPixel}"/> containing indexed pixels.</param>
         /// <param name="stream">The stream to write to.</param>
         private void WriteImageData<TPixel>(QuantizedFrame<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var encoder = new LzwEncoder(this.memoryAllocator, (byte)this.bitDepth))
             {

--- a/src/ImageSharp/Formats/IImageDecoder.cs
+++ b/src/ImageSharp/Formats/IImageDecoder.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Formats
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         // TODO: Document ImageFormatExceptions (https://github.com/SixLabors/ImageSharp/issues/1110)
         Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
 
         /// <summary>
         /// Decodes the image from the specified stream to an <see cref="Image"/>.

--- a/src/ImageSharp/Formats/IImageEncoder.cs
+++ b/src/ImageSharp/Formats/IImageEncoder.cs
@@ -18,6 +18,6 @@ namespace SixLabors.ImageSharp.Formats
         /// <param name="image">The <see cref="Image{TPixel}"/> to encode from.</param>
         /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
         void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegImagePostProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegImagePostProcessor.cs
@@ -112,7 +112,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <typeparam name="TPixel">The pixel type</typeparam>
         /// <param name="destination">The destination image</param>
         public void PostProcess<TPixel>(ImageFrame<TPixel> destination)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.PixelRowCounter = 0;
 
@@ -133,7 +133,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <typeparam name="TPixel">The pixel type</typeparam>
         /// <param name="destination">The destination image.</param>
         public void DoPostProcessorStep<TPixel>(ImageFrame<TPixel> destination)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (JpegComponentPostProcessor cpp in this.ComponentProcessors)
             {
@@ -151,7 +151,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <typeparam name="TPixel">The pixel type</typeparam>
         /// <param name="destination">The destination image</param>
         private void ConvertColorsInto<TPixel>(ImageFrame<TPixel> destination)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int maxY = Math.Min(destination.Height, this.PixelRowCounter + PixelRowsPerStep);
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/YCbCrForwardConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/YCbCrForwardConverter{TPixel}.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
     /// </summary>
     /// <typeparam name="TPixel">The pixel type to work on</typeparam>
     internal ref struct YCbCrForwardConverter<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// The Y component

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
 
         /// <inheritdoc/>
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(stream, nameof(stream));
 

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -208,7 +208,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <param name="stream">The stream, where the image should be.</param>
         /// <returns>The decoded image.</returns>
         public Image<TPixel> Decode<TPixel>(Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.ParseStream(stream);
             this.InitExifProfile();
@@ -958,7 +958,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         private Image<TPixel> PostProcessIntoImage<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (this.ImageWidth == 0 || this.ImageHeight == 0)
             {

--- a/src/ImageSharp/Formats/Jpeg/JpegEncoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoder.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <param name="image">The <see cref="Image{TPixel}"/> to encode from.</param>
         /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
         {
             var encoder = new JpegEncoderCore(this);
             encoder.Encode(image, stream);

--- a/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
@@ -192,7 +192,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <param name="image">The image to write from.</param>
         /// <param name="stream">The stream to write to.</param>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(image, nameof(image));
             Guard.NotNull(stream, nameof(stream));
@@ -394,7 +394,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="pixels">The pixel accessor providing access to the image pixels.</param>
         private void Encode444<TPixel>(Image<TPixel> pixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // TODO: Need a JpegScanEncoder<TPixel> class or struct that encapsulates the scan-encoding implementation. (Similar to JpegScanDecoder.)
             // (Partially done with YCbCrForwardConverter<TPixel>)
@@ -891,7 +891,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="image">The pixel accessor providing access to the image pixels.</param>
         private void WriteStartOfScan<TPixel>(Image<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // TODO: Need a JpegScanEncoder<TPixel> class or struct that encapsulates the scan-encoding implementation. (Similar to JpegScanDecoder.)
             // TODO: We should allow grayscale writing.
@@ -918,7 +918,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="pixels">The pixel accessor providing access to the image pixels.</param>
         private void Encode420<TPixel>(Image<TPixel> pixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // TODO: Need a JpegScanEncoder<TPixel> class or struct that encapsulates the scan-encoding implementation. (Similar to JpegScanDecoder.)
             Block8x8F b = default;

--- a/src/ImageSharp/Formats/PixelTypeInfo.cs
+++ b/src/ImageSharp/Formats/PixelTypeInfo.cs
@@ -27,7 +27,7 @@ namespace SixLabors.ImageSharp.Formats
         public int BitsPerPixel { get; }
 
         internal static PixelTypeInfo Create<TPixel>()
-            where TPixel : struct, IPixel<TPixel> =>
+            where TPixel : unmanaged, IPixel<TPixel> =>
             new PixelTypeInfo(Unsafe.SizeOf<TPixel>() * 8);
     }
 }

--- a/src/ImageSharp/Formats/Png/PngDecoder.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoder.cs
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <returns>The decoded image.</returns>
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var decoder = new PngDecoderCore(configuration, this);
 

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -150,7 +150,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </exception>
         /// <returns>The decoded image.</returns>
         public Image<TPixel> Decode<TPixel>(Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var metadata = new ImageMetadata();
             PngMetadata pngMetadata = metadata.GetPngMetadata();
@@ -378,7 +378,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="metadata">The metadata information for the image</param>
         /// <param name="image">The image that we will populate</param>
         private void InitializeImage<TPixel>(ImageMetadata metadata, out Image<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             image = new Image<TPixel>(this.configuration, this.header.Width, this.header.Height, metadata);
             this.bytesPerPixel = this.CalculateBytesPerPixel();
@@ -471,7 +471,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="image"> The pixel data.</param>
         /// <param name="pngMetadata">The png metadata</param>
         private void ReadScanlines<TPixel>(PngChunk chunk, ImageFrame<TPixel> image, PngMetadata pngMetadata)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var deframeStream = new ZlibInflateStream(this.currentStream, this.ReadNextDataChunk))
             {
@@ -497,7 +497,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="image">The image to decode to.</param>
         /// <param name="pngMetadata">The png metadata</param>
         private void DecodePixelData<TPixel>(Stream compressedStream, ImageFrame<TPixel> image, PngMetadata pngMetadata)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             while (this.currentRow < this.header.Height)
             {
@@ -553,7 +553,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="image">The current image.</param>
         /// <param name="pngMetadata">The png metadata.</param>
         private void DecodeInterlacedPixelData<TPixel>(Stream compressedStream, ImageFrame<TPixel> image, PngMetadata pngMetadata)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int pass = 0;
             int width = this.header.Width;
@@ -642,7 +642,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="pixels">The image</param>
         /// <param name="pngMetadata">The png metadata.</param>
         private void ProcessDefilteredScanline<TPixel>(ReadOnlySpan<byte> defilteredScanline, ImageFrame<TPixel> pixels, PngMetadata pngMetadata)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Span<TPixel> rowSpan = pixels.GetPixelRowSpan(this.currentRow);
 
@@ -726,7 +726,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="pixelOffset">The column start index. Always 0 for none interlaced images.</param>
         /// <param name="increment">The column increment. Always 1 for none interlaced images.</param>
         private void ProcessInterlacedDefilteredScanline<TPixel>(ReadOnlySpan<byte> defilteredScanline, Span<TPixel> rowSpan, PngMetadata pngMetadata, int pixelOffset = 0, int increment = 1)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Trim the first marker byte from the buffer
             ReadOnlySpan<byte> trimmed = defilteredScanline.Slice(1, defilteredScanline.Length - 1);

--- a/src/ImageSharp/Formats/Png/PngEncoder.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoder.cs
@@ -69,7 +69,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="image">The <see cref="Image{TPixel}"/> to encode from.</param>
         /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var encoder = new PngEncoderCore(image.GetMemoryAllocator(), image.GetConfiguration(), new PngEncoderOptions(this)))
             {

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -135,7 +135,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="image">The <see cref="ImageFrame{TPixel}"/> to encode from.</param>
         /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(image, nameof(image));
             Guard.NotNull(stream, nameof(stream));
@@ -187,7 +187,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="rowSpan">The image row span.</param>
         private void CollectGrayscaleBytes<TPixel>(ReadOnlySpan<TPixel> rowSpan)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
             Span<byte> rawScanlineSpan = this.currentScanline.GetSpan();
@@ -288,7 +288,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="rowSpan">The row span.</param>
         private void CollectTPixelBytes<TPixel>(ReadOnlySpan<TPixel> rowSpan)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Span<byte> rawScanlineSpan = this.currentScanline.GetSpan();
 
@@ -372,7 +372,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="quantized">The quantized pixels. Can be null.</param>
         /// <param name="row">The row.</param>
         private void CollectPixelBytes<TPixel>(ReadOnlySpan<TPixel> rowSpan, QuantizedFrame<TPixel> quantized, int row)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             switch (this.options.ColorType)
             {
@@ -441,7 +441,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="row">The row.</param>
         /// <returns>The <see cref="IManagedByteBuffer"/></returns>
         private IManagedByteBuffer EncodePixelRow<TPixel>(ReadOnlySpan<TPixel> rowSpan, QuantizedFrame<TPixel> quantized, int row)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.CollectPixelBytes(rowSpan, quantized, row);
             return this.FilterPixelBytes();
@@ -547,7 +547,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="quantized">The quantized frame.</param>
         private void WritePaletteChunk<TPixel>(Stream stream, QuantizedFrame<TPixel> quantized)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (quantized == null)
             {
@@ -784,7 +784,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="quantized">The quantized pixel data. Can be null.</param>
         /// <param name="stream">The stream.</param>
         private void WriteDataChunks<TPixel>(ImageFrame<TPixel> pixels, QuantizedFrame<TPixel> quantized, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             byte[] buffer;
             int bufferLength;
@@ -882,7 +882,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="quantized">The quantized pixels span.</param>
         /// <param name="deflateStream">The deflate stream.</param>
         private void EncodePixels<TPixel>(ImageFrame<TPixel> pixels, QuantizedFrame<TPixel> quantized, ZlibDeflateStream deflateStream)
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
         {
             int bytesPerScanline = this.CalculateScanlineLength(this.width);
             int resultLength = bytesPerScanline + 1;
@@ -906,7 +906,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="pixels">The pixels.</param>
         /// <param name="deflateStream">The deflate stream.</param>
         private void EncodeAdam7Pixels<TPixel>(ImageFrame<TPixel> pixels, ZlibDeflateStream deflateStream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int width = pixels.Width;
             int height = pixels.Height;
@@ -961,7 +961,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="quantized">The quantized.</param>
         /// <param name="deflateStream">The deflate stream.</param>
         private void EncodeAdam7IndexedPixels<TPixel>(QuantizedFrame<TPixel> quantized, ZlibDeflateStream deflateStream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int width = quantized.Width;
             int height = quantized.Height;

--- a/src/ImageSharp/Formats/Png/PngEncoderOptionsHelpers.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderOptionsHelpers.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             PngMetadata pngMetadata,
             out bool use16Bit,
             out int bytesPerPixel)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Always take the encoder options over the metadata values.
             options.Gamma ??= pngMetadata.Gamma;
@@ -56,7 +56,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         public static QuantizedFrame<TPixel> CreateQuantizedFrame<TPixel>(
             PngEncoderOptions options,
             Image<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (options.ColorType != PngColorType.Palette)
             {
@@ -95,7 +95,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             PngEncoderOptions options,
             Image<TPixel> image,
             QuantizedFrame<TPixel> quantizedFrame)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             byte bitDepth;
             if (options.ColorType == PngColorType.Palette)
@@ -153,7 +153,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// This is not exhaustive but covers many common pixel formats.
         /// </summary>
         private static PngColorType SuggestColorType<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return typeof(TPixel) switch
             {
@@ -179,7 +179,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// This is not exhaustive but covers many common pixel formats.
         /// </summary>
         private static PngBitDepth SuggestBitDepth<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return typeof(TPixel) switch
             {

--- a/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
+++ b/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             bool hasTrans,
             L16 luminance16Trans,
             L8 luminanceTrans)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             bool hasTrans,
             L16 luminance16Trans,
             L8 luminanceTrans)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
@@ -157,7 +157,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             Span<TPixel> rowSpan,
             int bytesPerPixel,
             int bytesPerSample)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
@@ -198,7 +198,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             int increment,
             int bytesPerPixel,
             int bytesPerSample)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
@@ -238,7 +238,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             Span<TPixel> rowSpan,
             ReadOnlySpan<byte> palette,
             byte[] paletteAlpha)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
@@ -284,7 +284,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             int increment,
             ReadOnlySpan<byte> palette,
             byte[] paletteAlpha)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
@@ -331,7 +331,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             bool hasTrans,
             Rgb48 rgb48Trans,
             Rgb24 rgb24Trans)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
@@ -404,7 +404,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             bool hasTrans,
             Rgb48 rgb48Trans,
             Rgb24 rgb24Trans)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
@@ -482,7 +482,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             Span<TPixel> rowSpan,
             int bytesPerPixel,
             int bytesPerSample)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
@@ -515,7 +515,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             int increment,
             int bytesPerPixel,
             int bytesPerSample)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = default;
             ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);

--- a/src/ImageSharp/Formats/Tga/TgaDecoder.cs
+++ b/src/ImageSharp/Formats/Tga/TgaDecoder.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
     {
         /// <inheritdoc/>
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(stream, nameof(stream));
 

--- a/src/ImageSharp/Formats/Tga/TgaDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tga/TgaDecoderCore.cs
@@ -76,7 +76,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// </exception>
         /// <returns>The decoded image.</returns>
         public Image<TPixel> Decode<TPixel>(Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             try
             {
@@ -222,7 +222,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="colorMapPixelSizeInBytes">Color map size of one entry in bytes.</param>
         /// <param name="inverted">Indicates, if the origin of the image is top left rather the bottom left (the default).</param>
         private void ReadPaletted<TPixel>(int width, int height, Buffer2D<TPixel> pixels, byte[] palette, int colorMapPixelSizeInBytes, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.memoryAllocator.AllocateManagedByteBuffer(width, AllocationOptions.Clean))
             {
@@ -285,7 +285,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="colorMapPixelSizeInBytes">Color map size of one entry in bytes.</param>
         /// <param name="inverted">Indicates, if the origin of the image is top left rather the bottom left (the default).</param>
         private void ReadPalettedRle<TPixel>(int width, int height, Buffer2D<TPixel> pixels, byte[] palette, int colorMapPixelSizeInBytes, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int bytesPerPixel = 1;
             using (IMemoryOwner<byte> buffer = this.memoryAllocator.Allocate<byte>(width * height * bytesPerPixel, AllocationOptions.Clean))
@@ -336,7 +336,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> to assign the palette to.</param>
         /// <param name="inverted">Indicates, if the origin of the image is top left rather the bottom left (the default).</param>
         private void ReadMonoChrome<TPixel>(int width, int height, Buffer2D<TPixel> pixels, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.memoryAllocator.AllocatePaddedPixelRowBuffer(width, 1, 0))
             {
@@ -363,7 +363,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> to assign the palette to.</param>
         /// <param name="inverted">Indicates, if the origin of the image is top left rather the bottom left (the default).</param>
         private void ReadBgra16<TPixel>(int width, int height, Buffer2D<TPixel> pixels, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.memoryAllocator.AllocatePaddedPixelRowBuffer(width, 2, 0))
             {
@@ -398,7 +398,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> to assign the palette to.</param>
         /// <param name="inverted">Indicates, if the origin of the image is top left rather the bottom left (the default).</param>
         private void ReadBgr24<TPixel>(int width, int height, Buffer2D<TPixel> pixels, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.memoryAllocator.AllocatePaddedPixelRowBuffer(width, 3, 0))
             {
@@ -425,7 +425,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> to assign the palette to.</param>
         /// <param name="inverted">Indicates, if the origin of the image is top left rather the bottom left (the default).</param>
         private void ReadBgra32<TPixel>(int width, int height, Buffer2D<TPixel> pixels, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.memoryAllocator.AllocatePaddedPixelRowBuffer(width, 4, 0))
             {
@@ -453,7 +453,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         /// <param name="inverted">Indicates, if the origin of the image is top left rather the bottom left (the default).</param>
         private void ReadRle<TPixel>(int width, int height, Buffer2D<TPixel> pixels, int bytesPerPixel, bool inverted)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel color = default;
             using (IMemoryOwner<byte> buffer = this.memoryAllocator.Allocate<byte>(width * height * bytesPerPixel, AllocationOptions.Clean))

--- a/src/ImageSharp/Formats/Tga/TgaEncoder.cs
+++ b/src/ImageSharp/Formats/Tga/TgaEncoder.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
 
         /// <inheritdoc/>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var encoder = new TgaEncoderCore(this, image.GetMemoryAllocator());
             encoder.Encode(image, stream);

--- a/src/ImageSharp/Formats/Tga/TgaEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tga/TgaEncoderCore.cs
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="image">The <see cref="ImageFrame{TPixel}"/> to encode from.</param>
         /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(image, nameof(image));
             Guard.NotNull(stream, nameof(stream));
@@ -121,7 +121,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// The <see cref="ImageFrame{TPixel}"/> containing pixel data.
         /// </param>
         private void WriteImage<TPixel>(Stream stream, ImageFrame<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Buffer2D<TPixel> pixels = image.PixelBuffer;
             switch (this.bitsPerPixel)
@@ -151,7 +151,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="stream">The stream to write the image to.</param>
         /// <param name="image">The image to encode.</param>
         private void WriteRunLengthEncodedImage<TPixel>(Stream stream, ImageFrame<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Rgba32 color = default;
             Buffer2D<TPixel> pixels = image.PixelBuffer;
@@ -209,7 +209,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="yStart">Y coordinate to start searching for the same pixels.</param>
         /// <returns>The number of equal pixels.</returns>
         private byte FindEqualPixels<TPixel>(Buffer2D<TPixel> pixels, int xStart, int yStart)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             byte equalPixelCount = 0;
             bool firstRow = true;
@@ -249,7 +249,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="stream">The <see cref="Stream"/> to write to.</param>
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> containing pixel data.</param>
         private void Write8Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 1))
             {
@@ -273,7 +273,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="stream">The <see cref="Stream"/> to write to.</param>
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> containing pixel data.</param>
         private void Write16Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 2))
             {
@@ -297,7 +297,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="stream">The <see cref="Stream"/> to write to.</param>
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> containing pixel data.</param>
         private void Write24Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 3))
             {
@@ -321,7 +321,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="stream">The <see cref="Stream"/> to write to.</param>
         /// <param name="pixels">The <see cref="Buffer2D{TPixel}"/> containing pixel data.</param>
         private void Write32Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 4))
             {
@@ -344,7 +344,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// <param name="sourcePixel">The pixel to get the luminance from.</param>
         [MethodImpl(InliningOptions.ShortMethod)]
         public static int GetLuminance<TPixel>(TPixel sourcePixel)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var vector = sourcePixel.ToVector4();
             return ImageMaths.GetBT709Luminance(ref vector, 256);

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp
             int width,
             int height,
             ImageMetadata metadata)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Buffer2D<TPixel> uninitializedMemoryBuffer =
                 configuration.MemoryAllocator.Allocate2D<TPixel>(width, height);
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp
         /// </returns>
         private static (Image<TPixel> img, IImageFormat format) Decode<TPixel>(Stream stream, Configuration config)
 #pragma warning restore SA1008 // Opening parenthesis must be spaced correctly
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             IImageDecoder decoder = DiscoverDecoder(stream, config, out IImageFormat format);
             if (decoder is null)

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(byte[] data)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Load<TPixel>(Configuration.Default, data);
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(byte[] data, out IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Load<TPixel>(Configuration.Default, data, out format);
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(Configuration config, byte[] data)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var stream = new MemoryStream(data, 0, data.Length, false, true))
             {
@@ -90,7 +90,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(Configuration config, byte[] data, out IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var stream = new MemoryStream(data, 0, data.Length, false, true))
             {
@@ -106,7 +106,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(byte[] data, IImageDecoder decoder)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var stream = new MemoryStream(data, 0, data.Length, false, true))
             {
@@ -123,7 +123,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(Configuration config, byte[] data, IImageDecoder decoder)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var stream = new MemoryStream(data, 0, data.Length, false, true))
             {
@@ -175,7 +175,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(ReadOnlySpan<byte> data)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Load<TPixel>(Configuration.Default, data);
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(ReadOnlySpan<byte> data, out IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Load<TPixel>(Configuration.Default, data, out format);
 
         /// <summary>
@@ -197,7 +197,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(ReadOnlySpan<byte> data, IImageDecoder decoder)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Load<TPixel>(Configuration.Default, data, decoder);
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static unsafe Image<TPixel> Load<TPixel>(Configuration config, ReadOnlySpan<byte> data)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             fixed (byte* ptr = &data.GetPinnableReference())
             {
@@ -231,7 +231,7 @@ namespace SixLabors.ImageSharp
             Configuration config,
             ReadOnlySpan<byte> data,
             IImageDecoder decoder)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             fixed (byte* ptr = &data.GetPinnableReference())
             {
@@ -254,7 +254,7 @@ namespace SixLabors.ImageSharp
             Configuration config,
             ReadOnlySpan<byte> data,
             out IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             fixed (byte* ptr = &data.GetPinnableReference())
             {

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -109,7 +109,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(string path)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return Load<TPixel>(Configuration.Default, path);
         }
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(string path, out IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return Load<TPixel>(Configuration.Default, path, out format);
         }
@@ -141,7 +141,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(Configuration config, string path)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Stream stream = config.FileSystem.OpenRead(path))
             {
@@ -161,7 +161,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(Configuration config, string path, out IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Stream stream = config.FileSystem.OpenRead(path))
             {
@@ -199,7 +199,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(string path, IImageDecoder decoder)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return Load<TPixel>(Configuration.Default, path, decoder);
         }
@@ -216,7 +216,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(Configuration config, string path, IImageDecoder decoder)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Stream stream = config.FileSystem.OpenRead(path))
             {

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -136,7 +136,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>>
         public static Image<TPixel> Load<TPixel>(Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Load<TPixel>(null, stream);
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>>
         public static Image<TPixel> Load<TPixel>(Stream stream, out IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Load<TPixel>(null, stream, out format);
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>>
         public static Image<TPixel> Load<TPixel>(Stream stream, IImageDecoder decoder)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => WithSeekableStream(Configuration.Default, stream, s => decoder.Decode<TPixel>(Configuration.Default, s));
 
         /// <summary>
@@ -176,7 +176,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>>
         public static Image<TPixel> Load<TPixel>(Configuration config, Stream stream, IImageDecoder decoder)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => WithSeekableStream(config, stream, s => decoder.Decode<TPixel>(config, s));
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>>
         public static Image<TPixel> Load<TPixel>(Configuration config, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Load<TPixel>(config, stream, out IImageFormat _);
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>>
         public static Image<TPixel> Load<TPixel>(Configuration config, Stream stream, out IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             config = config ?? Configuration.Default;
             (Image<TPixel> img, IImageFormat format) data = WithSeekableStream(config, stream, s => Decode<TPixel>(s, config));

--- a/src/ImageSharp/Image.LoadPixelData.cs
+++ b/src/ImageSharp/Image.LoadPixelData.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> LoadPixelData<TPixel>(TPixel[] data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => LoadPixelData(Configuration.Default, data, width, height);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> LoadPixelData<TPixel>(ReadOnlySpan<TPixel> data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => LoadPixelData(Configuration.Default, data, width, height);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> LoadPixelData<TPixel>(byte[] data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => LoadPixelData<TPixel>(Configuration.Default, data, width, height);
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> LoadPixelData<TPixel>(ReadOnlySpan<byte> data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => LoadPixelData<TPixel>(Configuration.Default, data, width, height);
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, byte[] data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => LoadPixelData(config, MemoryMarshal.Cast<byte, TPixel>(new ReadOnlySpan<byte>(data)), width, height);
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, ReadOnlySpan<byte> data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => LoadPixelData(config, MemoryMarshal.Cast<byte, TPixel>(data), width, height);
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, TPixel[] data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return LoadPixelData(config, new ReadOnlySpan<TPixel>(data), width, height);
         }
@@ -113,7 +113,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, ReadOnlySpan<TPixel> data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int count = width * height;
             Guard.MustBeGreaterThanOrEqualTo(data.Length, count, nameof(data));

--- a/src/ImageSharp/Image.WrapMemory.cs
+++ b/src/ImageSharp/Image.WrapMemory.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp
             int width,
             int height,
             ImageMetadata metadata)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var memorySource = MemoryGroup<TPixel>.Wrap(pixelMemory);
             return new Image<TPixel>(config, memorySource, width, height, metadata);
@@ -53,7 +53,7 @@ namespace SixLabors.ImageSharp
             Memory<TPixel> pixelMemory,
             int width,
             int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return WrapMemory(config, pixelMemory, width, height, new ImageMetadata());
         }
@@ -72,7 +72,7 @@ namespace SixLabors.ImageSharp
             Memory<TPixel> pixelMemory,
             int width,
             int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return WrapMemory(Configuration.Default, pixelMemory, width, height);
         }
@@ -97,7 +97,7 @@ namespace SixLabors.ImageSharp
             int width,
             int height,
             ImageMetadata metadata)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var memorySource = MemoryGroup<TPixel>.Wrap(pixelMemoryOwner);
             return new Image<TPixel>(config, memorySource, width, height, metadata);
@@ -121,7 +121,7 @@ namespace SixLabors.ImageSharp
             IMemoryOwner<TPixel> pixelMemoryOwner,
             int width,
             int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return WrapMemory(config, pixelMemoryOwner, width, height, new ImageMetadata());
         }
@@ -142,7 +142,7 @@ namespace SixLabors.ImageSharp
             IMemoryOwner<TPixel> pixelMemoryOwner,
             int width,
             int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return WrapMemory(Configuration.Default, pixelMemoryOwner, width, height);
         }

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -104,7 +104,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel2">The pixel format.</typeparam>
         /// <returns>The <see cref="Image{TPixel2}"/></returns>
         public Image<TPixel2> CloneAs<TPixel2>()
-            where TPixel2 : struct, IPixel<TPixel2> => this.CloneAs<TPixel2>(this.GetConfiguration());
+            where TPixel2 : unmanaged, IPixel<TPixel2> => this.CloneAs<TPixel2>(this.GetConfiguration());
 
         /// <summary>
         /// Returns a copy of the image in the given pixel format.
@@ -113,7 +113,7 @@ namespace SixLabors.ImageSharp
         /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
         /// <returns>The <see cref="Image{TPixel2}"/>.</returns>
         public abstract Image<TPixel2> CloneAs<TPixel2>(Configuration configuration)
-            where TPixel2 : struct, IPixel<TPixel2>;
+            where TPixel2 : unmanaged, IPixel<TPixel2>;
 
         /// <summary>
         /// Update the size of the image after mutation.
@@ -153,7 +153,7 @@ namespace SixLabors.ImageSharp
             }
 
             public void Visit<TPixel>(Image<TPixel> image)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 this.encoder.Encode(image, this.stream);
             }

--- a/src/ImageSharp/ImageExtensions.Internal.cs
+++ b/src/ImageSharp/ImageExtensions.Internal.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp
         /// The <see cref="Buffer2D{TPixel}" />
         /// </returns>
         internal static Buffer2D<TPixel> GetRootFramePixelBuffer<TPixel>(this Image<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return image.Frames.RootFrame.PixelBuffer;
         }

--- a/src/ImageSharp/ImageExtensions.cs
+++ b/src/ImageSharp/ImageExtensions.cs
@@ -110,7 +110,7 @@ namespace SixLabors.ImageSharp
         /// <param name="format">The format.</param>
         /// <returns>The <see cref="string"/></returns>
         public static string ToBase64String<TPixel>(this Image<TPixel> source, IImageFormat format)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var stream = new MemoryStream())
             {

--- a/src/ImageSharp/ImageFrame.LoadPixelData.cs
+++ b/src/ImageSharp/ImageFrame.LoadPixelData.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         internal static ImageFrame<TPixel> LoadPixelData<TPixel>(Configuration configuration, ReadOnlySpan<byte> data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => LoadPixelData(configuration, MemoryMarshal.Cast<byte, TPixel>(data), width, height);
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         internal static ImageFrame<TPixel> LoadPixelData<TPixel>(Configuration configuration, ReadOnlySpan<TPixel> data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int count = width * height;
             Guard.MustBeGreaterThanOrEqualTo(data.Length, count, nameof(data));

--- a/src/ImageSharp/ImageFrame.cs
+++ b/src/ImageSharp/ImageFrame.cs
@@ -80,7 +80,7 @@ namespace SixLabors.ImageSharp
         protected abstract void Dispose(bool disposing);
 
         internal abstract void CopyPixelsTo<TDestinationPixel>(MemoryGroup<TDestinationPixel> destination)
-            where TDestinationPixel : struct, IPixel<TDestinationPixel>;
+            where TDestinationPixel : unmanaged, IPixel<TDestinationPixel>;
 
         /// <summary>
         /// Updates the size of the image frame.

--- a/src/ImageSharp/ImageFrameCollection{TPixel}.cs
+++ b/src/ImageSharp/ImageFrameCollection{TPixel}.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp
     /// </summary>
     /// <typeparam name="TPixel">The type of the pixel.</typeparam>
     public sealed class ImageFrameCollection<TPixel> : ImageFrameCollection, IEnumerable<ImageFrame<TPixel>>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly IList<ImageFrame<TPixel>> frames = new List<ImageFrame<TPixel>>();
         private readonly Image<TPixel> parent;

--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public sealed class ImageFrame<TPixel> : ImageFrame, IPixelSource<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private bool isDisposed;
 
@@ -258,7 +258,7 @@ namespace SixLabors.ImageSharp
         /// <typeparam name="TPixel2">The pixel format.</typeparam>
         /// <returns>The <see cref="ImageFrame{TPixel2}"/></returns>
         internal ImageFrame<TPixel2> CloneAs<TPixel2>()
-            where TPixel2 : struct, IPixel<TPixel2> => this.CloneAs<TPixel2>(this.GetConfiguration());
+            where TPixel2 : unmanaged, IPixel<TPixel2> => this.CloneAs<TPixel2>(this.GetConfiguration());
 
         /// <summary>
         /// Returns a copy of the image frame in the given pixel format.
@@ -267,7 +267,7 @@ namespace SixLabors.ImageSharp
         /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
         /// <returns>The <see cref="ImageFrame{TPixel2}"/></returns>
         internal ImageFrame<TPixel2> CloneAs<TPixel2>(Configuration configuration)
-            where TPixel2 : struct, IPixel<TPixel2>
+            where TPixel2 : unmanaged, IPixel<TPixel2>
         {
             if (typeof(TPixel2) == typeof(TPixel))
             {
@@ -327,7 +327,7 @@ namespace SixLabors.ImageSharp
         /// A <see langword="struct"/> implementing the clone logic for <see cref="ImageFrame{TPixel}"/>.
         /// </summary>
         private readonly struct RowIntervalOperation<TPixel2> : IRowIntervalOperation
-            where TPixel2 : struct, IPixel<TPixel2>
+            where TPixel2 : unmanaged, IPixel<TPixel2>
         {
             private readonly ImageFrame<TPixel> source;
             private readonly ImageFrame<TPixel2> target;

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public sealed class Image<TPixel> : Image
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private bool isDisposed;
 

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
@@ -114,7 +114,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
         /// The <see cref="Image{TPixel}"/>.
         /// </returns>
         public Image<TPixel> CreateThumbnail<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.InitializeValues();
 

--- a/src/ImageSharp/PixelFormats/IPixel.cs
+++ b/src/ImageSharp/PixelFormats/IPixel.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.PixelFormats
     /// </summary>
     /// <typeparam name="TSelf">The type implementing this interface</typeparam>
     public interface IPixel<TSelf> : IPixel, IEquatable<TSelf>
-        where TSelf : struct, IPixel<TSelf>
+        where TSelf : unmanaged, IPixel<TSelf>
     {
         /// <summary>
         /// Creates a <see cref="PixelOperations{TPixel}"/> instance for this pixel type.

--- a/src/ImageSharp/PixelFormats/PixelBlenders/DefaultPixelBlenders.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelBlenders/DefaultPixelBlenders.Generated.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
     /// to be opaque
     /// </remarks>
     internal static class DefaultPixelBlenders<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
 
             /// <summary>

--- a/src/ImageSharp/PixelFormats/PixelBlenders/DefaultPixelBlenders.Generated.tt
+++ b/src/ImageSharp/PixelFormats/PixelBlenders/DefaultPixelBlenders.Generated.tt
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
     /// to be opaque
     /// </remarks>
     internal static class DefaultPixelBlenders<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
 
 <#

--- a/src/ImageSharp/PixelFormats/PixelBlenders/PorterDuffFunctions.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelBlenders/PorterDuffFunctions.Generated.cs
@@ -202,7 +202,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalSrc<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -221,7 +221,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalSrcAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -240,7 +240,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalSrcOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -259,7 +259,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalSrcIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -278,7 +278,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalSrcOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -297,7 +297,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalDest<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -316,7 +316,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalDestAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -335,7 +335,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalDestOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -354,7 +354,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalDestIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -373,7 +373,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalDestOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -392,7 +392,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalClear<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -411,7 +411,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel NormalXor<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -608,7 +608,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplySrc<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -627,7 +627,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplySrcAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -646,7 +646,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplySrcOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -665,7 +665,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplySrcIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -684,7 +684,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplySrcOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -703,7 +703,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplyDest<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -722,7 +722,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplyDestAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -741,7 +741,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplyDestOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -760,7 +760,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplyDestIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -779,7 +779,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplyDestOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -798,7 +798,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplyClear<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -817,7 +817,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel MultiplyXor<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1014,7 +1014,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddSrc<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1033,7 +1033,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddSrcAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1052,7 +1052,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddSrcOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1071,7 +1071,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddSrcIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1090,7 +1090,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddSrcOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1109,7 +1109,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddDest<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1128,7 +1128,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddDestAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1147,7 +1147,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddDestOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1166,7 +1166,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddDestIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1185,7 +1185,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddDestOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1204,7 +1204,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddClear<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1223,7 +1223,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel AddXor<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1420,7 +1420,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractSrc<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1439,7 +1439,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractSrcAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1458,7 +1458,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractSrcOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1477,7 +1477,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractSrcIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1496,7 +1496,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractSrcOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1515,7 +1515,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractDest<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1534,7 +1534,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractDestAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1553,7 +1553,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractDestOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1572,7 +1572,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractDestIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1591,7 +1591,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractDestOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1610,7 +1610,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractClear<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1629,7 +1629,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel SubtractXor<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1826,7 +1826,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenSrc<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1845,7 +1845,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenSrcAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1864,7 +1864,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenSrcOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1883,7 +1883,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenSrcIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1902,7 +1902,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenSrcOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1921,7 +1921,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenDest<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1940,7 +1940,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenDestAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1959,7 +1959,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenDestOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1978,7 +1978,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenDestIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -1997,7 +1997,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenDestOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2016,7 +2016,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenClear<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2035,7 +2035,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ScreenXor<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2232,7 +2232,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenSrc<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2251,7 +2251,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenSrcAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2270,7 +2270,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenSrcOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2289,7 +2289,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenSrcIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2308,7 +2308,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenSrcOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2327,7 +2327,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenDest<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2346,7 +2346,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenDestAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2365,7 +2365,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenDestOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2384,7 +2384,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenDestIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2403,7 +2403,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenDestOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2422,7 +2422,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenClear<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2441,7 +2441,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel DarkenXor<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2638,7 +2638,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenSrc<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2657,7 +2657,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenSrcAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2676,7 +2676,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenSrcOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2695,7 +2695,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenSrcIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2714,7 +2714,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenSrcOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2733,7 +2733,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenDest<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2752,7 +2752,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenDestAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2771,7 +2771,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenDestOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2790,7 +2790,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenDestIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2809,7 +2809,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenDestOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2828,7 +2828,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenClear<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -2847,7 +2847,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel LightenXor<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3044,7 +3044,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlaySrc<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3063,7 +3063,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlaySrcAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3082,7 +3082,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlaySrcOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3101,7 +3101,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlaySrcIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3120,7 +3120,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlaySrcOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3139,7 +3139,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlayDest<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3158,7 +3158,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlayDestAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3177,7 +3177,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlayDestOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3196,7 +3196,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlayDestIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3215,7 +3215,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlayDestOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3234,7 +3234,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlayClear<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3253,7 +3253,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel OverlayXor<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3450,7 +3450,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightSrc<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3469,7 +3469,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightSrcAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3488,7 +3488,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightSrcOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3507,7 +3507,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightSrcIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3526,7 +3526,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightSrcOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3545,7 +3545,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightDest<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3564,7 +3564,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightDestAtop<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3583,7 +3583,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightDestOver<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3602,7 +3602,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightDestIn<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3621,7 +3621,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightDestOut<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3640,7 +3640,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightClear<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;
@@ -3659,7 +3659,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel HardLightXor<TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;

--- a/src/ImageSharp/PixelFormats/PixelBlenders/PorterDuffFunctions.Generated.tt
+++ b/src/ImageSharp/PixelFormats/PixelBlenders/PorterDuffFunctions.Generated.tt
@@ -217,7 +217,7 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
         /// <returns>The <typeparamref name="TPixel"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel <#=blender#><#=composer#><TPixel>(TPixel backdrop, TPixel source, float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             opacity = opacity.Clamp(0, 1);
             TPixel dest = default;

--- a/src/ImageSharp/PixelFormats/PixelBlender{TPixel}.cs
+++ b/src/ImageSharp/PixelFormats/PixelBlender{TPixel}.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.PixelFormats
     /// </summary>
     /// <typeparam name="TPixel">The type of the pixel</typeparam>
     public abstract class PixelBlender<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Blend 2 pixels together.
@@ -45,7 +45,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ReadOnlySpan<TPixel> background,
             ReadOnlySpan<TPixelSrc> source,
             float amount)
-            where TPixelSrc : struct, IPixel<TPixelSrc>
+            where TPixelSrc : unmanaged, IPixel<TPixelSrc>
         {
             Guard.MustBeGreaterThanOrEqualTo(background.Length, destination.Length, nameof(background.Length));
             Guard.MustBeGreaterThanOrEqualTo(source.Length, destination.Length, nameof(source.Length));
@@ -107,7 +107,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             ReadOnlySpan<TPixel> background,
             ReadOnlySpan<TPixelSrc> source,
             ReadOnlySpan<float> amount)
-            where TPixelSrc : struct, IPixel<TPixelSrc>
+            where TPixelSrc : unmanaged, IPixel<TPixelSrc>
         {
             Guard.MustBeGreaterThanOrEqualTo(background.Length, destination.Length, nameof(background.Length));
             Guard.MustBeGreaterThanOrEqualTo(source.Length, destination.Length, nameof(source.Length));

--- a/src/ImageSharp/PixelFormats/PixelImplementations/A8.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/A8.cs
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(A8 left, A8 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<A8> CreatePixelOperations() => new PixelOperations<A8>();
+        public readonly PixelOperations<A8> CreatePixelOperations() => new PixelOperations<A8>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -65,7 +65,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -73,7 +73,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(0, 0, 0, this.PackedValue / 255F);
+        public readonly Vector4 ToVector4() => new Vector4(0, 0, 0, this.PackedValue / 255F);
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -136,7 +136,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <param name="obj">The object to compare.</param>
         /// <returns>True if the object is equal to the packed vector.</returns>
-        public override bool Equals(object obj) => obj is A8 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is A8 other && this.Equals(other);
 
         /// <summary>
         /// Compares another A8 packed vector with the packed vector.
@@ -144,17 +144,17 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <param name="other">The A8 packed vector to compare.</param>
         /// <returns>True if the packed vectors are equal.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(A8 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(A8 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <summary>
         /// Gets a string representation of the packed vector.
         /// </summary>
         /// <returns>A string representation of the packed vector.</returns>
-        public override string ToString() => $"A8({this.PackedValue})";
+        public override readonly string ToString() => $"A8({this.PackedValue})";
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <summary>
         /// Packs a <see cref="float"/> into a byte.

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Argb32.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Argb32.cs
@@ -138,7 +138,10 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <inheritdoc/>
         public uint PackedValue
         {
+            [MethodImpl(InliningOptions.ShortMethod)]
             readonly get => this.Argb;
+
+            [MethodImpl(InliningOptions.ShortMethod)]
             set => this.Argb = value;
         }
 

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Argb32.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Argb32.cs
@@ -129,7 +129,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public uint Argb
         {
             [MethodImpl(InliningOptions.ShortMethod)]
-            get => Unsafe.As<Argb32, uint>(ref this);
+            readonly get => Unsafe.As<Argb32, uint>(ref Unsafe.AsRef(this));
 
             [MethodImpl(InliningOptions.ShortMethod)]
             set => Unsafe.As<Argb32, uint>(ref this) = value;
@@ -138,7 +138,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <inheritdoc/>
         public uint PackedValue
         {
-            get => this.Argb;
+            readonly get => this.Argb;
             set => this.Argb = value;
         }
 
@@ -181,7 +181,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Argb32 left, Argb32 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Argb32> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<Argb32> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -189,7 +189,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -197,7 +197,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A) / MaxBytes;
+        public readonly Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A) / MaxBytes;
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -320,21 +320,21 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Argb32 argb32 && this.Equals(argb32);
+        public override readonly bool Equals(object obj) => obj is Argb32 argb32 && this.Equals(argb32);
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Argb32 other) => this.Argb == other.Argb;
+        public readonly bool Equals(Argb32 other) => this.Argb == other.Argb;
 
         /// <summary>
         /// Gets a string representation of the packed vector.
         /// </summary>
         /// <returns>A string representation of the packed vector.</returns>
-        public override string ToString() => $"Argb({this.A}, {this.R}, {this.G}, {this.B})";
+        public override readonly string ToString() => $"Argb({this.A}, {this.R}, {this.G}, {this.B})";
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.Argb.GetHashCode();
+        public override readonly int GetHashCode() => this.Argb.GetHashCode();
 
         /// <summary>
         /// Packs the four floats into a color.

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Bgr24.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Bgr24.cs
@@ -89,7 +89,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Bgr24 left, Bgr24 right) => !left.Equals(right);
 
         /// <inheritdoc/>
-        public PixelOperations<Bgr24> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<Bgr24> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -97,7 +97,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -110,7 +110,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Rgba32(this.R, this.G, this.B, byte.MaxValue).ToVector4();
+        public readonly Vector4 ToVector4() => new Rgba32(this.R, this.G, this.B, byte.MaxValue).ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -219,16 +219,16 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Bgr24 other) => this.R.Equals(other.R) && this.G.Equals(other.G) && this.B.Equals(other.B);
+        public readonly bool Equals(Bgr24 other) => this.R.Equals(other.R) && this.G.Equals(other.G) && this.B.Equals(other.B);
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Bgr24 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is Bgr24 other && this.Equals(other);
 
         /// <inheritdoc />
-        public override string ToString() => $"Bgra({this.B}, {this.G}, {this.R})";
+        public override readonly string ToString() => $"Bgra({this.B}, {this.G}, {this.R})";
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => HashCode.Combine(this.R, this.B, this.G);
+        public override readonly int GetHashCode() => HashCode.Combine(this.R, this.B, this.G);
     }
 }

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Bgr565.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Bgr565.cs
@@ -61,7 +61,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Bgr565 left, Bgr565 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Bgr565> CreatePixelOperations() => new PixelOperations<Bgr565>();
+        public readonly PixelOperations<Bgr565> CreatePixelOperations() => new PixelOperations<Bgr565>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -69,7 +69,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -81,7 +81,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.ToVector3(), 1F);
+        public readonly Vector4 ToVector4() => new Vector4(this.ToVector3(), 1F);
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -144,7 +144,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Vector3"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector3 ToVector3()
+        public readonly Vector3 ToVector3()
         {
             return new Vector3(
                        ((this.PackedValue >> 11) & 0x1F) * (1F / 31F),
@@ -153,14 +153,14 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is Bgr565 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is Bgr565 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Bgr565 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(Bgr565 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector3();
             return FormattableString.Invariant($"Bgr565({vector.Z:#0.##}, {vector.Y:#0.##}, {vector.X:#0.##})");
@@ -168,7 +168,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         [MethodImpl(InliningOptions.ShortMethod)]
         private static ushort Pack(ref Vector3 vector)

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Bgra32.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Bgra32.cs
@@ -85,7 +85,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public uint Bgra
         {
             [MethodImpl(InliningOptions.ShortMethod)]
-            get => Unsafe.As<Bgra32, uint>(ref this);
+            readonly get => Unsafe.As<Bgra32, uint>(ref Unsafe.AsRef(this));
 
             [MethodImpl(InliningOptions.ShortMethod)]
             set => Unsafe.As<Bgra32, uint>(ref this) = value;
@@ -94,7 +94,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <inheritdoc/>
         public uint PackedValue
         {
-            get => this.Bgra;
+            readonly get => this.Bgra;
             set => this.Bgra = value;
         }
 
@@ -137,7 +137,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Bgra32 left, Bgra32 right) => !left.Equals(right);
 
         /// <inheritdoc/>
-        public PixelOperations<Bgra32> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<Bgra32> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -145,7 +145,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -153,7 +153,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A) / MaxBytes;
+        public readonly Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A) / MaxBytes;
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -276,16 +276,16 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Bgra32 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is Bgra32 other && this.Equals(other);
 
         /// <inheritdoc/>
-        public bool Equals(Bgra32 other) => this.Bgra.Equals(other.Bgra);
+        public readonly bool Equals(Bgra32 other) => this.Bgra.Equals(other.Bgra);
 
         /// <inheritdoc/>
-        public override int GetHashCode() => this.Bgra.GetHashCode();
+        public override readonly int GetHashCode() => this.Bgra.GetHashCode();
 
         /// <inheritdoc />
-        public override string ToString() => $"Bgra32({this.B}, {this.G}, {this.R}, {this.A})";
+        public override readonly string ToString() => $"Bgra32({this.B}, {this.G}, {this.R}, {this.A})";
 
         /// <summary>
         /// Packs a <see cref="Vector4"/> into a color.

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Bgra4444.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Bgra4444.cs
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Bgra4444 left, Bgra4444 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Bgra4444> CreatePixelOperations() => new PixelOperations<Bgra4444>();
+        public readonly PixelOperations<Bgra4444> CreatePixelOperations() => new PixelOperations<Bgra4444>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -75,7 +75,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             const float Max = 1 / 15F;
 
@@ -142,14 +142,14 @@ namespace SixLabors.ImageSharp.PixelFormats
         public void FromRgba64(Rgba64 source) => this.FromScaledVector4(source.ToScaledVector4());
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is Bgra4444 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is Bgra4444 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Bgra4444 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(Bgra4444 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector4();
             return FormattableString.Invariant($"Bgra4444({vector.Z:#0.##}, {vector.Y:#0.##}, {vector.X:#0.##}, {vector.W:#0.##})");
@@ -157,7 +157,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         [MethodImpl(InliningOptions.ShortMethod)]
         private static ushort Pack(ref Vector4 vector)

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Bgra5551.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Bgra5551.cs
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Bgra5551 left, Bgra5551 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Bgra5551> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<Bgra5551> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -78,7 +78,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             return new Vector4(
                         ((this.PackedValue >> 10) & 0x1F) / 31F,
@@ -147,10 +147,10 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Bgra5551 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(Bgra5551 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector4();
             return FormattableString.Invariant($"Bgra5551({vector.Z:#0.##}, {vector.Y:#0.##}, {vector.X:#0.##}, {vector.W:#0.##})");
@@ -158,7 +158,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         [MethodImpl(InliningOptions.ShortMethod)]
         private static ushort Pack(ref Vector4 vector)

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Byte4.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Byte4.cs
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Byte4 left, Byte4 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Byte4> CreatePixelOperations() => new PixelOperations<Byte4>();
+        public readonly PixelOperations<Byte4> CreatePixelOperations() => new PixelOperations<Byte4>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4() / 255F;
+        public readonly Vector4 ToScaledVector4() => this.ToVector4() / 255F;
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -78,7 +78,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             return new Vector4(
                 this.PackedValue & 0xFF,
@@ -143,18 +143,18 @@ namespace SixLabors.ImageSharp.PixelFormats
         public void FromRgba64(Rgba64 source) => this.FromScaledVector4(source.ToScaledVector4());
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is Byte4 byte4 && this.Equals(byte4);
+        public override readonly bool Equals(object obj) => obj is Byte4 byte4 && this.Equals(byte4);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Byte4 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(Byte4 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector4();
             return FormattableString.Invariant($"Byte4({vector.X:#0.##}, {vector.Y:#0.##}, {vector.Z:#0.##}, {vector.W:#0.##})");

--- a/src/ImageSharp/PixelFormats/PixelImplementations/HalfSingle.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/HalfSingle.cs
@@ -61,7 +61,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4()
+        public readonly Vector4 ToScaledVector4()
         {
             float single = this.ToSingle() + 1F;
             single /= 2F;
@@ -74,7 +74,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.ToSingle(), 0, 0, 1F);
+        public readonly Vector4 ToVector4() => new Vector4(this.ToSingle(), 0, 0, 1F);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -136,20 +136,20 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="float"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public float ToSingle() => HalfTypeHelper.Unpack(this.PackedValue);
+        public readonly float ToSingle() => HalfTypeHelper.Unpack(this.PackedValue);
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is HalfSingle other && this.Equals(other);
-
-        /// <inheritdoc />
-        [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(HalfSingle other) => this.PackedValue.Equals(other.PackedValue);
-
-        /// <inheritdoc />
-        public override string ToString() => FormattableString.Invariant($"HalfSingle({this.ToSingle():#0.##})");
+        public override readonly bool Equals(object obj) => obj is HalfSingle other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public readonly bool Equals(HalfSingle other) => this.PackedValue.Equals(other.PackedValue);
+
+        /// <inheritdoc />
+        public override readonly string ToString() => FormattableString.Invariant($"HalfSingle({this.ToSingle():#0.##})");
+
+        /// <inheritdoc />
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
     }
 }

--- a/src/ImageSharp/PixelFormats/PixelImplementations/HalfVector2.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/HalfVector2.cs
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(HalfVector2 left, HalfVector2 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<HalfVector2> CreatePixelOperations() => new PixelOperations<HalfVector2>();
+        public readonly PixelOperations<HalfVector2> CreatePixelOperations() => new PixelOperations<HalfVector2>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4()
+        public readonly Vector4 ToScaledVector4()
         {
             var scaled = this.ToVector2();
             scaled += Vector2.One;
@@ -81,7 +81,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             var vector = this.ToVector2();
             return new Vector4(vector.X, vector.Y, 0F, 1F);
@@ -147,7 +147,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Vector2"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector2 ToVector2()
+        public readonly Vector2 ToVector2()
         {
             Vector2 vector;
             vector.X = HalfTypeHelper.Unpack((ushort)this.PackedValue);
@@ -156,14 +156,14 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is HalfVector2 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is HalfVector2 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(HalfVector2 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(HalfVector2 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector2();
             return FormattableString.Invariant($"HalfVector2({vector.X:#0.##}, {vector.Y:#0.##})");
@@ -171,7 +171,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         [MethodImpl(InliningOptions.ShortMethod)]
         private static uint Pack(float x, float y)

--- a/src/ImageSharp/PixelFormats/PixelImplementations/HalfVector4.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/HalfVector4.cs
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(HalfVector4 left, HalfVector4 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<HalfVector4> CreatePixelOperations() => new PixelOperations<HalfVector4>();
+        public readonly PixelOperations<HalfVector4> CreatePixelOperations() => new PixelOperations<HalfVector4>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -72,7 +72,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4()
+        public readonly Vector4 ToScaledVector4()
         {
             var scaled = this.ToVector4();
             scaled += Vector4.One;
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             return new Vector4(
                 HalfTypeHelper.Unpack((ushort)this.PackedValue),
@@ -151,14 +151,14 @@ namespace SixLabors.ImageSharp.PixelFormats
         public void FromRgba64(Rgba64 source) => this.FromScaledVector4(source.ToScaledVector4());
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is HalfVector4 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is HalfVector4 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(HalfVector4 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(HalfVector4 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector4();
             return FormattableString.Invariant($"HalfVector4({vector.X:#0.##}, {vector.Y:#0.##}, {vector.Z:#0.##}, {vector.W:#0.##})");
@@ -166,7 +166,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <summary>
         /// Packs a <see cref="Vector4"/> into a <see cref="ulong"/>.

--- a/src/ImageSharp/PixelFormats/PixelImplementations/L16.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/L16.cs
@@ -48,7 +48,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(L16 left, L16 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<L16> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<L16> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -56,7 +56,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -64,7 +64,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             float scaled = this.PackedValue / Max;
             return new Vector4(scaled, scaled, scaled, 1F);
@@ -160,18 +160,18 @@ namespace SixLabors.ImageSharp.PixelFormats
         public void FromRgba64(Rgba64 source) => this.PackedValue = ImageMaths.Get16BitBT709Luminance(source.R, source.G, source.B);
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is L16 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is L16 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(L16 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(L16 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString() => $"L16({this.PackedValue})";
+        public override readonly string ToString() => $"L16({this.PackedValue})";
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         [MethodImpl(InliningOptions.ShortMethod)]
         internal void ConvertFromRgbaScaledVector4(Vector4 vector)

--- a/src/ImageSharp/PixelFormats/PixelImplementations/L8.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/L8.cs
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(L8 left, L8 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<L8> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<L8> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -65,7 +65,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             float rgb = this.PackedValue / 255F;
             return new Vector4(rgb, rgb, rgb, 1F);
@@ -138,18 +138,18 @@ namespace SixLabors.ImageSharp.PixelFormats
                 ImageMaths.DownScaleFrom16BitTo8Bit(source.B));
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is L8 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is L8 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(L8 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(L8 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString() => $"L8({this.PackedValue})";
+        public override readonly string ToString() => $"L8({this.PackedValue})";
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         [MethodImpl(InliningOptions.ShortMethod)]
         internal void ConvertFromRgbaScaledVector4(Vector4 vector)

--- a/src/ImageSharp/PixelFormats/PixelImplementations/La16.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/La16.cs
@@ -45,8 +45,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <inheritdoc/>
         public ushort PackedValue
         {
-            get => Unsafe.As<La16, ushort>(ref this);
-
+            readonly get => Unsafe.As<La16, ushort>(ref Unsafe.AsRef(this));
             set => Unsafe.As<La16, ushort>(ref this) = value;
         }
 
@@ -73,21 +72,21 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(La16 left, La16 right) => !left.Equals(right);
 
         /// <inheritdoc/>
-        public PixelOperations<La16> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<La16> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(La16 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(La16 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is La16 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is La16 other && this.Equals(other);
 
         /// <inheritdoc />
-        public override string ToString() => $"La16({this.L}, {this.A})";
+        public override readonly string ToString() => $"La16({this.L}, {this.A})";
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -204,11 +203,11 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             const float Max = 255F;
             float rgb = this.L / Max;

--- a/src/ImageSharp/PixelFormats/PixelImplementations/La32.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/La32.cs
@@ -45,7 +45,10 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <inheritdoc/>
         public uint PackedValue
         {
+            [MethodImpl(InliningOptions.ShortMethod)]
             readonly get => Unsafe.As<La32, uint>(ref Unsafe.AsRef(this));
+
+            [MethodImpl(InliningOptions.ShortMethod)]
             set => Unsafe.As<La32, uint>(ref this) = value;
         }
 

--- a/src/ImageSharp/PixelFormats/PixelImplementations/La32.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/La32.cs
@@ -45,8 +45,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// <inheritdoc/>
         public uint PackedValue
         {
-            get => Unsafe.As<La32, uint>(ref this);
-
+            readonly get => Unsafe.As<La32, uint>(ref Unsafe.AsRef(this));
             set => Unsafe.As<La32, uint>(ref this) = value;
         }
 
@@ -73,21 +72,21 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(La32 left, La32 right) => !left.Equals(right);
 
         /// <inheritdoc/>
-        public PixelOperations<La32> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<La32> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(La32 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(La32 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is La32 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is La32 other && this.Equals(other);
 
         /// <inheritdoc />
-        public override string ToString() => $"La32({this.L}, {this.A})";
+        public override readonly string ToString() => $"La32({this.L}, {this.A})";
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -218,11 +217,11 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             float scaled = this.L / Max;
             return new Vector4(scaled, scaled, scaled, this.A / Max);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/NormalizedByte2.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/NormalizedByte2.cs
@@ -60,20 +60,20 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(NormalizedByte2 left, NormalizedByte2 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<NormalizedByte2> CreatePixelOperations() => new PixelOperations<NormalizedByte2>();
+        public readonly PixelOperations<NormalizedByte2> CreatePixelOperations() => new PixelOperations<NormalizedByte2>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
         public void FromScaledVector4(Vector4 vector)
         {
-            var scaled = new Vector2(vector.X, vector.Y) * 2F;
+            Vector2 scaled = new Vector2(vector.X, vector.Y) * 2F;
             scaled -= Vector2.One;
             this.PackedValue = Pack(scaled);
         }
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4()
+        public readonly Vector4 ToScaledVector4()
         {
             var scaled = this.ToVector2();
             scaled += Vector2.One;
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.ToVector2(), 0F, 1F);
+        public readonly Vector4 ToVector4() => new Vector4(this.ToVector2(), 0F, 1F);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -151,7 +151,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Vector2"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector2 ToVector2()
+        public readonly Vector2 ToVector2()
         {
             return new Vector2(
                 (sbyte)((this.PackedValue >> 0) & 0xFF) / 127F,
@@ -159,18 +159,18 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is NormalizedByte2 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is NormalizedByte2 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(NormalizedByte2 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(NormalizedByte2 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector2();
             return FormattableString.Invariant($"NormalizedByte2({vector.X:#0.##}, {vector.Y:#0.##})");

--- a/src/ImageSharp/PixelFormats/PixelImplementations/NormalizedByte4.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/NormalizedByte4.cs
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(NormalizedByte4 left, NormalizedByte4 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<NormalizedByte4> CreatePixelOperations() => new PixelOperations<NormalizedByte4>();
+        public readonly PixelOperations<NormalizedByte4> CreatePixelOperations() => new PixelOperations<NormalizedByte4>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -75,7 +75,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4()
+        public readonly Vector4 ToScaledVector4()
         {
             var scaled = this.ToVector4();
             scaled += Vector4.One;
@@ -89,7 +89,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             return new Vector4(
                 (sbyte)((this.PackedValue >> 0) & 0xFF) / 127F,
@@ -154,18 +154,18 @@ namespace SixLabors.ImageSharp.PixelFormats
         public void FromRgba64(Rgba64 source) => this.FromScaledVector4(source.ToScaledVector4());
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is NormalizedByte4 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is NormalizedByte4 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(NormalizedByte4 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(NormalizedByte4 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector4();
             return FormattableString.Invariant($"NormalizedByte4({vector.X:#0.##}, {vector.Y:#0.##}, {vector.Z:#0.##}, {vector.W:#0.##})");

--- a/src/ImageSharp/PixelFormats/PixelImplementations/NormalizedShort2.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/NormalizedShort2.cs
@@ -60,20 +60,20 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(NormalizedShort2 left, NormalizedShort2 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<NormalizedShort2> CreatePixelOperations() => new PixelOperations<NormalizedShort2>();
+        public readonly PixelOperations<NormalizedShort2> CreatePixelOperations() => new PixelOperations<NormalizedShort2>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
         public void FromScaledVector4(Vector4 vector)
         {
-            var scaled = new Vector2(vector.X, vector.Y) * 2F;
+            Vector2 scaled = new Vector2(vector.X, vector.Y) * 2F;
             scaled -= Vector2.One;
             this.PackedValue = Pack(scaled);
         }
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4()
+        public readonly Vector4 ToScaledVector4()
         {
             var scaled = this.ToVector2();
             scaled += Vector2.One;
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.ToVector2(), 0, 1);
+        public readonly Vector4 ToVector4() => new Vector4(this.ToVector2(), 0, 1);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -154,7 +154,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Vector2"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector2 ToVector2()
+        public readonly Vector2 ToVector2()
         {
             const float MaxVal = 0x7FFF;
 
@@ -164,18 +164,18 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is NormalizedShort2 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is NormalizedShort2 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(NormalizedShort2 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(NormalizedShort2 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector2();
             return FormattableString.Invariant($"NormalizedShort2({vector.X:#0.##}, {vector.Y:#0.##})");

--- a/src/ImageSharp/PixelFormats/PixelImplementations/NormalizedShort4.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/NormalizedShort4.cs
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(NormalizedShort4 left, NormalizedShort4 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<NormalizedShort4> CreatePixelOperations() => new PixelOperations<NormalizedShort4>();
+        public readonly PixelOperations<NormalizedShort4> CreatePixelOperations() => new PixelOperations<NormalizedShort4>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -75,7 +75,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4()
+        public readonly Vector4 ToScaledVector4()
         {
             var scaled = this.ToVector4();
             scaled += Vector4.One;
@@ -89,7 +89,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             const float MaxVal = 0x7FFF;
 
@@ -156,18 +156,18 @@ namespace SixLabors.ImageSharp.PixelFormats
         public void FromRgba64(Rgba64 source) => this.FromScaledVector4(source.ToScaledVector4());
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is NormalizedShort4 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is NormalizedShort4 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(NormalizedShort4 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(NormalizedShort4 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector4();
             return FormattableString.Invariant($"NormalizedShort4({vector.X:#0.##}, {vector.Y:#0.##}, {vector.Z:#0.##}, {vector.W:#0.##})");

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Rg32.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Rg32.cs
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Rg32 left, Rg32 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Rg32> CreatePixelOperations() => new PixelOperations<Rg32>();
+        public readonly PixelOperations<Rg32> CreatePixelOperations() => new PixelOperations<Rg32>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.ToVector2(), 0F, 1F);
+        public readonly Vector4 ToVector4() => new Vector4(this.ToVector2(), 0F, 1F);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -142,17 +142,17 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Vector2"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector2 ToVector2() => new Vector2(this.PackedValue & 0xFFFF, (this.PackedValue >> 16) & 0xFFFF) / Max;
+        public readonly Vector2 ToVector2() => new Vector2(this.PackedValue & 0xFFFF, (this.PackedValue >> 16) & 0xFFFF) / Max;
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is Rg32 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is Rg32 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Rg32 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(Rg32 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector2();
             return FormattableString.Invariant($"Rg32({vector.X:#0.##}, {vector.Y:#0.##})");
@@ -160,7 +160,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         [MethodImpl(InliningOptions.ShortMethod)]
         private static uint Pack(Vector2 vector)

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Rgb24.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Rgb24.cs
@@ -108,7 +108,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Rgb24 left, Rgb24 right) => !left.Equals(right);
 
         /// <inheritdoc/>
-        public PixelOperations<Rgb24> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<Rgb24> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -116,7 +116,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Rgba32(this.R, this.G, this.B, byte.MaxValue).ToVector4();
+        public readonly Vector4 ToVector4() => new Rgba32(this.R, this.G, this.B, byte.MaxValue).ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -232,18 +232,18 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Rgb24 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is Rgb24 other && this.Equals(other);
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Rgb24 other) => this.R.Equals(other.R) && this.G.Equals(other.G) && this.B.Equals(other.B);
+        public readonly bool Equals(Rgb24 other) => this.R.Equals(other.R) && this.G.Equals(other.G) && this.B.Equals(other.B);
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => HashCode.Combine(this.R, this.B, this.G);
+        public override readonly int GetHashCode() => HashCode.Combine(this.R, this.B, this.G);
 
         /// <inheritdoc/>
-        public override string ToString() => $"Rgb24({this.R}, {this.G}, {this.B})";
+        public override readonly string ToString() => $"Rgb24({this.R}, {this.G}, {this.B})";
 
         /// <summary>
         /// Packs a <see cref="Vector4"/> into a color.

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Rgb48.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Rgb48.cs
@@ -71,7 +71,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Rgb48 left, Rgb48 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Rgb48> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<Rgb48> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -93,7 +93,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.R / Max, this.G / Max, this.B / Max, 1F);
+        public readonly Vector4 ToVector4() => new Vector4(this.R / Max, this.G / Max, this.B / Max, 1F);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -201,17 +201,17 @@ namespace SixLabors.ImageSharp.PixelFormats
         public void FromRgb48(Rgb48 source) => this = source;
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is Rgb48 rgb48 && this.Equals(rgb48);
+        public override readonly bool Equals(object obj) => obj is Rgb48 rgb48 && this.Equals(rgb48);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Rgb48 other) => this.R.Equals(other.R) && this.G.Equals(other.G) && this.B.Equals(other.B);
+        public readonly bool Equals(Rgb48 other) => this.R.Equals(other.R) && this.G.Equals(other.G) && this.B.Equals(other.B);
 
         /// <inheritdoc />
-        public override string ToString() => $"Rgb48({this.R}, {this.G}, {this.B})";
+        public override readonly string ToString() => $"Rgb48({this.R}, {this.G}, {this.B})";
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => HashCode.Combine(this.R, this.G, this.B);
+        public override readonly int GetHashCode() => HashCode.Combine(this.R, this.G, this.B);
     }
 }

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Rgba1010102.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Rgba1010102.cs
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Rgba1010102 left, Rgba1010102 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Rgba1010102> CreatePixelOperations() => new PixelOperations<Rgba1010102>();
+        public readonly PixelOperations<Rgba1010102> CreatePixelOperations() => new PixelOperations<Rgba1010102>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -78,7 +78,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             return new Vector4(
                 (this.PackedValue >> 0) & 0x03FF,
@@ -143,14 +143,14 @@ namespace SixLabors.ImageSharp.PixelFormats
         public void FromRgba64(Rgba64 source) => this.FromScaledVector4(source.ToScaledVector4());
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is Rgba1010102 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is Rgba1010102 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Rgba1010102 other) => this.PackedValue == other.PackedValue;
+        public readonly bool Equals(Rgba1010102 other) => this.PackedValue == other.PackedValue;
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector4();
             return FormattableString.Invariant($"Rgba1010102({vector.X:#0.##}, {vector.Y:#0.##}, {vector.Z:#0.##}, {vector.W:#0.##})");
@@ -158,7 +158,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         [MethodImpl(InliningOptions.ShortMethod)]
         private static uint Pack(ref Vector4 vector)

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Rgba32.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Rgba32.cs
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public uint Rgba
         {
             [MethodImpl(InliningOptions.ShortMethod)]
-            get => Unsafe.As<Rgba32, uint>(ref this);
+            readonly get => Unsafe.As<Rgba32, uint>(ref Unsafe.AsRef(this));
 
             [MethodImpl(InliningOptions.ShortMethod)]
             set => Unsafe.As<Rgba32, uint>(ref this) = value;
@@ -137,7 +137,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public Rgb24 Rgb
         {
             [MethodImpl(InliningOptions.ShortMethod)]
-            get => new Rgb24(this.R, this.G, this.B);
+            readonly get => new Rgb24(this.R, this.G, this.B);
 
             [MethodImpl(InliningOptions.ShortMethod)]
             set
@@ -154,7 +154,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public Bgr24 Bgr
         {
             [MethodImpl(InliningOptions.ShortMethod)]
-            get => new Bgr24(this.R, this.G, this.B);
+            readonly get => new Bgr24(this.R, this.G, this.B);
 
             [MethodImpl(InliningOptions.ShortMethod)]
             set
@@ -169,7 +169,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public uint PackedValue
         {
             [MethodImpl(InliningOptions.ShortMethod)]
-            get => this.Rgba;
+            readonly get => this.Rgba;
 
             [MethodImpl(InliningOptions.ShortMethod)]
             set => this.Rgba = value;
@@ -287,7 +287,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc />
-        public PixelOperations<Rgba32> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<Rgba32> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -295,7 +295,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -303,7 +303,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A) / MaxBytes;
+        public readonly Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A) / MaxBytes;
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -422,25 +422,25 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// Converts the value of this instance to a hexadecimal string.
         /// </summary>
         /// <returns>A hexadecimal string representation of the value.</returns>
-        public string ToHex()
+        public readonly string ToHex()
         {
             uint hexOrder = (uint)(this.A << 0 | this.B << 8 | this.G << 16 | this.R << 24);
             return hexOrder.ToString("X8");
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Rgba32 rgba32 && this.Equals(rgba32);
+        public override readonly bool Equals(object obj) => obj is Rgba32 rgba32 && this.Equals(rgba32);
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Rgba32 other) => this.Rgba.Equals(other.Rgba);
+        public readonly bool Equals(Rgba32 other) => this.Rgba.Equals(other.Rgba);
 
         /// <inheritdoc/>
-        public override string ToString() => $"Rgba32({this.R}, {this.G}, {this.B}, {this.A})";
+        public override readonly string ToString() => $"Rgba32({this.R}, {this.G}, {this.B}, {this.A})";
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.Rgba.GetHashCode();
+        public override readonly int GetHashCode() => this.Rgba.GetHashCode();
 
         /// <summary>
         /// Packs a <see cref="Vector4"/> into a color returning a new instance as a result.

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Rgba64.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Rgba64.cs
@@ -140,7 +140,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public Rgb48 Rgb
         {
             [MethodImpl(InliningOptions.ShortMethod)]
-            get => Unsafe.As<Rgba64, Rgb48>(ref this);
+            readonly get => Unsafe.As<Rgba64, Rgb48>(ref Unsafe.AsRef(this));
 
             [MethodImpl(InliningOptions.ShortMethod)]
             set => Unsafe.As<Rgba64, Rgb48>(ref this) = value;
@@ -150,7 +150,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public ulong PackedValue
         {
             [MethodImpl(InliningOptions.ShortMethod)]
-            get => Unsafe.As<Rgba64, ulong>(ref this);
+            readonly get => Unsafe.As<Rgba64, ulong>(ref Unsafe.AsRef(this));
 
             [MethodImpl(InliningOptions.ShortMethod)]
             set => Unsafe.As<Rgba64, ulong>(ref this) = value;
@@ -195,7 +195,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Rgba64 left, Rgba64 right) => left.PackedValue != right.PackedValue;
 
         /// <inheritdoc />
-        public PixelOperations<Rgba64> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<Rgba64> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -203,7 +203,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -218,7 +218,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A) / Max;
+        public readonly Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A) / Max;
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -343,7 +343,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Rgba32"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Rgba32 ToRgba32()
+        public readonly Rgba32 ToRgba32()
         {
             byte r = ImageMaths.DownScaleFrom16BitTo8Bit(this.R);
             byte g = ImageMaths.DownScaleFrom16BitTo8Bit(this.G);
@@ -357,7 +357,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Bgra32"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Bgra32 ToBgra32()
+        public readonly Bgra32 ToBgra32()
         {
             byte r = ImageMaths.DownScaleFrom16BitTo8Bit(this.R);
             byte g = ImageMaths.DownScaleFrom16BitTo8Bit(this.G);
@@ -371,7 +371,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Argb32"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Argb32 ToArgb32()
+        public readonly Argb32 ToArgb32()
         {
             byte r = ImageMaths.DownScaleFrom16BitTo8Bit(this.R);
             byte g = ImageMaths.DownScaleFrom16BitTo8Bit(this.G);
@@ -385,7 +385,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Rgb24"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Rgb24 ToRgb24()
+        public readonly Rgb24 ToRgb24()
         {
             byte r = ImageMaths.DownScaleFrom16BitTo8Bit(this.R);
             byte g = ImageMaths.DownScaleFrom16BitTo8Bit(this.G);
@@ -398,7 +398,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Bgr24"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Bgr24 ToBgr24()
+        public readonly Bgr24 ToBgr24()
         {
             byte r = ImageMaths.DownScaleFrom16BitTo8Bit(this.R);
             byte g = ImageMaths.DownScaleFrom16BitTo8Bit(this.G);
@@ -407,17 +407,17 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is Rgba64 rgba64 && this.Equals(rgba64);
+        public override readonly bool Equals(object obj) => obj is Rgba64 rgba64 && this.Equals(rgba64);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Rgba64 other) => this.PackedValue.Equals(other.PackedValue);
+        public readonly bool Equals(Rgba64 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString() => $"Rgba64({this.R}, {this.G}, {this.B}, {this.A})";
+        public override readonly string ToString() => $"Rgba64({this.R}, {this.G}, {this.B}, {this.A})";
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
     }
 }

--- a/src/ImageSharp/PixelFormats/PixelImplementations/RgbaVector.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/RgbaVector.cs
@@ -97,7 +97,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static RgbaVector FromHex(string hex) => Color.ParseHex(hex).ToPixel<RgbaVector>();
 
         /// <inheritdoc />
-        public PixelOperations<RgbaVector> CreatePixelOperations() => new PixelOperations();
+        public readonly PixelOperations<RgbaVector> CreatePixelOperations() => new PixelOperations();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -105,7 +105,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4() => this.ToVector4();
+        public readonly Vector4 ToScaledVector4() => this.ToVector4();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -120,7 +120,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A);
+        public readonly Vector4 ToVector4() => new Vector4(this.R, this.G, this.B, this.A);
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -178,7 +178,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// Converts the value of this instance to a hexadecimal string.
         /// </summary>
         /// <returns>A hexadecimal string representation of the value.</returns>
-        public string ToHex()
+        public readonly string ToHex()
         {
             // Hex is RRGGBBAA
             Vector4 vector = this.ToVector4() * Max;
@@ -188,23 +188,23 @@ namespace SixLabors.ImageSharp.PixelFormats
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is RgbaVector other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is RgbaVector other && this.Equals(other);
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(RgbaVector other) =>
+        public readonly bool Equals(RgbaVector other) =>
             this.R.Equals(other.R)
             && this.G.Equals(other.G)
             && this.B.Equals(other.B)
             && this.A.Equals(other.A);
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return FormattableString.Invariant($"RgbaVector({this.R:#0.##}, {this.G:#0.##}, {this.B:#0.##}, {this.A:#0.##})");
         }
 
         /// <inheritdoc/>
-        public override int GetHashCode() => HashCode.Combine(this.R, this.G, this.B, this.A);
+        public override readonly int GetHashCode() => HashCode.Combine(this.R, this.G, this.B, this.A);
     }
 }

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Short2.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Short2.cs
@@ -66,20 +66,20 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Short2 left, Short2 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Short2> CreatePixelOperations() => new PixelOperations<Short2>();
+        public readonly PixelOperations<Short2> CreatePixelOperations() => new PixelOperations<Short2>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
         public void FromScaledVector4(Vector4 vector)
         {
-            var scaled = new Vector2(vector.X, vector.Y) * 65534F;
+            Vector2 scaled = new Vector2(vector.X, vector.Y) * 65534F;
             scaled -= new Vector2(32767F);
             this.PackedValue = Pack(scaled);
         }
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4()
+        public readonly Vector4 ToScaledVector4()
         {
             var scaled = this.ToVector2();
             scaled += new Vector2(32767F);
@@ -97,7 +97,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4() => new Vector4((short)(this.PackedValue & 0xFFFF), (short)(this.PackedValue >> 0x10), 0, 1);
+        public readonly Vector4 ToVector4() => new Vector4((short)(this.PackedValue & 0xFFFF), (short)(this.PackedValue >> 0x10), 0, 1);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -157,21 +157,21 @@ namespace SixLabors.ImageSharp.PixelFormats
         /// </summary>
         /// <returns>The <see cref="Vector2"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector2 ToVector2() => new Vector2((short)(this.PackedValue & 0xFFFF), (short)(this.PackedValue >> 0x10));
+        public readonly Vector2 ToVector2() => new Vector2((short)(this.PackedValue & 0xFFFF), (short)(this.PackedValue >> 0x10));
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is Short2 other && this.Equals(other);
-
-        /// <inheritdoc />
-        [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Short2 other) => this.PackedValue.Equals(other.PackedValue);
+        public override readonly bool Equals(object obj) => obj is Short2 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public readonly bool Equals(Short2 other) => this.PackedValue.Equals(other.PackedValue);
 
         /// <inheritdoc />
-        public override string ToString()
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
+
+        /// <inheritdoc />
+        public override readonly string ToString()
         {
             var vector = this.ToVector2();
             return FormattableString.Invariant($"Short2({vector.X:#0.##}, {vector.Y:#0.##})");

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Short4.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Short4.cs
@@ -68,7 +68,7 @@ namespace SixLabors.ImageSharp.PixelFormats
         public static bool operator !=(Short4 left, Short4 right) => !left.Equals(right);
 
         /// <inheritdoc />
-        public PixelOperations<Short4> CreatePixelOperations() => new PixelOperations<Short4>();
+        public readonly PixelOperations<Short4> CreatePixelOperations() => new PixelOperations<Short4>();
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -81,7 +81,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToScaledVector4()
+        public readonly Vector4 ToScaledVector4()
         {
             var scaled = this.ToVector4();
             scaled += new Vector4(32767F);
@@ -95,7 +95,7 @@ namespace SixLabors.ImageSharp.PixelFormats
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             return new Vector4(
                 (short)(this.PackedValue & 0xFFFF),
@@ -160,21 +160,21 @@ namespace SixLabors.ImageSharp.PixelFormats
         public void FromRgba64(Rgba64 source) => this.FromScaledVector4(source.ToScaledVector4());
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is Short4 other && this.Equals(other);
+        public override readonly bool Equals(object obj) => obj is Short4 other && this.Equals(other);
 
         /// <inheritdoc />
         [MethodImpl(InliningOptions.ShortMethod)]
-        public bool Equals(Short4 other) => this.PackedValue.Equals(other);
+        public readonly bool Equals(Short4 other) => this.PackedValue.Equals(other);
 
         /// <summary>
         /// Gets the hash code for the current instance.
         /// </summary>
         /// <returns>Hash code for the instance.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public override int GetHashCode() => this.PackedValue.GetHashCode();
+        public override readonly int GetHashCode() => this.PackedValue.GetHashCode();
 
         /// <inheritdoc />
-        public override string ToString()
+        public override readonly string ToString()
         {
             var vector = this.ToVector4();
             return FormattableString.Invariant($"Short4({vector.X:#0.##}, {vector.Y:#0.##}, {vector.Z:#0.##}, {vector.W:#0.##})");

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.PixelBenders.cs
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.PixelBenders.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.PixelFormats
     /// Provides access to pixel blenders
     /// </content>
     public partial class PixelOperations<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Find an instance of the pixel blender.

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.PixelFormats
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public partial class PixelOperations<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Gets the global <see cref="PixelOperations{TPixel}"/> instance for the pixel type <typeparamref name="TPixel"/>
@@ -104,7 +104,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             Configuration configuration,
             ReadOnlySpan<TSourcePixel> sourcePixels,
             Span<TPixel> destinationPixels)
-            where TSourcePixel : struct, IPixel<TSourcePixel>
+            where TSourcePixel : unmanaged, IPixel<TSourcePixel>
         {
             const int SliceLength = 1024;
             int numberOfSlices = sourcePixels.Length / SliceLength;
@@ -145,7 +145,7 @@ namespace SixLabors.ImageSharp.PixelFormats
             Configuration configuration,
             ReadOnlySpan<TPixel> sourcePixels,
             Span<TDestinationPixel> destinationPixels)
-            where TDestinationPixel : struct, IPixel<TDestinationPixel>
+            where TDestinationPixel : unmanaged, IPixel<TDestinationPixel>
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));

--- a/src/ImageSharp/PixelFormats/Utils/Vector4Converters.Default.cs
+++ b/src/ImageSharp/PixelFormats/Utils/Vector4Converters.Default.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
                 Span<Vector4> sourceVectors,
                 Span<TPixel> destPixels,
                 PixelConversionModifiers modifiers)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 Guard.DestinationShouldNotBeTooShort(sourceVectors, destPixels, nameof(destPixels));
 
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
                 ReadOnlySpan<TPixel> sourcePixels,
                 Span<Vector4> destVectors,
                 PixelConversionModifiers modifiers)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destVectors, nameof(destVectors));
 
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
                 Span<Vector4> sourceVectors,
                 Span<TPixel> destPixels,
                 PixelConversionModifiers modifiers)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 ApplyBackwardConversionModifiers(sourceVectors, modifiers);
 
@@ -68,7 +68,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
                 ReadOnlySpan<TPixel> sourcePixels,
                 Span<Vector4> destVectors,
                 PixelConversionModifiers modifiers)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 if (modifiers.IsDefined(PixelConversionModifiers.Scale))
                 {
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             private static void UnsafeFromVector4Core<TPixel>(
                 ReadOnlySpan<Vector4> sourceVectors,
                 Span<TPixel> destPixels)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 ref Vector4 sourceRef = ref MemoryMarshal.GetReference(sourceVectors);
                 ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
@@ -103,7 +103,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             private static void UnsafeToVector4Core<TPixel>(
                 ReadOnlySpan<TPixel> sourcePixels,
                 Span<Vector4> destVectors)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 ref TPixel sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
                 ref Vector4 destRef = ref MemoryMarshal.GetReference(destVectors);
@@ -120,7 +120,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             private static void UnsafeFromScaledVector4Core<TPixel>(
                 ReadOnlySpan<Vector4> sourceVectors,
                 Span<TPixel> destinationColors)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 ref Vector4 sourceRef = ref MemoryMarshal.GetReference(sourceVectors);
                 ref TPixel destRef = ref MemoryMarshal.GetReference(destinationColors);
@@ -137,7 +137,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             private static void UnsafeToScaledVector4Core<TPixel>(
                 ReadOnlySpan<TPixel> sourceColors,
                 Span<Vector4> destinationVectors)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 ref TPixel sourceRef = ref MemoryMarshal.GetReference(sourceColors);
                 ref Vector4 destRef = ref MemoryMarshal.GetReference(destinationVectors);

--- a/src/ImageSharp/PixelFormats/Utils/Vector4Converters.RgbaCompatible.cs
+++ b/src/ImageSharp/PixelFormats/Utils/Vector4Converters.RgbaCompatible.cs
@@ -39,7 +39,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
                 ReadOnlySpan<TPixel> sourcePixels,
                 Span<Vector4> destVectors,
                 PixelConversionModifiers modifiers)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destVectors, nameof(destVectors));
@@ -83,7 +83,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
                 Span<Vector4> sourceVectors,
                 Span<TPixel> destPixels,
                 PixelConversionModifiers modifiers)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourceVectors, destPixels, nameof(destPixels));

--- a/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing
     /// </summary>
     /// <typeparam name="TPixel">The pixel format</typeparam>
     internal class DefaultImageProcessorContext<TPixel> : IInternalImageProcessingContext<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly bool mutate;
         private readonly Image<TPixel> source;

--- a/src/ImageSharp/Processing/Extensions/ProcessingExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/ProcessingExtensions.cs
@@ -45,7 +45,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="source">The image to mutate.</param>
         /// <param name="operation">The operation to perform on the source.</param>
         public static void Mutate<TPixel>(this Image<TPixel> source, Action<IImageProcessingContext> operation)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Mutate(source, source.GetConfiguration(), operation);
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="operation">The operation to perform on the source.</param>
         public static void Mutate<TPixel>(this Image<TPixel> source, Configuration configuration, Action<IImageProcessingContext> operation)
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(source, nameof(source));
@@ -76,7 +76,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="source">The image to mutate.</param>
         /// <param name="operations">The operations to perform on the source.</param>
         public static void Mutate<TPixel>(this Image<TPixel> source, params IImageProcessor[] operations)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Mutate(source, source.GetConfiguration(), operations);
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="operations">The operations to perform on the source.</param>
         public static void Mutate<TPixel>(this Image<TPixel> source, Configuration configuration, params IImageProcessor[] operations)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(source, nameof(source));
             Guard.NotNull(operations, nameof(operations));
@@ -135,7 +135,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="operation">The operation to perform on the clone.</param>
         /// <returns>The new <see cref="SixLabors.ImageSharp.Image{TPixel}"/></returns>
         public static Image<TPixel> Clone<TPixel>(this Image<TPixel> source, Action<IImageProcessingContext> operation)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Clone(source, source.GetConfiguration(), operation);
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="operation">The operation to perform on the clone.</param>
         /// <returns>The new <see cref="SixLabors.ImageSharp.Image{TPixel}"/></returns>
         public static Image<TPixel> Clone<TPixel>(this Image<TPixel> source, Configuration configuration, Action<IImageProcessingContext> operation)
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(source, nameof(source));
@@ -169,7 +169,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="operations">The operations to perform on the clone.</param>
         /// <returns>The new <see cref="SixLabors.ImageSharp.Image{TPixel}"/></returns>
         public static Image<TPixel> Clone<TPixel>(this Image<TPixel> source, params IImageProcessor[] operations)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => Clone(source, source.GetConfiguration(), operations);
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="operations">The operations to perform on the clone.</param>
         /// <returns>The new <see cref="SixLabors.ImageSharp.Image{TPixel}"/></returns>
         public static Image<TPixel> Clone<TPixel>(this Image<TPixel> source, Configuration configuration, params IImageProcessor[] operations)
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(source, nameof(source));
@@ -231,7 +231,7 @@ namespace SixLabors.ImageSharp.Processing
             public Image ResultImage { get; private set; }
 
             public void Visit<TPixel>(Image<TPixel> image)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 IInternalImageProcessingContext<TPixel> operationsRunner =
                     this.configuration.ImageOperationsProvider.CreateImageProcessingContext(this.configuration, image, this.mutate);

--- a/src/ImageSharp/Processing/IImageProcessingContextFactory.cs
+++ b/src/ImageSharp/Processing/IImageProcessingContextFactory.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="mutate">A flag to determine whether image operations are allowed to mutate the source image.</param>
         /// <returns>A new <see cref="IInternalImageProcessingContext{TPixel}"/></returns>
         IInternalImageProcessingContext<TPixel> CreateImageProcessingContext<TPixel>(Configuration configuration, Image<TPixel> source, bool mutate)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
     }
 
     /// <summary>
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Processing
     {
         /// <inheritdoc/>
         public IInternalImageProcessingContext<TPixel> CreateImageProcessingContext<TPixel>(Configuration configuration, Image<TPixel> source, bool mutate)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return new DefaultImageProcessorContext<TPixel>(configuration, source, mutate);
         }

--- a/src/ImageSharp/Processing/IInternalImageProcessingContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/IInternalImageProcessingContext{TPixel}.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing
     /// </summary>
     /// <typeparam name="TPixel">The pixel type.</typeparam>
     internal interface IInternalImageProcessingContext<TPixel> : IImageProcessingContext
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Returns the result image to return by <see cref="ProcessingExtensions.Clone(Image, Configuration, System.Action{IImageProcessingContext})"/>

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new BinaryThresholdProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor{TPixel}.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class BinaryThresholdProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly BinaryThresholdProcessor definition;
 

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
     {
         /// <inheritdoc/>
         public abstract ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
 
         /// <inheritdoc/>
         IImageProcessor<TPixel> IImageProcessor.CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public abstract class CloningImageProcessor<TPixel> : ICloningImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CloningImageProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
@@ -71,7 +71,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new BokehBlurProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     /// <remarks>This processor is based on the code from Mike Pound, see <a href="https://github.com/mikepound/convolve">github.com/mikepound/convolve</a>.</remarks>
     internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// The gamma highlight factor to use when applying the effect

--- a/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new BoxBlurProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BoxBlurProcessor{TPixel}.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class BoxBlurProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BoxBlurProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor{TPixel}.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class Convolution2DProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Convolution2DProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Convolution2PassProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConvolutionProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor{TPixel}.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class EdgeDetector2DProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EdgeDetector2DProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class EdgeDetectorCompassProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EdgeDetectorCompassProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor.cs
@@ -26,6 +26,6 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
 
         /// <inheritdoc />
         public abstract IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class EdgeDetectorProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EdgeDetectorProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor.cs
@@ -71,7 +71,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new GaussianBlurProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor{TPixel}.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class GaussianBlurProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianBlurProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor.cs
@@ -71,7 +71,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new GaussianSharpenProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor{TPixel}.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class GaussianSharpenProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianSharpenProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
@@ -94,7 +94,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             Memory<byte> output,
             Rectangle bounds)
             where TFrameQuantizer : struct, IFrameQuantizer<TPixel>
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Span<byte> outputSpan = output.Span;
             ReadOnlySpan<TPixel> paletteSpan = palette.Span;
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             ImageFrame<TPixel> source,
             Rectangle bounds,
             float scale)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var pixelMap = new EuclideanPixelMap<TPixel>(palette);
 
@@ -152,7 +152,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             int x,
             int y,
             float scale)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Equal? Break out as there's no error to pass.
             if (source.Equals(transformed))

--- a/src/ImageSharp/Processing/Processors/Dithering/IDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/IDither.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             Memory<byte> output,
             Rectangle bounds)
             where TFrameQuantizer : struct, IFrameQuantizer<TPixel>
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
 
         /// <summary>
         /// Transforms the image frame applying a dither matrix.
@@ -48,6 +48,6 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             ImageFrame<TPixel> source,
             Rectangle bounds,
             float scale)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
@@ -110,7 +110,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             Memory<byte> output,
             Rectangle bounds)
             where TFrameQuantizer : struct, IFrameQuantizer<TPixel>
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var ditherOperation = new QuantizeDitherRowIntervalOperation<TFrameQuantizer, TPixel>(
                 ref quantizer,
@@ -135,7 +135,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             ImageFrame<TPixel> source,
             Rectangle bounds,
             float scale)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var ditherOperation = new PaletteDitherRowIntervalOperation<TPixel>(
                 in Unsafe.AsRef(this),
@@ -158,7 +158,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             int y,
             int bitDepth,
             float scale)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Rgba32 rgba = default;
             source.ToRgba32(ref rgba);
@@ -202,7 +202,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
 
         private readonly struct QuantizeDitherRowIntervalOperation<TFrameQuantizer, TPixel> : IRowIntervalOperation
             where TFrameQuantizer : struct, IFrameQuantizer<TPixel>
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             private readonly TFrameQuantizer quantizer;
             private readonly OrderedDither dither;
@@ -257,7 +257,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         }
 
         private readonly struct PaletteDitherRowIntervalOperation<TPixel> : IRowIntervalOperation
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             private readonly OrderedDither dither;
             private readonly ImageFrame<TPixel> source;

--- a/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessor.cs
@@ -73,7 +73,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new PaletteDitherProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/PaletteDitherProcessor{TPixel}.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal sealed class PaletteDitherProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly int paletteLength;
         private readonly IDither dither;

--- a/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor.cs
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
 
         /// <inheritdoc />
         public IImageProcessor<TPixelBg> CreatePixelSpecificProcessor<TPixelBg>(Configuration configuration, Image<TPixelBg> source, Rectangle sourceRectangle)
-            where TPixelBg : struct, IPixel<TPixelBg>
+            where TPixelBg : unmanaged, IPixel<TPixelBg>
         {
             var visitor = new ProcessorFactoryVisitor<TPixelBg>(configuration, this, source, sourceRectangle);
             this.Image.AcceptVisitor(visitor);
@@ -68,7 +68,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         }
 
         private class ProcessorFactoryVisitor<TPixelBg> : IImageVisitor
-            where TPixelBg : struct, IPixel<TPixelBg>
+            where TPixelBg : unmanaged, IPixel<TPixelBg>
         {
             private readonly Configuration configuration;
             private readonly DrawImageProcessor definition;
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
             public IImageProcessor<TPixelBg> Result { get; private set; }
 
             public void Visit<TPixelFg>(Image<TPixelFg> image)
-                where TPixelFg : struct, IPixel<TPixelFg>
+                where TPixelFg : unmanaged, IPixel<TPixelFg>
             {
                 this.Result = new DrawImageProcessor<TPixelBg, TPixelFg>(
                     this.configuration,

--- a/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
+++ b/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
@@ -15,8 +15,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
     /// <typeparam name="TPixelBg">The pixel format of destination image.</typeparam>
     /// <typeparam name="TPixelFg">The pixel format of source image.</typeparam>
     internal class DrawImageProcessor<TPixelBg, TPixelFg> : ImageProcessor<TPixelBg>
-        where TPixelBg : struct, IPixel<TPixelBg>
-        where TPixelFg : struct, IPixel<TPixelFg>
+        where TPixelBg : unmanaged, IPixel<TPixelBg>
+        where TPixelFg : unmanaged, IPixel<TPixelFg>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DrawImageProcessor{TPixelBg, TPixelFg}"/> class.

--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new OilPaintingProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
     /// <remarks>Adapted from <see href="https://softwarebydefault.com/2013/06/29/oil-painting-cartoon-filter/"/> by Dewald Esterhuizen.</remarks>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class OilPaintingProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly OilPaintingProcessor definition;
 

--- a/src/ImageSharp/Processing/Processors/Effects/PixelRowDelegateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelRowDelegateProcessor.cs
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return new PixelRowDelegateProcessor<TPixel, PixelRowDelegate>(
                 new PixelRowDelegate(this.PixelRowOperation),

--- a/src/ImageSharp/Processing/Processors/Effects/PixelRowDelegateProcessor{TPixel,TDelegate}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelRowDelegateProcessor{TPixel,TDelegate}.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     /// <typeparam name="TDelegate">The row processor type.</typeparam>
     internal sealed class PixelRowDelegateProcessor<TPixel, TDelegate> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
         where TDelegate : struct, IPixelRowDelegate
     {
         private readonly TDelegate rowDelegate;

--- a/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new PixelateProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelateProcessor{TPixel}.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class PixelateProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly PixelateProcessor definition;
 

--- a/src/ImageSharp/Processing/Processors/Effects/PositionAwarePixelRowDelegateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PositionAwarePixelRowDelegateProcessor.cs
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Effects
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return new PixelRowDelegateProcessor<TPixel, PixelRowDelegate>(
                 new PixelRowDelegate(this.PixelRowOperation),

--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessor.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
 
         /// <inheritdoc />
         public virtual IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new FilterProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessor{TPixel}.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class FilterProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly FilterProcessor definition;
 

--- a/src/ImageSharp/Processing/Processors/Filters/LomographProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/LomographProcessor{TPixel}.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating an old Lomograph effect.
     /// </summary>
     internal class LomographProcessor<TPixel> : FilterProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private static readonly Color VeryDarkGreen = Color.FromRgba(0, 10, 0, 255);
 

--- a/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/PolaroidProcessor{TPixel}.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
     /// Converts the colors of the image recreating an old Polaroid effect.
     /// </summary>
     internal class PolaroidProcessor<TPixel> : FilterProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private static readonly Color LightOrange = Color.FromRgba(255, 153, 102, 128);
         private static readonly Color VeryDarkOrange = Color.FromRgb(102, 34, 0);

--- a/src/ImageSharp/Processing/Processors/ICloningImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/ICloningImageProcessor.cs
@@ -22,6 +22,6 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// </param>
         /// <returns>The <see cref="ICloningImageProcessor{TPixel}"/></returns>
         ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Processing/Processors/ICloningImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/ICloningImageProcessor{TPixel}.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public interface ICloningImageProcessor<TPixel> : IImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Clones the specified <see cref="Image{TPixel}"/> and executes the process against the clone.

--- a/src/ImageSharp/Processing/Processors/IImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/IImageProcessor.cs
@@ -25,6 +25,6 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// </param>
         /// <returns>The <see cref="IImageProcessor{TPixel}"/></returns>
         IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Processing/Processors/IImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/IImageProcessor{TPixel}.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public interface IImageProcessor<TPixel> : IDisposable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Executes the process against the specified <see cref="Image{TPixel}"/>.

--- a/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessorExtensions.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
             }
 
             public void Visit<TPixel>(Image<TPixel> image)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 using (IImageProcessor<TPixel> processorImpl = this.processor.CreatePixelSpecificProcessor(this.configuration, image, this.sourceRectangle))
                 {

--- a/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/ImageProcessor{TPixel}.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public abstract class ImageProcessor<TPixel> : IImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationProcessor{TPixel}.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class AdaptiveHistogramEqualizationProcessor<TPixel> : HistogramEqualizationProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveHistogramEqualizationProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class AdaptiveHistogramEqualizationSlidingWindowProcessor<TPixel> : HistogramEqualizationProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Normalization/GlobalHistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/GlobalHistogramEqualizationProcessor{TPixel}.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class GlobalHistogramEqualizationProcessor<TPixel> : HistogramEqualizationProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GlobalHistogramEqualizationProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
 
         /// <inheritdoc />
         public abstract IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
 
         /// <summary>
         /// Creates the <see cref="HistogramEqualizationProcessor"/> that implements the algorithm

--- a/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor{TPixel}.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal abstract class HistogramEqualizationProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly float luminanceLevelsFloat;
 

--- a/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor.cs
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new BackgroundColorProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/BackgroundColorProcessor{TPixel}.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class BackgroundColorProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly BackgroundColorProcessor definition;
 

--- a/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
@@ -69,7 +69,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new GlowProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor{TPixel}.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class GlowProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly PixelBlender<TPixel> blender;
         private readonly GlowProcessor definition;

--- a/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new VignetteProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor{TPixel}.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Overlays
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class VignetteProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly PixelBlender<TPixel> blender;
         private readonly VignetteProcessor definition;

--- a/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal readonly struct EuclideanPixelMap<TPixel> : IPixelMap<TPixel>, IEquatable<EuclideanPixelMap<TPixel>>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly ConcurrentDictionary<int, Vector4> vectorCache;
         private readonly ConcurrentDictionary<TPixel, int> distanceCache;

--- a/src/ImageSharp/Processing/Processors/Quantization/FrameQuantizerExtensions.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/FrameQuantizerExtensions.cs
@@ -31,7 +31,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
             ImageFrame<TPixel> source,
             Rectangle bounds)
             where TFrameQuantizer : struct, IFrameQuantizer<TPixel>
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(source, nameof(source));
             var interest = Rectangle.Intersect(source.Bounds(), bounds);
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
             Memory<byte> output,
             ReadOnlyMemory<TPixel> palette)
             where TFrameQuantizer : struct, IFrameQuantizer<TPixel>
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             IDither dither = quantizer.Options.Dither;
 
@@ -87,7 +87,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
 
         private readonly struct RowIntervalOperation<TFrameQuantizer, TPixel> : IRowIntervalOperation
             where TFrameQuantizer : struct, IFrameQuantizer<TPixel>
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             private readonly TFrameQuantizer quantizer;
             private readonly ImageFrame<TPixel> source;

--- a/src/ImageSharp/Processing/Processors/Quantization/IFrameQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/IFrameQuantizer{TPixel}.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public interface IFrameQuantizer<TPixel> : IDisposable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Gets the configuration.

--- a/src/ImageSharp/Processing/Processors/Quantization/IPixelMap{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/IPixelMap{TPixel}.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal interface IPixelMap<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Gets the color palette containing colors to match.

--- a/src/ImageSharp/Processing/Processors/Quantization/IQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/IQuantizer.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>The <see cref="IFrameQuantizer{TPixel}"/>.</returns>
         IFrameQuantizer<TPixel> CreateFrameQuantizer<TPixel>(Configuration configuration)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
 
         /// <summary>
         /// Creates the generic frame quantizer.
@@ -32,6 +32,6 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         /// <param name="options">The options to create the quantizer with.</param>
         /// <returns>The <see cref="IFrameQuantizer{TPixel}"/>.</returns>
         IFrameQuantizer<TPixel> CreateFrameQuantizer<TPixel>(Configuration configuration, QuantizerOptions options)
-            where TPixel : struct, IPixel<TPixel>;
+            where TPixel : unmanaged, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Processing/Processors/Quantization/OctreeFrameQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/OctreeFrameQuantizer{TPixel}.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public struct OctreeFrameQuantizer<TPixel> : IFrameQuantizer<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly int colors;
         private readonly Octree octree;

--- a/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer.cs
@@ -35,12 +35,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
 
         /// <inheritdoc />
         public IFrameQuantizer<TPixel> CreateFrameQuantizer<TPixel>(Configuration configuration)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => this.CreateFrameQuantizer<TPixel>(configuration, this.Options);
 
         /// <inheritdoc />
         public IFrameQuantizer<TPixel> CreateFrameQuantizer<TPixel>(Configuration configuration, QuantizerOptions options)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new OctreeFrameQuantizer<TPixel>(configuration, options);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteFrameQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteFrameQuantizer{TPixel}.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal struct PaletteFrameQuantizer<TPixel> : IFrameQuantizer<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly ReadOnlyMemory<TPixel> palette;
         private readonly EuclideanPixelMap<TPixel> pixelMap;

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer.cs
@@ -44,12 +44,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
 
         /// <inheritdoc />
         public IFrameQuantizer<TPixel> CreateFrameQuantizer<TPixel>(Configuration configuration)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => this.CreateFrameQuantizer<TPixel>(configuration, this.Options);
 
         /// <inheritdoc />
         public IFrameQuantizer<TPixel> CreateFrameQuantizer<TPixel>(Configuration configuration, QuantizerOptions options)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.NotNull(options, nameof(options));
 

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new QuantizeProcessor<TPixel>(configuration, this.Quantizer, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor{TPixel}.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class QuantizeProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly IQuantizer quantizer;
 

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizedFrame{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizedFrame{TPixel}.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     public sealed class QuantizedFrame<TPixel> : IDisposable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private IMemoryOwner<byte> pixels;
         private bool isDisposed;

--- a/src/ImageSharp/Processing/Processors/Quantization/WuFrameQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/WuFrameQuantizer{TPixel}.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </remarks>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal struct WuFrameQuantizer<TPixel> : IFrameQuantizer<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly MemoryAllocator memoryAllocator;
 

--- a/src/ImageSharp/Processing/Processors/Quantization/WuQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/WuQuantizer.cs
@@ -34,12 +34,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
 
         /// <inheritdoc />
         public IFrameQuantizer<TPixel> CreateFrameQuantizer<TPixel>(Configuration configuration)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => this.CreateFrameQuantizer<TPixel>(configuration, this.Options);
 
         /// <inheritdoc />
         public IFrameQuantizer<TPixel> CreateFrameQuantizer<TPixel>(Configuration configuration, QuantizerOptions options)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new WuFrameQuantizer<TPixel>(configuration, options);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AffineTransformProcessor{TPixel}.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class AffineTransformProcessor<TPixel> : TransformProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly Size targetSize;
         private readonly Matrix3x2 transformMatrix;

--- a/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     {
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new AutoOrientProcessor<TPixel>(configuration, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/AutoOrientProcessor{TPixel}.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class AutoOrientProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoOrientProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Transforms/CropProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/CropProcessor{TPixel}.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class CropProcessor<TPixel> : TransformProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly Rectangle cropRectangle;
 

--- a/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor.cs
@@ -38,7 +38,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new EntropyCropProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class EntropyCropProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly EntropyCropProcessor definition;
 

--- a/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
             => new FlipProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/FlipProcessor{TPixel}.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class FlipProcessor<TPixel> : ImageProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly FlipProcessor definition;
 

--- a/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ProjectiveTransformProcessor{TPixel}.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class ProjectiveTransformProcessor<TPixel> : TransformProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly Size targetSize;
         private readonly IResampler resampler;

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </remarks>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class ResizeProcessor<TPixel> : TransformProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private bool isDisposed;
         private readonly int targetWidth;

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// For more details, and visual explanation, see "ResizeWorker.pptx".
     /// </summary>
     internal sealed class ResizeWorker<TPixel> : IDisposable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly Buffer2D<Vector4> transposedFirstPassBuffer;
 

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor{TPixel}.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal class RotateProcessor<TPixel> : AffineTransformProcessor<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private readonly float degrees;
 

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformKernelMap.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformKernelMap.cs
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             ref float xSpanRef,
             Buffer2D<TPixel> sourcePixels,
             Span<Vector4> targetRow)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Clamp sampling pixel radial extents to the source image edges
             Vector2 minXY = transformedPoint - this.extents;

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformProcessor.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal abstract class TransformProcessor<TPixel> : CloningImageProcessor<TPixel>
-         where TPixel : struct, IPixel<TPixel>
+         where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TransformProcessor{TPixel}"/> class.

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorHelpers.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorHelpers.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="image">The image to update</param>
         public static void UpdateDimensionalMetadata<TPixel>(Image<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ExifProfile profile = image.Metadata.ExifProfile;
             if (profile is null)

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/FromRgba32Bytes.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/FromRgba32Bytes.cs
@@ -12,7 +12,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
 {
     public abstract class FromRgba32Bytes<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private IMemoryOwner<TPixel> destination;
 

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/FromVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/FromVector4.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
 {
     [Config(typeof(Config.ShortClr))]
     public abstract class FromVector4<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         protected IMemoryOwner<Vector4> source;
 

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/Rgb24Bytes.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/Rgb24Bytes.cs
@@ -10,7 +10,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
 {
     public abstract class Rgb24Bytes<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private IMemoryOwner<TPixel> source;
 

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ToRgba32Bytes.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ToRgba32Bytes.cs
@@ -12,7 +12,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
 {
     public abstract class ToRgba32Bytes<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private IMemoryOwner<TPixel> source;
 

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ToVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ToVector4.cs
@@ -13,7 +13,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
 {
     public abstract class ToVector4<TPixel>
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         protected IMemoryOwner<TPixel> source;
 

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Argb32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Argb32.cs
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Benchmarks.General.PixelConversion
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void Default_GenericImpl<TPixel>(ReadOnlySpan<Rgba32> source, Span<TPixel> dest)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ref Rgba32 sBase = ref MemoryMarshal.GetReference(source);
             ref TPixel dBase = ref MemoryMarshal.GetReference(dest);

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Bgra32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Bgra32.cs
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.Benchmarks.General.PixelConversion
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void Default_GenericImpl<TPixel>(ReadOnlySpan<Rgba32> source, Span<TPixel> dest)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ref Rgba32 sBase = ref MemoryMarshal.GetReference(source);
             ref TPixel dBase = ref MemoryMarshal.GetReference(dest);
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp.Benchmarks.General.PixelConversion
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void Group4GenericImpl<TPixel>(ReadOnlySpan<Rgba32> source, Span<TPixel> dest)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ref Rgba32 sBase = ref MemoryMarshal.GetReference(source);
             ref TPixel dBase = ref MemoryMarshal.GetReference(dest);

--- a/tests/ImageSharp.Benchmarks/PixelBlenders/PorterDuffBulkVsPixel.cs
+++ b/tests/ImageSharp.Benchmarks/PixelBlenders/PorterDuffBulkVsPixel.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Benchmarks
             Span<TPixel> background,
             Span<TPixel> source,
             Span<float> amount)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.MustBeGreaterThanOrEqualTo(background.Length, destination.Length, nameof(background.Length));
             Guard.MustBeGreaterThanOrEqualTo(source.Length, destination.Length, nameof(source.Length));
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Benchmarks
             Span<TPixel> background,
             Span<TPixel> source,
             Span<float> amount)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Guard.MustBeGreaterThanOrEqualTo(destination.Length, background.Length, nameof(destination));
             Guard.MustBeGreaterThanOrEqualTo(source.Length, background.Length, nameof(destination));

--- a/tests/ImageSharp.Benchmarks/Samplers/Resize.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/Resize.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Benchmarks
 #pragma warning disable SA1649 // File name should match first type name
     public abstract class ResizeBenchmarkBase<TPixel>
 #pragma warning restore SA1649 // File name should match first type name
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         protected readonly Configuration Configuration = new Configuration(new JpegConfigurationModule());
 

--- a/tests/ImageSharp.Tests/Advanced/AdvancedImageExtensionsTests.cs
+++ b/tests/ImageSharp.Tests/Advanced/AdvancedImageExtensionsTests.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Tests.Advanced
             [WithBasicTestPatternImages(131, 127, PixelTypes.Rgba32)]
             [WithBasicTestPatternImages(333, 555, PixelTypes.Bgr24)]
             public void OwnedMemory_PixelDataIsCorrect<TPixel>(TestImageProvider<TPixel> provider)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 provider.LimitAllocatorBufferCapacity().InPixelsSqrt(200);
 
@@ -39,7 +39,7 @@ namespace SixLabors.ImageSharp.Tests.Advanced
             [Theory]
             [WithBlankImages(16, 16, PixelTypes.Rgba32)]
             public void OwnedMemory_DestructiveMutate_ShouldInvalidateMemoryGroup<TPixel>(TestImageProvider<TPixel> provider)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 using Image<TPixel> image = provider.GetImage();
 
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp.Tests.Advanced
             [WithBasicTestPatternImages(1, 1, PixelTypes.Rgba32)]
             [WithBasicTestPatternImages(131, 127, PixelTypes.Bgr24)]
             public void ConsumedMemory_PixelDataIsCorrect<TPixel>(TestImageProvider<TPixel> provider)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 using Image<TPixel> image0 = provider.GetImage();
                 var targetBuffer = new TPixel[image0.Width * image0.Height];
@@ -80,7 +80,7 @@ namespace SixLabors.ImageSharp.Tests.Advanced
                 TestImageProvider<TPixel> provider,
                 IMemoryGroup<TPixel> memoryGroup,
                 Size size)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 Assert.True(memoryGroup.IsValid);
                 Assert.Equal(size.Width * size.Height, memoryGroup.TotalLength);
@@ -104,7 +104,7 @@ namespace SixLabors.ImageSharp.Tests.Advanced
         [WithBasicTestPatternImages(131, 127, PixelTypes.Rgba32)]
         [WithBasicTestPatternImages(333, 555, PixelTypes.Bgr24)]
         public void GetPixelRowMemory_PixelDataIsCorrect<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(200);
 
@@ -127,7 +127,7 @@ namespace SixLabors.ImageSharp.Tests.Advanced
         [Theory]
         [WithBasicTestPatternImages(16, 16, PixelTypes.Rgba32)]
         public void GetPixelRowMemory_DestructiveMutate_ShouldInvalidateMemory<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using Image<TPixel> image = provider.GetImage();
 
@@ -145,7 +145,7 @@ namespace SixLabors.ImageSharp.Tests.Advanced
         [WithBlankImages(100, 111, PixelTypes.Rgba32)]
         [WithBlankImages(400, 600, PixelTypes.Rgba32)]
         public void GetPixelRowSpan_ShouldReferenceSpanOfMemory<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(200);
 

--- a/tests/ImageSharp.Tests/Drawing/DrawImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/DrawImageTests.cs
@@ -31,7 +31,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
         [Theory]
         [WithFile(TestImages.Png.Rainbow, nameof(BlendingModes), PixelTypes.Rgba32)]
         public void ImageBlendingMatchesSvgSpecExamples<TPixel>(TestImageProvider<TPixel> provider, PixelColorBlendingMode mode)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> background = provider.GetImage())
             using (var source = Image.Load<TPixel>(TestFile.Create(TestImages.Png.Ducky).Bytes))
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
             string brushImage,
             PixelColorBlendingMode mode,
             float opacity)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             using (var blend = Image.Load<TPixel>(TestFile.Create(brushImage).Bytes))
@@ -99,7 +99,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
         [Theory]
         [WithTestPatternImages(200, 200, PixelTypes.Rgba32 | PixelTypes.Bgra32)]
         public void DrawImageOfDifferentPixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             byte[] brushData = TestFile.Create(TestImages.Png.Ducky).Bytes;
 
@@ -149,7 +149,7 @@ namespace SixLabors.ImageSharp.Tests.Drawing
         [Theory]
         [WithFile(TestImages.Png.Splash, PixelTypes.Rgba32)]
         public void DrawTransformed<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             using (var blend = Image.Load<TPixel>(TestFile.Create(TestImages.Bmp.Car).Bytes))

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFileCollection(nameof(MiscBmpFiles), PixelTypes.Rgba32, false)]
         [WithFileCollection(nameof(MiscBmpFiles), PixelTypes.Rgba32, true)]
         public void BmpDecoder_CanDecode_MiscellaneousBitmaps<TPixel>(TestImageProvider<TPixel> provider, bool enforceDiscontiguousBuffers)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             static void RunTest(string providerDump, string nonContiguousBuffersStr)
             {
@@ -74,7 +74,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(Bit32Rgb, PixelTypes.Rgba32)]
         [WithFile(Bit16, PixelTypes.Rgba32)]
         public void BmpDecoder_DegenerateMemoryRequest_ShouldTranslateTo_ImageFormatException<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(10);
             ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(BmpDecoder));
@@ -84,7 +84,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFileCollection(nameof(BitfieldsBmpFiles), PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeBitfields<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -97,7 +97,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(Bit16Inverted, PixelTypes.Rgba32)]
         [WithFile(Bit8Inverted, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_Inverted<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -110,7 +110,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(Bit1, PixelTypes.Rgba32)]
         [WithFile(Bit1Pal1, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_1Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -122,7 +122,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Bit4, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_4Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -139,7 +139,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Bit8, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_8Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -151,7 +151,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Bit16, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_16Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -163,7 +163,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Bit32Rgb, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_32Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -175,7 +175,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Rgba32v4, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_32BitV4Header_Fast<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -189,7 +189,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(RLE4Delta, PixelTypes.Rgba32)]
         [WithFile(Rle4Delta320240, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_RunLengthEncoded_4Bit_WithDelta<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(new BmpDecoder { RleSkippedPixelHandling = RleSkippedPixelHandling.Black }))
             {
@@ -206,7 +206,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(RLE4, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_RunLengthEncoded_4Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(new BmpDecoder { RleSkippedPixelHandling = RleSkippedPixelHandling.Black }))
             {
@@ -226,7 +226,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(Rle8Delta320240, PixelTypes.Rgba32)]
         [WithFile(Rle8Blank160120, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_RunLengthEncoded_8Bit_WithDelta_SystemDrawingRefDecoder<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(new BmpDecoder { RleSkippedPixelHandling = RleSkippedPixelHandling.Black }))
             {
@@ -242,7 +242,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(RLE8Cut, PixelTypes.Rgba32)]
         [WithFile(RLE8Delta, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_RunLengthEncoded_8Bit_WithDelta_MagickRefDecoder<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(new BmpDecoder { RleSkippedPixelHandling = RleSkippedPixelHandling.FirstColorOfPalette }))
             {
@@ -257,7 +257,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(RLE8, PixelTypes.Rgba32, true)]
         [WithFile(RLE8Inverted, PixelTypes.Rgba32, true)]
         public void BmpDecoder_CanDecode_RunLengthEncoded_8Bit<TPixel>(TestImageProvider<TPixel> provider, bool enforceDiscontiguousBuffers)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (enforceDiscontiguousBuffers)
             {
@@ -279,7 +279,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(RLE24Cut, PixelTypes.Rgba32, true)]
         [WithFile(RLE24Delta, PixelTypes.Rgba32, true)]
         public void BmpDecoder_CanDecode_RunLengthEncoded_24Bit<TPixel>(TestImageProvider<TPixel> provider, bool enforceNonContiguous)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (enforceNonContiguous)
             {
@@ -298,7 +298,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(RgbaAlphaBitfields, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeAlphaBitfields<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -312,7 +312,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Bit32Rgba, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeBitmap_WithAlphaChannel<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -324,7 +324,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Rgba321010102, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeBitfields_WithUnusualBitmasks<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -343,7 +343,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(WinBmpv2, PixelTypes.Rgba32)]
         [WithFile(CoreHeader, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeBmpv2<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -355,7 +355,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(WinBmpv3, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeBmpv3<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -367,7 +367,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(LessThanFullSizedPalette, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeLessThanFullPalette<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -380,7 +380,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(OversizedPalette, PixelTypes.Rgba32)]
         [WithFile(Rgb24LargePalette, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeOversizedPalette<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -395,7 +395,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(InvalidPaletteSize, PixelTypes.Rgba32)]
         public void BmpDecoder_ThrowsImageFormatException_OnInvalidPaletteSize<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Assert.Throws<ImageFormatException>(() =>
             {
@@ -409,7 +409,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(Rgb24jpeg, PixelTypes.Rgba32)]
         [WithFile(Rgb24png, PixelTypes.Rgba32)]
         public void BmpDecoder_ThrowsNotSupportedException_OnUnsupportedBitmaps<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Assert.Throws<NotSupportedException>(() =>
             {
@@ -422,7 +422,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Rgb32h52AdobeV3, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeAdobeBmpv3<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -434,7 +434,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Rgba32bf56AdobeV3, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeAdobeBmpv3_WithAlpha<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -446,7 +446,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(WinBmpv4, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeBmpv4<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -459,7 +459,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(WinBmpv5, PixelTypes.Rgba32)]
         [WithFile(V5Header, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecodeBmpv5<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -471,7 +471,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Pal8Offset, PixelTypes.Rgba32)]
         public void BmpDecoder_RespectsFileHeaderOffset<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -483,7 +483,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(F, CommonNonDefaultPixelTypes)]
         public void BmpDecoder_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -495,7 +495,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Bit8Palette4, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode4BytePerEntryPalette<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -570,7 +570,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Os2v2Short, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_Os2v2XShortHeader<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -584,7 +584,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Os2v2, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_Os2v2Header<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
@@ -608,7 +608,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(Os2BitmapArrayWarpd, PixelTypes.Rgba32)]
         [WithFile(Os2BitmapArrayPines, PixelTypes.Rgba32)]
         public void BmpDecoder_CanDecode_Os2BitmapArray<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -99,7 +99,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithTestPatternImages(nameof(BitsPerPixel), 24, 24, PixelTypes.Rgba32 | PixelTypes.Bgra32 | PixelTypes.Rgb24)]
         public void Encode_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel);
 
         [Theory]
         [WithTestPatternImages(nameof(BitsPerPixel), 48, 24, PixelTypes.Rgba32)]
@@ -108,7 +108,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithSolidFilledImages(nameof(BitsPerPixel), 1, 1, 255, 100, 50, 255, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(BitsPerPixel), 7, 5, PixelTypes.Rgba32)]
         public void Encode_WorksWithDifferentSizes<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel);
 
         [Theory]
         [WithFile(Bit32Rgb, PixelTypes.Rgba32 | PixelTypes.Rgb24, BmpBitsPerPixel.Pixel32)]
@@ -118,7 +118,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         public void Encode_32Bit_WithV3Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
 
             // If supportTransparency is false, a v3 bitmap header will be written.
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
 
         [Theory]
         [WithFile(Bit32Rgb, PixelTypes.Rgba32 | PixelTypes.Rgb24, BmpBitsPerPixel.Pixel32)]
@@ -126,48 +126,48 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(WinBmpv4, PixelTypes.Rgba32 | PixelTypes.Rgb24, BmpBitsPerPixel.Pixel32)]
         [WithFile(WinBmpv5, PixelTypes.Rgba32 | PixelTypes.Rgb24, BmpBitsPerPixel.Pixel32)]
         public void Encode_32Bit_WithV4Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
 
         [Theory]
         [WithFile(WinBmpv3, PixelTypes.Rgb24, BmpBitsPerPixel.Pixel24)] // WinBmpv3 is a 24 bits per pixel image.
         [WithFile(F, PixelTypes.Rgb24, BmpBitsPerPixel.Pixel24)]
         public void Encode_24Bit_WithV3Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
 
         [Theory]
         [WithFile(WinBmpv3, PixelTypes.Rgb24, BmpBitsPerPixel.Pixel24)]
         [WithFile(F, PixelTypes.Rgb24, BmpBitsPerPixel.Pixel24)]
         public void Encode_24Bit_WithV4Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
 
         [Theory]
         [WithFile(Rgb16, PixelTypes.Bgra5551, BmpBitsPerPixel.Pixel16)]
         [WithFile(Bit16, PixelTypes.Bgra5551, BmpBitsPerPixel.Pixel16)]
         public void Encode_16Bit_WithV3Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
 
         [Theory]
         [WithFile(Rgb16, PixelTypes.Bgra5551, BmpBitsPerPixel.Pixel16)]
         [WithFile(Bit16, PixelTypes.Bgra5551, BmpBitsPerPixel.Pixel16)]
         public void Encode_16Bit_WithV4Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
 
         [Theory]
         [WithFile(WinBmpv5, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel8)]
         [WithFile(Bit8Palette4, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel8)]
         public void Encode_8Bit_WithV3Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
 
         [Theory]
         [WithFile(WinBmpv5, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel8)]
         [WithFile(Bit8Palette4, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel8)]
         public void Encode_8Bit_WithV4Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
 
         [Theory]
         [WithFile(Bit8Gs, PixelTypes.L8, BmpBitsPerPixel.Pixel8)]
         public void Encode_8BitGray_WithV3Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> =>
+            where TPixel : unmanaged, IPixel<TPixel> =>
             TestBmpEncoderCore(
                 provider,
                 bitsPerPixel,
@@ -176,7 +176,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Bit8Gs, PixelTypes.L8, BmpBitsPerPixel.Pixel8)]
         public void Encode_8BitGray_WithV4Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> =>
+            where TPixel : unmanaged, IPixel<TPixel> =>
             TestBmpEncoderCore(
                 provider,
                 bitsPerPixel,
@@ -185,7 +185,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Bit32Rgb, PixelTypes.Rgba32)]
         public void Encode_8BitColor_WithWuQuantizer<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (!TestEnvironment.Is64BitProcess)
             {
@@ -211,7 +211,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [Theory]
         [WithFile(Bit32Rgb, PixelTypes.Rgba32)]
         public void Encode_8BitColor_WithOctreeQuantizer<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (!TestEnvironment.Is64BitProcess)
             {
@@ -238,13 +238,13 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(TestImages.Png.GrayAlpha2BitInterlaced, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel32)]
         [WithFile(Bit32Rgba, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel32)]
         public void Encode_PreservesAlpha<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
 
         [Theory]
         [WithFile(Car, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel32)]
         [WithFile(V5Header, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel32)]
         public void Encode_WorksWithDiscontiguousBuffers<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InBytesSqrt(100);
             TestBmpEncoderCore(provider, bitsPerPixel);
@@ -255,7 +255,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
             BmpBitsPerPixel bitsPerPixel,
             bool supportTransparency = true,
             ImageComparer customComparer = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
+++ b/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithFileCollection(nameof(DefaultFiles), DefaultPixelType)]
         public void ResolutionShouldChange<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -74,7 +74,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithFile(TestImages.Png.CalliphoraPartial, nameof(QuantizerNames), PixelTypes.Rgba32)]
         [WithFile(TestImages.Png.Bike, nameof(QuantizerNames), PixelTypes.Rgba32)]
         public void QuantizeImageShouldPreserveMaximumColorPrecision<TPixel>(TestImageProvider<TPixel> provider, string quantizerName)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.Configuration.MemoryAllocator = ArrayPoolMemoryAllocator.CreateWithModeratePooling();
 

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [Theory]
         [WithFileCollection(nameof(MultiFrameTestFiles), PixelTypes.Rgba32)]
         public void Decode_VerifyAllFrames<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -90,7 +90,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [Theory]
         [WithFile(TestImages.Gif.Trans, TestPixelTypes)]
         public void GifDecoder_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -102,7 +102,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [Theory]
         [WithFileCollection(nameof(BasicVerificationFiles), PixelTypes.Rgba32)]
         public void Decode_VerifyRootFrameAndFrameCount<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (!BasicVerificationFrameCount.TryGetValue(provider.SourceFileOrDescription, out int expectedFrameCount))
             {
@@ -120,7 +120,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [Theory]
         [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
         public void CanDecodeJustOneFrame<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(new GifDecoder { DecodingMode = FrameDecodingMode.First }))
             {
@@ -131,7 +131,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [Theory]
         [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
         public void CanDecodeAllFrames<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(new GifDecoder { DecodingMode = FrameDecodingMode.All }))
             {
@@ -173,7 +173,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
         [WithFile(TestImages.Gif.Kumin, PixelTypes.Rgba32)]
         public void GifDecoder_DegenerateMemoryRequest_ShouldTranslateTo_ImageFormatException<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(10);
             ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(GifDecoder));
@@ -184,7 +184,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
         [WithFile(TestImages.Gif.Kumin, PixelTypes.Rgba32)]
         public void GifDecoder_CanDecode_WithLimitedAllocatorBufferCapacity<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             static void RunTest(string providerDump, string nonContiguousBuffersStr)
             {

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [WithTestPatternImages(100, 100, TestPixelTypes, false)]
         [WithTestPatternImages(100, 100, TestPixelTypes, false)]
         public void EncodeGeneratedPatterns<TPixel>(TestImageProvider<TPixel> provider, bool limitAllocationBuffer)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (limitAllocationBuffer)
             {
@@ -109,7 +109,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [Theory]
         [WithFile(TestImages.Gif.Cheers, PixelTypes.Rgba32)]
         public void EncodeGlobalPaletteReturnsSmallerFile<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/Formats/Jpg/GenericBlock8x8Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/GenericBlock8x8Tests.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
     public class GenericBlock8x8Tests
     {
         public static Image<TPixel> CreateTestImage<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var image = new Image<TPixel>(10, 10);
             Buffer2D<TPixel> pixels = image.GetRootFramePixelBuffer();
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Theory]
         [WithMemberFactory(nameof(CreateTestImage), PixelTypes.Rgb24 | PixelTypes.Rgba32 /* | PixelTypes.Rgba32 | PixelTypes.Argb32*/)]
         public void LoadAndStretchCorners_FromOrigo<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> s = provider.GetImage())
             {
@@ -61,7 +61,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Theory]
         [WithMemberFactory(nameof(CreateTestImage), PixelTypes.Rgb24 | PixelTypes.Rgba32)]
         public void LoadAndStretchCorners_WithOffset<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> s = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Baseline.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Baseline.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [WithFile(TestImages.Jpeg.Baseline.Calliphora, PixelTypes.Rgba32, true)]
         [WithFile(TestImages.Jpeg.Baseline.Turtle420, PixelTypes.Rgba32, true)]
         public void DecodeBaselineJpeg<TPixel>(TestImageProvider<TPixel> provider, bool enforceDiscontiguousBuffers)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             static void RunTest(string providerDump, string nonContiguousBuffersStr)
             {
@@ -53,6 +53,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Theory]
         [WithFileCollection(nameof(UnrecoverableTestJpegs), PixelTypes.Rgba32)]
         public void UnrecoverableImage_Throws_ImageFormatException<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel> => Assert.Throws<ImageFormatException>(provider.GetImage);
+            where TPixel : unmanaged, IPixel<TPixel> => Assert.Throws<ImageFormatException>(provider.GetImage);
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Progressive.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Progressive.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [WithFileCollection(nameof(ProgressiveTestJpegs), PixelTypes.Rgba32, false)]
         [WithFile(TestImages.Jpeg.Progressive.Progress, PixelTypes.Rgba32, true)]
         public void DecodeProgressiveJpeg<TPixel>(TestImageProvider<TPixel> provider, bool enforceDiscontiguousBuffers)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             static void RunTest(string providerDump, string nonContiguousBuffersStr)
             {

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         }
 
         private static ImageComparer GetImageComparer<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string file = provider.SourceFileOrDescription;
 
@@ -93,7 +93,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Theory]
         [WithFile(TestImages.Jpeg.Baseline.Calliphora, CommonNonDefaultPixelTypes)]
         public void JpegDecoder_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using Image<TPixel> image = provider.GetImage(JpegDecoder);
             image.DebugSave(provider);
@@ -109,7 +109,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [WithFile(TestImages.Jpeg.Baseline.Floorplan, PixelTypes.Rgba32)]
         [WithFile(TestImages.Jpeg.Progressive.Festzug, PixelTypes.Rgba32)]
         public void DegenerateMemoryRequest_ShouldTranslateTo_ImageFormatException<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InBytesSqrt(10);
             ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(JpegDecoder));
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         public void ValidateProgressivePdfJsOutput<TPixel>(
             TestImageProvider<TPixel> provider,
             string pdfJsOriginalResultImage)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // tests\ImageSharp.Tests\Formats\Jpg\pdfjs\jpeg-converter.htm
             string pdfJsOriginalResultPath = Path.Combine(

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
@@ -74,12 +74,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [WithTestPatternImages(nameof(BitsPerPixel_Quality), 7, 5, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(BitsPerPixel_Quality), 600, 400, PixelTypes.Rgba32)]
         public void EncodeBaseline_WorksWithDifferentSizes<TPixel>(TestImageProvider<TPixel> provider, JpegSubsample subsample, int quality)
-            where TPixel : struct, IPixel<TPixel> => TestJpegEncoderCore(provider, subsample, quality);
+            where TPixel : unmanaged, IPixel<TPixel> => TestJpegEncoderCore(provider, subsample, quality);
 
         [Theory]
         [WithTestPatternImages(nameof(BitsPerPixel_Quality), 48, 48, PixelTypes.Rgba32 | PixelTypes.Bgra32)]
         public void EncodeBaseline_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider, JpegSubsample subsample, int quality)
-            where TPixel : struct, IPixel<TPixel> => TestJpegEncoderCore(provider, subsample, quality);
+            where TPixel : unmanaged, IPixel<TPixel> => TestJpegEncoderCore(provider, subsample, quality);
 
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32, JpegSubsample.Ratio444)]
@@ -87,7 +87,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [WithTestPatternImages(677, 683, PixelTypes.Bgra32, JpegSubsample.Ratio420)]
         [WithSolidFilledImages(400, 400, "Red", PixelTypes.Bgr24, JpegSubsample.Ratio420)]
         public void EncodeBaseline_WorksWithDiscontiguousBuffers<TPixel>(TestImageProvider<TPixel> provider, JpegSubsample subsample)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ImageComparer comparer = subsample == JpegSubsample.Ratio444
                 ? ImageComparer.TolerantPercentage(0.1f)
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             JpegSubsample subsample,
             int quality = 100,
             ImageComparer comparer = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using Image<TPixel> image = provider.GetImage();
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegImagePostProcessorTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegImagePostProcessorTests.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         private ITestOutputHelper Output { get; }
 
         private static void SaveBuffer<TPixel>(JpegComponentPostProcessor cp, TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<Rgba32> image = cp.ColorBuffer.ToGrayscaleImage(1f / 255f))
             {
@@ -44,7 +44,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [WithFile(TestImages.Jpeg.Baseline.Calliphora, PixelTypes.Rgba32)]
         [WithFile(TestImages.Jpeg.Baseline.Testorig420, PixelTypes.Rgba32)]
         public void DoProcessorStep<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string imageFile = provider.SourceFileOrDescription;
             using (JpegDecoderCore decoder = JpegFixture.ParseJpegStream(imageFile))
@@ -64,7 +64,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Theory]
         [WithFileCollection(nameof(BaselineTestJpegs), PixelTypes.Rgba32)]
         public void PostProcess<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string imageFile = provider.SourceFileOrDescription;
             using (JpegDecoderCore decoder = JpegFixture.ParseJpegStream(imageFile))

--- a/tests/ImageSharp.Tests/Formats/Jpg/LibJpegToolsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/LibJpegToolsTests.cs
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [WithFile(TestImages.Jpeg.Baseline.Calliphora, PixelTypes.Rgba32)]
         [WithFile(TestImages.Jpeg.Progressive.Progress, PixelTypes.Rgba32)]
         public void ExtractSpectralData<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (!TestEnvironment.IsWindows)
             {

--- a/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
@@ -45,7 +45,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Theory(Skip = "Debug only, enable manually!")]
         [WithFileCollection(nameof(AllTestJpegs), PixelTypes.Rgba32)]
         public void Decoder_ParseStream_SaveSpectralResult<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var decoder = new JpegDecoderCore(Configuration.Default, new JpegDecoder());
 
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Theory]
         [WithFileCollection(nameof(AllTestJpegs), PixelTypes.Rgba32)]
         public void VerifySpectralCorrectness<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (!TestEnvironment.IsWindows)
             {
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         private void VerifySpectralCorrectnessImpl<TPixel>(
             TestImageProvider<TPixel> provider,
             LibJpegTools.SpectralData imageSharpData)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             LibJpegTools.SpectralData libJpegData = LibJpegTools.ExtractSpectralData(provider.SourceFileOrDescription);
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/Utils/VerifyJpeg.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/Utils/VerifyJpeg.cs
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg.Utils
             TestImageProvider<TPixel> provider,
             LibJpegTools.SpectralData data,
             ITestOutputHelper output = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (LibJpegTools.ComponentData comp in data.Components)
             {

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -92,7 +92,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), PixelTypes.Rgba32)]
         public void Decode<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(PngDecoder))
             {
@@ -116,7 +116,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFile(TestImages.Png.Interlaced, PixelTypes.Rgba32)]
         public void Decode_Interlaced_ImageIsCorrect<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(PngDecoder))
             {
@@ -128,7 +128,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFileCollection(nameof(TestImages48Bpp), PixelTypes.Rgb48)]
         public void Decode_48Bpp<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(PngDecoder))
             {
@@ -140,7 +140,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFileCollection(nameof(TestImages64Bpp), PixelTypes.Rgba64)]
         public void Decode_64Bpp<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(PngDecoder))
             {
@@ -152,7 +152,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFileCollection(nameof(TestImagesL8BitInterlaced), PixelTypes.Rgba32)]
         public void Decoder_L8bitInterlaced<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(PngDecoder))
             {
@@ -164,7 +164,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFileCollection(nameof(TestImagesL16Bit), PixelTypes.Rgb48)]
         public void Decode_L16Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(PngDecoder))
             {
@@ -176,7 +176,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFileCollection(nameof(TestImagesGrayAlpha16Bit), PixelTypes.Rgba64)]
         public void Decode_GrayAlpha16Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(PngDecoder))
             {
@@ -188,7 +188,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFile(TestImages.Png.GrayA8BitInterlaced, PixelTypes)]
         public void Decoder_CanDecodeGrey8bitWithAlpha<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(PngDecoder))
             {
@@ -200,7 +200,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFile(TestImages.Png.Splash, PixelTypes)]
         public void Decoder_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(PngDecoder))
             {
@@ -229,7 +229,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFileCollection(nameof(TestImagesIssue1014), PixelTypes.Rgba32)]
         public void Issue1014<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             System.Exception ex = Record.Exception(
                 () =>
@@ -247,7 +247,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [WithFile(TestImages.Png.Splash, PixelTypes.Rgba32)]
         [WithFile(TestImages.Png.Bike, PixelTypes.Rgba32)]
         public void PngDecoder_DegenerateMemoryRequest_ShouldTranslateTo_ImageFormatException<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(10);
             ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(PngDecoder));
@@ -258,7 +258,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [WithFile(TestImages.Png.Splash, PixelTypes.Rgba32)]
         [WithFile(TestImages.Png.Bike, PixelTypes.Rgba32)]
         public void PngDecoder_CanDecode_WithLimitedAllocatorBufferCapacity<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             static void RunTest(string providerDump, string nonContiguousBuffersStr)
             {

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [WithSolidFilledImages(nameof(PngColorTypes), 1, 1, 255, 100, 50, 255, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(PngColorTypes), 7, 5, PixelTypes.Rgba32)]
         public void WorksWithDifferentSizes<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TestPngEncoderCore(
                 provider,
@@ -112,7 +112,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithTestPatternImages(nameof(PngColorTypes), 24, 24, PixelTypes.Rgba32 | PixelTypes.Bgra32 | PixelTypes.Rgb24)]
         public void IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (PngInterlaceMode interlaceMode in InterlaceMode)
             {
@@ -130,7 +130,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithTestPatternImages(nameof(PngFilterMethods), 24, 24, PixelTypes.Rgba32)]
         public void WorksWithAllFilterMethods<TPixel>(TestImageProvider<TPixel> provider, PngFilterMethod pngFilterMethod)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (PngInterlaceMode interlaceMode in InterlaceMode)
             {
@@ -147,7 +147,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithTestPatternImages(nameof(CompressionLevels), 24, 24, PixelTypes.Rgba32)]
         public void WorksWithAllCompressionLevels<TPixel>(TestImageProvider<TPixel> provider, int compressionLevel)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (PngInterlaceMode interlaceMode in InterlaceMode)
             {
@@ -179,7 +179,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [WithTestPatternImages(24, 24, PixelTypes.Rgba32, PngColorType.GrayscaleWithAlpha, PngBitDepth.Bit8)]
         [WithTestPatternImages(24, 24, PixelTypes.Rgba64, PngColorType.GrayscaleWithAlpha, PngBitDepth.Bit16)]
         public void WorksWithAllBitDepths<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType, PngBitDepth pngBitDepth)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // TODO: Investigate WuQuantizer to see if we can reduce memory pressure.
             if (TestEnvironment.RunsOnCI && !TestEnvironment.Is64BitProcess)
@@ -230,7 +230,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [WithBlankImages(1, 1, PixelTypes.La16, PngColorType.GrayscaleWithAlpha, PngBitDepth.Bit8)]
         [WithBlankImages(1, 1, PixelTypes.La32, PngColorType.GrayscaleWithAlpha, PngBitDepth.Bit16)]
         public void InfersColorTypeAndBitDepth<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType, PngBitDepth pngBitDepth)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Stream stream = new MemoryStream())
             {
@@ -252,7 +252,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFile(TestImages.Png.Palette8Bpp, nameof(PaletteLargeOnly), PixelTypes.Rgba32)]
         public void PaletteColorType_WuQuantizer<TPixel>(TestImageProvider<TPixel> provider, int paletteSize)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // TODO: Investigate WuQuantizer to see if we can reduce memory pressure.
             if (TestEnvironment.RunsOnCI && !TestEnvironment.Is64BitProcess)
@@ -276,7 +276,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithBlankImages(1, 1, PixelTypes.Rgba32)]
         public void WritesFileMarker<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             using (var ms = new MemoryStream())
@@ -408,7 +408,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [WithTestPatternImages(587, 821, PixelTypes.Rgba32)]
         [WithTestPatternImages(677, 683, PixelTypes.Rgba32)]
         public void Encode_WorksWithDiscontiguousBuffers<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(200);
             foreach (PngInterlaceMode interlaceMode in InterlaceMode)
@@ -438,7 +438,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             bool appendCompressionLevel = false,
             bool appendPaletteSize = false,
             bool appendPngBitDepth = false)
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/Formats/Png/PngMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngMetadataTests.cs
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFile(TestImages.Png.PngWithMetadata, PixelTypes.Rgba32)]
         public void Decoder_CanReadTextData<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(new PngDecoder()))
             {
@@ -73,7 +73,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFile(TestImages.Png.PngWithMetadata, PixelTypes.Rgba32)]
         public void Encoder_PreservesTextData<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var decoder = new PngDecoder();
             using (Image<TPixel> input = provider.GetImage(decoder))
@@ -103,7 +103,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFile(TestImages.Png.InvalidTextData, PixelTypes.Rgba32)]
         public void Decoder_IgnoresInvalidTextData<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(new PngDecoder()))
             {
@@ -120,7 +120,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithFile(TestImages.Png.PngWithMetadata, PixelTypes.Rgba32)]
         public void Encode_UseCompression_WhenTextIsGreaterThenThreshold_Works<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var decoder = new PngDecoder();
             using (Image<TPixel> input = provider.GetImage(decoder))

--- a/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithTestPatternImages(300, 300, PixelTypes.Rgba32)]
         public void GeneralTest<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // does saving a file then reopening mean both files are identical???
             using (Image<TPixel> image = provider.GetImage())
@@ -38,7 +38,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithTestPatternImages(100, 100, PixelTypes.Rgba32)]
         public void CanSaveIndexedPng<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // does saving a file then reopening mean both files are identical???
             using (Image<TPixel> image = provider.GetImage())
@@ -58,7 +58,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithTestPatternImages(100, 100, PixelTypes.Color)]
         public void CanSaveIndexedPngTwice<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // does saving a file then reopening mean both files are identical???
             using (Image<TPixel> source = provider.GetImage())
@@ -100,7 +100,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Theory]
         [WithTestPatternImages(300, 300, PixelTypes.Rgba32)]
         public void Resize<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // does saving a file then reopening mean both files are identical???
             using (Image<TPixel> image = provider.GetImage())

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Grey, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_Uncompressed_MonoChrome<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit15, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_Uncompressed_15Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -45,7 +45,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit15Rle, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_RunLengthEncoded_15Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit16, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_Uncompressed_16Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -69,7 +69,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit16PalRle, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_RunLengthEncoded_WithPalette_16Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -81,7 +81,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit24, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_Uncompressed_24Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -93,7 +93,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit24RleTopLeft, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_RunLengthEncoded_WithTopLeftOrigin_24Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -105,7 +105,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit24TopLeft, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_Palette_WithTopLeftOrigin_24Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -117,7 +117,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_Uncompressed_32Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -129,7 +129,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(GreyRle, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_RunLengthEncoded_MonoChrome<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -141,7 +141,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit16Rle, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_RunLengthEncoded_16Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -153,7 +153,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit24Rle, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_RunLengthEncoded_24Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -165,7 +165,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit32Rle, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_RunLengthEncoded_32Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -177,7 +177,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit16Pal, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_WithPalette_16Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -189,7 +189,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [Theory]
         [WithFile(Bit24Pal, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_WithPalette_24Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(TgaDecoder))
             {
@@ -203,7 +203,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [WithFile(Bit24, PixelTypes.Rgba32)]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void TgaDecoder_DegenerateMemoryRequest_ShouldTranslateTo_ImageFormatException<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(10);
             ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(TgaDecoder));
@@ -214,7 +214,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         [WithFile(Bit24, PixelTypes.Rgba32)]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void TgaDecoder_CanDecode_WithLimitedAllocatorBufferCapacity<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             static void RunTest(string providerDump, string nonContiguousBuffersStr)
             {

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaEncoderTests.cs
@@ -83,50 +83,50 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         public void Encode_Bit8_Works<TPixel>(TestImageProvider<TPixel> provider, TgaBitsPerPixel bitsPerPixel = TgaBitsPerPixel.Pixel8)
 
             // Using tolerant comparer here. The results from magick differ slightly. Maybe a different ToGrey method is used. The image looks otherwise ok.
-            where TPixel : struct, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.None, useExactComparer: false, compareTolerance: 0.03f);
+            where TPixel : unmanaged, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.None, useExactComparer: false, compareTolerance: 0.03f);
 
         [Theory]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void Encode_Bit16_Works<TPixel>(TestImageProvider<TPixel> provider, TgaBitsPerPixel bitsPerPixel = TgaBitsPerPixel.Pixel16)
-            where TPixel : struct, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.None, useExactComparer: false);
+            where TPixel : unmanaged, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.None, useExactComparer: false);
 
         [Theory]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void Encode_Bit24_Works<TPixel>(TestImageProvider<TPixel> provider, TgaBitsPerPixel bitsPerPixel = TgaBitsPerPixel.Pixel24)
-            where TPixel : struct, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.None);
+            where TPixel : unmanaged, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.None);
 
         [Theory]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void Encode_Bit32_Works<TPixel>(TestImageProvider<TPixel> provider, TgaBitsPerPixel bitsPerPixel = TgaBitsPerPixel.Pixel32)
-            where TPixel : struct, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.None);
+            where TPixel : unmanaged, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.None);
 
         [Theory]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void Encode_Bit8_WithRunLengthEncoding_Works<TPixel>(TestImageProvider<TPixel> provider, TgaBitsPerPixel bitsPerPixel = TgaBitsPerPixel.Pixel8)
 
             // Using tolerant comparer here. The results from magick differ slightly. Maybe a different ToGrey method is used. The image looks otherwise ok.
-            where TPixel : struct, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.RunLength, useExactComparer: false, compareTolerance: 0.03f);
+            where TPixel : unmanaged, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.RunLength, useExactComparer: false, compareTolerance: 0.03f);
 
         [Theory]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void Encode_Bit16_WithRunLengthEncoding_Works<TPixel>(TestImageProvider<TPixel> provider, TgaBitsPerPixel bitsPerPixel = TgaBitsPerPixel.Pixel16)
-            where TPixel : struct, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.RunLength, useExactComparer: false);
+            where TPixel : unmanaged, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.RunLength, useExactComparer: false);
 
         [Theory]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void Encode_Bit24_WithRunLengthEncoding_Works<TPixel>(TestImageProvider<TPixel> provider, TgaBitsPerPixel bitsPerPixel = TgaBitsPerPixel.Pixel24)
-            where TPixel : struct, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.RunLength);
+            where TPixel : unmanaged, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.RunLength);
 
         [Theory]
         [WithFile(Bit32, PixelTypes.Rgba32)]
         public void Encode_Bit32_WithRunLengthEncoding_Works<TPixel>(TestImageProvider<TPixel> provider, TgaBitsPerPixel bitsPerPixel = TgaBitsPerPixel.Pixel32)
-            where TPixel : struct, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.RunLength);
+            where TPixel : unmanaged, IPixel<TPixel> => TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.RunLength);
 
         [Theory]
         [WithFile(Bit32, PixelTypes.Rgba32, TgaBitsPerPixel.Pixel32)]
         [WithFile(Bit24, PixelTypes.Rgba32, TgaBitsPerPixel.Pixel24)]
         public void Encode_WorksWithDiscontiguousBuffers<TPixel>(TestImageProvider<TPixel> provider, TgaBitsPerPixel bitsPerPixel)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(100);
             TestTgaEncoderCore(provider, bitsPerPixel, TgaCompression.RunLength);
@@ -138,7 +138,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
             TgaCompression compression = TgaCompression.None,
             bool useExactComparer = true,
             float compareTolerance = 0.01f)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaTestUtils.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaTestUtils.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
             Image<TPixel> image,
             bool useExactComparer = true,
             float compareTolerance = 0.01f)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string path = TestImageProvider<TPixel>.GetFilePathOrNull(provider);
             if (path == null)
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         }
 
         public static Image<TPixel> DecodeWithMagick<TPixel>(Configuration configuration, FileInfo fileInfo)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var magickImage = new MagickImage(fileInfo))
             {

--- a/tests/ImageSharp.Tests/Image/ImageFrameCollectionTests.Generic.cs
+++ b/tests/ImageSharp.Tests/Image/ImageFrameCollectionTests.Generic.cs
@@ -190,7 +190,7 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [WithTestPatternImages(10, 10, PixelTypes.Rgba32)]
             public void CloneFrame<TPixel>(TestImageProvider<TPixel> provider)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 using (Image<TPixel> img = provider.GetImage())
                 {
@@ -206,7 +206,7 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [WithTestPatternImages(10, 10, PixelTypes.Rgba32)]
             public void ExtractFrame<TPixel>(TestImageProvider<TPixel> provider)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 using (Image<TPixel> img = provider.GetImage())
                 {

--- a/tests/ImageSharp.Tests/Image/ImageFrameCollectionTests.NonGeneric.cs
+++ b/tests/ImageSharp.Tests/Image/ImageFrameCollectionTests.NonGeneric.cs
@@ -146,7 +146,7 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [WithTestPatternImages(10, 10, PixelTypes.Rgba32 | PixelTypes.Bgr24)]
             public void CloneFrame<TPixel>(TestImageProvider<TPixel> provider)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 using (Image<TPixel> img = provider.GetImage())
                 {
@@ -167,7 +167,7 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [WithTestPatternImages(10, 10, PixelTypes.Rgba32)]
             public void ExtractFrame<TPixel>(TestImageProvider<TPixel> provider)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 using (Image<TPixel> img = provider.GetImage())
                 {
@@ -268,7 +268,7 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
             public void ConstructGif_FromDifferentPixelTypes<TPixel>(TestImageProvider<TPixel> provider)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 using (Image source = provider.GetImage())
                 using (var dest = new Image<TPixel>(source.GetConfiguration(), source.Width, source.Height))
@@ -294,7 +294,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             private static void ImportFrameAs<TPixel>(ImageFrameCollection source, ImageFrameCollection destination, int index)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 using (Image temp = source.CloneFrame(index))
                 {

--- a/tests/ImageSharp.Tests/PixelFormats/PixelBlenderTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelBlenderTests.cs
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats
         [Theory]
         [MemberData(nameof(BlenderMappings))]
         public void ReturnsCorrectBlender<TPixel>(TestPixel<TPixel> pixel, Type type, PixelColorBlendingMode mode)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             PixelBlender<TPixel> blender = PixelOperations<TPixel>.Instance.GetPixelBlender(mode, PixelAlphaCompositionMode.SrcOver);
             Assert.IsType(type, blender);

--- a/tests/ImageSharp.Tests/PixelFormats/PixelBlenders/PorterDuffFunctionsTestsTPixel.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelBlenders/PorterDuffFunctionsTestsTPixel.cs
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(NormalBlendFunctionData))]
         public void NormalBlendFunction<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = PorterDuffFunctions.NormalSrcOver(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(NormalBlendFunctionData))]
         public void NormalBlendFunctionBlender<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = new DefaultPixelBlenders<TPixel>.NormalSrcOver().Blend(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -46,7 +46,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(NormalBlendFunctionData))]
         public void NormalBlendFunctionBlenderBulk<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var dest = new Span<TPixel>(new TPixel[1]);
             new DefaultPixelBlenders<TPixel>.NormalSrcOver().Blend(this.Configuration, dest, back.AsSpan(), source.AsSpan(), AsSpan(amount));
@@ -68,7 +68,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(MultiplyFunctionData))]
         public void MultiplyFunction<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = PorterDuffFunctions.MultiplySrcOver(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -77,7 +77,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(MultiplyFunctionData))]
         public void MultiplyFunctionBlender<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = new DefaultPixelBlenders<TPixel>.MultiplySrcOver().Blend(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(MultiplyFunctionData))]
         public void MultiplyFunctionBlenderBulk<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var dest = new Span<TPixel>(new TPixel[1]);
             new DefaultPixelBlenders<TPixel>.MultiplySrcOver().Blend(this.Configuration, dest, back.AsSpan(), source.AsSpan(), AsSpan(amount));
@@ -118,7 +118,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(AddFunctionData))]
         public void AddFunction<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = PorterDuffFunctions.AddSrcOver(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -127,7 +127,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(AddFunctionData))]
         public void AddFunctionBlender<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = new DefaultPixelBlenders<TPixel>.AddSrcOver().Blend(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -136,7 +136,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(AddFunctionData))]
         public void AddFunctionBlenderBulk<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var dest = new Span<TPixel>(new TPixel[1]);
             new DefaultPixelBlenders<TPixel>.AddSrcOver().Blend(this.Configuration, dest, back.AsSpan(), source.AsSpan(), AsSpan(amount));
@@ -158,7 +158,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(SubtractFunctionData))]
         public void SubtractFunction<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = PorterDuffFunctions.SubtractSrcOver(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -167,7 +167,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(SubtractFunctionData))]
         public void SubtractFunctionBlender<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = new DefaultPixelBlenders<TPixel>.SubtractSrcOver().Blend(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -176,7 +176,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(SubtractFunctionData))]
         public void SubtractFunctionBlenderBulk<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var dest = new Span<TPixel>(new TPixel[1]);
             new DefaultPixelBlenders<TPixel>.SubtractSrcOver().Blend(this.Configuration, dest, back.AsSpan(), source.AsSpan(), AsSpan(amount));
@@ -198,7 +198,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(ScreenFunctionData))]
         public void ScreenFunction<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = PorterDuffFunctions.ScreenSrcOver(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -207,7 +207,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(ScreenFunctionData))]
         public void ScreenFunctionBlender<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = new DefaultPixelBlenders<TPixel>.ScreenSrcOver().Blend(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -216,7 +216,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(ScreenFunctionData))]
         public void ScreenFunctionBlenderBulk<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var dest = new Span<TPixel>(new TPixel[1]);
             new DefaultPixelBlenders<TPixel>.ScreenSrcOver().Blend(this.Configuration, dest, back.AsSpan(), source.AsSpan(), AsSpan(amount));
@@ -238,7 +238,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(DarkenFunctionData))]
         public void DarkenFunction<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = PorterDuffFunctions.DarkenSrcOver(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -247,7 +247,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(DarkenFunctionData))]
         public void DarkenFunctionBlender<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = new DefaultPixelBlenders<TPixel>.DarkenSrcOver().Blend(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -256,7 +256,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(DarkenFunctionData))]
         public void DarkenFunctionBlenderBulk<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var dest = new Span<TPixel>(new TPixel[1]);
             new DefaultPixelBlenders<TPixel>.DarkenSrcOver().Blend(this.Configuration, dest, back.AsSpan(), source.AsSpan(), AsSpan(amount));
@@ -278,7 +278,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(LightenFunctionData))]
         public void LightenFunction<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = PorterDuffFunctions.LightenSrcOver(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -287,7 +287,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(LightenFunctionData))]
         public void LightenFunctionBlender<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = new DefaultPixelBlenders<TPixel>.LightenSrcOver().Blend(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -296,7 +296,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(LightenFunctionData))]
         public void LightenFunctionBlenderBulk<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var dest = new Span<TPixel>(new TPixel[1]);
             new DefaultPixelBlenders<TPixel>.LightenSrcOver().Blend(this.Configuration, dest, back.AsSpan(), source.AsSpan(), AsSpan(amount));
@@ -318,7 +318,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(OverlayFunctionData))]
         public void OverlayFunction<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = PorterDuffFunctions.OverlaySrcOver(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -327,7 +327,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(OverlayFunctionData))]
         public void OverlayFunctionBlender<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = new DefaultPixelBlenders<TPixel>.OverlaySrcOver().Blend(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -336,7 +336,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(OverlayFunctionData))]
         public void OverlayFunctionBlenderBulk<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var dest = new Span<TPixel>(new TPixel[1]);
             new DefaultPixelBlenders<TPixel>.OverlaySrcOver().Blend(this.Configuration, dest, back.AsSpan(), source.AsSpan(), AsSpan(amount));
@@ -358,7 +358,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(HardLightFunctionData))]
         public void HardLightFunction<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = PorterDuffFunctions.HardLightSrcOver(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -367,7 +367,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(HardLightFunctionData))]
         public void HardLightFunctionBlender<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel actual = new DefaultPixelBlenders<TPixel>.HardLightSrcOver().Blend(back.AsPixel(), source.AsPixel(), amount);
             VectorAssert.Equal(expected.AsPixel(), actual, 2);
@@ -376,7 +376,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelBlenders
         [Theory]
         [MemberData(nameof(HardLightFunctionData))]
         public void HardLightFunctionBlenderBulk<TPixel>(TestPixel<TPixel> back, TestPixel<TPixel> source, float amount, TestPixel<TPixel> expected)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var dest = new Span<TPixel>(new TPixel[1]);
             new DefaultPixelBlenders<TPixel>.HardLightSrcOver().Blend(this.Configuration, dest, back.AsSpan(), source.AsSpan(), AsSpan(amount));

--- a/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
@@ -47,8 +47,8 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats
                 Configuration configuration,
                 ReadOnlySpan<TSourcePixel> sourcePixels,
                 Span<TDestinationPixel> destinationPixels)
-                where TSourcePixel : struct, IPixel<TSourcePixel>
-                where TDestinationPixel : struct, IPixel<TDestinationPixel>
+                where TSourcePixel : unmanaged, IPixel<TSourcePixel>
+                where TDestinationPixel : unmanaged, IPixel<TDestinationPixel>
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));

--- a/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.cs
@@ -22,12 +22,12 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelOperations
         [Theory]
         [WithBlankImages(1, 1, PixelTypes.All)]
         public void GetGlobalInstance<T>(TestImageProvider<T> _)
-            where T : struct, IPixel<T> => Assert.NotNull(PixelOperations<T>.Instance);
+            where T : unmanaged, IPixel<T> => Assert.NotNull(PixelOperations<T>.Instance);
     }
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
 
     public abstract class PixelOperationsTests<TPixel> : MeasureFixture
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         public const string SkipProfilingBenchmarks =
 #if true
@@ -288,7 +288,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelOperations
         [Theory]
         [MemberData(nameof(Generic_To_Data))]
         public void Generic_To<TDestPixel>(TestPixel<TDestPixel> dummy)
-            where TDestPixel : struct, IPixel<TDestPixel>
+            where TDestPixel : unmanaged, IPixel<TDestPixel>
         {
             const int Count = 2134;
             TPixel[] source = CreatePixelTestData(Count);

--- a/tests/ImageSharp.Tests/Processing/FakeImageOperationsProvider.cs
+++ b/tests/ImageSharp.Tests/Processing/FakeImageOperationsProvider.cs
@@ -14,27 +14,27 @@ namespace SixLabors.ImageSharp.Tests.Processing
         private readonly List<object> imageOperators = new List<object>();
 
         public bool HasCreated<TPixel>(Image<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return this.Created(source).Any();
         }
 
         public IEnumerable<FakeImageOperations<TPixel>> Created<TPixel>(Image<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return this.imageOperators.OfType<FakeImageOperations<TPixel>>()
                 .Where(x => x.Source == source);
         }
 
         public IEnumerable<FakeImageOperations<TPixel>.AppliedOperation> AppliedOperations<TPixel>(Image<TPixel> source)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return this.Created(source)
                 .SelectMany(x => x.Applied);
         }
 
         public IInternalImageProcessingContext<TPixel> CreateImageProcessingContext<TPixel>(Configuration configuration, Image<TPixel> source, bool mutate)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var op = new FakeImageOperations<TPixel>(configuration, source, mutate);
             this.imageOperators.Add(op);
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Tests.Processing
         }
 
         public class FakeImageOperations<TPixel> : IInternalImageProcessingContext<TPixel>
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             public FakeImageOperations(Configuration configuration, Image<TPixel> source, bool mutate)
             {

--- a/tests/ImageSharp.Tests/Processing/Normalization/HistogramEqualizationTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Normalization/HistogramEqualizationTests.cs
@@ -78,7 +78,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Normalization
         [Theory]
         [WithFile(TestImages.Jpeg.Baseline.LowContrast, PixelTypes.Rgba32)]
         public void Adaptive_SlidingWindow_15Tiles_WithClipping<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Normalization
         [Theory]
         [WithFile(TestImages.Jpeg.Baseline.LowContrast, PixelTypes.Rgba32)]
         public void Adaptive_TileInterpolation_10Tiles_WithClipping<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Normalization
         [WithTestPatternImages(110, 110, PixelTypes.Rgb24)]
         [WithTestPatternImages(170, 170, PixelTypes.Rgb24)]
         public void Issue984<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/Processing/Processors/Binarization/BinaryDitherTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Binarization/BinaryDitherTests.cs
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [WithFileCollection(nameof(CommonTestImages), nameof(OrderedDitherers), PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(OrderedDitherers), 100, 100, PixelTypes.Rgba32)]
         public void BinaryDitherFilter_WorksWithAllDitherers<TPixel>(TestImageProvider<TPixel> provider, string name, IDither ditherer)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [WithFileCollection(nameof(CommonTestImages), nameof(ErrorDiffusers), PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(ErrorDiffusers), 100, 100, PixelTypes.Rgba32)]
         public void DiffusionFilter_WorksWithAllErrorDiffusers<TPixel>(TestImageProvider<TPixel> provider, string name, IDither diffuser)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -74,7 +74,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFile(TestImages.Png.Bike, TestPixelTypes)]
         public void BinaryDitherFilter_ShouldNotDependOnSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFile(TestImages.Png.Bike, TestPixelTypes)]
         public void DiffusionFilter_ShouldNotDependOnSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void ApplyDitherFilterInBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> source = provider.GetImage())
             using (Image<TPixel> image = source.Clone())
@@ -115,7 +115,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void ApplyDiffusionFilterInBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> source = provider.GetImage())
             using (Image<TPixel> image = source.Clone())

--- a/tests/ImageSharp.Tests/Processing/Processors/Binarization/BinaryThresholdTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Binarization/BinaryThresholdTest.cs
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), nameof(BinaryThresholdValues), PixelTypes.Rgba32)]
         public void ImageShouldApplyBinaryThresholdFilter<TPixel>(TestImageProvider<TPixel> provider, float value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), nameof(BinaryThresholdValues), PixelTypes.Rgba32)]
         public void ImageShouldApplyBinaryThresholdInBox<TPixel>(TestImageProvider<TPixel> provider, float value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> source = provider.GetImage())
             using (var image = source.Clone())

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/Basic1ParameterConvolutionTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/Basic1ParameterConvolutionTests.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [Theory]
         [WithFileCollection(nameof(InputImages), nameof(Values), PixelTypes.Rgba32)]
         public void OnFullImage<TPixel>(TestImageProvider<TPixel> provider, int value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.Utility.TestGroupName = this.GetType().Name;
             provider.RunValidatingProcessorTest(
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [Theory]
         [WithFileCollection(nameof(InputImages), nameof(Values), PixelTypes.Rgba32)]
         public void InBox<TPixel>(TestImageProvider<TPixel> provider, int value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.Utility.TestGroupName = this.GetType().Name;
             provider.RunRectangleConstrainedValidatingProcessorTest(

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/BokehBlurTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/BokehBlurTest.cs
@@ -128,7 +128,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [WithTestPatternImages(nameof(BokehBlurValues), 23, 31, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(BokehBlurValues), 30, 20, PixelTypes.Rgba32)]
         public void BokehBlurFilterProcessor<TPixel>(TestImageProvider<TPixel> provider, BokehBlurInfo value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             static void RunTest(string providerDump, string infoDump)
             {
@@ -154,7 +154,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         */
         [WithTestPatternImages(200, 200, PixelTypes.Bgr24 | PixelTypes.Bgra32)]
         public void BokehBlurFilterProcessor_WorksWithAllPixelTypes<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             static void RunTest(string providerDump)
             {
@@ -173,7 +173,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [Theory]
         [WithFileCollection(nameof(TestFiles), nameof(BokehBlurValues), PixelTypes.Rgba32)]
         public void BokehBlurFilterProcessor_Bounded<TPixel>(TestImageProvider<TPixel> provider, BokehBlurInfo value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             static void RunTest(string providerDump, string infoDump)
             {
@@ -200,7 +200,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [Theory]
         [WithTestPatternImages(100, 300, PixelTypes.Bgr24)]
         public void WorksWithDiscoBuffers<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunBufferCapacityLimitProcessorTest(41, c => c.BokehBlur());
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/DetectEdgesTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/DetectEdgesTest.cs
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [Theory]
         [WithFileCollection(nameof(TestImages), PixelTypes.Rgba32)]
         public void DetectEdges_WorksOnWrappedMemoryImage<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTestOnWrappedMemoryImage(
                 ctx =>
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [WithTestPatternImages(nameof(DetectEdgesFilters), 100, 100, PixelTypes.Rgba32)]
         [WithFileCollection(nameof(TestImages), nameof(DetectEdgesFilters), PixelTypes.Rgba32)]
         public void DetectEdges_WorksWithAllFilters<TPixel>(TestImageProvider<TPixel> provider, EdgeDetectionOperators detector)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [Theory]
         [WithFileCollection(nameof(TestImages), CommonNonDefaultPixelTypes)]
         public void DetectEdges_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -80,7 +80,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [Theory]
         [WithFile(Tests.TestImages.Gif.Giphy, PixelTypes.Rgba32)]
         public void DetectEdges_IsAppliedToAllFrames<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -92,7 +92,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [Theory]
         [WithFileCollection(nameof(TestImages), PixelTypes.Rgba32)]
         public void DetectEdges_InBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -107,7 +107,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
         [Theory]
         [WithFile(Tests.TestImages.Png.Bike, nameof(DetectEdgesFilters), PixelTypes.Rgba32)]
         public void WorksWithDiscoBuffers<TPixel>(TestImageProvider<TPixel> provider, EdgeDetectionOperators detector)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunBufferCapacityLimitProcessorTest(
                 41,

--- a/tests/ImageSharp.Tests/Processing/Processors/Dithering/DitherTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Dithering/DitherTests.cs
@@ -56,7 +56,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void ApplyDiffusionFilterInBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (SkipAllDitherTests)
             {
@@ -71,7 +71,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void ApplyDitherFilterInBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (SkipAllDitherTests)
             {
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFile(TestImages.Png.Filter0, CommonNonDefaultPixelTypes)]
         public void DiffusionFilter_ShouldNotDependOnSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (SkipAllDitherTests)
             {
@@ -104,7 +104,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
             TestImageProvider<TPixel> provider,
             IDither diffuser,
             string name)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (SkipAllDitherTests)
             {
@@ -121,7 +121,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         [Theory]
         [WithFile(TestImages.Png.Filter0, CommonNonDefaultPixelTypes)]
         public void DitherFilter_ShouldNotDependOnSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (SkipAllDitherTests)
             {
@@ -139,7 +139,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
             TestImageProvider<TPixel> provider,
             IDither ditherer,
             string name)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (SkipAllDitherTests)
             {
@@ -159,7 +159,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Binarization
         public void CommonDitherers_WorkWithDiscoBuffers<TPixel>(
             TestImageProvider<TPixel> provider,
             string name)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             IDither dither = TestUtils.GetDither(name);
             if (SkipAllDitherTests)

--- a/tests/ImageSharp.Tests/Processing/Processors/Effects/BackgroundColorTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Effects/BackgroundColorTest.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithFileCollection(nameof(InputImages), PixelTypes.Rgba32)]
         public void FullImage<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.BackgroundColor(Color.HotPink));
         }
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithFileCollection(nameof(InputImages), PixelTypes.Rgba32)]
         public void InBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunRectangleConstrainedValidatingProcessorTest(
                 (x, rect) => x.BackgroundColor(Color.HotPink, rect));

--- a/tests/ImageSharp.Tests/Processing/Processors/Effects/OilPaintTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Effects/OilPaintTest.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithFileCollection(nameof(InputImages), nameof(OilPaintValues), PixelTypes.Rgba32)]
         public void FullImage<TPixel>(TestImageProvider<TPixel> provider, int levels, int brushSize)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(
                 x => x.OilPaint(levels, brushSize),
@@ -38,7 +38,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [WithFileCollection(nameof(InputImages), nameof(OilPaintValues), PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(OilPaintValues), 100, 100, PixelTypes.Rgba32)]
         public void InBox<TPixel>(TestImageProvider<TPixel> provider, int levels, int brushSize)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunRectangleConstrainedValidatingProcessorTest(
                 (x, rect) => x.OilPaint(levels, brushSize, rect),

--- a/tests/ImageSharp.Tests/Processing/Processors/Effects/PixelShaderTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Effects/PixelShaderTest.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void FullImage<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(
                 x => x.ProcessPixelRowsAsVector4(
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void InBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunRectangleConstrainedValidatingProcessorTest(
                 (x, rect) => x.ProcessPixelRowsAsVector4(
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void PositionAwareFullImage<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(
                 c => c.ProcessPixelRowsAsVector4(
@@ -84,7 +84,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void PositionAwareInBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunRectangleConstrainedValidatingProcessorTest(
                 (c, rect) => c.ProcessPixelRowsAsVector4(

--- a/tests/ImageSharp.Tests/Processing/Processors/Effects/PixelateTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Effects/PixelateTest.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithFile(TestImages.Png.Ducky, nameof(PixelateValues), PixelTypes.Rgba32)]
         public void FullImage<TPixel>(TestImageProvider<TPixel> provider, int value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Pixelate(value), value, appendPixelTypeToFileName: false);
         }
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [WithTestPatternImages(nameof(PixelateValues), 320, 240, PixelTypes.Rgba32)]
         [WithFile(TestImages.Png.CalliphoraPartial, nameof(PixelateValues), PixelTypes.Rgba32)]
         public void InBox<TPixel>(TestImageProvider<TPixel> provider, int value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunRectangleConstrainedValidatingProcessorTest((x, rect) => x.Pixelate(value, rect), value);
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/BlackWhiteTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/BlackWhiteTest.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(48, 48, PixelTypes.Rgba32)]
         public void ApplyBlackWhiteFilter<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(ctx => ctx.BlackWhite(), comparer: ImageComparer.TolerantPercentage(0.002f));
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/BrightnessTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/BrightnessTest.cs
@@ -25,6 +25,6 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithTestPatternImages(nameof(BrightnessValues), 48, 48, PixelTypes.Rgba32)]
         public void ApplyBrightnessFilter<TPixel>(TestImageProvider<TPixel> provider, float value)
-            where TPixel : struct, IPixel<TPixel> => provider.RunValidatingProcessorTest(ctx => ctx.Brightness(value), value, this.imageComparer);
+            where TPixel : unmanaged, IPixel<TPixel> => provider.RunValidatingProcessorTest(ctx => ctx.Brightness(value), value, this.imageComparer);
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/ColorBlindnessTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/ColorBlindnessTest.cs
@@ -31,6 +31,6 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(nameof(ColorBlindnessFilters), 48, 48, PixelTypes.Rgba32)]
         public void ApplyColorBlindnessFilter<TPixel>(TestImageProvider<TPixel> provider, ColorBlindnessMode colorBlindness)
-            where TPixel : struct, IPixel<TPixel> => provider.RunValidatingProcessorTest(x => x.ColorBlindness(colorBlindness), colorBlindness.ToString(), this.imageComparer);
+            where TPixel : unmanaged, IPixel<TPixel> => provider.RunValidatingProcessorTest(x => x.ColorBlindness(colorBlindness), colorBlindness.ToString(), this.imageComparer);
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/ContrastTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/ContrastTest.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithTestPatternImages(nameof(ContrastValues), 48, 48, PixelTypes.Rgba32)]
         public void ApplyContrastFilter<TPixel>(TestImageProvider<TPixel> provider, float value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Contrast(value), value);
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/FilterTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/FilterTest.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(48, 48, PixelTypes.Rgba32 | PixelTypes.Bgra32)]
         public void ApplyFilter<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ColorMatrix m = CreateCombinedTestFilterMatrix();
 
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(48, 48, PixelTypes.Rgba32)]
         public void ApplyFilterInBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ColorMatrix m = CreateCombinedTestFilterMatrix();
 
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(70, 120, PixelTypes.Rgba32)]
         public void FilterProcessor_WorksWithDiscoBuffers<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             ColorMatrix m = CreateCombinedTestFilterMatrix();
 

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/GrayscaleTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/GrayscaleTest.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(nameof(GrayscaleModeTypes), 48, 48, PixelTypes.Rgba32)]
         public void ApplyGrayscaleFilter<TPixel>(TestImageProvider<TPixel> provider, GrayscaleMode value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Grayscale(value), value);
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/HueTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/HueTest.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(nameof(HueValues), 48, 48, PixelTypes.Rgba32)]
         public void ApplyHueFilter<TPixel>(TestImageProvider<TPixel> provider, int value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Hue(value), value);
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/InvertTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/InvertTest.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithTestPatternImages(48, 48, PixelTypes.Rgba32)]
         public void ApplyInvertFilter<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Invert());
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/KodachromeTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/KodachromeTest.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(48, 48, PixelTypes.Rgba32)]
         public void ApplyKodachromeFilter<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Kodachrome());
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/LightnessTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/LightnessTest.cs
@@ -25,6 +25,6 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithTestPatternImages(nameof(LightnessValues), 48, 48, PixelTypes.Rgba32)]
         public void ApplyLightnessFilter<TPixel>(TestImageProvider<TPixel> provider, float value)
-            where TPixel : struct, IPixel<TPixel> => provider.RunValidatingProcessorTest(ctx => ctx.Lightness(value), value, this.imageComparer);
+            where TPixel : unmanaged, IPixel<TPixel> => provider.RunValidatingProcessorTest(ctx => ctx.Lightness(value), value, this.imageComparer);
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/LomographTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/LomographTest.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(48, 48, PixelTypes.Rgba32)]
         public void ApplyLomographFilter<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Lomograph());
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/OpacityTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/OpacityTest.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Effects
         [Theory]
         [WithTestPatternImages(nameof(AlphaValues), 48, 48, PixelTypes.Rgba32)]
         public void ApplyAlphaFilter<TPixel>(TestImageProvider<TPixel> provider, float value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Opacity(value), value);
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/PolaroidTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/PolaroidTest.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(48, 48, PixelTypes.Rgba32)]
         public void ApplyPolaroidFilter<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Polaroid());
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/SaturateTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/SaturateTest.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(nameof(SaturationValues), 48, 48, PixelTypes.Rgba32)]
         public void ApplySaturationFilter<TPixel>(TestImageProvider<TPixel> provider, float value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Saturate(value), value);
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Filters/SepiaTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Filters/SepiaTest.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Filters
         [Theory]
         [WithTestPatternImages(48, 48, PixelTypes.Rgba32)]
         public void ApplySepiaFilter<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Sepia());
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Overlays/OverlayTestBase.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Overlays/OverlayTestBase.cs
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Overlays
         [Theory]
         [WithFileCollection(nameof(InputImages), nameof(ColorNames), PixelTypes.Rgba32)]
         public void FullImage_ApplyColor<TPixel>(TestImageProvider<TPixel> provider, string colorName)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.Utility.TestGroupName = this.GetType().Name;
             Color color = TestUtils.GetColorByName(colorName);
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Overlays
         [Theory]
         [WithFileCollection(nameof(InputImages), PixelTypes.Rgba32)]
         public void FullImage_ApplyRadius<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.Utility.TestGroupName = this.GetType().Name;
             provider.RunValidatingProcessorTest(
@@ -48,7 +48,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Overlays
         [Theory]
         [WithFileCollection(nameof(InputImages), PixelTypes.Rgba32)]
         public void InBox<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.Utility.TestGroupName = this.GetType().Name;
             provider.RunRectangleConstrainedValidatingProcessorTest(this.Apply);
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Overlays
         [Theory]
         [WithTestPatternImages(70, 120, PixelTypes.Rgba32)]
         public void WorksWithDiscoBuffers<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunBufferCapacityLimitProcessorTest(37, c => this.Apply(c, Color.DarkRed));
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Quantization/QuantizerTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Quantization/QuantizerTests.cs
@@ -156,7 +156,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Quantization
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), nameof(Quantizers), PixelTypes.Rgba32)]
         public void ApplyQuantizationInBox<TPixel>(TestImageProvider<TPixel> provider, IQuantizer quantizer)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (SkipAllQuantizerTests)
             {
@@ -177,7 +177,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Quantization
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), nameof(Quantizers), PixelTypes.Rgba32)]
         public void ApplyQuantization<TPixel>(TestImageProvider<TPixel> provider, IQuantizer quantizer)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (SkipAllQuantizerTests)
             {
@@ -198,7 +198,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Quantization
         [Theory]
         [WithFile(TestImages.Png.David, nameof(DitherScaleQuantizers), PixelTypes.Rgba32)]
         public void ApplyQuantizationWithDitheringScale<TPixel>(TestImageProvider<TPixel> provider, IQuantizer quantizer)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (SkipAllQuantizerTests)
             {

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/AffineTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/AffineTransformTests.cs
@@ -77,7 +77,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithSolidFilledImages(nameof(Transform_DoesNotCreateEdgeArtifacts_ResamplerNames), 5, 5, 255, 255, 255, 255, PixelTypes.Rgba32)]
         public void Transform_DoesNotCreateEdgeArtifacts<TPixel>(TestImageProvider<TPixel> provider, string resamplerName)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             IResampler resampler = GetResampler(resamplerName);
             using (Image<TPixel> image = provider.GetImage())
@@ -101,7 +101,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
             float sy,
             float tx,
             float ty)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithTestPatternImages(96, 96, PixelTypes.Rgba32, 50, 0.8f)]
         public void Transform_RotateScale_ManuallyCentered<TPixel>(TestImageProvider<TPixel> provider, float angleDeg, float s)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -158,7 +158,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithTestPatternImages(96, 48, PixelTypes.Rgba32)]
         public void Transform_FromSourceRectangle1<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var rectangle = new Rectangle(48, 0, 48, 24);
 
@@ -178,7 +178,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithTestPatternImages(96, 48, PixelTypes.Rgba32)]
         public void Transform_FromSourceRectangle2<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var rectangle = new Rectangle(0, 24, 48, 24);
 
@@ -197,7 +197,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithTestPatternImages(nameof(ResamplerNames), 150, 150, PixelTypes.Rgba32)]
         public void Transform_WithSampler<TPixel>(TestImageProvider<TPixel> provider, string resamplerName)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             IResampler sampler = GetResampler(resamplerName);
             using (Image<TPixel> image = provider.GetImage())
@@ -216,7 +216,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithTestPatternImages(100, 100, PixelTypes.Rgba32, 21)]
         public void WorksWithDiscoBuffers<TPixel>(TestImageProvider<TPixel> provider, int bufferCapacityInPixelRows)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             AffineTransformBuilder builder = new AffineTransformBuilder()
                 .AppendRotationDegrees(50)
@@ -239,7 +239,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         }
 
         private static void VerifyAllPixelsAreWhiteOrTransparent<TPixel>(Image<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Span<TPixel> data = image.Frames.RootFrame.GetPixelSpan();
             var white = new Rgb24(255, 255, 255);

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/AutoOrientTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/AutoOrientTests.cs
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFile(FlipTestFile, nameof(ExifOrientationValues), PixelTypes.Rgba32)]
         public void AutoOrient_WorksForAllExifOrientations<TPixel>(TestImageProvider<TPixel> provider, ushort orientation)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -58,7 +58,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFile(FlipTestFile, nameof(InvalidOrientationValues), PixelTypes.Rgba32)]
         public void AutoOrient_WorksWithCorruptExifData<TPixel>(TestImageProvider<TPixel> provider, ExifDataType dataType, byte[] orientation)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var profile = new ExifProfile();
             profile.SetValue(ExifTag.JPEGTables, orientation);

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/CropTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/CropTest.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithTestPatternImages(70, 30, PixelTypes.Rgba32, 0, 0, 70, 30)]
         [WithTestPatternImages(30, 70, PixelTypes.Rgba32, 7, 13, 20, 50)]
         public void Crop<TPixel>(TestImageProvider<TPixel> provider, int x, int y, int w, int h)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var rect = new Rectangle(x, y, w, h);
             FormattableString info = $"X{x}Y{y}.W{w}H{h}";

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/EntropyCropTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/EntropyCropTest.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(InputImages), nameof(EntropyCropValues), PixelTypes.Rgba32)]
         public void EntropyCrop<TPixel>(TestImageProvider<TPixel> provider, float value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.EntropyCrop(value), value, appendPixelTypeToFileName: false);
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/FlipTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/FlipTests.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithTestPatternImages(nameof(FlipValues), 53, 37, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(FlipValues), 17, 32, PixelTypes.Rgba32)]
         public void Flip<TPixel>(TestImageProvider<TPixel> provider, FlipMode flipMode)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(
                 ctx => ctx.Flip(flipMode),
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithTestPatternImages(nameof(FlipValues), 53, 37, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(FlipValues), 17, 32, PixelTypes.Rgba32)]
         public void Flip_WorksOnWrappedMemoryImage<TPixel>(TestImageProvider<TPixel> provider, FlipMode flipMode)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTestOnWrappedMemoryImage(
                 ctx => ctx.Flip(flipMode),

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/PadTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/PadTest.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), PixelTypes.Rgba32)]
         public void ImageShouldPad<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -38,7 +38,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), PixelTypes.Rgba32)]
         public void ImageShouldPadWithBackgroundColor<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var color = Color.Red;
             TPixel expected = color.ToPixel<TPixel>();

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -58,7 +58,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithTestPatternImages(3032, 3032, PixelTypes.Rgba32, 400, 1024)]
         [WithTestPatternImages(3032, 3032, PixelTypes.Rgba32, 400, 128)]
         public void LargeImage<TPixel>(TestImageProvider<TPixel> provider, int destSize, int workingBufferSizeHintInKilobytes)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (!TestEnvironment.Is64BitProcess)
             {
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithBasicTestPatternImages(2, 256, PixelTypes.Rgba32, 1, 1, 1, 8)]
         [WithBasicTestPatternImages(2, 32, PixelTypes.Rgba32, 1, 1, 1, 2)]
         public void Resize_BasicSmall<TPixel>(TestImageProvider<TPixel> provider, int wN, int wD, int hN, int hD)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Basic test case, very helpful for debugging
             // [WithBasicTestPatternImages(15, 12, PixelTypes.Rgba32, 2, 3, 1, 2)] means:
@@ -108,7 +108,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         public void WorkingBufferSizeHintInBytes_IsAppliedCorrectly<TPixel>(
             TestImageProvider<TPixel> provider,
             int workingBufferLimitInRows)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image0 = provider.GetImage())
             {
@@ -164,7 +164,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
             TestImageProvider<TPixel> provider,
             int workingBufferLimitInRows,
             int bufferCapacityInRows)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using Image<TPixel> expected = provider.GetImage();
             int width = expected.Width;
@@ -189,7 +189,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithTestPatternImages(100, 100, DefaultPixelType)]
         public void Resize_Compand<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -204,7 +204,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithFile(TestImages.Png.Kaboom, DefaultPixelType, false)]
         [WithFile(TestImages.Png.Kaboom, DefaultPixelType, true)]
         public void Resize_DoesNotBleedAlphaPixels<TPixel>(TestImageProvider<TPixel> provider, bool compand)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string details = compand ? "Compand" : string.Empty;
 
@@ -218,7 +218,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFile(TestImages.Gif.Giphy, DefaultPixelType)]
         public void Resize_IsAppliedToAllFrames<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -232,7 +232,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithTestPatternImages(50, 50, CommonNonDefaultPixelTypes)]
         public void Resize_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.Resize(x.GetCurrentSize() / 2), comparer: ValidatorComparer);
         }
@@ -240,7 +240,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void Resize_ThrowsForWrappedMemoryImage<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image0 = provider.GetImage())
             {
@@ -262,7 +262,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         public void Resize_WorksWithAllParallelismLevels<TPixel>(
             TestImageProvider<TPixel> provider,
             int maxDegreeOfParallelism)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.Configuration.MaxDegreeOfParallelism =
                 maxDegreeOfParallelism > 0 ? maxDegreeOfParallelism : Environment.ProcessorCount;
@@ -304,7 +304,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
             float? ratio,
             int? specificDestWidth,
             int? specificDestHeight)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             IResampler sampler = TestUtils.GetResampler(samplerName);
 
@@ -356,7 +356,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeFromSourceRectangle<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -384,7 +384,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeHeightAndKeepAspect<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -398,7 +398,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithTestPatternImages(10, 100, DefaultPixelType)]
         public void ResizeHeightCannotKeepAspectKeepsOnePixel<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -411,7 +411,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeWidthAndKeepAspect<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -425,7 +425,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithTestPatternImages(100, 10, DefaultPixelType)]
         public void ResizeWidthCannotKeepAspectKeepsOnePixel<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -438,7 +438,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeWithBoxPadMode<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -458,7 +458,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeWithCropHeightMode<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -474,7 +474,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeWithCropWidthMode<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -490,7 +490,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFile(TestImages.Jpeg.Issues.IncorrectResize1006, DefaultPixelType)]
         public void CanResizeLargeImageWithCropMode<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -510,7 +510,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeWithMaxMode<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -526,7 +526,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeWithMinMode<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -548,7 +548,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeWithPadMode<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -568,7 +568,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), DefaultPixelType)]
         public void ResizeWithStretchMode<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -590,7 +590,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithFile(TestImages.Jpeg.Issues.ExifGetString750Transform, DefaultPixelType)]
         [WithFile(TestImages.Jpeg.Issues.ExifResize1049, DefaultPixelType)]
         public void CanResizeExifIssueImages<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Test images are large so skip on 32bit for now.
             if (!TestEnvironment.Is64BitProcess)

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/RotateFlipTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/RotateFlipTests.cs
@@ -27,7 +27,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithTestPatternImages(nameof(RotateFlipValues), 100, 50, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(RotateFlipValues), 50, 100, PixelTypes.Rgba32)]
         public void RotateFlip<TPixel>(TestImageProvider<TPixel> provider, RotateMode rotateType, FlipMode flipType)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/RotateTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/RotateTests.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithTestPatternImages(nameof(RotateAngles), 100, 50, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(RotateAngles), 50, 100, PixelTypes.Rgba32)]
         public void Rotate_WithAngle<TPixel>(TestImageProvider<TPixel> provider, float value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(ctx => ctx.Rotate(value), value, appendPixelTypeToFileName: false);
         }
@@ -38,7 +38,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [WithTestPatternImages(nameof(RotateEnumValues), 100, 50, PixelTypes.Rgba32)]
         [WithTestPatternImages(nameof(RotateEnumValues), 50, 100, PixelTypes.Rgba32)]
         public void Rotate_WithRotateTypeEnum<TPixel>(TestImageProvider<TPixel> provider, RotateMode value)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(ctx => ctx.Rotate(value), value, appendPixelTypeToFileName: false);
         }

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/SkewTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/SkewTests.cs
@@ -45,7 +45,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithTestPatternImages(nameof(SkewValues), 100, 50, CommonPixelTypes)]
         public void Skew_IsNotBoundToSinglePixelType<TPixel>(TestImageProvider<TPixel> provider, float x, float y)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(ctx => ctx.Skew(x, y), $"{x}_{y}", ValidatorComparer);
         }
@@ -53,7 +53,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         [Theory]
         [WithFile(TestImages.Png.Ducky, nameof(ResamplerNames), PixelTypes.Rgba32)]
         public void Skew_WorksWithAllResamplers<TPixel>(TestImageProvider<TPixel> provider, string resamplerName)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             IResampler sampler = TestUtils.GetResampler(resamplerName);
 

--- a/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
@@ -61,7 +61,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithTestPatternImages(nameof(ResamplerNames), 150, 150, PixelTypes.Rgba32)]
         public void Transform_WithSampler<TPixel>(TestImageProvider<TPixel> provider, string resamplerName)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             IResampler sampler = GetResampler(resamplerName);
             using (Image<TPixel> image = provider.GetImage())
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithSolidFilledImages(nameof(TaperMatrixData), 30, 30, nameof(Color.Red), PixelTypes.Rgba32)]
         public void Transform_WithTaperMatrix<TPixel>(TestImageProvider<TPixel> provider, TaperSide taperSide, TaperCorner taperCorner)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -97,7 +97,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithSolidFilledImages(100, 100, 0, 0, 255, PixelTypes.Rgba32)]
         public void RawTransformMatchesDocumentedExample<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Printing some extra output to help investigating rounding errors:
             this.Output.WriteLine($"Vector.IsHardwareAccelerated: {Vector.IsHardwareAccelerated}");
@@ -122,7 +122,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
         [Theory]
         [WithSolidFilledImages(290, 154, 0, 0, 255, PixelTypes.Rgba32)]
         public void PerspectiveTransformMatchesCSS<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // https://jsfiddle.net/dFrHS/545/
             // https://github.com/SixLabors/ImageSharp/issues/787

--- a/tests/ImageSharp.Tests/Quantization/QuantizedImageTests.cs
+++ b/tests/ImageSharp.Tests/Quantization/QuantizedImageTests.cs
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Tests
         public void OctreeQuantizerYieldsCorrectTransparentPixel<TPixel>(
             TestImageProvider<TPixel> provider,
             bool dither)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -84,7 +84,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32, true)]
         [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32, false)]
         public void WuQuantizerYieldsCorrectTransparentPixel<TPixel>(TestImageProvider<TPixel> provider, bool dither)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -111,7 +111,7 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         private int GetTransparentIndex<TPixel>(QuantizedFrame<TPixel> quantized)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // Transparent pixels are much more likely to be found at the end of a palette
             int index = -1;

--- a/tests/ImageSharp.Tests/Quantization/WuQuantizerTests.cs
+++ b/tests/ImageSharp.Tests/Quantization/WuQuantizerTests.cs
@@ -113,7 +113,7 @@ namespace SixLabors.ImageSharp.Tests.Quantization
         [Theory]
         [WithFile(TestImages.Png.LowColorVariance, PixelTypes.Rgba32)]
         public void LowVariance<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             // See https://github.com/SixLabors/ImageSharp/issues/866
             using (Image<TPixel> image = provider.GetImage())

--- a/tests/ImageSharp.Tests/TestFormat.cs
+++ b/tests/ImageSharp.Tests/TestFormat.cs
@@ -53,7 +53,7 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         public void VerifySpecificDecodeCall<TPixel>(byte[] marker, Configuration config)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             DecodeOperation[] discovered = this.DecodeCalls.Where(x => x.IsMatch(marker, config, typeof(TPixel))).ToArray();
 
@@ -78,7 +78,7 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         public Image<TPixel> Sample<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             lock (this.sampleImages)
             {
@@ -203,7 +203,7 @@ namespace SixLabors.ImageSharp.Tests
             public int HeaderSize => this.testFormat.HeaderSize;
 
             public Image<TPixel> Decode<TPixel>(Configuration config, Stream stream)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 var ms = new MemoryStream();
                 stream.CopyTo(ms);
@@ -238,7 +238,7 @@ namespace SixLabors.ImageSharp.Tests
             public IEnumerable<string> FileExtensions => this.testFormat.SupportedExtensions;
 
             public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 // TODO record this happened so we can verify it.
             }

--- a/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageComparer.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageComparer.cs
@@ -34,8 +34,8 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison
         public abstract ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(
             ImageFrame<TPixelA> expected,
             ImageFrame<TPixelB> actual)
-            where TPixelA : struct, IPixel<TPixelA>
-            where TPixelB : struct, IPixel<TPixelB>;
+            where TPixelA : unmanaged, IPixel<TPixelA>
+            where TPixelB : unmanaged, IPixel<TPixelB>;
     }
 
     public static class ImageComparerExtensions
@@ -44,8 +44,8 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison
             this ImageComparer comparer,
             Image<TPixelA> expected,
             Image<TPixelB> actual)
-            where TPixelA : struct, IPixel<TPixelA>
-            where TPixelB : struct, IPixel<TPixelB>
+            where TPixelA : unmanaged, IPixel<TPixelA>
+            where TPixelB : unmanaged, IPixel<TPixelB>
         {
             return comparer.CompareImagesOrFrames(expected.Frames.RootFrame, actual.Frames.RootFrame);
         }
@@ -54,8 +54,8 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison
             this ImageComparer comparer,
             Image<TPixelA> expected,
             Image<TPixelB> actual)
-            where TPixelA : struct, IPixel<TPixelA>
-            where TPixelB : struct, IPixel<TPixelB>
+            where TPixelA : unmanaged, IPixel<TPixelA>
+            where TPixelB : unmanaged, IPixel<TPixelB>
         {
             var result = new List<ImageSimilarityReport<TPixelA, TPixelB>>();
 
@@ -80,8 +80,8 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison
             this ImageComparer comparer,
             Image<TPixelA> expected,
             Image<TPixelB> actual)
-            where TPixelA : struct, IPixel<TPixelA>
-            where TPixelB : struct, IPixel<TPixelB>
+            where TPixelA : unmanaged, IPixel<TPixelA>
+            where TPixelB : unmanaged, IPixel<TPixelB>
         {
             if (expected.Size() != actual.Size())
             {
@@ -105,8 +105,8 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison
             Image<TPixelA> expected,
             Image<TPixelB> actual,
             Rectangle ignoredRegion)
-            where TPixelA : struct, IPixel<TPixelA>
-            where TPixelB : struct, IPixel<TPixelB>
+            where TPixelA : unmanaged, IPixel<TPixelA>
+            where TPixelB : unmanaged, IPixel<TPixelB>
         {
             if (expected.Size() != actual.Size())
             {

--- a/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageSimilarityReport.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageSimilarityReport.cs
@@ -88,8 +88,8 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison
     }
 
     public class ImageSimilarityReport<TPixelA, TPixelB> : ImageSimilarityReport
-        where TPixelA : struct, IPixel<TPixelA>
-        where TPixelB : struct, IPixel<TPixelB>
+        where TPixelA : unmanaged, IPixel<TPixelA>
+        where TPixelB : unmanaged, IPixel<TPixelB>
     {
         public ImageSimilarityReport(
             ImageFrame<TPixelA> expectedImage,

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/BlankProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/BlankProvider.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 namespace SixLabors.ImageSharp.Tests
 {
     public abstract partial class TestImageProvider<TPixel> : IXunitSerializable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private class BlankProvider : TestImageProvider<TPixel>, IXunitSerializable
         {

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 namespace SixLabors.ImageSharp.Tests
 {
     public abstract partial class TestImageProvider<TPixel> : IXunitSerializable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private class FileProvider : TestImageProvider<TPixel>, IXunitSerializable
         {

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/MemberMethodProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/MemberMethodProvider.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Tests
     /// </summary>
     /// <typeparam name="TPixel">The pixel format of the image</typeparam>
     public abstract partial class TestImageProvider<TPixel> : IXunitSerializable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private class MemberMethodProvider : TestImageProvider<TPixel>
         {

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/SolidProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/SolidProvider.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Tests
     /// </summary>
     /// <typeparam name="TPixel">The pixel format of the image</typeparam>
     public abstract partial class TestImageProvider<TPixel> : IXunitSerializable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         private class SolidProvider : BlankProvider
         {

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests
     /// </summary>
     /// <typeparam name="TPixel">The pixel format of the image.</typeparam>
     public abstract partial class TestImageProvider<TPixel> : ITestImageProvider, IXunitSerializable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         public PixelTypes PixelType { get; private set; } = typeof(TPixel).GetPixelType();
 

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 namespace SixLabors.ImageSharp.Tests
 {
     public abstract partial class TestImageProvider<TPixel> : IXunitSerializable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
         /// A test image provider that produces test patterns.

--- a/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
@@ -211,7 +211,7 @@ namespace SixLabors.ImageSharp.Tests
             IImageEncoder encoder = null,
             object testOutputDetails = null,
             bool appendPixelTypeToFileName = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             encoder = encoder ?? TestEnvironment.GetReferenceEncoder($"foo.{extension}");
 
@@ -276,10 +276,10 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         public static void ModifyPixel<TPixel>(Image<TPixel> img, int x, int y, byte perChannelChange)
-            where TPixel : struct, IPixel<TPixel> => ModifyPixel(img.Frames.RootFrame, x, y, perChannelChange);
+            where TPixel : unmanaged, IPixel<TPixel> => ModifyPixel(img.Frames.RootFrame, x, y, perChannelChange);
 
         public static void ModifyPixel<TPixel>(ImageFrame<TPixel> img, int x, int y, byte perChannelChange)
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
         {
             TPixel pixel = img[x, y];
             Rgba64 rgbaPixel = default;

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         public static MagickReferenceDecoder Instance { get; } = new MagickReferenceDecoder();
 
         private static void FromRgba32Bytes<TPixel>(Configuration configuration, Span<byte> rgbaBytes, IMemoryGroup<TPixel> destinationGroup)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (Memory<TPixel> m in destinationGroup)
             {
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         }
 
         private static void FromRgba64Bytes<TPixel>(Configuration configuration, Span<byte> rgbaBytes, IMemoryGroup<TPixel> destinationGroup)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (Memory<TPixel> m in destinationGroup)
             {
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         }
 
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using var magickImage = new MagickImage(stream);
             var result = new Image<TPixel>(configuration, magickImage.Width, magickImage.Height);

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingBridge.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingBridge.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         /// <param name="bmp">The input bitmap.</param>
         /// <exception cref="ArgumentException">Thrown if the image pixel format is not of type <see cref="PixelFormat.Format32bppArgb"/></exception>
         internal static unsafe Image<TPixel> From32bppArgbSystemDrawingBitmap<TPixel>(Bitmap bmp)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int w = bmp.Width;
             int h = bmp.Height;
@@ -83,7 +83,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         /// <param name="bmp">The input bitmap.</param>
         /// <exception cref="ArgumentException">Thrown if the image pixel format is not of type <see cref="PixelFormat.Format24bppRgb"/></exception>
         internal static unsafe Image<TPixel> From24bppRgbSystemDrawingBitmap<TPixel>(Bitmap bmp)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             int w = bmp.Width;
             int h = bmp.Height;
@@ -133,7 +133,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         }
 
         internal static unsafe Bitmap To32bppArgbSystemDrawingBitmap<TPixel>(Image<TPixel> image)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Configuration configuration = image.GetConfiguration();
             int w = image.Width;

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceDecoder.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         public static SystemDrawingReferenceDecoder Instance { get; } = new SystemDrawingReferenceDecoder();
 
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var sourceBitmap = new System.Drawing.Bitmap(stream))
             {

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceEncoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceEncoder.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         public static SystemDrawingReferenceEncoder Bmp { get; } = new SystemDrawingReferenceEncoder(ImageFormat.Bmp);
 
         public void Encode<TPixel>(Image<TPixel> image, Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (System.Drawing.Bitmap sdBitmap = SystemDrawingBridge.To32bppArgbSystemDrawingBitmap(image))
             {

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp.Tests
             object testOutputDetails = null,
             string extension = "png",
             bool appendPixelTypeToFileName = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (TestEnvironment.RunsOnCI)
             {
@@ -148,7 +148,7 @@ namespace SixLabors.ImageSharp.Tests
             bool grayscale = false,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return image.CompareToReferenceOutput(
                 provider,
@@ -180,7 +180,7 @@ namespace SixLabors.ImageSharp.Tests
             bool grayscale = false,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return CompareToReferenceOutput(
                 image,
@@ -201,7 +201,7 @@ namespace SixLabors.ImageSharp.Tests
             string extension = "png",
             bool grayscale = false,
             bool appendPixelTypeToFileName = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return image.CompareToReferenceOutput(
                 comparer,
@@ -237,7 +237,7 @@ namespace SixLabors.ImageSharp.Tests
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true,
             IImageDecoder decoder = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> referenceImage = GetReferenceOutputImage<TPixel>(
                 provider,
@@ -262,7 +262,7 @@ namespace SixLabors.ImageSharp.Tests
             bool grayscale = false,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return image.CompareFirstFrameToReferenceOutput(
                 comparer,
@@ -283,7 +283,7 @@ namespace SixLabors.ImageSharp.Tests
             bool grayscale = false,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var firstFrameOnlyImage = new Image<TPixel>(image.Width, image.Height))
             using (Image<TPixel> referenceImage = GetReferenceOutputImage<TPixel>(
@@ -310,7 +310,7 @@ namespace SixLabors.ImageSharp.Tests
             string extension = "png",
             bool grayscale = false,
             bool appendPixelTypeToFileName = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> referenceImage = GetReferenceOutputImageMultiFrame<TPixel>(
                 provider,
@@ -332,7 +332,7 @@ namespace SixLabors.ImageSharp.Tests
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true,
             IImageDecoder decoder = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string referenceOutputFile = provider.Utility.GetReferenceOutputFileName(
                 extension,
@@ -356,7 +356,7 @@ namespace SixLabors.ImageSharp.Tests
             object testOutputDetails = null,
             string extension = "png",
             bool appendPixelTypeToFileName = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string[] frameFiles = provider.Utility.GetReferenceOutputFileNamesMultiFrame(
                 frameCount,
@@ -401,7 +401,7 @@ namespace SixLabors.ImageSharp.Tests
             object testOutputDetails = null,
             string extension = "png",
             bool appendPixelTypeToFileName = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> referenceImage = provider.GetReferenceOutputImage<TPixel>(
                 testOutputDetails,
@@ -415,7 +415,7 @@ namespace SixLabors.ImageSharp.Tests
         public static Image<TPixel> ComparePixelBufferTo<TPixel>(
             this Image<TPixel> image,
             Span<TPixel> expectedPixels)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Span<TPixel> actualPixels = image.GetPixelSpan();
 
@@ -444,7 +444,7 @@ namespace SixLabors.ImageSharp.Tests
         /// <typeparam name="TPixel">The pixel type of the image.</typeparam>
         /// <returns>The image.</returns>
         public static Image<TPixel> ComparePixelBufferTo<TPixel>(this Image<TPixel> image, TPixel expectedPixel)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (ImageFrame<TPixel> imageFrame in image.Frames)
             {
@@ -460,7 +460,7 @@ namespace SixLabors.ImageSharp.Tests
         /// <typeparam name="TPixel">The pixel type of the image.</typeparam>
         /// <returns>The image.</returns>
         public static Image<TPixel> ComparePixelBufferTo<TPixel>(this Image<TPixel> image, Color expectedPixelColor)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (ImageFrame<TPixel> imageFrame in image.Frames)
             {
@@ -476,7 +476,7 @@ namespace SixLabors.ImageSharp.Tests
         /// <typeparam name="TPixel">The pixel type of the image.</typeparam>
         /// <returns>The image.</returns>
         public static ImageFrame<TPixel> ComparePixelBufferTo<TPixel>(this ImageFrame<TPixel> imageFrame, TPixel expectedPixel)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Span<TPixel> actualPixels = imageFrame.GetPixelSpan();
 
@@ -491,7 +491,7 @@ namespace SixLabors.ImageSharp.Tests
         public static ImageFrame<TPixel> ComparePixelBufferTo<TPixel>(
                     this ImageFrame<TPixel> image,
                     Span<TPixel> expectedPixels)
-                    where TPixel : struct, IPixel<TPixel>
+                    where TPixel : unmanaged, IPixel<TPixel>
         {
             Span<TPixel> actual = image.GetPixelSpan();
 
@@ -509,7 +509,7 @@ namespace SixLabors.ImageSharp.Tests
             this Image<TPixel> image,
             ITestImageProvider provider,
             IImageDecoder referenceDecoder = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             return CompareToOriginal(image, provider, ImageComparer.Tolerant(), referenceDecoder);
         }
@@ -519,7 +519,7 @@ namespace SixLabors.ImageSharp.Tests
             ITestImageProvider provider,
             ImageComparer comparer,
             IImageDecoder referenceDecoder = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string path = TestImageProvider<TPixel>.GetFilePathOrNull(provider);
             if (path == null)
@@ -552,7 +552,7 @@ namespace SixLabors.ImageSharp.Tests
             FormattableString testOutputDetails,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -585,7 +585,7 @@ namespace SixLabors.ImageSharp.Tests
             FormattableString testOutputDetails,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.VerifyOperation(
                 ImageComparer.Tolerant(),
@@ -607,7 +607,7 @@ namespace SixLabors.ImageSharp.Tests
             Action<Image<TPixel>> operation,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.VerifyOperation(
                 comparer,
@@ -628,7 +628,7 @@ namespace SixLabors.ImageSharp.Tests
             Action<Image<TPixel>> operation,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.VerifyOperation(operation, $"", appendPixelTypeToFileName, appendSourceFileOrDescription);
         }
@@ -647,7 +647,7 @@ namespace SixLabors.ImageSharp.Tests
             bool appendPixelTypeToFileName = true,
             string referenceImageExtension = null,
             IImageDecoder referenceDecoder = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string actualOutputFile = provider.Utility.SaveTestOutputFile(
                 image,
@@ -667,7 +667,7 @@ namespace SixLabors.ImageSharp.Tests
 
         internal static AllocatorBufferCapacityConfigurator LimitAllocatorBufferCapacity<TPixel>(
             this TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var allocator = (ArrayPoolMemoryAllocator)provider.Configuration.MemoryAllocator;
             return new AllocatorBufferCapacityConfigurator(allocator, Unsafe.SizeOf<TPixel>());
@@ -694,12 +694,12 @@ namespace SixLabors.ImageSharp.Tests
         private class MakeOpaqueProcessor : IImageProcessor
         {
             public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
                 => new MakeOpaqueProcessor<TPixel>(configuration, source, sourceRectangle);
         }
 
         private class MakeOpaqueProcessor<TPixel> : ImageProcessor<TPixel>
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             public MakeOpaqueProcessor(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
                 : base(configuration, source, sourceRectangle)

--- a/tests/ImageSharp.Tests/TestUtilities/TestPixel.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestPixel.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace SixLabors.ImageSharp.Tests.TestUtilities
 {
     public class TestPixel<TPixel> : IXunitSerializable
-        where TPixel : struct, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         public TestPixel()
         {

--- a/tests/ImageSharp.Tests/TestUtilities/TestUtils.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestUtils.cs
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Tests
         public static bool HasFlag(this PixelTypes pixelTypes, PixelTypes flag) => (pixelTypes & flag) == flag;
 
         public static bool IsEquivalentTo<TPixel>(this Image<TPixel> a, Image<TPixel> b, bool compareAlpha = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (a.Width != b.Width || a.Height != b.Height)
             {
@@ -149,7 +149,7 @@ namespace SixLabors.ImageSharp.Tests
         }
 
         internal static TPixel GetPixelOfNamedColor<TPixel>(string colorName)
-            where TPixel : struct, IPixel<TPixel> =>
+            where TPixel : unmanaged, IPixel<TPixel> =>
             GetColorByName(colorName).ToPixel<TPixel>();
 
         internal static void RunBufferCapacityLimitProcessorTest<TPixel>(
@@ -158,7 +158,7 @@ namespace SixLabors.ImageSharp.Tests
             Action<IImageProcessingContext> process,
             object testOutputDetails = null,
             ImageComparer comparer = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             comparer??= ImageComparer.Exact;
             using Image<TPixel> expected = provider.GetImage();
@@ -193,7 +193,7 @@ namespace SixLabors.ImageSharp.Tests
             ImageComparer comparer = null,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (comparer == null)
             {
@@ -229,7 +229,7 @@ namespace SixLabors.ImageSharp.Tests
             ImageComparer comparer = null,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (comparer == null)
             {
@@ -268,7 +268,7 @@ namespace SixLabors.ImageSharp.Tests
             string useReferenceOutputFrom = null,
             bool appendPixelTypeToFileName = true,
             bool appendSourceFileOrDescription = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (comparer == null)
             {
@@ -320,7 +320,7 @@ namespace SixLabors.ImageSharp.Tests
             object testOutputDetails = null,
             ImageComparer comparer = null,
             bool appendPixelTypeToFileName = true)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (comparer == null)
             {
@@ -343,7 +343,7 @@ namespace SixLabors.ImageSharp.Tests
             this TestImageProvider<TPixel> provider,
             Action<IImageProcessingContext> process,
             object testOutputDetails = null)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/GroupOutputTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/GroupOutputTests.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithBlankImages(1, 1, PixelTypes.Rgba32)]
         public void OutputSubfolderName_ValueIsTakeFromGroupOutputAttribute<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Assert.Equal("Foo", provider.Utility.OutputSubfolderName);
         }
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithBlankImages(1, 1, PixelTypes.Rgba32)]
         public void GetTestOutputDir_ShouldDefineSubfolder<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string expected = $"{Path.DirectorySeparatorChar}Foo{Path.DirectorySeparatorChar}";
             Assert.Contains(expected, provider.Utility.GetTestOutputDir());

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/ImageComparerTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/ImageComparerTests.cs
@@ -31,7 +31,7 @@ namespace SixLabors.ImageSharp.Tests
             TestImageProvider<TPixel> provider,
             float imageThreshold,
             int pixelThreshold)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -46,7 +46,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithTestPatternImages(110, 110, PixelTypes.Rgba32)]
         public void TolerantImageComparer_ApprovesSimilarityBelowTolerance<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithTestPatternImages(100, 100, PixelTypes.Rgba32)]
         public void TolerantImageComparer_DoesNotApproveSimilarityAboveTolerance<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithTestPatternImages(100, 100, PixelTypes.Rgba64)]
         public void TolerantImageComparer_TestPerPixelThreshold<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -106,7 +106,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithTestPatternImages(100, 100, PixelTypes.Rgba32, 99, 100)]
         [WithTestPatternImages(100, 100, PixelTypes.Rgba32, 100, 99)]
         public void VerifySimilarity_ThrowsOnSizeMismatch<TPixel>(TestImageProvider<TPixel> provider, int w, int h)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -126,7 +126,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
         public void VerifySimilarity_WhenAnImageFrameIsDifferent_Reports<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -145,7 +145,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithTestPatternImages(100, 100, PixelTypes.Rgba32)]
         public void ExactComparer_ApprovesExactEquality<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -159,7 +159,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithTestPatternImages(100, 100, PixelTypes.Rgba32)]
         public void ExactComparer_DoesNotTolerateAnyPixelDifference<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/MagickReferenceCodecTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/MagickReferenceCodecTests.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [WithBlankImages(1, 1, PixelTypesToTest32, TestImages.Png.Splash)]
         [WithBlankImages(1, 1, PixelTypesToTest32, TestImages.Png.Indexed)]
         public void MagickDecode_8BitDepthImage_IsEquivalentTo_SystemDrawingResult<TPixel>(TestImageProvider<TPixel> dummyProvider, string testImage)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string path = TestFile.GetInputFileFullPath(testImage);
 
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [WithBlankImages(1, 1, PixelTypesToTest48, TestImages.Png.Rgb48BppTrans)]
         [WithBlankImages(1, 1, PixelTypesToTest48, TestImages.Png.L16Bit)]
         public void MagickDecode_16BitDepthImage_IsApproximatelyEquivalentTo_SystemDrawingResult<TPixel>(TestImageProvider<TPixel> dummyProvider, string testImage)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string path = TestFile.GetInputFileFullPath(testImage);
 

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/ReferenceDecoderBenchmarks.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/ReferenceDecoderBenchmarks.cs
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory(Skip = SkipBenchmarks)]
         [WithFile(TestImages.Png.Kaboom, PixelTypes.Rgba32)]
         public void BenchmarkMagickPngDecoder<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.BenchmarkDecoderImpl(PngBenchmarkFiles, new MagickReferenceDecoder(), "Magick Decode Png");
         }
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory(Skip = SkipBenchmarks)]
         [WithFile(TestImages.Png.Kaboom, PixelTypes.Rgba32)]
         public void BenchmarkSystemDrawingPngDecoder<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.BenchmarkDecoderImpl(PngBenchmarkFiles, new SystemDrawingReferenceDecoder(), "System.Drawing Decode Png");
         }
@@ -65,7 +65,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory(Skip = SkipBenchmarks)]
         [WithFile(TestImages.Png.Kaboom, PixelTypes.Rgba32)]
         public void BenchmarkMagickBmpDecoder<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.BenchmarkDecoderImpl(BmpBenchmarkFiles, new MagickReferenceDecoder(), "Magick Decode Bmp");
         }
@@ -73,7 +73,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory(Skip = SkipBenchmarks)]
         [WithFile(TestImages.Png.Kaboom, PixelTypes.Rgba32)]
         public void BenchmarkSystemDrawingBmpDecoder<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.BenchmarkDecoderImpl(BmpBenchmarkFiles, new SystemDrawingReferenceDecoder(), "System.Drawing Decode Bmp");
         }

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/SystemDrawingReferenceCodecTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/SystemDrawingReferenceCodecTests.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory]
         [WithTestPatternImages(20, 20, PixelTypes.Rgba32 | PixelTypes.Bgra32)]
         public void To32bppArgbSystemDrawingBitmap<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -39,7 +39,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory]
         [WithBlankImages(1, 1, PixelTypes.Rgba32 | PixelTypes.Bgra32)]
         public void From32bppArgbSystemDrawingBitmap<TPixel>(TestImageProvider<TPixel> dummyProvider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string path = TestFile.GetInputFileFullPath(TestImages.Png.Splash);
 
@@ -53,7 +53,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         }
 
         private static string SavePng<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> sourceImage = provider.GetImage())
             {
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory]
         [WithTestPatternImages(100, 100, PixelTypes.Rgba32)]
         public void From32bppArgbSystemDrawingBitmap2<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (TestEnvironment.IsLinux)
             {
@@ -93,7 +93,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory]
         [WithTestPatternImages(100, 100, PixelTypes.Rgb24)]
         public void From24bppRgbSystemDrawingBitmap<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string path = SavePng(provider, PngColorType.Rgb);
 
@@ -113,7 +113,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory]
         [WithBlankImages(1, 1, PixelTypes.Rgba32 | PixelTypes.Bgra32)]
         public void OpenWithReferenceDecoder<TPixel>(TestImageProvider<TPixel> dummyProvider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             string path = TestFile.GetInputFileFullPath(TestImages.Png.Splash);
             using (var image = Image.Load<TPixel>(path, SystemDrawingReferenceDecoder.Instance))
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         [Theory]
         [WithTestPatternImages(20, 20, PixelTypes.Rgba32 | PixelTypes.Argb32)]
         public void SaveWithReferenceEncoder<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageExtensionsTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithSolidFilledImages(10, 10, 0, 0, 255, PixelTypes.Rgba32)]
         public void CompareToReferenceOutput_WhenReferenceOutputMatches_ShouldNotThrow<TPixel>(
             TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithSolidFilledImages(10, 10, 0, 0, 255, PixelTypes.Rgba32)]
         public void CompareToReferenceOutput_WhenReferenceOutputDoesNotMatch_Throws<TPixel>(
             TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithSolidFilledImages(10, 10, 0, 0, 255, PixelTypes.Rgba32)]
         public void CompareToReferenceOutput_DoNotAppendPixelType<TPixel>(
             TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithSolidFilledImages(10, 10, 0, 0, 255, PixelTypes.Rgba32)]
         public void CompareToReferenceOutput_WhenReferenceFileMissing_Throws<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -65,7 +65,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void CompareToOriginal_WhenSimilar<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithFile(TestImages.Png.CalliphoraPartial, PixelTypes.Rgba32)]
         public void CompareToOriginal_WhenDifferent_Throws<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -95,7 +95,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithBlankImages(10, 10, PixelTypes.Rgba32)]
         public void CompareToOriginal_WhenInputIsNotFromFile_Throws<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageProviderTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageProviderTests.cs
@@ -42,13 +42,13 @@ namespace SixLabors.ImageSharp.Tests
         /// <typeparam name="TPixel">The pixel type of the image.</typeparam>
         /// <returns>A test image.</returns>
         public static Image<TPixel> CreateTestImage<TPixel>()
-            where TPixel : struct, IPixel<TPixel> =>
+            where TPixel : unmanaged, IPixel<TPixel> =>
             new Image<TPixel>(3, 3);
 
         [Theory]
         [MemberData(nameof(BasicData))]
         public void Blank_MemberData<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Image<TPixel> img = provider.GetImage();
 
@@ -58,7 +58,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [MemberData(nameof(FileData))]
         public void File_MemberData<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             this.Output.WriteLine("SRC: " + provider.Utility.SourceFileOrDescription);
             this.Output.WriteLine("OUT: " + provider.Utility.GetTestOutputFileName());
@@ -72,7 +72,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithFile(TestImages.Bmp.F, PixelTypes.Rgba32)]
         public void GetImage_WithCustomParameterlessDecoder_ShouldUtilizeCache<TPixel>(
             TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (!TestEnvironment.Is64BitProcess)
             {
@@ -102,7 +102,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithFile(TestImages.Bmp.F, PixelTypes.Rgba32)]
         public void GetImage_WithCustomParametricDecoder_ShouldNotUtilizeCache_WhenParametersAreNotEqual<TPixel>(
             TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Assert.NotNull(provider.Utility.SourceFileOrDescription);
 
@@ -130,7 +130,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithFile(TestImages.Bmp.F, PixelTypes.Rgba32)]
         public void GetImage_WithCustomParametricDecoder_ShouldUtilizeCache_WhenParametersAreEqual<TPixel>(
             TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             if (!TestEnvironment.Is64BitProcess)
             {
@@ -163,7 +163,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithBlankImages(1, 1, PixelTypes.Rgba32)]
         public void NoOutputSubfolderIsPresentByDefault<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel> =>
+            where TPixel : unmanaged, IPixel<TPixel> =>
             Assert.Empty(provider.Utility.OutputSubfolderName);
 
         [Theory]
@@ -171,13 +171,13 @@ namespace SixLabors.ImageSharp.Tests
         [WithBlankImages(1, 1, PixelTypes.A8, PixelTypes.A8)]
         [WithBlankImages(1, 1, PixelTypes.Argb32, PixelTypes.Argb32)]
         public void PixelType_PropertyValueIsCorrect<TPixel>(TestImageProvider<TPixel> provider, PixelTypes expected)
-            where TPixel : struct, IPixel<TPixel> =>
+            where TPixel : unmanaged, IPixel<TPixel> =>
             Assert.Equal(expected, provider.PixelType);
 
         [Theory]
         [WithFile(TestImages.Gif.Giphy, PixelTypes.Rgba32)]
         public void SaveTestOutputFileMultiFrame<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage())
             {
@@ -197,7 +197,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithBasicTestPatternImages(49, 17, PixelTypes.Rgba32)]
         [WithBasicTestPatternImages(20, 10, PixelTypes.Rgba32)]
         public void Use_WithBasicTestPatternImages<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> img = provider.GetImage())
             {
@@ -210,7 +210,7 @@ namespace SixLabors.ImageSharp.Tests
         public void Use_WithBlankImagesAttribute_WithAllPixelTypes<TPixel>(
             TestImageProvider<TPixel> provider,
             string message)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Image<TPixel> img = provider.GetImage();
 
@@ -222,7 +222,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithBlankImages(42, 666, PixelTypes.Rgba32 | PixelTypes.Argb32 | PixelTypes.HalfSingle, "hello")]
         public void Use_WithEmptyImageAttribute<TPixel>(TestImageProvider<TPixel> provider, string message)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Image<TPixel> img = provider.GetImage();
 
@@ -235,7 +235,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithFile(TestImages.Bmp.Car, PixelTypes.All, 123)]
         [WithFile(TestImages.Bmp.F, PixelTypes.All, 123)]
         public void Use_WithFileAttribute<TPixel>(TestImageProvider<TPixel> provider, int yo)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Assert.NotNull(provider.Utility.SourceFileOrDescription);
             using (Image<TPixel> img = provider.GetImage())
@@ -252,7 +252,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithFile(TestImages.Jpeg.Baseline.Testorig420, PixelTypes.Rgba32)]
         public void Use_WithFileAttribute_CustomConfig<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             EnsureCustomConfigurationIsApplied(provider);
         }
@@ -260,7 +260,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithFileCollection(nameof(AllBmpFiles), PixelTypes.Rgba32 | PixelTypes.Argb32)]
         public void Use_WithFileCollection<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Assert.NotNull(provider.Utility.SourceFileOrDescription);
             using (Image<TPixel> image = provider.GetImage())
@@ -272,7 +272,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithMemberFactory(nameof(CreateTestImage), PixelTypes.All)]
         public void Use_WithMemberFactoryAttribute<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Image<TPixel> img = provider.GetImage();
             Assert.Equal(3, img.Width);
@@ -285,7 +285,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithSolidFilledImages(10, 20, 255, 100, 50, 200, PixelTypes.Rgba32 | PixelTypes.Argb32)]
         public void Use_WithSolidFilledImagesAttribute<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Image<TPixel> img = provider.GetImage();
             Assert.Equal(10, img.Width);
@@ -310,7 +310,7 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithTestPatternImages(49, 20, PixelTypes.Rgba32)]
         public void Use_WithTestPatternImages<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> img = provider.GetImage())
             {
@@ -321,13 +321,13 @@ namespace SixLabors.ImageSharp.Tests
         [Theory]
         [WithTestPatternImages(20, 20, PixelTypes.Rgba32)]
         public void Use_WithTestPatternImages_CustomConfiguration<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             EnsureCustomConfigurationIsApplied(provider);
         }
 
         private static void EnsureCustomConfigurationIsApplied<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             using (provider.GetImage())
             {
@@ -362,7 +362,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 InvocationCounts[this.callerName]++;
                 return new Image<TPixel>(42, 42);
@@ -401,7 +401,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
-                where TPixel : struct, IPixel<TPixel>
+                where TPixel : unmanaged, IPixel<TPixel>
             {
                 InvocationCounts[this.callerName]++;
                 return new Image<TPixel>(42, 42);

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestUtilityExtensionsTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestUtilityExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Tests
         private ITestOutputHelper Output { get; }
 
         public static Image<TPixel> CreateTestImage<TPixel>()
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             var image = new Image<TPixel>(10, 10);
 
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithFile(TestImages.Bmp.Car, PixelTypes.Rgba32, true)]
         [WithFile(TestImages.Bmp.Car, PixelTypes.Rgba32, false)]
         public void IsEquivalentTo_WhenFalse<TPixel>(TestImageProvider<TPixel> provider, bool compareAlpha)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Image<TPixel> a = provider.GetImage();
             Image<TPixel> b = provider.GetImage(x => x.OilPaint(3, 2));
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.Tests
         [WithMemberFactory(nameof(CreateTestImage), PixelTypes.Rgba32 | PixelTypes.Bgr565, true)]
         [WithMemberFactory(nameof(CreateTestImage), PixelTypes.Rgba32 | PixelTypes.Bgr565, false)]
         public void IsEquivalentTo_WhenTrue<TPixel>(TestImageProvider<TPixel> provider, bool compareAlpha)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Image<TPixel> a = provider.GetImage();
             Image<TPixel> b = provider.GetImage();

--- a/tests/ImageSharp.Tests/VectorAssert.cs
+++ b/tests/ImageSharp.Tests/VectorAssert.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Tests
     public static class VectorAssert
     {
         public static void Equal<TPixel>(TPixel expected, TPixel actual, int precision = int.MaxValue)
-            where TPixel : struct, IPixel<TPixel>
+            where TPixel : unmanaged, IPixel<TPixel>
         {
             Equal(expected.ToVector4(), actual.ToVector4(), precision);
         }


### PR DESCRIPTION
Fixes #1111.

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
- [X] Upgrading all the various `struct` constraints to unmanaged (eg. in `where TPixel : unmanaged, IPixel<TPixel>`, instead of the previous `where TPixel : struct, IPixel<TPixel>`)
- [X] Marking all the `struct`-s, or at least all the various method/property getters/etc. as `readonly` as possible (this is more expressive and avoids safety copies by the compiler)
