### PR TITLE
Text segment ReadOnlySpan<byte> initialization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -368,8 +368,6 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 csharp_style_unused_value_assignment_preference = discard_variable:suggestion
 
-csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_for_built_in_types = never
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = false:warning
-
-csharp_prefer_simple_using_statement = false:silent

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = tests/Images/External
 	url = https://github.com/SixLabors/Imagesharp.Tests.Images.git
 	branch = master
+[submodule "shared-infrastructure"]
+	path = shared-infrastructure
+	url = https://github.com/SixLabors/SharedInfrastructure

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = tests/Images/External
 	url = https://github.com/SixLabors/Imagesharp.Tests.Images.git
 	branch = master
-[submodule "shared-infrastructure"]
-	path = shared-infrastructure
-	url = https://github.com/SixLabors/SharedInfrastructure

--- a/ImageSharp.sln
+++ b/ImageSharp.sln
@@ -334,6 +334,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageSharp.Tests.ProfilingS
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems*{2aa31a1f-142c-43f4-8687-09abca4b3a26}*SharedItemsImports = 5
 		shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems*{68a8cc40-6aed-4e96-b524-31b1158fdeea}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -34,4 +34,6 @@
     <InternalsVisibleTo Include="SixLabors.ImageSharp.Tests" PublicKey="$(SixLaborsPublicKey)" />
   </ItemGroup>
 
+
+  
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -55,17 +55,34 @@
   <ItemGroup>
     <!--Shared config files that have to exist at root level.-->
     <ConfigFilesToCopy Include="..\..\shared-infrastructure\.editorconfig;..\..\shared-infrastructure\.gitattributes" />
+    <!--
+    Copy submodule files generated via T4 templates.
+    We cannot include the generated files in the submodule as any solution wide T4 regeneration
+    could potentially cause the module to be marked dirty which is a headache.
+    This, instead, combined with using 'Compile Update' over 'Include' allows us to copy the file
+    across from the submodule and place it directly in the src folder for compilation.    
+    -->
+    <SubmoduleSourceFilesToCopy Include="..\..\shared-infrastructure\src\SharedInfrastructure\Guard.Numeric.cs" />
   </ItemGroup>
 
   <!--Ensures our config files are up to date.-->
   <Target Name="CopyFiles" BeforeTargets="Build">
-    <Copy SourceFiles="@(ConfigFilesToCopy)" DestinationFolder="..\..\" />
+    <Copy SourceFiles="@(ConfigFilesToCopy)"
+          SkipUnchangedFiles = "true"
+          DestinationFolder="..\..\" />
+    
+    <Copy SourceFiles="@(SubmoduleSourceFilesToCopy)"
+          DestinationFolder="..\..\src\ImageSharp\Common\Helpers"
+          SkipUnchangedFiles="true"
+          ContinueOnError="true" />
   </Target>
   
   <!-- Allows regenerating T4-generated files at build time using MsBuild -->
+  <!-- Enable on Windows OS to build all T4 templates. TODO: XPlat
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TextTemplating\Microsoft.TextTemplating.targets" />
   <PropertyGroup>
     <TransformOnBuild>true</TransformOnBuild>
   </PropertyGroup>
+  -->
   
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -52,4 +52,20 @@
   <!-- https://github.com/Microsoft/vstest/issues/411 -->
   <Target Name="VSTest" Condition="'$(IsTestProject)' == 'true'"/>
 
+  <ItemGroup>
+    <!--Shared config files that have to exist at root level.-->
+    <ConfigFilesToCopy Include="..\..\shared-infrastructure\.editorconfig;..\..\shared-infrastructure\.gitattributes" />
+  </ItemGroup>
+
+  <!--Ensures our config files are up to date.-->
+  <Target Name="CopyFiles" BeforeTargets="Build">
+    <Copy SourceFiles="@(ConfigFilesToCopy)" DestinationFolder="..\..\" />
+  </Target>
+  
+  <!-- Allows regenerating T4-generated files at build time using MsBuild -->
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TextTemplating\Microsoft.TextTemplating.targets" />
+  <PropertyGroup>
+    <TransformOnBuild>true</TransformOnBuild>
+  </PropertyGroup>
+  
 </Project>

--- a/src/ImageSharp/Common/Extensions/StreamExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/StreamExtensions.cs
@@ -4,6 +4,9 @@
 using System;
 using System.IO;
 using SixLabors.ImageSharp.Memory;
+#if !SUPPORTS_SPAN_STREAM
+using System.Buffers;
+#endif
 
 namespace SixLabors.ImageSharp
 {

--- a/src/ImageSharp/Common/Extensions/StreamExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/StreamExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Buffers;
 using System.IO;
 using SixLabors.ImageSharp.Memory;
 

--- a/src/ImageSharp/Common/Helpers/Guard.Numeric.cs
+++ b/src/ImageSharp/Common/Helpers/Guard.Numeric.cs
@@ -1,0 +1,1154 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace SixLabors
+{
+    /// <summary>
+    /// Provides methods to protect against invalid parameters.
+    /// </summary>
+    internal static partial class Guard
+    {
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(byte value, byte max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(byte value, byte max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(byte value, byte min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(byte value, byte min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(byte value, byte min, byte max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(sbyte value, sbyte max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(sbyte value, sbyte max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(sbyte value, sbyte min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(sbyte value, sbyte min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(sbyte value, sbyte min, sbyte max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(short value, short max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(short value, short max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(short value, short min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(short value, short min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(short value, short min, short max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(ushort value, ushort max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(ushort value, ushort max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(ushort value, ushort min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(ushort value, ushort min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(ushort value, ushort min, ushort max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(char value, char max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(char value, char max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(char value, char min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(char value, char min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(char value, char min, char max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(int value, int max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(int value, int max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(int value, int min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(int value, int min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(int value, int min, int max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(uint value, uint max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(uint value, uint max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(uint value, uint min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(uint value, uint min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(uint value, uint min, uint max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(float value, float max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(float value, float max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(float value, float min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(float value, float min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(float value, float min, float max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(long value, long max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(long value, long max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(long value, long min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(long value, long min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(long value, long min, long max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(ulong value, ulong max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(ulong value, ulong max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(ulong value, ulong min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(ulong value, ulong min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(ulong value, ulong min, ulong max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(double value, double max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(double value, double max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(double value, double min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(double value, double min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(double value, double min, double max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the specified value is less than a maximum value.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThan(decimal value, decimal max, string parameterName)
+        {
+            if (value >= max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is less than or equal to a maximum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeLessThanOrEqualTo(decimal value, decimal max, string parameterName)
+        {
+            if (value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThan(decimal value, decimal min, string parameterName)
+        {
+            if (value <= min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value
+        /// and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeGreaterThanOrEqualTo(decimal value, decimal min, string parameterName)
+        {
+            if (value < min)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the specified value is greater than or equal to a minimum value and less than
+        /// or equal to a maximum value and throws an exception if it is not.
+        /// </summary>
+        /// <param name="value">The target value, which should be validated.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is less than the minimum value of greater than the maximum value.
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MustBeBetweenOrEqualTo(decimal value, decimal min, decimal max, string parameterName)
+        {
+            if (value < min || value > max)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Common/Helpers/Guard.cs
+++ b/src/ImageSharp/Common/Helpers/Guard.cs
@@ -22,7 +22,7 @@ namespace SixLabors
         {
             if (!value.GetType().GetTypeInfo().IsValueType)
             {
-                ThrowArgumentException("Type must be a struct.", parameterName);
+                ThrowHelper.ThrowArgumentException("Type must be a struct.", parameterName);
             }
         }
     }

--- a/src/ImageSharp/Formats/Gif/GifConstants.cs
+++ b/src/ImageSharp/Formats/Gif/GifConstants.cs
@@ -93,6 +93,16 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public static readonly Encoding Encoding = Encoding.ASCII;
 
         /// <summary>
+        /// The collection of mimetypes that equate to a Gif.
+        /// </summary>
+        public static readonly IEnumerable<string> MimeTypes = new[] { "image/gif" };
+
+        /// <summary>
+        /// The collection of file extensions that equate to a Gif.
+        /// </summary>
+        public static readonly IEnumerable<string> FileExtensions = new[] { "gif" };
+
+        /// <summary>
         /// Gets the ASCII encoded bytes used to identify the GIF file (combining <see cref="FileType"/> and <see cref="FileVersion"/>).
         /// </summary>
         internal static ReadOnlySpan<byte> MagicNumber => new[]
@@ -111,15 +121,5 @@ namespace SixLabors.ImageSharp.Formats.Gif
             (byte)'P', (byte)'E',
             (byte)'2', (byte)'.', (byte)'0'
         };
-
-        /// <summary>
-        /// The collection of mimetypes that equate to a Gif.
-        /// </summary>
-        public static readonly IEnumerable<string> MimeTypes = new[] { "image/gif" };
-
-        /// <summary>
-        /// The collection of file extensions that equate to a Gif.
-        /// </summary>
-        public static readonly IEnumerable<string> FileExtensions = new[] { "gif" };
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifConstants.cs
+++ b/src/ImageSharp/Formats/Gif/GifConstants.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -20,11 +21,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// The file version.
         /// </summary>
         public const string FileVersion = "89a";
-
-        /// <summary>
-        /// The ASCII encoded bytes used to identify the GIF file.
-        /// </summary>
-        internal static readonly byte[] MagicNumber = Encoding.ASCII.GetBytes(FileType + FileVersion);
 
         /// <summary>
         /// The extension block introducer <value>!</value>.
@@ -50,11 +46,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// The application identification.
         /// </summary>
         public const string NetscapeApplicationIdentification = "NETSCAPE2.0";
-
-        /// <summary>
-        /// The ASCII encoded application identification bytes.
-        /// </summary>
-        internal static readonly byte[] NetscapeApplicationIdentificationBytes = Encoding.ASCII.GetBytes(NetscapeApplicationIdentification);
 
         /// <summary>
         /// The Netscape looping application sub block size.
@@ -100,6 +91,26 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// The character encoding to use when reading and writing comments - (ASCII 7bit).
         /// </summary>
         public static readonly Encoding Encoding = Encoding.ASCII;
+
+        /// <summary>
+        /// Gets the ASCII encoded bytes used to identify the GIF file (combining <see cref="FileType"/> and <see cref="FileVersion"/>).
+        /// </summary>
+        internal static ReadOnlySpan<byte> MagicNumber => new[]
+        {
+            (byte)'G', (byte)'I', (byte)'F',
+            (byte)'8', (byte)'9', (byte)'a'
+        };
+
+        /// <summary>
+        /// Gets the ASCII encoded application identification bytes (representing <see cref="NetscapeApplicationIdentification"/>).
+        /// </summary>
+        internal static ReadOnlySpan<byte> NetscapeApplicationIdentificationBytes => new[]
+        {
+            (byte)'N', (byte)'E', (byte)'T',
+            (byte)'S', (byte)'C', (byte)'A',
+            (byte)'P', (byte)'E',
+            (byte)'2', (byte)'.', (byte)'0'
+        };
 
         /// <summary>
         /// The collection of mimetypes that equate to a Gif.

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -238,7 +238,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         /// <param name="stream">The stream to write to.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteHeader(Stream stream) => stream.Write(GifConstants.MagicNumber, 0, GifConstants.MagicNumber.Length);
+        private void WriteHeader(Stream stream) => stream.Write(GifConstants.MagicNumber);
 
         /// <summary>
         /// Writes the logical screen descriptor to the stream.

--- a/src/ImageSharp/Formats/Gif/Sections/GifNetscapeLoopingApplicationExtension.cs
+++ b/src/ImageSharp/Formats/Gif/Sections/GifNetscapeLoopingApplicationExtension.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             buffer[0] = GifConstants.ApplicationBlockSize;
 
             // Write NETSCAPE2.0
-            GifConstants.NetscapeApplicationIdentificationBytes.AsSpan().CopyTo(buffer.Slice(1, 11));
+            GifConstants.NetscapeApplicationIdentificationBytes.CopyTo(buffer.Slice(1, 11));
 
             // Application Data ----
             buffer[12] = 3; // Application block length (always 3)

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ProfileResolver.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ProfileResolver.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Text;
 
 namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 {
@@ -12,24 +11,38 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
     internal static class ProfileResolver
     {
         /// <summary>
-        /// Describes the JFIF specific markers.
+        /// Gets the JFIF specific markers.
         /// </summary>
-        public static readonly byte[] JFifMarker = Encoding.ASCII.GetBytes("JFIF\0");
+        public static ReadOnlySpan<byte> JFifMarker => new[]
+        {
+            (byte)'J', (byte)'F', (byte)'I', (byte)'F', (byte)'\0'
+        };
 
         /// <summary>
-        /// Describes the ICC specific markers.
+        /// Gets the ICC specific markers.
         /// </summary>
-        public static readonly byte[] IccMarker = Encoding.ASCII.GetBytes("ICC_PROFILE\0");
+        public static ReadOnlySpan<byte> IccMarker => new[]
+        {
+            (byte)'I', (byte)'C', (byte)'C', (byte)'_',
+            (byte)'P', (byte)'R', (byte)'O', (byte)'F',
+            (byte)'I', (byte)'L', (byte)'E', (byte)'\0'
+        };
 
         /// <summary>
-        /// Describes the EXIF specific markers.
+        /// Gets the EXIF specific markers.
         /// </summary>
-        public static readonly byte[] ExifMarker = Encoding.ASCII.GetBytes("Exif\0\0");
+        public static ReadOnlySpan<byte> ExifMarker => new[]
+        {
+            (byte)'E', (byte)'x', (byte)'i', (byte)'f', (byte)'\0', (byte)'\0'
+        };
 
         /// <summary>
-        /// Describes Adobe specific markers <see href="http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/JPEG.html#Adobe"/>.
+        /// Gets the Adobe specific markers <see href="http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/JPEG.html#Adobe"/>.
         /// </summary>
-        public static readonly byte[] AdobeMarker = Encoding.ASCII.GetBytes("Adobe");
+        public static ReadOnlySpan<byte> AdobeMarker => new[]
+        {
+            (byte)'A', (byte)'d', (byte)'o', (byte)'b', (byte)'e'
+        };
 
         /// <summary>
         /// Returns a value indicating whether the passed bytes are a match to the profile identifier.

--- a/src/ImageSharp/Formats/Jpeg/Components/ZigZag.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ZigZag.cs
@@ -77,7 +77,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
             ref byte sourceRef = ref MemoryMarshal.GetReference(Unzig);
             ref byte destinationRef = ref Unsafe.AsRef<byte>(result.Data);
 
-            Unsafe.CopyBlock(ref sourceRef, ref destinationRef, Size);
+            Unzig.CopyTo(new Span<byte>(result.Data, Size));
 
             return result;
         }

--- a/src/ImageSharp/Formats/Jpeg/Components/ZigZag.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ZigZag.cs
@@ -34,12 +34,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
         public fixed byte Data[Size];
 
         /// <summary>
-        /// Unzig maps from the zigzag ordering to the natural ordering. For example,
-        /// unzig[3] is the column and row of the fourth element in zigzag order. The
-        /// value is 16, which means first column (16%8 == 0) and third row (16/8 == 2).
+        /// Gets the unzigs map, which maps from the zigzag ordering to the natural ordering.
+        /// For example, unzig[3] is the column and row of the fourth element in zigzag order.
+        /// The value is 16, which means first column (16%8 == 0) and third row (16/8 == 2).
         /// </summary>
-        private static readonly byte[] Unzig =
-        new byte[Size]
+        private static ReadOnlySpan<byte> Unzig => new byte[]
         {
             0,  1,  8, 16,  9,  2,  3, 10,
             17, 24, 32, 25, 18, 11,  4,  5,
@@ -75,8 +74,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
         public static ZigZag CreateUnzigTable()
         {
             ZigZag result = default;
-            byte* unzigPtr = result.Data;
-            Marshal.Copy(Unzig, 0, (IntPtr)unzigPtr, Size);
+            ref byte sourceRef = ref MemoryMarshal.GetReference(Unzig);
+            ref byte destinationRef = ref Unsafe.AsRef<byte>(result.Data);
+
+            Unsafe.CopyBlock(ref sourceRef, ref destinationRef, Size);
+
             return result;
         }
 

--- a/src/ImageSharp/Formats/Png/PngConstants.cs
+++ b/src/ImageSharp/Formats/Png/PngConstants.cs
@@ -38,21 +38,6 @@ namespace SixLabors.ImageSharp.Formats.Png
         public static readonly IEnumerable<string> FileExtensions = new[] { "png" };
 
         /// <summary>
-        /// Gets the header bytes identifying a Png.
-        /// </summary>
-        public static ReadOnlySpan<byte> HeaderBytes => new byte[]
-        {
-             0x89, // Set the high bit.
-             0x50, // P
-             0x4E, // N
-             0x47, // G
-             0x0D, // Line ending CRLF
-             0x0A, // Line ending CRLF
-             0x1A, // EOF
-             0x0A // LF
-        };
-
-        /// <summary>
         /// The header bytes as a big-endian coded ulong.
         /// </summary>
         public const ulong HeaderValue = 0x89504E470D0A1A0AUL;
@@ -78,5 +63,20 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// The minimum length of a keyword in a text chunk is 1 byte.
         /// </summary>
         public const int MinTextKeywordLength = 1;
+
+        /// <summary>
+        /// Gets the header bytes identifying a Png.
+        /// </summary>
+        public static ReadOnlySpan<byte> HeaderBytes => new byte[]
+        {
+            0x89, // Set the high bit.
+            0x50, // P
+            0x4E, // N
+            0x47, // G
+            0x0D, // Line ending CRLF
+            0x0A, // Line ending CRLF
+            0x1A, // EOF
+            0x0A // LF
+        };
     }
 }

--- a/src/ImageSharp/Formats/Png/PngConstants.cs
+++ b/src/ImageSharp/Formats/Png/PngConstants.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -37,9 +38,9 @@ namespace SixLabors.ImageSharp.Formats.Png
         public static readonly IEnumerable<string> FileExtensions = new[] { "png" };
 
         /// <summary>
-        /// The header bytes identifying a Png.
+        /// Gets the header bytes identifying a Png.
         /// </summary>
-        public static readonly byte[] HeaderBytes =
+        public static ReadOnlySpan<byte> HeaderBytes => new byte[]
         {
              0x89, // Set the high bit.
              0x50, // P

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -149,7 +149,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             QuantizedFrame<TPixel> quantized = PngEncoderOptionsHelpers.CreateQuantizedFrame(this.options, image);
             this.bitDepth = PngEncoderOptionsHelpers.CalculateBitDepth(this.options, image, quantized);
 
-            stream.Write(PngConstants.HeaderBytes, 0, PngConstants.HeaderBytes.Length);
+            stream.Write(PngConstants.HeaderBytes);
 
             this.WriteHeaderChunk(stream);
             this.WritePaletteChunk(stream, quantized);

--- a/src/ImageSharp/Formats/Png/Zlib/DeflaterHuffman.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/DeflaterHuffman.cs
@@ -381,14 +381,15 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
              *      fail as expected. We can't simply check whether the value is lower than
              *      15 << 12, because higher values are acceptable in the first 3 accesses.
              * Doing this reduces the total number of index checks from 4 down to just 1. */
-            Guard.MustBeLessThanOrEqualTo<uint>((uint)(toReverse >> 12), 15, nameof(toReverse));
+            int toReverseRightShiftBy12 = toReverse >> 12;
+            Guard.MustBeLessThanOrEqualTo<uint>((uint)toReverseRightShiftBy12, 15, nameof(toReverse));
 
             ref byte bit4ReverseRef = ref MemoryMarshal.GetReference(Bit4Reverse);
 
             return (short)(Unsafe.Add(ref bit4ReverseRef, toReverse & 0xF) << 12
                            | Unsafe.Add(ref bit4ReverseRef, (toReverse >> 4) & 0xF) << 8
                            | Unsafe.Add(ref bit4ReverseRef, (toReverse >> 8) & 0xF) << 4
-                           | Unsafe.Add(ref bit4ReverseRef, toReverse >> 12));
+                           | Unsafe.Add(ref bit4ReverseRef, toReverseRightShiftBy12));
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Formats/Png/Zlib/DeflaterHuffman.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/DeflaterHuffman.cs
@@ -371,12 +371,14 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
              *      As a result, no input validation is needed at all in this case.
              *   2. There are two cases where the input value might cause an invalid access:
              *      when it is either negative, or greater than 15 << 12. We can test both
-             *      conditions in a single pass by casting the input value to uint, and checking
-             *      whether that value is lower than 15 << 12. If it was a negative value (2-complement),
-             *      the test will fail as the uint cast will result in a much larger value.
-             *      If the value was simply too high, the test will fail as expected.
+             *      conditions in a single pass by casting the input value to uint and right
+             *      shifting it by 12, which also preserves the sign. If it is a negative
+             *      value (2-complement), the test will fail as the uint cast will result
+             *      in a much larger value. If the value was simply too high, the test will
+             *      fail as expected. We can't simply check whether the value is lower than
+             *      15 << 12, because higher values are acceptable in the first 3 accesses.
              * Doing this reduces the total number of index checks from 4 down to just 1. */
-            Guard.MustBeLessThanOrEqualTo<uint>((uint)toReverse, 15 << 12, nameof(toReverse));
+            Guard.MustBeLessThanOrEqualTo<uint>((uint)(toReverse >> 12), 15, nameof(toReverse));
 
             ref byte bit4ReverseRef = ref MemoryMarshal.GetReference(Bit4Reverse);
 

--- a/src/ImageSharp/Formats/Png/Zlib/DeflaterHuffman.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/DeflaterHuffman.cs
@@ -160,13 +160,9 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
             this.Pending.WriteBits(this.distTree.NumCodes - 1, 5);
             this.Pending.WriteBits(blTreeCodes - 4, 4);
 
-            ref byte bitLengthOrderRef = ref MemoryMarshal.GetReference(BitLengthOrder);
-
             for (int rank = 0; rank < blTreeCodes; rank++)
             {
-                ref byte bitsRef = ref Unsafe.Add(ref bitLengthOrderRef, rank);
-
-                this.Pending.WriteBits(this.blTree.Length[bitsRef], 3);
+                this.Pending.WriteBits(this.blTree.Length[BitLengthOrder[rank]], 3);
             }
 
             this.literalTree.WriteTree(this.Pending, this.blTree);
@@ -255,14 +251,11 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
             // Build bitlen tree
             this.blTree.BuildTree();
 
-            ref byte bitLengthOrderRef = ref MemoryMarshal.GetReference(BitLengthOrder);
             int blTreeCodes = 4;
 
             for (int i = 18; i > blTreeCodes; i--)
             {
-                ref byte bits = ref Unsafe.Add(ref bitLengthOrderRef, i);
-
-                if (this.blTree.Length[bits] > 0)
+                if (this.blTree.Length[BitLengthOrder[i]] > 0)
                 {
                     blTreeCodes = i + 1;
                 }

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -37,6 +37,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="..\..\shared-infrastructure\src\SharedInfrastructure\Guard.Numeric.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Guard.Numeric.tt</DependentUpon>
+    </Compile>    
     <Compile Update="Formats\Jpeg\Components\Block8x8F.Generated.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -202,6 +207,9 @@
       <LastGenOutput>DefaultPixelBlenders.Generated.cs</LastGenOutput>
       <Generator>TextTemplatingFileGenerator</Generator>
     </None>
+    <None Update="..\..\shared-infrastructure\src\SharedInfrastructure\Guard.Numeric.tt">
+      <LastGenOutput>Guard.Numeric.cs</LastGenOutput>
+    </None>
   </ItemGroup>
 
   <ItemGroup>
@@ -209,5 +217,4 @@
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />
-
 </Project>

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -37,11 +37,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+    Note: Generating all templates via Visual Studio causes a duplicate entry that requires deleting
+    post operation. MSBuild target leaves the csproj file intact.
+    -->
     <Compile Update="..\..\shared-infrastructure\src\SharedInfrastructure\Guard.Numeric.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Guard.Numeric.tt</DependentUpon>
-    </Compile>    
+    </Compile>
+    
     <Compile Update="Formats\Jpeg\Components\Block8x8F.Generated.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -209,6 +214,7 @@
     </None>
     <None Update="..\..\shared-infrastructure\src\SharedInfrastructure\Guard.Numeric.tt">
       <LastGenOutput>Guard.Numeric.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
     </None>
   </ItemGroup>
 

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifConstants.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifConstants.cs
@@ -1,11 +1,13 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
+
+using System;
 
 namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
 {
     internal static class ExifConstants
     {
-        public static readonly byte[] LittleEndianByteOrderMarker =
+        public static ReadOnlySpan<byte> LittleEndianByteOrderMarker => new byte[]
         {
             (byte)'I',
             (byte)'I',
@@ -13,7 +15,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
             0x00,
         };
 
-        public static readonly byte[] BigEndianByteOrderMarker =
+        public static ReadOnlySpan<byte> BigEndianByteOrderMarker => new byte[]
         {
             (byte)'M',
             (byte)'M',

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifWriter.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifWriter.cs
@@ -77,7 +77,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
             int i = 0;
 
             // The byte order marker for little-endian, followed by the number 42 and a 0
-            ExifConstants.LittleEndianByteOrderMarker.AsSpan().CopyTo(result.AsSpan(start: i));
+            ExifConstants.LittleEndianByteOrderMarker.CopyTo(result.AsSpan(start: i));
             i += ExifConstants.LittleEndianByteOrderMarker.Length;
 
             uint ifdOffset = ((uint)i - startIndex) + 4U;

--- a/src/ImageSharp/PixelFormats/PixelBlenders/PorterDuffFunctions.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelBlenders/PorterDuffFunctions.Generated.cs
@@ -13,7 +13,6 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
 
 
 
-
         /// <summary>
         /// Returns the result of the "NormalSrc" compositing equation.
         /// </summary>
@@ -418,7 +417,6 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             dest.FromScaledVector4(NormalXor(backdrop.ToScaledVector4(), source.ToScaledVector4(), opacity));
             return dest;
         }
-
 
         /// <summary>
         /// Returns the result of the "MultiplySrc" compositing equation.
@@ -825,7 +823,6 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             return dest;
         }
 
-
         /// <summary>
         /// Returns the result of the "AddSrc" compositing equation.
         /// </summary>
@@ -1230,7 +1227,6 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             dest.FromScaledVector4(AddXor(backdrop.ToScaledVector4(), source.ToScaledVector4(), opacity));
             return dest;
         }
-
 
         /// <summary>
         /// Returns the result of the "SubtractSrc" compositing equation.
@@ -1637,7 +1633,6 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             return dest;
         }
 
-
         /// <summary>
         /// Returns the result of the "ScreenSrc" compositing equation.
         /// </summary>
@@ -2042,7 +2037,6 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             dest.FromScaledVector4(ScreenXor(backdrop.ToScaledVector4(), source.ToScaledVector4(), opacity));
             return dest;
         }
-
 
         /// <summary>
         /// Returns the result of the "DarkenSrc" compositing equation.
@@ -2449,7 +2443,6 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             return dest;
         }
 
-
         /// <summary>
         /// Returns the result of the "LightenSrc" compositing equation.
         /// </summary>
@@ -2855,7 +2848,6 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             return dest;
         }
 
-
         /// <summary>
         /// Returns the result of the "OverlaySrc" compositing equation.
         /// </summary>
@@ -3260,7 +3252,6 @@ namespace SixLabors.ImageSharp.PixelFormats.PixelBlenders
             dest.FromScaledVector4(OverlayXor(backdrop.ToScaledVector4(), source.ToScaledVector4(), opacity));
             return dest;
         }
-
 
         /// <summary>
         /// Returns the result of the "HardLightSrc" compositing equation.

--- a/tests/ImageSharp.Tests/Formats/Jpg/ProfileResolverTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ProfileResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Text;
@@ -19,25 +19,25 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Fact]
         public void ProfileResolverHasCorrectJFifMarker()
         {
-            Assert.Equal(JFifMarker, ProfileResolver.JFifMarker);
+            Assert.Equal(JFifMarker, ProfileResolver.JFifMarker.ToArray());
         }
 
         [Fact]
         public void ProfileResolverHasCorrectExifMarker()
         {
-            Assert.Equal(ExifMarker, ProfileResolver.ExifMarker);
+            Assert.Equal(ExifMarker, ProfileResolver.ExifMarker.ToArray());
         }
 
         [Fact]
         public void ProfileResolverHasCorrectIccMarker()
         {
-            Assert.Equal(IccMarker, ProfileResolver.IccMarker);
+            Assert.Equal(IccMarker, ProfileResolver.IccMarker.ToArray());
         }
 
         [Fact]
         public void ProfileResolverHasCorrectAdobeMarker()
         {
-            Assert.Equal(AdobeMarker, ProfileResolver.AdobeMarker);
+            Assert.Equal(AdobeMarker, ProfileResolver.AdobeMarker.ToArray());
         }
 
         [Fact]

--- a/tests/ImageSharp.Tests/Image/ImageFrameCollectionTests.Generic.cs
+++ b/tests/ImageSharp.Tests/Image/ImageFrameCollectionTests.Generic.cs
@@ -43,7 +43,7 @@ namespace SixLabors.ImageSharp.Tests
                         this.Collection.AddFrame((ImageFrame<Rgba32>)null);
                     });
 
-                Assert.StartsWith("Value cannot be null.", ex.Message);
+                Assert.StartsWith("Parameter \"frame\" must be not null.", ex.Message);
             }
 
             [Fact]
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp.Tests
                         this.Collection.AddFrame(data);
                     });
 
-                Assert.StartsWith("Value cannot be null.", ex.Message);
+                Assert.StartsWith("Parameter \"source\" must be not null.", ex.Message);
             }
 
             [Fact]
@@ -69,7 +69,7 @@ namespace SixLabors.ImageSharp.Tests
                         this.Collection.AddFrame(new Rgba32[0]);
                     });
 
-                Assert.StartsWith("Value 0 must be greater than or equal to 100.", ex.Message);
+                Assert.StartsWith($"Parameter \"data\" ({typeof(int)}) must be greater than or equal to {100}, was {0}", ex.Message);
             }
 
             [Fact]
@@ -93,7 +93,7 @@ namespace SixLabors.ImageSharp.Tests
                         this.Collection.InsertFrame(1, null);
                     });
 
-                Assert.StartsWith("Value cannot be null.", ex.Message);
+                Assert.StartsWith("Parameter \"frame\" must be not null.", ex.Message);
             }
 
             [Fact]

--- a/tests/ImageSharp.Tests/Image/ImageFrameCollectionTests.NonGeneric.cs
+++ b/tests/ImageSharp.Tests/Image/ImageFrameCollectionTests.NonGeneric.cs
@@ -90,7 +90,7 @@ namespace SixLabors.ImageSharp.Tests
                         this.Collection.AddFrame(null);
                     });
 
-                Assert.StartsWith("Value cannot be null.", ex.Message);
+                Assert.StartsWith("Parameter \"source\" must be not null.", ex.Message);
             }
 
             [Fact]
@@ -114,7 +114,7 @@ namespace SixLabors.ImageSharp.Tests
                         this.Collection.InsertFrame(1, null);
                     });
 
-                Assert.StartsWith("Value cannot be null.", ex.Message);
+                Assert.StartsWith("Parameter \"source\" must be not null.", ex.Message);
             }
 
             [Fact]

--- a/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifProfileTests.cs
@@ -394,7 +394,7 @@ namespace SixLabors.ImageSharp.Tests
         public void ProfileToByteArray()
         {
             // Arrange
-            byte[] exifBytesWithoutExifCode = ExifConstants.LittleEndianByteOrderMarker;
+            byte[] exifBytesWithoutExifCode = ExifConstants.LittleEndianByteOrderMarker.ToArray();
             ExifProfile expectedProfile = CreateExifProfile();
             var expectedProfileTags = expectedProfile.Values.Select(x => x.Tag).ToList();
 


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
This PR includes a couple of minor optimizations:

- Replaced some `static readonly byte[]` arrays with static `ReadOnlySpan<byte>` values that directly map over constant data in the `.text` segment (see [here](https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static/)).
- Removed some bound checks when accessing those static sections (added some DEBUG checks)
- Removed some type initialization calls to `Encoding.ASCII.GetBytes`, no longer necessary
- Switched the `Stream.Write` calls to the `ReadOnlySpan<byte>` overloads.

No rush at all for this, just saw those `byte[]` arrays and thought I'd have some fun optimizing them away. Pinging @antonfirsov for the reviews as he's the official performance guru. 😄
