### PR TITLE
Fix edge detection and reenable entropy crop tests

### DIFF
--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
@@ -58,9 +58,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
             var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
             var operation = new RowOperation(interest, targetPixels, source.PixelBuffer, this.KernelXY, this.Configuration, this.PreserveAlpha);
             ParallelRowIterator.IterateRows<RowOperation, Vector4>(
-                this.Configuration,
-                interest,
-                in operation);
+               this.Configuration,
+               interest,
+               in operation);
 
             Buffer2D<TPixel>.SwapOrCopyContent(source.PixelBuffer, targetPixels);
         }

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetector2DProcessor{TPixel}.cs
@@ -52,6 +52,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <inheritdoc/>
         protected override void BeforeImageApply()
         {
+            using (IImageProcessor<TPixel> opaque = new OpaqueProcessor<TPixel>(this.Configuration, this.Source, this.SourceRectangle))
+            {
+                opaque.Execute();
+            }
+
             if (this.Grayscale)
             {
                 new GrayscaleBt709Processor(1F).Execute(this.Configuration, this.Source, this.SourceRectangle);

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
@@ -40,6 +40,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <inheritdoc/>
         protected override void BeforeImageApply()
         {
+            using (IImageProcessor<TPixel> opaque = new OpaqueProcessor<TPixel>(this.Configuration, this.Source, this.SourceRectangle))
+            {
+                opaque.Execute();
+            }
+
             if (this.Grayscale)
             {
                 new GrayscaleBt709Processor(1F).Execute(this.Configuration, this.Source, this.SourceRectangle);

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
@@ -43,6 +43,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// <inheritdoc/>
         protected override void BeforeImageApply()
         {
+            using (IImageProcessor<TPixel> opaque = new OpaqueProcessor<TPixel>(this.Configuration, this.Source, this.SourceRectangle))
+            {
+                opaque.Execute();
+            }
+
             if (this.Grayscale)
             {
                 new GrayscaleBt709Processor(1F).Execute(this.Configuration, this.Source, this.SourceRectangle);

--- a/src/ImageSharp/Processing/Processors/Filters/OpaqueProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/OpaqueProcessor{TPixel}.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Processing.Processors.Filters
+{
+    internal sealed class OpaqueProcessor<TPixel> : ImageProcessor<TPixel>
+          where TPixel : unmanaged, IPixel<TPixel>
+    {
+        public OpaqueProcessor(
+            Configuration configuration,
+            Image<TPixel> source,
+            Rectangle sourceRectangle)
+            : base(configuration, source, sourceRectangle)
+        {
+        }
+
+        protected override void OnFrameApply(ImageFrame<TPixel> source)
+        {
+            var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
+
+            var operation = new OpaqueRowOperation(this.Configuration, source, interest);
+            ParallelRowIterator.IterateRows<OpaqueRowOperation, Vector4>(this.Configuration, interest, in operation);
+        }
+
+        private readonly struct OpaqueRowOperation : IRowOperation<Vector4>
+        {
+            private readonly Configuration configuration;
+            private readonly ImageFrame<TPixel> target;
+            private readonly Rectangle bounds;
+
+            [MethodImpl(InliningOptions.ShortMethod)]
+            public OpaqueRowOperation(
+                Configuration configuration,
+                ImageFrame<TPixel> target,
+                Rectangle bounds)
+            {
+                this.configuration = configuration;
+                this.target = target;
+                this.bounds = bounds;
+            }
+
+            /// <inheritdoc/>
+            [MethodImpl(InliningOptions.ShortMethod)]
+            public void Invoke(int y, Span<Vector4> span)
+            {
+                Span<TPixel> targetRowSpan = this.target.GetPixelRowSpan(y).Slice(this.bounds.X);
+                PixelOperations<TPixel>.Instance.ToVector4(this.configuration, targetRowSpan.Slice(0, span.Length), span, PixelConversionModifiers.Scale);
+                ref Vector4 baseRef = ref MemoryMarshal.GetReference(span);
+
+                for (int x = 0; x < this.bounds.Width; x++)
+                {
+                    ref Vector4 v = ref Unsafe.Add(ref baseRef, x);
+                    v.W = 1F;
+                }
+
+                PixelOperations<TPixel>.Instance.FromVector4Destructive(this.configuration, span, targetRowSpan, PixelConversionModifiers.Scale);
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/EntropyCropTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/EntropyCropTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -25,15 +25,6 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         public void EntropyCrop<TPixel>(TestImageProvider<TPixel> provider, float value)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            // The result dimensions of EntropyCrop may differ on .NET Core 3.1 because of unstable edge detection results.
-            // TODO: Re-enable this test case if we manage to improve stability.
-#if SUPPORTS_RUNTIME_INTRINSICS
-            if (provider.SourceFileOrDescription.Contains(TestImages.Png.Ducky))
-            {
-                return;
-            }
-#endif
-
             provider.RunValidatingProcessorTest(x => x.EntropyCrop(value), value, appendPixelTypeToFileName: false);
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Edge detection now produces fully opaque output. This stabilizes the output across platforms and also fixes entropy cropping. 

<!-- Thanks for contributing to ImageSharp! -->
