### PR TITLE
Simple copy & paste error fixed, GetMaxX must return width not height.

### DIFF
--- a/src/ImageSharp/Common/Helpers/ImageMaths.cs
+++ b/src/ImageSharp/Common/Helpers/ImageMaths.cs
@@ -359,7 +359,7 @@ namespace SixLabors.ImageSharp
                     }
                 }
 
-                return height;
+                return width;
             }
 
             topLeft.Y = GetMinY(bitmap);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
GetMaxY must return height, this was ok.
GetMaxX must return width, but it returns height instead.
The PR change it to width.

<!-- Thanks for contributing to ImageSharp! -->
All of you, keep up the good work.