### PR TITLE
Add image extension method for save as tga

### DIFF
--- a/src/ImageSharp/Formats/Tga/ImageExtensions.cs
+++ b/src/ImageSharp/Formats/Tga/ImageExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.IO;
+
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.Formats.Tga;
+
+namespace SixLabors.ImageSharp
+{
+    /// <summary>
+    /// Extension methods for the <see cref="Image"/> type.
+    /// </summary>
+    public static partial class ImageExtensions
+    {
+        /// <summary>
+        /// Saves the image to the given stream with the tga format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        public static void SaveAsTga(this Image source, Stream stream) => SaveAsTga(source, stream, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the tga format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The options for the encoder.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        public static void SaveAsTga(this Image source, Stream stream, TgaEncoder encoder) =>
+            source.Save(
+                stream,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(TgaFormat.Instance));
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
+++ b/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
@@ -15,7 +15,7 @@ using SixLabors.ImageSharp.Processing.Processors.Quantization;
 
 using Xunit;
 
-namespace SixLabors.ImageSharp.Tests
+namespace SixLabors.ImageSharp.Tests.Formats
 {
     public class GeneralFormatTests : FileTestBase
     {
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 using (Image<Rgba32> image = file.CreateRgba32Image())
                 {
-                    string filename = path + "/" + file.FileNameWithoutExtension + ".txt";
+                    string filename = Path.Combine(path, $"{file.FileNameWithoutExtension}.txt");
                     File.WriteAllText(filename, image.ToBase64String(PngFormat.Instance));
                 }
             }
@@ -56,7 +56,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 using (Image<Rgba32> image = file.CreateRgba32Image())
                 {
-                    image.Save($"{path}/{file.FileName}");
+                    image.Save(Path.Combine(path, file.FileName));
                 }
             }
         }
@@ -103,24 +103,29 @@ namespace SixLabors.ImageSharp.Tests
             {
                 using (Image<Rgba32> image = file.CreateRgba32Image())
                 {
-                    using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.bmp"))
+                    using (FileStream output = File.OpenWrite(Path.Combine(path, $"{file.FileNameWithoutExtension}.bmp")))
                     {
                         image.SaveAsBmp(output);
                     }
 
-                    using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.jpg"))
+                    using (FileStream output = File.OpenWrite(Path.Combine(path, $"{file.FileNameWithoutExtension}.jpg")))
                     {
                         image.SaveAsJpeg(output);
                     }
 
-                    using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.png"))
+                    using (FileStream output = File.OpenWrite(Path.Combine(path, $"{file.FileNameWithoutExtension}.png")))
                     {
                         image.SaveAsPng(output);
                     }
 
-                    using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.gif"))
+                    using (FileStream output = File.OpenWrite(Path.Combine(path, $"{file.FileNameWithoutExtension}.gif")))
                     {
                         image.SaveAsGif(output);
+                    }
+
+                    using (FileStream output = File.OpenWrite(Path.Combine(path, $"{file.FileNameWithoutExtension}.tga")))
+                    {
+                        image.SaveAsTga(output);
                     }
                 }
             }

--- a/tests/ImageSharp.Tests/Formats/ImageFormatManagerTests.cs
+++ b/tests/ImageSharp.Tests/Formats/ImageFormatManagerTests.cs
@@ -10,10 +10,11 @@ using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Tga;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
-namespace SixLabors.ImageSharp.Tests
+namespace SixLabors.ImageSharp.Tests.Formats
 {
     public class ImageFormatManagerTests
     {
@@ -34,11 +35,13 @@ namespace SixLabors.ImageSharp.Tests
             Assert.Equal(1, this.DefaultFormatsManager.ImageEncoders.Select(item => item.Value).OfType<BmpEncoder>().Count());
             Assert.Equal(1, this.DefaultFormatsManager.ImageEncoders.Select(item => item.Value).OfType<JpegEncoder>().Count());
             Assert.Equal(1, this.DefaultFormatsManager.ImageEncoders.Select(item => item.Value).OfType<GifEncoder>().Count());
+            Assert.Equal(1, this.DefaultFormatsManager.ImageEncoders.Select(item => item.Value).OfType<TgaEncoder>().Count());
 
             Assert.Equal(1, this.DefaultFormatsManager.ImageDecoders.Select(item => item.Value).OfType<PngDecoder>().Count());
             Assert.Equal(1, this.DefaultFormatsManager.ImageDecoders.Select(item => item.Value).OfType<BmpDecoder>().Count());
             Assert.Equal(1, this.DefaultFormatsManager.ImageDecoders.Select(item => item.Value).OfType<JpegDecoder>().Count());
             Assert.Equal(1, this.DefaultFormatsManager.ImageDecoders.Select(item => item.Value).OfType<BmpDecoder>().Count());
+            Assert.Equal(1, this.DefaultFormatsManager.ImageDecoders.Select(item => item.Value).OfType<TgaDecoder>().Count());
         }
 
         [Fact]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR adds SaveAsTga extension method.