### PR TITLE
Add unit test for #1154: entropy crop on white image should not crop

### DIFF
--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/EntropyCropTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/EntropyCropTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using Xunit;
@@ -26,6 +25,25 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
             where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.RunValidatingProcessorTest(x => x.EntropyCrop(value), value, appendPixelTypeToFileName: false);
+        }
+
+        [Theory]
+        [WithBlankImages(40, 30, PixelTypes.Rgba32)]
+        [WithBlankImages(30, 40, PixelTypes.Rgba32)]
+        public void Entropy_WillNotCropWhiteImage<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // arrange
+            using Image<TPixel> image = provider.GetImage();
+            var expectedHeight = image.Height;
+            var expectedWidth = image.Width;
+
+            // act
+            image.Mutate(img => img.EntropyCrop());
+
+            // assert
+            Assert.Equal(image.Width, expectedWidth);
+            Assert.Equal(image.Height, expectedHeight);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

 Adds a unit test for #1154