### PR TITLE
Update ToBase64String

### DIFF
--- a/src/ImageSharp/ImageExtensions.cs
+++ b/src/ImageSharp/ImageExtensions.cs
@@ -103,14 +103,18 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// Returns a Base64 encoded string from the given image.
+        /// The result is prepended with a Data URI <see href="https://en.wikipedia.org/wiki/Data_URI_scheme"/>
+        /// <para>
+        /// <example>
+        /// For example:
+        /// <see href="data:image/gif;base64,R0lGODlhAQABAIABAEdJRgAAACwAAAAAAQABAAACAkQBAA=="/>
+        /// </example>
+        /// </para>
         /// </summary>
-        /// <example><see href="data:image/gif;base64,R0lGODlhAQABAIABAEdJRgAAACwAAAAAAQABAAACAkQBAA=="/></example>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="source">The source image</param>
         /// <param name="format">The format.</param>
         /// <returns>The <see cref="string"/></returns>
-        public static string ToBase64String<TPixel>(this Image<TPixel> source, IImageFormat format)
-            where TPixel : unmanaged, IPixel<TPixel>
+        public static string ToBase64String(this Image source, IImageFormat format)
         {
             using var stream = new MemoryStream();
             source.Save(stream, format);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Removes the `TPixel` type parameter from the `ToBase64String(this Image source, IImageFormat format)` method as it was unnecessary. Also fleshed out the intellisense documentation to correctly show the example output.

<!-- Thanks for contributing to ImageSharp! -->
