### PR TITLE
Fix nuget package icon.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -84,7 +84,7 @@
     <LangVersion>8.0</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <OverwriteReadOnlyFiles>true</OverwriteReadOnlyFiles>
-    <PackageIcon>icon.png</PackageIcon>
+    <PackageIcon>sixlabors.imagesharp.128.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
@@ -107,7 +107,7 @@
     <PackageReference Include="StyleCop.Analyzers" IsImplicitlyDefined="true"  />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)shared-infrastructure\stylecop.json" />
     <!--NuGet package icon source-->
-    <None Include="$(MSBuildThisFileDirectory)shared-infrastructure\branding\icons\imagesharp\sixlabors.imagesharp.128.png" Pack="true" PackagePath="\icon.png" />
+    <None Include="$(MSBuildThisFileDirectory)shared-infrastructure\branding\icons\imagesharp\sixlabors.imagesharp.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
The docs have changed since we implemented them and the icon does not appear in the Nuget Package Manager

https://github.com/NuGet/Home/wiki/Packaging-Icon-within-the-nupkg#icon

![image](https://user-images.githubusercontent.com/385879/80248610-2ee98c80-8668-11ea-8ce9-202d1c9e9198.png)

Proof of fix in package explorer
![image](https://user-images.githubusercontent.com/385879/80250161-2e9ec080-866b-11ea-9e99-175b5a42d955.png)


<!-- Thanks for contributing to ImageSharp! -->
