### PR TITLE
Remove obsolete PngTextProperties from png metadata

### DIFF
--- a/src/ImageSharp/Formats/Png/PngMetadata.cs
+++ b/src/ImageSharp/Formats/Png/PngMetadata.cs
@@ -91,34 +91,12 @@ namespace SixLabors.ImageSharp.Formats.Png
         public bool HasTransparency { get; set; }
 
         /// <summary>
-        /// Gets or sets the collection of text data stored within the  iTXt, tEXt, and zTXt chunks.
+        /// Gets or sets the collection of text data stored within the iTXt, tEXt, and zTXt chunks.
         /// Used for conveying textual information associated with the image.
         /// </summary>
         public IList<PngTextData> TextData { get; set; } = new List<PngTextData>();
 
-        /// <summary>
-        /// Gets the list of png text properties for storing meta information about this image.
-        /// </summary>
-        public IList<PngTextData> PngTextProperties { get; } = new List<PngTextData>();
-
         /// <inheritdoc/>
         public IDeepCloneable DeepClone() => new PngMetadata(this);
-
-        internal bool TryGetPngTextProperty(string keyword, out PngTextData result)
-        {
-            for (int i = 0; i < this.TextData.Count; i++)
-            {
-                if (this.TextData[i].Keyword == keyword)
-                {
-                    result = this.TextData[i];
-
-                    return true;
-                }
-            }
-
-            result = default;
-
-            return false;
-        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Removed obsolete `PngTextProperties`, `TextData` Property should be used instead.