### PR TITLE
Change ImageFormatException to InvalidImageContentException

### DIFF
--- a/src/ImageSharp/Common/Exceptions/InvalidImageContentException.cs
+++ b/src/ImageSharp/Common/Exceptions/InvalidImageContentException.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
+
 namespace SixLabors.ImageSharp
 {
     /// <summary>
@@ -16,6 +18,18 @@ namespace SixLabors.ImageSharp
         /// <param name="errorMessage">The error message that explains the reason for this exception.</param>
         public InvalidImageContentException(string errorMessage)
             : base(errorMessage)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidImageContentException"/> class with the name of the
+        /// parameter that causes this exception.
+        /// </summary>
+        /// <param name="errorMessage">The error message that explains the reason for this exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic)
+        /// if no inner exception is specified.</param>
+        public InvalidImageContentException(string errorMessage, Exception innerException)
+            : base(errorMessage, innerException)
         {
         }
     }

--- a/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
@@ -43,9 +43,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             {
                 Size dims = decoder.Dimensions;
 
-                // TODO: use InvalidImageContentException here, if we decide to define it
-                // https://github.com/SixLabors/ImageSharp/issues/1110
-                throw new ImageFormatException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}. This error can happen for very large RLE bitmaps, which are not supported.", ex);
+                throw new InvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}. This error can happen for very large RLE bitmaps, which are not supported.", ex);
             }
         }
 

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -38,9 +38,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             {
                 Size dims = decoder.Dimensions;
 
-                // TODO: use InvalidImageContentException here, if we decide to define it
-                // https://github.com/SixLabors/ImageSharp/issues/1110
-                throw new ImageFormatException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
+                throw new InvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
             }
         }
 

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -38,7 +38,10 @@ namespace SixLabors.ImageSharp.Formats.Gif
             {
                 Size dims = decoder.Dimensions;
 
-                throw new InvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
+                GifThrowHelper.ThrowInvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
+
+                // Not reachable, as the previous statement will throw a exception.
+                return null;
             }
         }
 

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -101,7 +101,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// Decodes the stream to the image.
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image data. </param>
+        /// <param name="stream">The stream containing image data.</param>
         /// <returns>The decoded image</returns>
         public Image<TPixel> Decode<TPixel>(Stream stream)
             where TPixel : unmanaged, IPixel<TPixel>

--- a/src/ImageSharp/Formats/Gif/GifThrowHelper.cs
+++ b/src/ImageSharp/Formats/Gif/GifThrowHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.Formats.Gif
@@ -11,8 +12,17 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// Cold path optimization for throwing <see cref="InvalidImageContentException"/>'s
         /// </summary>
         /// <param name="errorMessage">The error message for the exception.</param>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowInvalidImageContentException(string errorMessage)
             => throw new InvalidImageContentException(errorMessage);
+
+        /// <summary>
+        /// Cold path optimization for throwing <see cref="InvalidImageContentException"/>'s.
+        /// </summary>
+        /// <param name="errorMessage">The error message for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference
+        /// if no inner exception is specified.</param>
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowInvalidImageContentException(string errorMessage, Exception innerException) => throw new InvalidImageContentException(errorMessage, innerException);
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
@@ -32,7 +32,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             {
                 (int w, int h) = (decoder.ImageWidth, decoder.ImageHeight);
 
-                throw new InvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {w}x{h}.", ex);
+                JpegThrowHelper.ThrowInvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {w}x{h}.", ex);
+
+                // Not reachable, as the previous statement will throw a exception.
+                return null;
             }
         }
 

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
@@ -32,9 +32,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             {
                 (int w, int h) = (decoder.ImageWidth, decoder.ImageHeight);
 
-                // TODO: use InvalidImageContentException here, if we decide to define it
-                // https://github.com/SixLabors/ImageSharp/issues/1110
-                throw new ImageFormatException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {w}x{h}.", ex);
+                throw new InvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {w}x{h}.", ex);
             }
         }
 

--- a/src/ImageSharp/Formats/Jpeg/JpegThrowHelper.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegThrowHelper.cs
@@ -16,6 +16,15 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         public static void ThrowInvalidImageContentException(string errorMessage) => throw new InvalidImageContentException(errorMessage);
 
         /// <summary>
+        /// Cold path optimization for throwing <see cref="InvalidImageContentException"/>'s.
+        /// </summary>
+        /// <param name="errorMessage">The error message for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference
+        /// if no inner exception is specified.</param>
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowInvalidImageContentException(string errorMessage, Exception innerException) => throw new InvalidImageContentException(errorMessage, innerException);
+
+        /// <summary>
         /// Cold path optimization for throwing <see cref="NotImplementedException"/>'s
         /// </summary>
         /// <param name="errorMessage">The error message for the exception.</param>

--- a/src/ImageSharp/Formats/Png/PngDecoder.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoder.cs
@@ -54,7 +54,10 @@ namespace SixLabors.ImageSharp.Formats.Png
             {
                 Size dims = decoder.Dimensions;
 
-                throw new InvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
+                PngThrowHelper.ThrowInvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
+
+                // Not reachable, as the previous statement will throw a exception.
+                return null;
             }
         }
 

--- a/src/ImageSharp/Formats/Png/PngDecoder.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoder.cs
@@ -54,9 +54,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             {
                 Size dims = decoder.Dimensions;
 
-                // TODO: use InvalidImageContentException here, if we decide to define it
-                // https://github.com/SixLabors/ImageSharp/issues/1110
-                throw new ImageFormatException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
+                throw new InvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
             }
         }
 

--- a/src/ImageSharp/Formats/Png/PngThrowHelper.cs
+++ b/src/ImageSharp/Formats/Png/PngThrowHelper.cs
@@ -12,6 +12,10 @@ namespace SixLabors.ImageSharp.Formats.Png
     internal static class PngThrowHelper
     {
         [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowInvalidImageContentException(string errorMessage, Exception innerException)
+            => throw new InvalidImageContentException(errorMessage, innerException);
+
+        [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowNoHeader() => throw new InvalidImageContentException("PNG Image does not contain a header chunk");
 
         [MethodImpl(InliningOptions.ColdPath)]

--- a/src/ImageSharp/Formats/Tga/TgaDecoder.cs
+++ b/src/ImageSharp/Formats/Tga/TgaDecoder.cs
@@ -28,7 +28,10 @@ namespace SixLabors.ImageSharp.Formats.Tga
             {
                 Size dims = decoder.Dimensions;
 
-                throw new InvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
+                TgaThrowHelper.ThrowInvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
+
+                // Not reachable, as the previous statement will throw a exception.
+                return null;
             }
         }
 

--- a/src/ImageSharp/Formats/Tga/TgaDecoder.cs
+++ b/src/ImageSharp/Formats/Tga/TgaDecoder.cs
@@ -28,9 +28,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
             {
                 Size dims = decoder.Dimensions;
 
-                // TODO: use InvalidImageContentException here, if we decide to define it
-                // https://github.com/SixLabors/ImageSharp/issues/1110
-                throw new ImageFormatException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
+                throw new InvalidImageContentException($"Can not decode image. Failed to allocate buffers for possibly degenerate dimensions: {dims.Width}x{dims.Height}.", ex);
             }
         }
 

--- a/src/ImageSharp/Formats/Tga/TgaThrowHelper.cs
+++ b/src/ImageSharp/Formats/Tga/TgaThrowHelper.cs
@@ -12,15 +12,25 @@ namespace SixLabors.ImageSharp.Formats.Tga
         /// Cold path optimization for throwing <see cref="ImageFormatException"/>'s
         /// </summary>
         /// <param name="errorMessage">The error message for the exception.</param>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowInvalidImageContentException(string errorMessage)
             => throw new InvalidImageContentException(errorMessage);
+
+        /// <summary>
+        /// Cold path optimization for throwing <see cref="ImageFormatException"/>'s
+        /// </summary>
+        /// <param name="errorMessage">The error message for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference
+        /// if no inner exception is specified.</param>
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowInvalidImageContentException(string errorMessage, Exception innerException)
+            => throw new InvalidImageContentException(errorMessage, innerException);
 
         /// <summary>
         /// Cold path optimization for throwing <see cref="NotSupportedException"/>'s
         /// </summary>
         /// <param name="errorMessage">The error message for the exception.</param>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowNotSupportedException(string errorMessage)
             => throw new NotSupportedException(errorMessage);
     }

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -77,7 +77,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
             where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(10);
-            ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(BmpDecoder));
+            InvalidImageContentException ex = Assert.Throws<InvalidImageContentException>(() => provider.GetImage(BmpDecoder));
             Assert.IsType<InvalidMemoryOperationException>(ex.InnerException);
         }
 

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -179,7 +179,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
             where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(10);
-            ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(GifDecoder));
+            InvalidImageContentException ex = Assert.Throws<InvalidImageContentException>(() => provider.GetImage(GifDecoder));
             Assert.IsType<InvalidMemoryOperationException>(ex.InnerException);
         }
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -107,7 +107,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InBytesSqrt(10);
-            ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(JpegDecoder));
+            InvalidImageContentException ex = Assert.Throws<InvalidImageContentException>(() => provider.GetImage(JpegDecoder));
             this.Output.WriteLine(ex.Message);
             Assert.IsType<InvalidMemoryOperationException>(ex.InnerException);
         }

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -397,7 +397,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(10);
-            ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(PngDecoder));
+            InvalidImageContentException ex = Assert.Throws<InvalidImageContentException>(() => provider.GetImage(PngDecoder));
             Assert.IsType<InvalidMemoryOperationException>(ex.InnerException);
         }
 

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
@@ -740,7 +740,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
             where TPixel : unmanaged, IPixel<TPixel>
         {
             provider.LimitAllocatorBufferCapacity().InPixelsSqrt(10);
-            ImageFormatException ex = Assert.Throws<ImageFormatException>(() => provider.GetImage(TgaDecoder));
+            InvalidImageContentException ex = Assert.Throws<InvalidImageContentException>(() => provider.GetImage(TgaDecoder));
             Assert.IsType<InvalidMemoryOperationException>(ex.InnerException);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Change a few exceptions to `InvalidImageContentException` which were missed in #1179