### PR TITLE
Introduce PngCompressionLevel

### DIFF
--- a/src/ImageSharp/Formats/Png/IPngEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Png/IPngEncoderOptions.cs
@@ -28,9 +28,9 @@ namespace SixLabors.ImageSharp.Formats.Png
 
         /// <summary>
         /// Gets the compression level 1-9.
-        /// <remarks>Defaults to 6.</remarks>
+        /// <remarks>Defaults to <see cref="PngCompressionLevel.DefaultCompression"/>.</remarks>
         /// </summary>
-        int CompressionLevel { get; }
+        PngCompressionLevel CompressionLevel { get; }
 
         /// <summary>
         /// Gets the threshold of characters in text metadata, when compression should be used.

--- a/src/ImageSharp/Formats/Png/PngCompressionLevel.cs
+++ b/src/ImageSharp/Formats/Png/PngCompressionLevel.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Formats.Png
+{
+    /// <summary>
+    /// Provides enumeration of available PNG compression levels.
+    /// </summary>
+    public enum PngCompressionLevel
+    {
+        /// <summary>
+        /// Level 0. Equivalent to <see cref="NoCompression"/>.
+        /// </summary>
+        Level0 = 0,
+
+        /// <summary>
+        /// No compression. Equivalent to <see cref="Level0"/>.
+        /// </summary>
+        NoCompression = Level0,
+
+        /// <summary>
+        /// Level 1. Equivalent to <see cref="BestSpeed"/>.
+        /// </summary>
+        Level1 = 1,
+
+        /// <summary>
+        /// Best speed compression level.
+        /// </summary>
+        BestSpeed = Level1,
+
+        /// <summary>
+        /// Level 2.
+        /// </summary>
+        Level2 = 2,
+
+        /// <summary>
+        /// Level 3.
+        /// </summary>
+        Level3 = 3,
+
+        /// <summary>
+        /// Level 4.
+        /// </summary>
+        Level4 = 4,
+
+        /// <summary>
+        /// Level 5.
+        /// </summary>
+        Level5 = 5,
+
+        /// <summary>
+        /// Level 6. Equivalent to <see cref="DefaultCompression"/>.
+        /// </summary>
+        Level6 = 6,
+
+        /// <summary>
+        /// The default compression level. Equivalent to <see cref="Level6"/>.
+        /// </summary>
+        DefaultCompression = Level6,
+
+        /// <summary>
+        /// Level 7.
+        /// </summary>
+        Level7 = 7,
+
+        /// <summary>
+        /// Level 8.
+        /// </summary>
+        Level8 = 8,
+
+        /// <summary>
+        /// Level 9. Equivalent to <see cref="BestCompression"/>.
+        /// </summary>
+        Level9 = 9,
+
+        /// <summary>
+        /// Best compression level. Equivalent to <see cref="Level9"/>.
+        /// </summary>
+        BestCompression = Level9,
+    }
+}

--- a/src/ImageSharp/Formats/Png/PngEncoder.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoder.cs
@@ -13,43 +13,25 @@ namespace SixLabors.ImageSharp.Formats.Png
     /// </summary>
     public sealed class PngEncoder : IImageEncoder, IPngEncoderOptions
     {
-        /// <summary>
-        /// Gets or sets the number of bits per sample or per palette index (not per pixel).
-        /// Not all values are allowed for all <see cref="ColorType"/> values.
-        /// </summary>
+        /// <inheritdoc/>
         public PngBitDepth? BitDepth { get; set; }
 
-        /// <summary>
-        /// Gets or sets the color type.
-        /// </summary>
+        /// <inheritdoc/>
         public PngColorType? ColorType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the filter method.
-        /// </summary>
+        /// <inheritdoc/>
         public PngFilterMethod? FilterMethod { get; set; }
 
-        /// <summary>
-        /// Gets or sets the compression level 1-9.
-        /// <remarks>Defaults to 6.</remarks>
-        /// </summary>
-        public int CompressionLevel { get; set; } = 6;
+        /// <inheritdoc/>
+        public PngCompressionLevel CompressionLevel { get; set; } = PngCompressionLevel.DefaultCompression;
 
-        /// <summary>
-        /// Gets or sets the threshold of characters in text metadata, when compression should be used.
-        /// Defaults to 1024.
-        /// </summary>
+        /// <inheritdoc/>
         public int TextCompressionThreshold { get; set; } = 1024;
 
-        /// <summary>
-        /// Gets or sets the gamma value, that will be written the image.
-        /// </summary>
+        /// <inheritdoc/>
         public float? Gamma { get; set; }
 
-        /// <summary>
-        /// Gets or sets quantizer for reducing the color count.
-        /// Defaults to the <see cref="WuQuantizer"/>.
-        /// </summary>
+        /// <inheritdoc/>
         public IQuantizer Quantizer { get; set; }
 
         /// <summary>
@@ -57,9 +39,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </summary>
         public byte Threshold { get; set; } = byte.MaxValue;
 
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance should write an Adam7 interlaced image.
-        /// </summary>
+        /// <inheritdoc/>
         public PngInterlaceMode? InterlaceMethod { get; set; }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Png/PngEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderOptions.cs
@@ -31,52 +31,31 @@ namespace SixLabors.ImageSharp.Formats.Png
             this.InterlaceMethod = source.InterlaceMethod;
         }
 
-        /// <summary>
-        /// Gets or sets the number of bits per sample or per palette index (not per pixel).
-        /// Not all values are allowed for all <see cref="P:SixLabors.ImageSharp.Formats.Png.IPngEncoderOptions.ColorType" /> values.
-        /// </summary>
+        /// <inheritdoc/>
         public PngBitDepth? BitDepth { get; set; }
 
-        /// <summary>
-        /// Gets or sets the color type.
-        /// </summary>
+        /// <inheritdoc/>
         public PngColorType? ColorType { get; set; }
 
-        /// <summary>
-        /// Gets the filter method.
-        /// </summary>
+        /// <inheritdoc/>
         public PngFilterMethod? FilterMethod { get; }
 
-        /// <summary>
-        /// Gets the compression level 1-9.
-        /// <remarks>Defaults to 6.</remarks>
-        /// </summary>
-        public int CompressionLevel { get; }
+        /// <inheritdoc/>
+        public PngCompressionLevel CompressionLevel { get; } = PngCompressionLevel.DefaultCompression;
 
         /// <inheritdoc/>
         public int TextCompressionThreshold { get; }
 
-        /// <summary>
-        /// Gets or sets the gamma value, that will be written the image.
-        /// </summary>
-        /// <value>
-        /// The gamma value of the image.
-        /// </value>
+        /// <inheritdoc/>
         public float? Gamma { get; set; }
 
-        /// <summary>
-        /// Gets or sets the quantizer for reducing the color count.
-        /// </summary>
+        /// <inheritdoc/>
         public IQuantizer Quantizer { get; set; }
 
-        /// <summary>
-        /// Gets the transparency threshold.
-        /// </summary>
+        /// <inheritdoc/>
         public byte Threshold { get; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance should write an Adam7 interlaced image.
-        /// </summary>
+        /// <inheritdoc/>
         public PngInterlaceMode? InterlaceMethod { get; set; }
     }
 }

--- a/src/ImageSharp/Formats/Png/Zlib/ZlibDeflateStream.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/ZlibDeflateStream.cs
@@ -46,9 +46,10 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         /// </summary>
         /// <param name="memoryAllocator">The memory allocator to use for buffer allocations.</param>
         /// <param name="stream">The stream to compress.</param>
-        /// <param name="compressionLevel">The compression level.</param>
-        public ZlibDeflateStream(MemoryAllocator memoryAllocator, Stream stream, int compressionLevel)
+        /// <param name="level">The compression level.</param>
+        public ZlibDeflateStream(MemoryAllocator memoryAllocator, Stream stream, PngCompressionLevel level)
         {
+            int compressionLevel = (int)level;
             this.rawStream = stream;
 
             // Write the zlib header : http://tools.ietf.org/html/rfc1950

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -65,9 +65,19 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         /// <summary>
         /// All types except Palette
         /// </summary>
-        public static readonly TheoryData<int> CompressionLevels = new TheoryData<int>
+        public static readonly TheoryData<PngCompressionLevel> CompressionLevels
+        = new TheoryData<PngCompressionLevel>
         {
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+            PngCompressionLevel.Level0,
+            PngCompressionLevel.Level1,
+            PngCompressionLevel.Level2,
+            PngCompressionLevel.Level3,
+            PngCompressionLevel.Level4,
+            PngCompressionLevel.Level5,
+            PngCompressionLevel.Level6,
+            PngCompressionLevel.Level7,
+            PngCompressionLevel.Level8,
+            PngCompressionLevel.Level9,
         };
 
         public static readonly TheoryData<int> PaletteSizes = new TheoryData<int>
@@ -150,7 +160,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
         [Theory]
         [WithTestPatternImages(nameof(CompressionLevels), 24, 24, PixelTypes.Rgba32)]
-        public void WorksWithAllCompressionLevels<TPixel>(TestImageProvider<TPixel> provider, int compressionLevel)
+        public void WorksWithAllCompressionLevels<TPixel>(TestImageProvider<TPixel> provider, PngCompressionLevel compressionLevel)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             foreach (PngInterlaceMode interlaceMode in InterlaceMode)
@@ -547,7 +557,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             PngFilterMethod pngFilterMethod,
             PngBitDepth bitDepth,
             PngInterlaceMode interlaceMode,
-            int compressionLevel = 6,
+            PngCompressionLevel compressionLevel = PngCompressionLevel.DefaultCompression,
             int paletteSize = 255,
             bool appendPngColorType = false,
             bool appendPngFilterMethod = false,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
We were previously using an `int` which was nasty. This PR introduces a new `PngCompressionLevel` which constrains this property properly.

<!-- Thanks for contributing to ImageSharp! -->
