### PR TITLE
Change Scanlines and SamplesPerLine from short to int

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the GNU Affero General Public License, Version 3.
 
 using System;
@@ -28,12 +28,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <summary>
         /// Gets or sets the number of scanlines within the frame.
         /// </summary>
-        public short Scanlines { get; set; }
+        public int Scanlines { get; set; }
 
         /// <summary>
         /// Gets or sets the number of samples per scanline.
         /// </summary>
-        public short SamplesPerLine { get; set; }
+        public int SamplesPerLine { get; set; }
 
         /// <summary>
         /// Gets or sets the number of components within a frame. In progressive frames this value can range from only 1 to 4.

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -841,8 +841,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 Extended = frameMarker.Marker == JpegConstants.Markers.SOF1,
                 Progressive = frameMarker.Marker == JpegConstants.Markers.SOF2,
                 Precision = this.temp[0],
-                Scanlines = (short)((this.temp[1] << 8) | this.temp[2]),
-                SamplesPerLine = (short)((this.temp[3] << 8) | this.temp[4]),
+                Scanlines = (this.temp[1] << 8) | this.temp[2],
+                SamplesPerLine = (this.temp[3] << 8) | this.temp[4],
                 ComponentCount = this.temp[5]
             };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

This fixes an issue with very large jpeg images. For example: [This](https://pointlesswaymarks.com/Photos/2019/2019-october-sea-of-sand/1910-Sea-of-Sand-Full-Resolution.jpg)

I have not added a test image, because i dont want such super large test files in the repo. Im not sure how we can properly test it without it.