### PR TITLE
Ensure min dimension of 1px following rounding.

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeHelper.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeHelper.cs
@@ -72,7 +72,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
                 // case ResizeMode.Stretch:
                 default:
-                    return (new Size(width, height), new Rectangle(0, 0, width, height));
+                    return (new Size(Sanitize(width), Sanitize(height)), new Rectangle(0, 0, width, height));
             }
         }
 
@@ -143,7 +143,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 }
 
                 // Target image width and height can be different to the rectangle width and height.
-                return (new Size(width, height), new Rectangle(targetX, targetY, targetWidth, targetHeight));
+                return (new Size(Sanitize(width), Sanitize(height)), new Rectangle(targetX, targetY, Sanitize(targetWidth), Sanitize(targetHeight)));
             }
 
             // Switch to pad mode to downscale and calculate from there.
@@ -253,7 +253,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             }
 
             // Target image width and height can be different to the rectangle width and height.
-            return (new Size(width, height), new Rectangle(targetX, targetY, targetWidth, targetHeight));
+            return (new Size(Sanitize(width), Sanitize(height)), new Rectangle(targetX, targetY, Sanitize(targetWidth), Sanitize(targetHeight)));
         }
 
         private static (Size, Rectangle) CalculateMaxRectangle(
@@ -282,7 +282,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             }
 
             // Replace the size to match the rectangle.
-            return (new Size(targetWidth, targetHeight), new Rectangle(0, 0, targetWidth, targetHeight));
+            return (new Size(Sanitize(targetWidth), Sanitize(targetHeight)), new Rectangle(0, 0, Sanitize(targetWidth), Sanitize(targetHeight)));
         }
 
         private static (Size, Rectangle) CalculateMinRectangle(
@@ -330,7 +330,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             }
 
             // Replace the size to match the rectangle.
-            return (new Size(targetWidth, targetHeight), new Rectangle(0, 0, targetWidth, targetHeight));
+            return (new Size(Sanitize(targetWidth), Sanitize(targetHeight)), new Rectangle(0, 0, Sanitize(targetWidth), Sanitize(targetHeight)));
         }
 
         private static (Size, Rectangle) CalculatePadRectangle(
@@ -398,7 +398,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             }
 
             // Target image width and height can be different to the rectangle width and height.
-            return (new Size(width, height), new Rectangle(targetX, targetY, targetWidth, targetHeight));
+            return (new Size(Sanitize(width), Sanitize(height)), new Rectangle(targetX, targetY, Sanitize(targetWidth), Sanitize(targetHeight)));
         }
 
         private static (Size, Rectangle) CalculateManualRectangle(
@@ -419,9 +419,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             int targetHeight = targetRectangle.Height > 0 ? targetRectangle.Height : height;
 
             // Target image width and height can be different to the rectangle width and height.
-            return (new Size(width, height), new Rectangle(targetX, targetY, targetWidth, targetHeight));
+            return (new Size(Sanitize(width), Sanitize(height)), new Rectangle(targetX, targetY, Sanitize(targetWidth), Sanitize(targetHeight)));
         }
 
         private static void ThrowInvalid(string message) => throw new InvalidOperationException(message);
+
+        private static int Sanitize(int input)
+        {
+            return Math.Max(1, input);
+        }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeHelper.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeHelper.cs
@@ -72,7 +72,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
                 // case ResizeMode.Stretch:
                 default:
-                    return (new Size(Sanitize(width), Sanitize(height)), new Rectangle(0, 0, width, height));
+                    return (new Size(Sanitize(width), Sanitize(height)), new Rectangle(0, 0, Sanitize(width), Sanitize(height)));
             }
         }
 
@@ -424,9 +424,6 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
         private static void ThrowInvalid(string message) => throw new InvalidOperationException(message);
 
-        private static int Sanitize(int input)
-        {
-            return Math.Max(1, input);
-        }
+        private static int Sanitize(int input) => Math.Max(1, input);
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -605,5 +605,21 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
                 image.Mutate(x => x.Resize(image.Width / 2, image.Height / 2));
             }
         }
+
+        [Fact]
+        public void Issue1195()
+        {
+            using (var image = new Image<Rgba32>(2, 300))
+            {
+                var size = new Size(50, 50);
+                image.Mutate(x => x
+                    .Resize(
+                        new ResizeOptions
+                        {
+                            Size = size,
+                            Mode = ResizeMode.Max
+                        }));
+            }
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
When calculating a target size/rectangle during resizing ensure that rounding doesn't leave a width/height of zero. Fixes #1195

<!-- Thanks for contributing to ImageSharp! -->
