### PR TITLE
Return input checksum value on empty buffer

### DIFF
--- a/src/ImageSharp/Formats/Png/Zlib/Adler32.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/Adler32.cs
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         {
             if (buffer.IsEmpty)
             {
-                return SeedValue;
+                return adler;
             }
 
 #if SUPPORTS_RUNTIME_INTRINSICS

--- a/src/ImageSharp/Formats/Png/Zlib/Crc32.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/Crc32.cs
@@ -57,7 +57,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
         {
             if (buffer.IsEmpty)
             {
-                return SeedValue;
+                return crc;
             }
 
 #if SUPPORTS_RUNTIME_INTRINSICS

--- a/tests/ImageSharp.Tests/Formats/Png/Adler32Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/Adler32Tests.cs
@@ -12,6 +12,15 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
     {
         [Theory]
         [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void ReturnsCorrectWhenEmpty(uint input)
+        {
+            Assert.Equal(input, Adler32.Calculate(input, default));
+        }
+
+        [Theory]
+        [InlineData(0)]
         [InlineData(8)]
         [InlineData(215)]
         [InlineData(1024)]

--- a/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
@@ -12,6 +12,15 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
     {
         [Theory]
         [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void ReturnsCorrectWhenEmpty(uint input)
+        {
+            Assert.Equal(input, Crc32.Calculate(input, default));
+        }
+
+        [Theory]
+        [InlineData(0)]
         [InlineData(8)]
         [InlineData(215)]
         [InlineData(1024)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Found an issue in the new hash implementations where the default value was returned rather than the input value on buffers with zero length.

<!-- Thanks for contributing to ImageSharp! -->
