### PR TITLE
Swap buffers when encoding PNG with Filtered Adam7 Palette mode

### DIFF
--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -1081,6 +1081,10 @@ namespace SixLabors.ImageSharp.Formats.Png
                         // encode data
                         IManagedByteBuffer r = this.EncodeAdam7IndexedPixelRow(destSpan);
                         deflateStream.Write(r.Array, 0, resultLength);
+
+                        IManagedByteBuffer temp = this.currentScanline;
+                        this.currentScanline = this.previousScanline;
+                        this.previousScanline = temp;
                     }
                 }
             }

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -199,17 +199,20 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 return;
             }
 
-            foreach (PngInterlaceMode interlaceMode in InterlaceMode)
+            foreach (var filterMethod in PngFilterMethods)
             {
-                TestPngEncoderCore(
-                provider,
-                pngColorType,
-                PngFilterMethod.Adaptive,
-                pngBitDepth,
-                interlaceMode,
-                appendPngColorType: true,
-                appendPixelType: true,
-                appendPngBitDepth: true);
+                foreach (PngInterlaceMode interlaceMode in InterlaceMode)
+                {
+                    TestPngEncoderCore(
+                    provider,
+                    pngColorType,
+                    (PngFilterMethod)filterMethod[0],
+                    pngBitDepth,
+                    interlaceMode,
+                    appendPngColorType: true,
+                    appendPixelType: true,
+                    appendPngBitDepth: true);
+                }
             }
         }
 
@@ -232,18 +235,22 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void WorksWithAllBitDepthsAndExcludeAllFilter<TPixel>(TestImageProvider<TPixel> provider, PngColorType pngColorType, PngBitDepth pngBitDepth)
           where TPixel : unmanaged, IPixel<TPixel>
         {
-            foreach (PngInterlaceMode interlaceMode in InterlaceMode)
+            foreach (var filterMethod in PngFilterMethods)
             {
-                TestPngEncoderCore(
-                provider,
                 pngColorType,
-                PngFilterMethod.Adaptive,
-                pngBitDepth,
-                interlaceMode,
-                appendPngColorType: true,
-                appendPixelType: true,
-                appendPngBitDepth: true,
-                optimizeMethod: PngChunkFilter.ExcludeAll);
+                foreach (PngInterlaceMode interlaceMode in InterlaceMode)
+                {
+                    TestPngEncoderCore(
+                    provider,
+                    pngColorType,
+                    (PngFilterMethod)filterMethod[0],
+                    pngBitDepth,
+                    interlaceMode,
+                    appendPngColorType: true,
+                    appendPixelType: true,
+                    appendPngBitDepth: true,
+                    optimizeMethod: PngChunkFilter.ExcludeAll);
+                }
             }
         }
 

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -237,7 +237,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         {
             foreach (var filterMethod in PngFilterMethods)
             {
-                pngColorType,
                 foreach (PngInterlaceMode interlaceMode in InterlaceMode)
                 {
                     TestPngEncoderCore(


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
We weren't swapping the scanline buffers after collecting the filtered pixel in palette mode so certain filters were failing to encode correctly. 

Fixes #1211 

<!-- Thanks for contributing to ImageSharp! -->
