### PR TITLE
Update Adler32 to correctly filter intrinsics. 

### DIFF
--- a/src/ImageSharp/Formats/Png/Zlib/Adler32.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/Adler32.cs
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Zlib
             }
 
 #if SUPPORTS_RUNTIME_INTRINSICS
-            if (Sse3.IsSupported && buffer.Length >= MinBufferSize)
+            if (Ssse3.IsSupported && buffer.Length >= MinBufferSize)
             {
                 return CalculateSse(adler, buffer);
             }

--- a/tests/ImageSharp.Tests/TestUtilities/TestEnvironment.Features.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestEnvironment.Features.cs
@@ -10,6 +10,27 @@ namespace SixLabors.ImageSharp.Tests
             public const string On = "1";
             public const string Off = "0";
 
+            // See https://github.com/SixLabors/ImageSharp/pull/1229#discussion_r440477861
+            // * EnableHWIntrinsic
+            //   * EnableSSE
+            //     * EnableSSE2
+            //       * EnableAES
+            //       * EnablePCLMULQDQ
+            //       * EnableSSE3
+            //         * EnableSSSE3
+            //           * EnableSSE41
+            //             * EnableSSE42
+            //               * EnablePOPCNT
+            //               * EnableAVX
+            //                 * EnableFMA
+            //                 * EnableAVX2
+            //   * EnableBMI1
+            //   * EnableBMI2
+            //   * EnableLZCNT
+            //
+            // `FeatureSIMD` ends up impacting all SIMD support(including `System.Numerics`) but not things
+            // like `LZCNT`, `BMI1`, or `BMI2`
+            // `EnableSSE3_4` is a legacy switch that exists for compat and is basically the same as `EnableSSE3`
             public const string EnableAES = "COMPlus_EnableAES";
             public const string EnableAVX = "COMPlus_EnableAVX";
             public const string EnableAVX2 = "COMPlus_EnableAVX2";
@@ -17,7 +38,6 @@ namespace SixLabors.ImageSharp.Tests
             public const string EnableBMI2 = "COMPlus_EnableBMI2";
             public const string EnableFMA = "COMPlus_EnableFMA";
             public const string EnableHWIntrinsic = "COMPlus_EnableHWIntrinsic";
-            public const string EnableIncompleteISAClass = "COMPlus_EnableIncompleteISAClass";
             public const string EnableLZCNT = "COMPlus_EnableLZCNT";
             public const string EnablePCLMULQDQ = "COMPlus_EnablePCLMULQDQ";
             public const string EnablePOPCNT = "COMPlus_EnablePOPCNT";

--- a/tests/ImageSharp.Tests/TestUtilities/TestEnvironment.Features.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestEnvironment.Features.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Tests
+{
+    public static partial class TestEnvironment
+    {
+        internal static class Features
+        {
+            public const string On = "1";
+            public const string Off = "0";
+
+            public const string EnableAES = "COMPlus_EnableAES";
+            public const string EnableAVX = "COMPlus_EnableAVX";
+            public const string EnableAVX2 = "COMPlus_EnableAVX2";
+            public const string EnableBMI1 = "COMPlus_EnableBMI1";
+            public const string EnableBMI2 = "COMPlus_EnableBMI2";
+            public const string EnableFMA = "COMPlus_EnableFMA";
+            public const string EnableHWIntrinsic = "COMPlus_EnableHWIntrinsic";
+            public const string EnableIncompleteISAClass = "COMPlus_EnableIncompleteISAClass";
+            public const string EnableLZCNT = "COMPlus_EnableLZCNT";
+            public const string EnablePCLMULQDQ = "COMPlus_EnablePCLMULQDQ";
+            public const string EnablePOPCNT = "COMPlus_EnablePOPCNT";
+            public const string EnableSSE = "COMPlus_EnableSSE";
+            public const string EnableSSE2 = "COMPlus_EnableSSE2";
+            public const string EnableSSE3 = "COMPlus_EnableSSE3";
+            public const string EnableSSE3_4 = "COMPlus_EnableSSE3_4";
+            public const string EnableSSE41 = "COMPlus_EnableSSE41";
+            public const string EnableSSE42 = "COMPlus_EnableSSE42";
+            public const string EnableSSSE3 = "COMPlus_EnableSSSE3";
+            public const string FeatureSIMD = "COMPlus_FeatureSIMD";
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Introduces the correct intrinsics support check in the enhanced Adler32 implementation. Fix #1228

@antonfirsov if you have any idea how to test this please let me know if you have any thoughts.

<!-- Thanks for contributing to ImageSharp! -->
