### PR TITLE
Use ConcurrentDictionary for options properties.

### DIFF
--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Http;
 using SixLabors.ImageSharp.Formats;
@@ -78,7 +79,7 @@ namespace SixLabors.ImageSharp
         /// Gets a set of properties for the Congiguration.
         /// </summary>
         /// <remarks>This can be used for storing global settings and defaults to be accessable to processors.</remarks>
-        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
+        public IDictionary<object, object> Properties { get; } = new ConcurrentDictionary<object, object>();
 
         /// <summary>
         /// Gets the currently registered <see cref="IImageFormat"/>s.

--- a/src/ImageSharp/GraphicOptionsDefaultsExtensions.cs
+++ b/src/ImageSharp/GraphicOptionsDefaultsExtensions.cs
@@ -71,11 +71,9 @@ namespace SixLabors.ImageSharp
                 return go;
             }
 
-            var configOptions = context.Configuration.GetGraphicsOptions();
-
             // do not cache the fall back to config into the the processing context
             // in case someone want to change the value on the config and expects it re trflow thru
-            return configOptions;
+            return context.Configuration.GetGraphicsOptions();
         }
 
         /// <summary>

--- a/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors;
@@ -41,7 +42,7 @@ namespace SixLabors.ImageSharp.Processing
         public Configuration Configuration { get; }
 
         /// <inheritdoc/>
-        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
+        public IDictionary<object, object> Properties { get; } = new ConcurrentDictionary<object, object>();
 
         /// <inheritdoc/>
         public Image<TPixel> GetResultImage()

--- a/tests/ImageSharp.Tests/GraphicOptionsDefaultsExtensionsTests.cs
+++ b/tests/ImageSharp.Tests/GraphicOptionsDefaultsExtensionsTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Tests.Processing;
 using SixLabors.ImageSharp.Tests.TestUtilities;
 using Xunit;
@@ -167,6 +169,19 @@ namespace SixLabors.ImageSharp.Tests
             var options = context.GetGraphicsOptions();
             Assert.NotNull(options);
             Assert.IsType<GraphicsOptions>(options);
+        }
+
+        [Theory]
+        [WithBlankImages(100, 100, PixelTypes.Rgba32)]
+        public void CanGetGraphicsOptionsMultiThreaded<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // Could not get fake operations to trigger #1230 so using a real image.
+            Parallel.For(0, 10, _ =>
+            {
+                using Image<TPixel> image = provider.GetImage();
+                image.Mutate(x => x.BackgroundColor(Color.White));
+            });
         }
     }
 }

--- a/tests/ImageSharp.Tests/Processing/FakeImageOperationsProvider.cs
+++ b/tests/ImageSharp.Tests/Processing/FakeImageOperationsProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using SixLabors.ImageSharp.PixelFormats;
@@ -56,7 +57,7 @@ namespace SixLabors.ImageSharp.Tests.Processing
 
             public Configuration Configuration { get; }
 
-            public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
+            public IDictionary<object, object> Properties { get; } = new ConcurrentDictionary<object, object>();
 
             public Image<TPixel> GetResultImage()
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #1230 #1224 

The two dictionaries used in `Configuration `and `DefaultImageProcessorContext` were not thread safe and would throw when accessed in a parallel context.

I've replaced them with `ConcurrentDictionary` instances which fixes the issue but I wonder whether we should be exposing the property as `IDictionary<object, object>` over the concrete type since we require thread safety. 

<!-- Thanks for contributing to ImageSharp! -->
