### PR TITLE
Added Third Party Notices document

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1,0 +1,32 @@
+ImageSharp uses third-party libraries or other resources that may be
+distributed under licenses different than ImageSharp itself.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention by posting an issue.
+
+The attached notices are provided for information only.
+
+
+License notice for Zlib
+-----
+
+DeflateStream implementation adapted from SharpZipLib.
+Licensed under MIT.
+https://github.com/icsharpcode/SharpZipLib
+
+
+Crc32 and Adler32 SIMD implementation adapted from Chromium.
+Licensed under BSD 3-Clause "New" or "Revised" License.
+https://github.com/chromium/chromium
+
+
+License notice for Stream Read/Write Extensions
+-----
+
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MIT license.
+See the LICENSE file in the CoreFX project root for more information.
+
+https://github.com/dotnet/corefx/blob/17300169760c61a90cab8d913636c1058a30a8c1/LICENSE.TXT
+https://github.com/dotnet/corefx/blob/17300169760c61a90cab8d913636c1058a30a8c1/src/Common/src/CoreLib/System/IO/Stream.cs#L742
+https://github.com/dotnet/corefx/blob/17300169760c61a90cab8d913636c1058a30a8c1/src/Common/src/CoreLib/System/IO/Stream.cs#L775


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Adds a Third Party Notices file, closes #856 . Opening language copied from dotnet/runtime, license information copied from the various sources in the code base.

One thing to note, the shared infrastructure repo also has a file with MIT and BSD licensing. I didn't include that reference here as I see the shared infrastructure to be its own dependency. It probably deserves to have its own Third Party Notices file.