### PR TITLE
Better Builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -107,5 +107,7 @@ jobs:
 
             - name: Publish to MyGet
               shell: pwsh
-              run: nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
+              run: |
+                  nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
+                  nuget.exe push .\artifacts\*.snupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v3/index.json
               # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,7 +55,7 @@ jobs:
             - name: Setup DotNet SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "3.1.x"
+                  dotnet-version: "3.1.101"
 
             - name: Build
               shell: pwsh
@@ -99,7 +99,7 @@ jobs:
             - name: Setup DotNet SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "3.1.x"
+                  dotnet-version: "3.1.101"
 
             - name: Pack
               shell: pwsh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,7 +59,6 @@ jobs:
 
             - name: Build
               shell: pwsh
-              if: startsWith(github.ref, 'refs/tags/') == false
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
 
             - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,7 +55,7 @@ jobs:
             - name: Setup DotNet SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "3.1.101"
+                  dotnet-version: "3.1.x"
 
             - name: Build
               shell: pwsh
@@ -98,7 +98,7 @@ jobs:
             - name: Setup DotNet SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "3.1.101"
+                  dotnet-version: "3.1.x"
 
             - name: Pack
               shell: pwsh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,31 +52,15 @@ jobs:
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
 
-            - name: Fetch Tags for GitVersion
-              run: |
-                  git fetch --tags
-
-            - name: Fetch master for GitVersion
-              if: github.ref != 'refs/heads/master'
-              run: git branch --create-reflog master origin/master
-
-            - name: Install GitVersion
-              uses: gittools/actions/gitversion/setup@v0.9.3
-              with:
-                  versionSpec: "5.3.x"
-
-            - name: Use GitVersion
-              id: gitversion # step id used as reference for output values
-              uses: gittools/actions/gitversion/execute@v0.9.3
-
             - name: Setup DotNet SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "3.1.101"
+                  dotnet-version: "3.1.x"
 
             - name: Build
               shell: pwsh
-              run: ./ci-build.ps1 "${{steps.gitversion.outputs.nuGetVersion}}" "${{matrix.options.framework}}"
+              if: startsWith(github.ref, 'refs/tags/') == false
+              run: ./ci-build.ps1 "${{matrix.options.framework}}"
 
             - name: Test
               shell: pwsh
@@ -112,31 +96,14 @@ jobs:
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
 
-            - name: Fetch Tags for GitVersion
-              run: |
-                  git fetch --tags
-
-            - name: Fetch master for GitVersion
-              if: github.ref != 'refs/heads/master'
-              run: git branch --create-reflog master origin/master
-
-            - name: Install GitVersion
-              uses: gittools/actions/gitversion/setup@v0.9.3
-              with:
-                  versionSpec: "5.3.x"
-
-            - name: Use GitVersion
-              id: gitversion # step id used as reference for output values
-              uses: gittools/actions/gitversion/execute@v0.9.3
-
             - name: Setup DotNet SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "3.1.101"
+                  dotnet-version: "3.1.x"
 
             - name: Pack
               shell: pwsh
-              run: ./ci-pack.ps1 "${{steps.gitversion.outputs.nuGetVersion}}"
+              run: ./ci-pack.ps1
 
             - name: Publish to MyGet
               shell: pwsh

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -92,6 +92,12 @@
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
+  <!--Add deterministic builds in CI-->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,6 +29,12 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
+  <!--MinVer Properties for versioning-->
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerVerbosity>normal</MinVerVerbosity>
+  </PropertyGroup>
+
   <!--
     https://apisof.net/
     +===================+=======+==========+=====================+=============+=================+====================+==============+=========+

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,14 +25,7 @@
     <DebugType Condition="'$(codecov)' != ''">full</DebugType>
     <NullableContextOptions>disable</NullableContextOptions>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <SignAssembly>false</SignAssembly>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-  </PropertyGroup>
-
-  <!--MinVer Properties for versioning-->
-  <PropertyGroup>
-    <MinVerTagPrefix>v</MinVerTagPrefix>
-    <MinVerVerbosity>normal</MinVerVerbosity>
   </PropertyGroup>
 
   <!--
@@ -97,6 +90,19 @@
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionPrefix Condition="'$(packageversion)' != ''">$(PackageVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <!--MinVer Properties for versioning-->
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerVerbosity>normal</MinVerVerbosity>
   </PropertyGroup>
 
   <!-- Default settings that are otherwise undefined -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -92,19 +92,6 @@
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
-  <!--Add deterministic builds in CI-->
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-
   <!--MinVer Properties for versioning-->
   <PropertyGroup>
     <MinVerTagPrefix>v</MinVerTagPrefix>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,6 +23,7 @@
     <PackageReference Update="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
     
     <!--Src Dependencies-->
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Update="MinVer" PrivateAssets="All" Version="2.3.0" />
     <PackageReference Update="System.Buffers" Version="4.5.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,6 +23,7 @@
     <PackageReference Update="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
     
     <!--Src Dependencies-->
+    <PackageReference Update="MinVer" PrivateAssets="All" Version="2.3.0" />
     <PackageReference Update="System.Buffers" Version="4.5.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.UnmanagedMemoryStream" Version="4.3.0" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,7 +23,6 @@
     <PackageReference Update="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
     
     <!--Src Dependencies-->
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Update="MinVer" PrivateAssets="All" Version="2.3.0" />
     <PackageReference Update="System.Buffers" Version="4.5.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,9 +1,0 @@
-# Use mainline mode to match our development approach.
-# https://gitversion.readthedocs.io/en/latest/input/docs/reference/versioning-modes/mainline-development/
-mode: Mainline
-continuous-delivery-fallback-tag: ci
-branches:
-    master:
-        tag: unstable
-    pull-request:
-        tag: pr

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,9 @@
+# Use mainline mode to match our development approach.
+# https://gitversion.readthedocs.io/en/latest/input/docs/reference/versioning-modes/mainline-development/
+mode: Mainline
 continuous-delivery-fallback-tag: ci
 branches:
     master:
         tag: unstable
-        mode: ContinuousDeployment
     pull-request:
         tag: pr

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -1,7 +1,5 @@
 param(
-  [Parameter(Mandatory, Position = 0)]
-  [string]$version,
-  [Parameter(Mandatory = $true, Position = 1)]
+  [Parameter(Mandatory = $true, Position = 0)]
   [string]$targetFramework
 )
 
@@ -10,4 +8,4 @@ dotnet clean -c Release
 $repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
 
 # Building for a specific framework.
-dotnet build -c Release -f $targetFramework /p:packageversion=$version /p:RepositoryUrl=$repositoryUrl
+dotnet build -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl

--- a/ci-pack.ps1
+++ b/ci-pack.ps1
@@ -1,11 +1,6 @@
-param(
-  [Parameter(Mandatory, Position = 0)]
-  [string]$version
-)
-
 dotnet clean -c Release
 
 $repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
 
 # Building for packing and publishing.
-dotnet pack -c Release --output "$PSScriptRoot/artifacts" /p:packageversion=$version /p:RepositoryUrl=$repositoryUrl
+dotnet pack -c Release --output "$PSScriptRoot/artifacts" /p:RepositoryUrl=$repositoryUrl

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,6 +26,19 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <!--Add deterministic builds in CI-->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  
   <ItemGroup>
     <!-- DynamicProxyGenAssembly2 is needed so Moq can use our internals -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -20,15 +20,6 @@
     <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
   </PropertyGroup>
 
-  <!-- Workaround for using SDK < 3.1.300, which we cannot use since it breaks coverlet -->
-  <!-- https://github.com/clairernovotny/DeterministicBuilds -->
-  <!--<PropertyGroup>
-    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
-  </PropertyGroup>
-  <ItemGroup>
-    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
-  </ItemGroup>-->
-
   <!-- Workaround for running Coverlet with Determenistic builds -->
   <!-- https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/DeterministicBuild.md -->
   <Target Name="CoverletGetPathMap"

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -20,11 +20,6 @@
     <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!--Src Dependencies-->
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-  </ItemGroup>
-  
   <ItemDefinitionGroup>
     <InternalsVisibleTo>
       <Visible>false</Visible>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -20,6 +20,11 @@
     <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!--Src Dependencies-->
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+  </ItemGroup>
+  
   <ItemDefinitionGroup>
     <InternalsVisibleTo>
       <Visible>false</Visible>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -20,6 +20,17 @@
     <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
   </PropertyGroup>
 
+  <!-- Workaround for using SDK < 3.1.300, which we cannot use since it breaks coverlet -->
+  <!-- https://github.com/clairernovotny/DeterministicBuilds -->
+  <Project>
+    <PropertyGroup>
+      <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+    </ItemGroup>
+  </Project>
+
   <ItemDefinitionGroup>
     <InternalsVisibleTo>
       <Visible>false</Visible>
@@ -51,7 +62,7 @@
   <!-- Empty target so that `dotnet test` will work on the solution -->
   <!-- https://github.com/Microsoft/vstest/issues/411 -->
   <Target Name="VSTest" Condition="'$(IsTestProject)' == 'true'"/>
-
+  
   <ItemGroup>
     <!--Shared config files that have to exist at root level.-->
     <ConfigFilesToCopy Include="..\..\shared-infrastructure\.editorconfig;..\..\shared-infrastructure\.gitattributes" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -22,13 +22,24 @@
 
   <!-- Workaround for using SDK < 3.1.300, which we cannot use since it breaks coverlet -->
   <!-- https://github.com/clairernovotny/DeterministicBuilds -->
-  <PropertyGroup>
+  <!--<PropertyGroup>
     <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
-  </ItemGroup>
+  </ItemGroup>-->
 
+  <!-- Workaround for running Coverlet with Determenistic builds -->
+  <!-- https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/DeterministicBuild.md -->
+  <Target Name="CoverletGetPathMap"
+            DependsOnTargets="InitializeSourceRootMappedPaths"
+            Returns="@(_LocalTopLevelSourceRoot)"
+            Condition="'$(DeterministicSourcePaths)' == 'true'">
+    <ItemGroup>
+      <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
+    </ItemGroup>
+  </Target>
+  
   <ItemDefinitionGroup>
     <InternalsVisibleTo>
       <Visible>false</Visible>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -22,14 +22,12 @@
 
   <!-- Workaround for using SDK < 3.1.300, which we cannot use since it breaks coverlet -->
   <!-- https://github.com/clairernovotny/DeterministicBuilds -->
-  <Project>
-    <PropertyGroup>
-      <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
-    </ItemGroup>
-  </Project>
+  <PropertyGroup>
+    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+  </ItemGroup>
 
   <ItemDefinitionGroup>
     <InternalsVisibleTo>

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub"/>
     <PackageReference Include="MinVer" PrivateAssets="All" />
   </ItemGroup>
   

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -19,6 +19,10 @@
     <RootNamespace>SixLabors.ImageSharp</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MinVer" PrivateAssets="All" />
+  </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -28,7 +28,7 @@
     <PackageReference Update="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.0" Condition="'$(OS)' == 'Windows_NT'" />    
     <PackageReference Update="Colourful" Version="2.0.3" />
-    <PackageReference Update="coverlet.collector" Version="1.2.0" PrivateAssets="All"/>
+    <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All"/>
     <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="7.15.5" />
     <PackageReference Update="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20069.1" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20200116-01" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
- Fixes  #1233 by replacing broken GitVersion with MinVer. This changes the nightly build numbers (unavoidable) but creates a better format in my opinion. Nightly builds now use the tag with added commit height e.g `1.0.0-rc.3.{height}`.
- Adds Source Link and Deterministic builds to the resultant output. A separate `snupkg` file is generated following best practice to keep package sizes down for consumers during restore. Fixes #1251 

<!-- Thanks for contributing to ImageSharp! -->
