### PR TITLE
Save as extensions

### DIFF
--- a/src/ImageSharp/Formats/Bmp/ImageExtensions.cs
+++ b/src/ImageSharp/Formats/Bmp/ImageExtensions.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
-
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats.Bmp;
 
@@ -17,9 +17,60 @@ namespace SixLabors.ImageSharp
         /// Saves the image to the given stream with the bmp format.
         /// </summary>
         /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsBmp(this Image source, string path) => SaveAsBmp(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the bmp format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsBmpAsync(this Image source, string path) => SaveAsBmpAsync(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the bmp format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsBmp(this Image source, string path, BmpEncoder encoder) =>
+            source.Save(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(BmpFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the bmp format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsBmpAsync(this Image source, string path, BmpEncoder encoder) =>
+            source.SaveAsync(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(BmpFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the bmp format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SaveAsBmp(this Image source, Stream stream) => source.SaveAsBmp(stream, null);
+        public static void SaveAsBmp(this Image source, Stream stream) => SaveAsBmp(source, stream, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the bmp format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsBmpAsync(this Image source, Stream stream) => SaveAsBmpAsync(source, stream, null);
 
         /// <summary>
         /// Saves the image to the given stream with the bmp format.
@@ -30,6 +81,19 @@ namespace SixLabors.ImageSharp
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
         public static void SaveAsBmp(this Image source, Stream stream, BmpEncoder encoder) =>
             source.Save(
+                stream,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(BmpFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the bmp format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsBmpAsync(this Image source, Stream stream, BmpEncoder encoder) =>
+            source.SaveAsync(
                 stream,
                 encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(BmpFormat.Instance));
     }

--- a/src/ImageSharp/Formats/Gif/ImageExtensions.cs
+++ b/src/ImageSharp/Formats/Gif/ImageExtensions.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
-
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats.Gif;
 
@@ -14,22 +14,86 @@ namespace SixLabors.ImageSharp
     public static partial class ImageExtensions
     {
         /// <summary>
-        /// Saves the image to the given stream in the gif format.
+        /// Saves the image to the given stream with the gif format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsGif(this Image source, string path) => SaveAsGif(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the gif format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsGifAsync(this Image source, string path) => SaveAsGifAsync(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the gif format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsGif(this Image source, string path, GifEncoder encoder) =>
+            source.Save(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(GifFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the gif format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsGifAsync(this Image source, string path, GifEncoder encoder) =>
+            source.SaveAsync(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(GifFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the gif format.
         /// </summary>
         /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SaveAsGif(this Image source, Stream stream) => source.SaveAsGif(stream, null);
+        public static void SaveAsGif(this Image source, Stream stream) => SaveAsGif(source, stream, null);
 
         /// <summary>
-        /// Saves the image to the given stream in the gif format.
+        /// Saves the image to the given stream with the gif format.
         /// </summary>
         /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
-        /// <param name="encoder">The options for the encoder.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsGifAsync(this Image source, Stream stream) => SaveAsGifAsync(source, stream, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the gif format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
         public static void SaveAsGif(this Image source, Stream stream, GifEncoder encoder) =>
             source.Save(
+                stream,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(GifFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the gif format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsGifAsync(this Image source, Stream stream, GifEncoder encoder) =>
+            source.SaveAsync(
                 stream,
                 encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(GifFormat.Instance));
     }

--- a/src/ImageSharp/Formats/Jpeg/ImageExtensions.cs
+++ b/src/ImageSharp/Formats/Jpeg/ImageExtensions.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
-
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats.Jpeg;
 
@@ -17,6 +17,48 @@ namespace SixLabors.ImageSharp
         /// Saves the image to the given stream with the jpeg format.
         /// </summary>
         /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsJpeg(this Image source, string path) => SaveAsJpeg(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the jpeg format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsJpegAsync(this Image source, string path) => SaveAsJpegAsync(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the jpeg format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsJpeg(this Image source, string path, JpegEncoder encoder) =>
+            source.Save(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(JpegFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the jpeg format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsJpegAsync(this Image source, string path, JpegEncoder encoder) =>
+            source.SaveAsync(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(JpegFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the jpeg format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
         public static void SaveAsJpeg(this Image source, Stream stream) => SaveAsJpeg(source, stream, null);
@@ -26,10 +68,32 @@ namespace SixLabors.ImageSharp
         /// </summary>
         /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
-        /// <param name="encoder">The options for the encoder.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsJpegAsync(this Image source, Stream stream) => SaveAsJpegAsync(source, stream, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the jpeg format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
         public static void SaveAsJpeg(this Image source, Stream stream, JpegEncoder encoder) =>
             source.Save(
+                stream,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(JpegFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the jpeg format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsJpegAsync(this Image source, Stream stream, JpegEncoder encoder) =>
+            source.SaveAsync(
                 stream,
                 encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(JpegFormat.Instance));
     }

--- a/src/ImageSharp/Formats/Png/ImageExtensions.cs
+++ b/src/ImageSharp/Formats/Png/ImageExtensions.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
-
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats.Png;
 
@@ -17,6 +17,48 @@ namespace SixLabors.ImageSharp
         /// Saves the image to the given stream with the png format.
         /// </summary>
         /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsPng(this Image source, string path) => SaveAsPng(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the png format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsPngAsync(this Image source, string path) => SaveAsPngAsync(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the png format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsPng(this Image source, string path, PngEncoder encoder) =>
+            source.Save(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(PngFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the png format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsPngAsync(this Image source, string path, PngEncoder encoder) =>
+            source.SaveAsync(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(PngFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the png format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
         public static void SaveAsPng(this Image source, Stream stream) => SaveAsPng(source, stream, null);
@@ -26,10 +68,32 @@ namespace SixLabors.ImageSharp
         /// </summary>
         /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
-        /// <param name="encoder">The options for the encoder.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsPngAsync(this Image source, Stream stream) => SaveAsPngAsync(source, stream, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the png format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
         public static void SaveAsPng(this Image source, Stream stream, PngEncoder encoder) =>
             source.Save(
+                stream,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(PngFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the png format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsPngAsync(this Image source, Stream stream, PngEncoder encoder) =>
+            source.SaveAsync(
                 stream,
                 encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(PngFormat.Instance));
     }

--- a/src/ImageSharp/Formats/Tga/ImageExtensions.cs
+++ b/src/ImageSharp/Formats/Tga/ImageExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
-
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats.Tga;
 
@@ -17,6 +17,48 @@ namespace SixLabors.ImageSharp
         /// Saves the image to the given stream with the tga format.
         /// </summary>
         /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsTga(this Image source, string path) => SaveAsTga(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the tga format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsTgaAsync(this Image source, string path) => SaveAsTgaAsync(source, path, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the tga format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        public static void SaveAsTga(this Image source, string path, TgaEncoder encoder) =>
+            source.Save(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(TgaFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the tga format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="path">The file path to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsTgaAsync(this Image source, string path, TgaEncoder encoder) =>
+            source.SaveAsync(
+                path,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(TgaFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the tga format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
         public static void SaveAsTga(this Image source, Stream stream) => SaveAsTga(source, stream, null);
@@ -26,10 +68,32 @@ namespace SixLabors.ImageSharp
         /// </summary>
         /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
-        /// <param name="encoder">The options for the encoder.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsTgaAsync(this Image source, Stream stream) => SaveAsTgaAsync(source, stream, null);
+
+        /// <summary>
+        /// Saves the image to the given stream with the tga format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
         /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
         public static void SaveAsTga(this Image source, Stream stream, TgaEncoder encoder) =>
             source.Save(
+                stream,
+                encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(TgaFormat.Instance));
+
+        /// <summary>
+        /// Saves the image to the given stream with the tga format.
+        /// </summary>
+        /// <param name="source">The image this method extends.</param>
+        /// <param name="stream">The stream to save the image to.</param>
+        /// <param name="encoder">The encoder to save the image with.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the stream is null.</exception>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static Task SaveAsTgaAsync(this Image source, Stream stream, TgaEncoder encoder) =>
+            source.SaveAsync(
                 stream,
                 encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(TgaFormat.Instance));
     }

--- a/tests/ImageSharp.Tests/Formats/Bmp/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/ImageExtensionsTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats;

--- a/tests/ImageSharp.Tests/Formats/Bmp/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/ImageExtensionsTest.cs
@@ -1,0 +1,152 @@
+using System.IO;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Bmp
+{
+    public class ImageExtensionsTest
+    {
+        [Fact]
+        public void SaveAsBmp_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsBmp_Path.bmp");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsBmp(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/bmp", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsBmpAsync_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsBmpAsync_Path.bmp");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsBmpAsync(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/bmp", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsBmp_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsBmp_Path_Encoder.bmp");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsBmp(file, new BmpEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/bmp", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsBmpAsync_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsBmpAsync_Path_Encoder.bmp");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsBmpAsync(file, new BmpEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/bmp", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsBmp_Stream()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsBmp(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/bmp", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsBmpAsync_StreamAsync()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsBmpAsync(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/bmp", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsBmp_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsBmp(memoryStream, new BmpEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/bmp", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsBmpAsync_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsBmpAsync(memoryStream, new BmpEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/bmp", mime.DefaultMimeType);
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Gif/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/ImageExtensionsTest.cs
@@ -1,0 +1,152 @@
+using System.IO;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Gif
+{
+    public class ImageExtensionsTest
+    {
+        [Fact]
+        public void SaveAsGif_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsGif_Path.gif");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsGif(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/gif", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsGifAsync_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsGifAsync_Path.gif");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsGifAsync(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/gif", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsGif_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsGif_Path_Encoder.gif");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsGif(file, new GifEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/gif", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsGifAsync_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsGifAsync_Path_Encoder.gif");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsGifAsync(file, new GifEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/gif", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsGif_Stream()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsGif(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/gif", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsGifAsync_StreamAsync()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsGifAsync(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/gif", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsGif_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsGif(memoryStream, new GifEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/gif", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsGifAsync_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsGifAsync(memoryStream, new GifEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/gif", mime.DefaultMimeType);
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Gif/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/ImageExtensionsTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats;

--- a/tests/ImageSharp.Tests/Formats/Jpg/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ImageExtensionsTest.cs
@@ -1,0 +1,152 @@
+using System.IO;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Jpg
+{
+    public class ImageExtensionsTest
+    {
+        [Fact]
+        public void SaveAsJpeg_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsJpeg_Path.jpg");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsJpeg(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/jpeg", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsJpegAsync_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsJpegAsync_Path.jpg");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsJpegAsync(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/jpeg", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsJpeg_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsJpeg_Path_Encoder.jpg");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsJpeg(file, new JpegEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/jpeg", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsJpegAsync_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsJpegAsync_Path_Encoder.jpg");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsJpegAsync(file, new JpegEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/jpeg", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsJpeg_Stream()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsJpeg(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/jpeg", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsJpegAsync_StreamAsync()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsJpegAsync(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/jpeg", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsJpeg_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsJpeg(memoryStream, new JpegEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/jpeg", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsJpegAsync_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsJpegAsync(memoryStream, new JpegEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/jpeg", mime.DefaultMimeType);
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Jpg/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ImageExtensionsTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats;

--- a/tests/ImageSharp.Tests/Formats/Png/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/ImageExtensionsTest.cs
@@ -1,0 +1,152 @@
+using System.IO;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Png
+{
+    public class ImageExtensionsTest
+    {
+        [Fact]
+        public void SaveAsPng_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsPng_Path.png");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsPng(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/png", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsPngAsync_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsPngAsync_Path.png");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsPngAsync(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/png", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsPng_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsPng_Path_Encoder.png");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsPng(file, new PngEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/png", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsPngAsync_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsPngAsync_Path_Encoder.png");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsPngAsync(file, new PngEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/png", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsPng_Stream()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsPng(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/png", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsPngAsync_StreamAsync()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsPngAsync(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/png", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsPng_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsPng(memoryStream, new PngEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/png", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsPngAsync_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsPngAsync(memoryStream, new PngEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/png", mime.DefaultMimeType);
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Png/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/ImageExtensionsTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats;

--- a/tests/ImageSharp.Tests/Formats/Tga/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/ImageExtensionsTest.cs
@@ -1,0 +1,152 @@
+using System.IO;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Tga;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Tga
+{
+    public class ImageExtensionsTest
+    {
+        [Fact]
+        public void SaveAsTga_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsTga_Path.tga");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsTga(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/tga", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsTgaAsync_Path()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensionsTest));
+            string file = Path.Combine(dir, "SaveAsTgaAsync_Path.tga");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsTgaAsync(file);
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/tga", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsTga_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsTga_Path_Encoder.tga");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsTga(file, new TgaEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/tga", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsTgaAsync_Path_Encoder()
+        {
+            string dir = TestEnvironment.CreateOutputDirectory(nameof(ImageExtensions));
+            string file = Path.Combine(dir, "SaveAsTgaAsync_Path_Encoder.tga");
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsTgaAsync(file, new TgaEncoder());
+            }
+
+            using (Image.Load(file, out IImageFormat mime))
+            {
+                Assert.Equal("image/tga", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsTga_Stream()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsTga(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/tga", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsTgaAsync_StreamAsync()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsTgaAsync(memoryStream);
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/tga", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public void SaveAsTga_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                image.SaveAsTga(memoryStream, new TgaEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/tga", mime.DefaultMimeType);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsTgaAsync_Stream_Encoder()
+        {
+            using var memoryStream = new MemoryStream();
+
+            using (var image = new Image<Rgba32>(10, 10))
+            {
+                await image.SaveAsTgaAsync(memoryStream, new TgaEncoder());
+            }
+
+            memoryStream.Position = 0;
+
+            using (Image.Load(memoryStream, out IImageFormat mime))
+            {
+                Assert.Equal("image/tga", mime.DefaultMimeType);
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Tga/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/ImageExtensionsTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This add several methods for saving images. Id addresses #1255.

There were no unit test for the existing extensions so I did not ceate anyone for this either. But I did make sure that all extensions for all file formats produced identical files with this code:

    using SixLabors.ImageSharp;
    using System;
    using System.IO;
    using System.Threading.Tasks;

    namespace ConsoleAppImageSharpTester
    {
        class Program
        {
            static async Task Main(string[] args)
            {
                var img = Image.Load(@"testimage.png");

                Directory.CreateDirectory(@".\test");

                {
                    img.SaveAsTga(@".\test\norm_name.tga");
                    img.SaveAsTga(@".\test\norm_name_enc.tga", new SixLabors.ImageSharp.Formats.Tga.TgaEncoder());
                    await img.SaveAsTgaAsync(@".\test\async_name.tga");
                    await img.SaveAsTgaAsync(@".\test\async_name_enc.tga", new SixLabors.ImageSharp.Formats.Tga.TgaEncoder());
                    using var f1 = new FileStream(@".\test\norm_stream.tga", FileMode.OpenOrCreate);
                    img.SaveAsTga(f1);
                    using var f2 = new FileStream(@".\test\norm_stream_enc.tga", FileMode.OpenOrCreate);
                    img.SaveAsTga(f2, new SixLabors.ImageSharp.Formats.Tga.TgaEncoder());
                    using var f3 = new FileStream(@".\test\async_stream.tga", FileMode.OpenOrCreate);
                    await img.SaveAsTgaAsync(f3);
                    using var f4 = new FileStream(@".\test\async_stream_enc.tga", FileMode.OpenOrCreate);
                    await img.SaveAsTgaAsync(f4, new SixLabors.ImageSharp.Formats.Tga.TgaEncoder());
                }


                {
                    img.SaveAsPng(@".\test\norm_name.png");
                    img.SaveAsPng(@".\test\norm_name_enc.png", new SixLabors.ImageSharp.Formats.Png.PngEncoder());
                    await img.SaveAsPngAsync(@".\test\async_name.png");
                    await img.SaveAsPngAsync(@".\test\async_name_enc.png", new SixLabors.ImageSharp.Formats.Png.PngEncoder());
                    using var f1 = new FileStream(@".\test\norm_stream.png", FileMode.OpenOrCreate);
                    img.SaveAsPng(f1);
                    using var f2 = new FileStream(@".\test\norm_stream_enc.png", FileMode.OpenOrCreate);
                    img.SaveAsPng(f2, new SixLabors.ImageSharp.Formats.Png.PngEncoder());
                    using var f3 = new FileStream(@".\test\async_stream.png", FileMode.OpenOrCreate);
                    await img.SaveAsPngAsync(f3);
                    using var f4 = new FileStream(@".\test\async_stream_enc.png", FileMode.OpenOrCreate);
                    await img.SaveAsPngAsync(f4, new SixLabors.ImageSharp.Formats.Png.PngEncoder());
                }
            

                {
                    img.SaveAsBmp(@".\test\norm_name.bmp");
                    img.SaveAsBmp(@".\test\norm_name_enc.bmp", new SixLabors.ImageSharp.Formats.Bmp.BmpEncoder());
                    await img.SaveAsBmpAsync(@".\test\async_name.bmp");
                    await img.SaveAsBmpAsync(@".\test\async_name_enc.bmp", new SixLabors.ImageSharp.Formats.Bmp.BmpEncoder());
                    using var f1 = new FileStream(@".\test\norm_stream.bmp", FileMode.OpenOrCreate);
                    img.SaveAsBmp(f1);
                    using var f2 = new FileStream(@".\test\norm_stream_enc.bmp", FileMode.OpenOrCreate);
                    img.SaveAsBmp(f2, new SixLabors.ImageSharp.Formats.Bmp.BmpEncoder());
                    using var f3 = new FileStream(@".\test\async_stream.bmp", FileMode.OpenOrCreate);
                    await img.SaveAsBmpAsync(f3);
                    using var f4 = new FileStream(@".\test\async_stream_enc.bmp", FileMode.OpenOrCreate);
                    await img.SaveAsBmpAsync(f4, new SixLabors.ImageSharp.Formats.Bmp.BmpEncoder());
                }


                {
                    img.SaveAsGif(@".\test\norm_name.gif");
                    img.SaveAsGif(@".\test\norm_name_enc.gif", new SixLabors.ImageSharp.Formats.Gif.GifEncoder());
                    await img.SaveAsGifAsync(@".\test\async_name.gif");
                    await img.SaveAsGifAsync(@".\test\async_name_enc.gif", new SixLabors.ImageSharp.Formats.Gif.GifEncoder());
                    using var f1 = new FileStream(@".\test\norm_stream.gif", FileMode.OpenOrCreate);
                    img.SaveAsGif(f1);
                    using var f2 = new FileStream(@".\test\norm_stream_enc.gif", FileMode.OpenOrCreate);
                    img.SaveAsGif(f2, new SixLabors.ImageSharp.Formats.Gif.GifEncoder());
                    using var f3 = new FileStream(@".\test\async_stream.gif", FileMode.OpenOrCreate);
                    await img.SaveAsGifAsync(f3);
                    using var f4 = new FileStream(@".\test\async_stream_enc.gif", FileMode.OpenOrCreate);
                    await img.SaveAsGifAsync(f4, new SixLabors.ImageSharp.Formats.Gif.GifEncoder());
                }


                {
                    img.SaveAsJpeg(@".\test\norm_name.jpg");
                    img.SaveAsJpeg(@".\test\norm_name_enc.jpg", new SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder());
                    await img.SaveAsJpegAsync(@".\test\async_name.jpg");
                    await img.SaveAsJpegAsync(@".\test\async_name_enc.jpg", new SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder());
                    using var f1 = new FileStream(@".\test\norm_stream.jpg", FileMode.OpenOrCreate);
                    img.SaveAsJpeg(f1);
                    using var f2 = new FileStream(@".\test\norm_stream_enc.jpg", FileMode.OpenOrCreate);
                    img.SaveAsJpeg(f2, new SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder());
                    using var f3 = new FileStream(@".\test\async_stream.jpg", FileMode.OpenOrCreate);
                    await img.SaveAsJpegAsync(f3);
                    using var f4 = new FileStream(@".\test\async_stream_enc.jpg", FileMode.OpenOrCreate);
                    await img.SaveAsJpegAsync(f4, new SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder());
                }



            }
        }
    }
  
