### PR TITLE
LoadAsync methods accepting string path.

### DIFF
--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -93,6 +94,17 @@ namespace SixLabors.ImageSharp
         /// Create a new instance of the <see cref="Image"/> class from the given file.
         /// </summary>
         /// <param name="path">The file path to the image.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>A <see cref="Task{Image}"/> representing the asynchronous operation.</returns>
+        public static Task<Image> LoadAsync(string path)
+            => LoadAsync(Configuration.Default, path);
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image"/> class from the given file.
+        /// </summary>
+        /// <param name="path">The file path to the image.</param>
         /// <param name="format">The mime type of the decoded image.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
@@ -117,6 +129,25 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Create a new instance of the <see cref="Image"/> class from the given file.
         /// </summary>
+        /// <param name="configuration">The configuration for the decoder.</param>
+        /// <param name="path">The file path to the image.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The path is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>A <see cref="Task{Image}"/> representing the asynchronous operation.</returns>
+        public static async Task<Image> LoadAsync(Configuration configuration, string path)
+        {
+            using (Stream stream = configuration.FileSystem.OpenRead(path))
+            {
+                (Image img, _) = await LoadWithFormatAsync(configuration, stream).ConfigureAwait(false);
+                return img;
+            }
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image"/> class from the given file.
+        /// </summary>
         /// <param name="configuration">The Configuration.</param>
         /// <param name="path">The file path to the image.</param>
         /// <param name="decoder">The decoder.</param>
@@ -134,6 +165,29 @@ namespace SixLabors.ImageSharp
             using (Stream stream = configuration.FileSystem.OpenRead(path))
             {
                 return Load(configuration, stream, decoder);
+            }
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image"/> class from the given file.
+        /// </summary>
+        /// <param name="configuration">The Configuration.</param>
+        /// <param name="path">The file path to the image.</param>
+        /// <param name="decoder">The decoder.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The path is null.</exception>
+        /// <exception cref="ArgumentNullException">The decoder is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>A <see cref="Task{Image}"/> representing the asynchronous operation.</returns>
+        public static Task<Image> LoadAsync(Configuration configuration, string path, IImageDecoder decoder)
+        {
+            Guard.NotNull(configuration, nameof(configuration));
+            Guard.NotNull(path, nameof(path));
+
+            using (Stream stream = configuration.FileSystem.OpenRead(path))
+            {
+                return LoadAsync(configuration, stream, decoder);
             }
         }
 

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_UseDefaultConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_UseDefaultConfiguration.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -35,6 +35,15 @@ namespace SixLabors.ImageSharp.Tests
             public void Path_Agnostic()
             {
                 using (var img = Image.Load(this.Path))
+                {
+                    VerifyDecodedImage(img);
+                }
+            }
+
+            [Fact]
+            public async Task Path_Agnostic_Async()
+            {
+                using (var img = await Image.LoadAsync(this.Path))
                 {
                     VerifyDecodedImage(img);
                 }

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_UseDefaultConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_UseDefaultConfiguration.cs
@@ -68,6 +68,15 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            public async Task Path_Decoder_Agnostic_Async()
+            {
+                using (var img = await Image.LoadAsync(Configuration.Default, this.Path, new BmpDecoder()))
+                {
+                    VerifyDecodedImage(img);
+                }
+            }
+
+            [Fact]
             public void Path_OutFormat_Specific()
             {
                 using (var img = Image.Load<Rgba32>(this.Path, out IImageFormat format))

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_UseDefaultConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_UseDefaultConfiguration.cs
@@ -50,6 +50,15 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            public async Task Path_Agnostic_Configuration_Async()
+            {
+                using (var img = await Image.LoadAsync(Configuration.Default, this.Path))
+                {
+                    VerifyDecodedImage(img);
+                }
+            }
+
+            [Fact]
             public void Path_Decoder_Specific()
             {
                 using (var img = Image.Load<Rgba32>(this.Path, new BmpDecoder()))


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Add LoadAsync methods that accepts `string path`.

This solves #1255 