### PR TITLE
Async version of DiscoverDecoder

### DIFF
--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -102,6 +102,22 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
+        /// By reading the header on the provided stream this calculates the images format.
+        /// </summary>
+        /// <param name="stream">The image stream to read the header from.</param>
+        /// <param name="config">The configuration.</param>
+        /// <param name="format">The IImageFormat.</param>
+        /// <returns>The image format or null if none found.</returns>
+        private static async Task<IImageDecoder> DiscoverDecoderAsync(Stream stream, Configuration config, out IImageFormat format)
+        {
+            format = await InternalDetectFormatAsync(stream, config).ConfigureAwait(false);
+
+            return format != null
+                ? config.ImageFormatsManager.FindDecoder(format)
+                : null;
+        }
+
+        /// <summary>
         /// Decodes the image stream to the current image.
         /// </summary>
         /// <param name="stream">The stream.</param>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
It was no async version of DiscoverDecoder, so I added DiscoverDecoderAsync. Since async methods can’t have out parameters, I return a tuple instead. I would not mind doing the same change on DiscoverDecoder so they look the same.
