### PR TITLE
Make stream buffer size configurable. 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# How to contribute to ImageSharp
+# How to contribute to SixLabors.ImageSharp
 
 #### **Did you find a bug?**
 
@@ -12,11 +12,11 @@
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
-* Before submitting, please ensure that your code matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
+* Before submitting, please ensure that your code matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
 
 #### **Do you intend to add a new feature or change an existing one?**
 
-* Suggest your change in the [ImageSharp Gitter Chat Room](https://gitter.im/ImageSharp/General) and start writing code.
+* Suggest your change in the [Ideas Discussions Channel](https://github.com/SixLabors/ImageSharp/discussions?discussions_q=category%3AIdeas) and start writing code.
 
 * Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
 
@@ -33,14 +33,12 @@
 
 #### **Do you have questions about consuming the library or the source code?**
 
-* Ask any question about how to use ImageSharp over in the [discussions section](https://github.com/SixLabors/ImageSharp/discussions).
+* Ask any question about how to use SixLabors.ImageSharp in the [Help Discussions Channel](https://github.com/SixLabors/ImageSharp/discussions?discussions_q=category%3AHelp).
 
 #### Code of Conduct  
 This project has adopted the code of conduct defined by the [Contributor Covenant](https://contributor-covenant.org/) to clarify expected behavior in our community.
 For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
 
-And please remember. ImageSharp is the work of a very, very, small number of developers who struggle balancing time to contribute to the project with family time and work commitments. We encourage you to pitch in and help make our vision of simple accessible imageprocessing available to all. Open Source can only exist with your help.
+And please remember. SixLabors.ImageSharp is the work of a very, very, small number of developers who struggle balancing time to contribute to the project with family time and work commitments. We encourage you to pitch in and help make our vision of simple accessible image processing available to all. Open Source can only exist with your help.
 
 Thanks for reading!
-
-James Jackson-South :heart:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
     - name: Ask a Question
-      url: https://github.com/SixLabors/ImageSharp/discussions/new?category_id=6331980
+      url: https://github.com/SixLabors/ImageSharp/discussions?discussions_q=category%3AHelp
       about: Ask a question about this project.
     - name: Feature Request
-      url: https://github.com/SixLabors/ImageSharp/discussions/new?category_id=6331981
+      url: https://github.com/SixLabors/ImageSharp/discussions?discussions_q=category%3AIdeas
       about: Share ideas for new features for this project.

--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Net.Http;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Gif;
@@ -27,6 +26,9 @@ namespace SixLabors.ImageSharp
         /// </summary>
         private static readonly Lazy<Configuration> Lazy = new Lazy<Configuration>(CreateDefaultInstance);
 
+        private const int MinStreamProcessingBufferSize = 128;
+        private const int DefaultStreamProcessingBufferSize = 8096;
+        private int streamProcessingBufferSize = DefaultStreamProcessingBufferSize;
         private int maxDegreeOfParallelism = Environment.ProcessorCount;
 
         /// <summary>
@@ -72,6 +74,25 @@ namespace SixLabors.ImageSharp
                 }
 
                 this.maxDegreeOfParallelism = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the buffer to use when working with streams.
+        /// Intitialized with <see cref="DefaultStreamProcessingBufferSize"/> by default
+        /// and can accept a minimum value of <see cref="MinStreamProcessingBufferSize"/>.
+        /// </summary>
+        public int StreamProcessingBufferSize
+        {
+            get => this.streamProcessingBufferSize;
+            set
+            {
+                if (value < MinStreamProcessingBufferSize)
+                {
+                    value = MinStreamProcessingBufferSize;
+                }
+
+                this.streamProcessingBufferSize = value;
             }
         }
 
@@ -145,6 +166,7 @@ namespace SixLabors.ImageSharp
             return new Configuration
             {
                 MaxDegreeOfParallelism = this.MaxDegreeOfParallelism,
+                StreamProcessingBufferSize = this.StreamProcessingBufferSize,
                 ImageFormatsManager = this.ImageFormatsManager,
                 MemoryAllocator = this.MemoryAllocator,
                 ImageOperationsProvider = this.ImageOperationsProvider,

--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -25,8 +25,6 @@ namespace SixLabors.ImageSharp
         /// A lazily initialized configuration default instance.
         /// </summary>
         private static readonly Lazy<Configuration> Lazy = new Lazy<Configuration>(CreateDefaultInstance);
-
-        private const int MinStreamProcessingBufferSize = 128;
         private const int DefaultStreamProcessingBufferSize = 8096;
         private int streamProcessingBufferSize = DefaultStreamProcessingBufferSize;
         private int maxDegreeOfParallelism = Environment.ProcessorCount;
@@ -79,17 +77,16 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// Gets or sets the size of the buffer to use when working with streams.
-        /// Intitialized with <see cref="DefaultStreamProcessingBufferSize"/> by default
-        /// and can accept a minimum value of <see cref="MinStreamProcessingBufferSize"/>.
+        /// Intitialized with <see cref="DefaultStreamProcessingBufferSize"/> by default.
         /// </summary>
         public int StreamProcessingBufferSize
         {
             get => this.streamProcessingBufferSize;
             set
             {
-                if (value < MinStreamProcessingBufferSize)
+                if (value <= 0)
                 {
-                    value = MinStreamProcessingBufferSize;
+                    throw new ArgumentOutOfRangeException(nameof(this.StreamProcessingBufferSize));
                 }
 
                 this.streamProcessingBufferSize = value;

--- a/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
@@ -39,7 +39,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
 
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return decoder.Decode<TPixel>(bufferedStream);
             }
             catch (InvalidMemoryOperationException ex)
@@ -64,7 +64,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
 
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return await decoder.DecodeAsync<TPixel>(bufferedStream).ConfigureAwait(false);
             }
             catch (InvalidMemoryOperationException ex)
@@ -84,7 +84,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         {
             Guard.NotNull(stream, nameof(stream));
 
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
             return new BmpDecoderCore(configuration, this).Identify(bufferedStream);
         }
 
@@ -93,7 +93,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         {
             Guard.NotNull(stream, nameof(stream));
 
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
             return new BmpDecoderCore(configuration, this).IdentifyAsync(bufferedStream);
         }
     }

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return decoder.Decode<TPixel>(bufferedStream);
             }
             catch (InvalidMemoryOperationException ex)
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return await decoder.DecodeAsync<TPixel>(bufferedStream).ConfigureAwait(false);
             }
             catch (InvalidMemoryOperationException ex)
@@ -84,7 +84,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
             var decoder = new GifDecoderCore(configuration, this);
 
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
             return decoder.Identify(bufferedStream);
         }
 
@@ -95,7 +95,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
             var decoder = new GifDecoderCore(configuration, this);
 
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
             return decoder.IdentifyAsync(bufferedStream);
         }
     }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             using var decoder = new JpegDecoderCore(configuration, this);
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return decoder.Decode<TPixel>(bufferedStream);
             }
             catch (InvalidMemoryOperationException ex)
@@ -53,7 +53,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             using var decoder = new JpegDecoderCore(configuration, this);
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return await decoder.DecodeAsync<TPixel>(bufferedStream).ConfigureAwait(false);
             }
             catch (InvalidMemoryOperationException ex)
@@ -77,7 +77,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             Guard.NotNull(stream, nameof(stream));
 
             using var decoder = new JpegDecoderCore(configuration, this);
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
 
             return decoder.Identify(bufferedStream);
         }
@@ -88,7 +88,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             Guard.NotNull(stream, nameof(stream));
 
             using var decoder = new JpegDecoderCore(configuration, this);
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
 
             return decoder.IdentifyAsync(bufferedStream);
         }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -560,7 +560,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     this.ExtendProfile(ref this.exifData, profile.AsSpan(Exif00).ToArray());
                 }
             }
-
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -514,6 +514,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             // TODO: thumbnail
             if (remaining > 0)
             {
+                if (stream.Position + remaining >= stream.Length)
+                {
+                    JpegThrowHelper.ThrowInvalidImageContentException("Bad App0 Marker length.");
+                }
+
                 stream.Skip(remaining);
             }
         }
@@ -533,6 +538,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 return;
             }
 
+            if (stream.Position + remaining >= stream.Length)
+            {
+                JpegThrowHelper.ThrowInvalidImageContentException("Bad App1 Marker length.");
+            }
+
             var profile = new byte[remaining];
             stream.Read(profile, 0, remaining);
 
@@ -550,6 +560,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     this.ExtendProfile(ref this.exifData, profile.AsSpan(Exif00).ToArray());
                 }
             }
+
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Png/PngDecoder.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoder.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return decoder.Decode<TPixel>(bufferedStream);
             }
             catch (InvalidMemoryOperationException ex)
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return await decoder.DecodeAsync<TPixel>(bufferedStream).ConfigureAwait(false);
             }
             catch (InvalidMemoryOperationException ex)
@@ -71,7 +71,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         public IImageInfo Identify(Configuration configuration, Stream stream)
         {
             var decoder = new PngDecoderCore(configuration, this);
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
             return decoder.Identify(bufferedStream);
         }
 
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         public Task<IImageInfo> IdentifyAsync(Configuration configuration, Stream stream)
         {
             var decoder = new PngDecoderCore(configuration, this);
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
             return decoder.IdentifyAsync(bufferedStream);
         }
     }

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -9,7 +9,6 @@ using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats.Png.Chunks;
 using SixLabors.ImageSharp.Formats.Png.Filters;
 using SixLabors.ImageSharp.Formats.Png.Zlib;
@@ -1027,7 +1026,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         private bool TryUncompressTextData(ReadOnlySpan<byte> compressedData, Encoding encoding, out string value)
         {
             using (var memoryStream = new MemoryStream(compressedData.ToArray()))
-            using (var bufferedStream = new BufferedReadStream(memoryStream))
+            using (var bufferedStream = new BufferedReadStream(this.Configuration, memoryStream))
             using (var inflateStream = new ZlibInflateStream(bufferedStream))
             {
                 if (!inflateStream.AllocateNewBytes(compressedData.Length, false))

--- a/src/ImageSharp/Formats/Tga/TgaDecoder.cs
+++ b/src/ImageSharp/Formats/Tga/TgaDecoder.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
 
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return decoder.Decode<TPixel>(bufferedStream);
             }
             catch (InvalidMemoryOperationException ex)
@@ -52,7 +52,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
 
             try
             {
-                using var bufferedStream = new BufferedReadStream(stream);
+                using var bufferedStream = new BufferedReadStream(configuration, stream);
                 return await decoder.DecodeAsync<TPixel>(bufferedStream).ConfigureAwait(false);
             }
             catch (InvalidMemoryOperationException ex)
@@ -75,7 +75,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         {
             Guard.NotNull(stream, nameof(stream));
 
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
             return new TgaDecoderCore(configuration, this).Identify(bufferedStream);
         }
 
@@ -84,7 +84,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
         {
             Guard.NotNull(stream, nameof(stream));
 
-            using var bufferedStream = new BufferedReadStream(stream);
+            using var bufferedStream = new BufferedReadStream(configuration, stream);
             return new TgaDecoderCore(configuration, this).IdentifyAsync(bufferedStream);
         }
     }

--- a/src/ImageSharp/IO/BufferedReadStream.cs
+++ b/src/ImageSharp/IO/BufferedReadStream.cs
@@ -14,12 +14,7 @@ namespace SixLabors.ImageSharp.IO
     /// </summary>
     internal sealed class BufferedReadStream : Stream
     {
-        /// <summary>
-        /// The length, in bytes, of the underlying buffer.
-        /// </summary>
-        public const int BufferLength = 8192;
-
-        private const int MaxBufferIndex = BufferLength - 1;
+        private readonly int maxBufferIndex;
 
         private readonly byte[] readBuffer;
 
@@ -38,9 +33,11 @@ namespace SixLabors.ImageSharp.IO
         /// <summary>
         /// Initializes a new instance of the <see cref="BufferedReadStream"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="stream">The input stream.</param>
-        public BufferedReadStream(Stream stream)
+        public BufferedReadStream(Configuration configuration, Stream stream)
         {
+            Guard.NotNull(configuration, nameof(configuration));
             Guard.IsTrue(stream.CanRead, nameof(stream), "Stream must be readable.");
             Guard.IsTrue(stream.CanSeek, nameof(stream), "Stream must be seekable.");
 
@@ -55,8 +52,9 @@ namespace SixLabors.ImageSharp.IO
             this.BaseStream = stream;
             this.Position = (int)stream.Position;
             this.Length = stream.Length;
-
-            this.readBuffer = ArrayPool<byte>.Shared.Rent(BufferLength);
+            this.BufferSize = configuration.StreamProcessingBufferSize;
+            this.maxBufferIndex = this.BufferSize - 1;
+            this.readBuffer = ArrayPool<byte>.Shared.Rent(this.BufferSize);
             this.readBufferHandle = new Memory<byte>(this.readBuffer).Pin();
             unsafe
             {
@@ -64,7 +62,16 @@ namespace SixLabors.ImageSharp.IO
             }
 
             // This triggers a full read on first attempt.
-            this.readBufferIndex = BufferLength;
+            this.readBufferIndex = this.BufferSize;
+        }
+
+        /// <summary>
+        /// Gets the size, in bytes, of the underlying buffer.
+        /// </summary>
+        public int BufferSize
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
         }
 
         /// <inheritdoc/>
@@ -91,7 +98,7 @@ namespace SixLabors.ImageSharp.IO
                     // Base stream seek will throw for us if invalid.
                     this.BaseStream.Seek(value, SeekOrigin.Begin);
                     this.readerPosition = value;
-                    this.readBufferIndex = BufferLength;
+                    this.readBufferIndex = this.BufferSize;
                 }
             }
         }
@@ -125,7 +132,7 @@ namespace SixLabors.ImageSharp.IO
 
             // Our buffer has been read.
             // We need to refill and start again.
-            if (this.readBufferIndex > MaxBufferIndex)
+            if (this.readBufferIndex > this.maxBufferIndex)
             {
                 this.FillReadBuffer();
             }
@@ -142,14 +149,14 @@ namespace SixLabors.ImageSharp.IO
         public override int Read(byte[] buffer, int offset, int count)
         {
             // Too big for our buffer. Read directly from the stream.
-            if (count > BufferLength)
+            if (count > this.BufferSize)
             {
                 return this.ReadToBufferDirectSlow(buffer, offset, count);
             }
 
             // Too big for remaining buffer but less than entire buffer length
             // Copy to buffer then read from there.
-            if (count + this.readBufferIndex > BufferLength)
+            if (count + this.readBufferIndex > this.BufferSize)
             {
                 return this.ReadToBufferViaCopySlow(buffer, offset, count);
             }
@@ -164,14 +171,14 @@ namespace SixLabors.ImageSharp.IO
         {
             // Too big for our buffer. Read directly from the stream.
             int count = buffer.Length;
-            if (count > BufferLength)
+            if (count > this.BufferSize)
             {
                 return this.ReadToBufferDirectSlow(buffer);
             }
 
             // Too big for remaining buffer but less than entire buffer length
             // Copy to buffer then read from there.
-            if (count + this.readBufferIndex > BufferLength)
+            if (count + this.readBufferIndex > this.BufferSize)
             {
                 return this.ReadToBufferViaCopySlow(buffer);
             }
@@ -192,7 +199,7 @@ namespace SixLabors.ImageSharp.IO
             }
 
             // Reset to trigger full read on next attempt.
-            this.readBufferIndex = BufferLength;
+            this.readBufferIndex = this.BufferSize;
         }
 
         /// <inheritdoc/>
@@ -249,7 +256,7 @@ namespace SixLabors.ImageSharp.IO
         private bool IsInReadBuffer(long newPosition, out long index)
         {
             index = newPosition - this.readerPosition + this.readBufferIndex;
-            return index > -1 && index < BufferLength;
+            return index > -1 && index < this.BufferSize;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -267,10 +274,10 @@ namespace SixLabors.ImageSharp.IO
             int i;
             do
             {
-                i = baseStream.Read(this.readBuffer, n, BufferLength - n);
+                i = baseStream.Read(this.readBuffer, n, this.BufferSize - n);
                 n += i;
             }
-            while (n < BufferLength && i > 0);
+            while (n < this.BufferSize && i > 0);
 
             this.readBufferIndex = 0;
         }

--- a/src/ImageSharp/IO/BufferedReadStream.cs
+++ b/src/ImageSharp/IO/BufferedReadStream.cs
@@ -50,8 +50,8 @@ namespace SixLabors.ImageSharp.IO
             }
 
             this.BaseStream = stream;
-            this.Position = (int)stream.Position;
             this.Length = stream.Length;
+            this.Position = (int)stream.Position;
             this.BufferSize = configuration.StreamProcessingBufferSize;
             this.maxBufferIndex = this.BufferSize - 1;
             this.readBuffer = ArrayPool<byte>.Shared.Rent(this.BufferSize);
@@ -86,6 +86,9 @@ namespace SixLabors.ImageSharp.IO
             [MethodImpl(MethodImplOptions.NoInlining)]
             set
             {
+                Guard.MustBeGreaterThanOrEqualTo(value, 0, nameof(this.Position));
+                Guard.MustBeLessThan(value, this.Length, nameof(this.Position));
+
                 // Only reset readBufferIndex if we are out of bounds of our working buffer
                 // otherwise we should simply move the value by the diff.
                 if (this.IsInReadBuffer(value, out long index))

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -687,7 +687,7 @@ namespace SixLabors.ImageSharp
 
             // We want to be able to load images from things like HttpContext.Request.Body
             using MemoryStream memoryStream = configuration.MemoryAllocator.AllocateFixedCapacityMemoryStream(stream.Length);
-            stream.CopyTo(memoryStream);
+            stream.CopyTo(memoryStream, configuration.StreamProcessingBufferSize);
             memoryStream.Position = 0;
 
             return action(memoryStream);
@@ -729,7 +729,7 @@ namespace SixLabors.ImageSharp
             }
 
             using MemoryStream memoryStream = configuration.MemoryAllocator.AllocateFixedCapacityMemoryStream(stream.Length);
-            await stream.CopyToAsync(memoryStream).ConfigureAwait(false);
+            await stream.CopyToAsync(memoryStream, configuration.StreamProcessingBufferSize).ConfigureAwait(false);
             memoryStream.Position = 0;
 
             return await action(memoryStream).ConfigureAwait(false);

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/DecodeJpegParseStreamOnly.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/DecodeJpegParseStreamOnly.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs.Jpeg
         public void ParseStreamPdfJs()
         {
             using var memoryStream = new MemoryStream(this.jpegBytes);
-            using var bufferedStream = new BufferedReadStream(memoryStream);
+            using var bufferedStream = new BufferedReadStream(Configuration.Default, memoryStream);
 
             var decoder = new JpegDecoderCore(Configuration.Default, new JpegDecoder { IgnoreMetadata = true });
             decoder.ParseStream(bufferedStream);

--- a/tests/ImageSharp.Benchmarks/General/IO/BufferedStreams.cs
+++ b/tests/ImageSharp.Benchmarks/General/IO/BufferedStreams.cs
@@ -35,8 +35,8 @@ namespace SixLabors.ImageSharp.Benchmarks.IO
             this.stream4 = new MemoryStream(this.buffer);
             this.stream5 = new MemoryStream(this.buffer);
             this.stream6 = new MemoryStream(this.buffer);
-            this.bufferedStream1 = new BufferedReadStream(this.stream3);
-            this.bufferedStream2 = new BufferedReadStream(this.stream4);
+            this.bufferedStream1 = new BufferedReadStream(Configuration.Default, this.stream3);
+            this.bufferedStream2 = new BufferedReadStream(Configuration.Default, this.stream4);
             this.bufferedStreamWrap1 = new BufferedReadStreamWrapper(this.stream5);
             this.bufferedStreamWrap2 = new BufferedReadStreamWrapper(this.stream6);
         }
@@ -158,7 +158,7 @@ namespace SixLabors.ImageSharp.Benchmarks.IO
 
         private static byte[] CreateTestBytes()
         {
-            var buffer = new byte[BufferedReadStream.BufferLength * 3];
+            var buffer = new byte[Configuration.Default.StreamProcessingBufferSize * 3];
             var random = new Random();
             random.NextBytes(buffer);
 

--- a/tests/ImageSharp.Tests/ConfigurationTests.cs
+++ b/tests/ImageSharp.Tests/ConfigurationTests.cs
@@ -76,10 +76,7 @@ namespace SixLabors.ImageSharp.Tests
             if (throws)
             {
                 Assert.Throws<ArgumentOutOfRangeException>(
-                    () =>
-                    {
-                        cfg.MaxDegreeOfParallelism = maxDegreeOfParallelism;
-                    });
+                    () => cfg.MaxDegreeOfParallelism = maxDegreeOfParallelism);
             }
             else
             {
@@ -122,7 +119,7 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void DefaultConfigurationHasCorrectFormatCount()
         {
-            Configuration config = Configuration.CreateDefaultInstance();
+            var config = Configuration.CreateDefaultInstance();
 
             Assert.Equal(this.expectedDefaultConfigurationCount, config.ImageFormats.Count());
         }
@@ -139,6 +136,17 @@ namespace SixLabors.ImageSharp.Tests
         {
             Configuration config = this.DefaultConfiguration;
             Assert.True(config.StreamProcessingBufferSize == 8096);
+        }
+
+        [Fact]
+        public void StreamBufferSize_CannotGoBelowMinimum()
+        {
+            var config = new Configuration
+            {
+                StreamProcessingBufferSize = 0
+            };
+
+            Assert.Equal(128, config.StreamProcessingBufferSize);
         }
     }
 }

--- a/tests/ImageSharp.Tests/ConfigurationTests.cs
+++ b/tests/ImageSharp.Tests/ConfigurationTests.cs
@@ -133,5 +133,12 @@ namespace SixLabors.ImageSharp.Tests
             Configuration config = this.DefaultConfiguration;
             Assert.True(config.WorkingBufferSizeHintInBytes > 1024);
         }
+
+        [Fact]
+        public void StreamBufferSize_DefaultIsCorrect()
+        {
+            Configuration config = this.DefaultConfiguration;
+            Assert.True(config.StreamProcessingBufferSize == 8096);
+        }
     }
 }

--- a/tests/ImageSharp.Tests/ConfigurationTests.cs
+++ b/tests/ImageSharp.Tests/ConfigurationTests.cs
@@ -141,12 +141,10 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void StreamBufferSize_CannotGoBelowMinimum()
         {
-            var config = new Configuration
-            {
-                StreamProcessingBufferSize = 0
-            };
+            var config = new Configuration();
 
-            Assert.Equal(128, config.StreamProcessingBufferSize);
+            Assert.Throws<ArgumentOutOfRangeException>(
+                    () => config.StreamProcessingBufferSize = 0);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -73,7 +73,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         {
             byte[] bytes = TestFile.Create(TestImages.Jpeg.Progressive.Progress).Bytes;
             using var ms = new MemoryStream(bytes);
-            using var bufferedStream = new BufferedReadStream(ms);
+            using var bufferedStream = new BufferedReadStream(Configuration.Default, ms);
             var decoder = new JpegDecoderCore(Configuration.Default, new JpegDecoder());
             decoder.ParseStream(bufferedStream);
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
@@ -53,7 +53,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             byte[] sourceBytes = TestFile.Create(provider.SourceFileOrDescription).Bytes;
 
             using var ms = new MemoryStream(sourceBytes);
-            using var bufferedStream = new BufferedReadStream(ms);
+            using var bufferedStream = new BufferedReadStream(Configuration.Default, ms);
             decoder.ParseStream(bufferedStream);
 
             var data = LibJpegTools.SpectralData.LoadFromImageSharpDecoder(decoder);
@@ -75,7 +75,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             byte[] sourceBytes = TestFile.Create(provider.SourceFileOrDescription).Bytes;
 
             using var ms = new MemoryStream(sourceBytes);
-            using var bufferedStream = new BufferedReadStream(ms);
+            using var bufferedStream = new BufferedReadStream(Configuration.Default, ms);
             decoder.ParseStream(bufferedStream);
 
             var imageSharpData = LibJpegTools.SpectralData.LoadFromImageSharpDecoder(decoder);

--- a/tests/ImageSharp.Tests/Formats/Jpg/Utils/JpegFixture.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/Utils/JpegFixture.cs
@@ -193,7 +193,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg.Utils
         {
             byte[] bytes = TestFile.Create(testFileName).Bytes;
             using var ms = new MemoryStream(bytes);
-            using var bufferedStream = new BufferedReadStream(ms);
+            using var bufferedStream = new BufferedReadStream(Configuration.Default, ms);
 
             var decoder = new JpegDecoderCore(Configuration.Default, new JpegDecoder());
             decoder.ParseStream(bufferedStream, metaDataOnly);

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.Chunks.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.Chunks.cs
@@ -77,7 +77,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 var decoder = new PngDecoder();
 
                 ImageFormatException exception =
-                    Assert.Throws<InvalidImageContentException>(() => decoder.Decode<Rgb24>(null, memStream));
+                    Assert.Throws<InvalidImageContentException>(() => decoder.Decode<Rgb24>(Configuration.Default, memStream));
 
                 Assert.Equal($"CRC Error. PNG {chunkName} chunk is corrupt!", exception.Message);
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Adds a new property `Configuration.StreamProcessingBufferSize` which allows the configuration of internal buffers used to reduce synchronization costs of network streaming.  The value defaults to 8096 with a minimum of 128.

Fixes #1276

<!-- Thanks for contributing to ImageSharp! -->
