### PR TITLE
Work out the crunch configs for lossless webp

### DIFF
--- a/src/ImageSharp/Formats/WebP/EntropyIx.cs
+++ b/src/ImageSharp/Formats/WebP/EntropyIx.cs
@@ -18,6 +18,8 @@ namespace SixLabors.ImageSharp.Formats.WebP
 
         Palette = 4,
 
-        NumEntropyIx = 5
+        PaletteAndSpatial = 5,
+
+        NumEntropyIx = 6
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
I have had a punt at EncoderAnalyze and think the crunch config should now come out of that OK.

The rest is very much WIP, I started carrying these configs through the EncodeStream in the Vp8LEncoder. The reference implementation starts spinning up threads and then comparing sizes and picking the best. There was nothing so far for that, is that something we want to do. It might be simpler, for now, to get it all working on a single thread save some headaches.

<!-- Thanks for contributing to ImageSharp! -->
