### PR TITLE
Change position guard from MustBeLessThanTo to MustBeLessThanOrEqualTo

### DIFF
--- a/src/ImageSharp/IO/BufferedReadStream.cs
+++ b/src/ImageSharp/IO/BufferedReadStream.cs
@@ -87,7 +87,7 @@ namespace SixLabors.ImageSharp.IO
             set
             {
                 Guard.MustBeGreaterThanOrEqualTo(value, 0, nameof(this.Position));
-                Guard.MustBeLessThan(value, this.Length, nameof(this.Position));
+                Guard.MustBeLessThanOrEqualTo(value, this.Length, nameof(this.Position));
 
                 // Only reset readBufferIndex if we are out of bounds of our working buffer
                 // otherwise we should simply move the value by the diff.

--- a/tests/ImageSharp.Tests/IO/BufferedReadStreamTests.cs
+++ b/tests/ImageSharp.Tests/IO/BufferedReadStreamTests.cs
@@ -322,7 +322,21 @@ namespace SixLabors.ImageSharp.Tests.IO
                 using (var reader = new BufferedReadStream(this.configuration, stream))
                 {
                     Assert.Throws<ArgumentOutOfRangeException>(() => reader.Position = -stream.Length);
-                    Assert.Throws<ArgumentOutOfRangeException>(() => reader.Position = stream.Length);
+                    Assert.Throws<ArgumentOutOfRangeException>(() => reader.Position = stream.Length + 1);
+                }
+            }
+        }
+
+        [Fact]
+        public void BufferedStreamCanSetPositionToEnd()
+        {
+            var bufferSize = 8;
+            this.configuration.StreamProcessingBufferSize = bufferSize;
+            using (MemoryStream stream = this.CreateTestStream(bufferSize * 2))
+            {
+                using (var reader = new BufferedReadStream(this.configuration, stream))
+                {
+                    reader.Position = reader.Length;
                 }
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

As the title says: The guard of the position was a bit too strict.