### PR TITLE
Add "macos-latest" to build matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: false
-                    - os: macos-10.15
+                    - os: macos-latest
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: false
@@ -63,8 +63,8 @@ jobs:
 
             - name: Install macos dependencies
               shell: pwsh
-              #if: "${{matrix.options.os}}" == 'macos-10.15'
-              run: if ("${{matrix.options.os}}" -eq "macos-10.15") { brew install mono-libgdiplus } else { write-output "Not macOS" }
+              if: startsWith(matrix.options.os, 'macos')
+              run: brew install mono-libgdiplus
 
             - name: Build
               shell: pwsh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,6 +61,10 @@ jobs:
               with:
                   dotnet-version: "3.1.x"
 
+            - name: Install macos dependencies
+              if: matrix.os == 'macos-latest'
+              run: brew install mono-libgdiplus
+
             - name: Build
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,6 +19,10 @@ jobs:
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: false
+                    - os: macos-latest
+                      framework: netcoreapp3.1
+                      runtime: -x64
+                      codecov: false
                     - os: windows-latest
                       framework: netcoreapp3.1
                       runtime: -x64

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,7 +62,7 @@ jobs:
                   dotnet-version: "3.1.x"
 
             - name: Install macos dependencies
-              if: matrix.os == 'macos-10.15'
+              if: ${{matrix.options.os}} == 'macos-10.15'
               run: brew install mono-libgdiplus
 
             - name: Build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,6 +62,7 @@ jobs:
                   dotnet-version: "3.1.x"
 
             - name: Install macos dependencies
+              shell: bash
               if: matrix.os == 'macos-latest'
               run: brew install mono-libgdiplus
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: false
-                    - os: macos-latest
+                    - os: macos-10.15
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: false
@@ -62,8 +62,7 @@ jobs:
                   dotnet-version: "3.1.x"
 
             - name: Install macos dependencies
-              shell: bash
-              if: matrix.os == 'macos-latest'
+              if: matrix.os == 'macos-10.15'
               run: brew install mono-libgdiplus
 
             - name: Build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,8 +62,9 @@ jobs:
                   dotnet-version: "3.1.x"
 
             - name: Install macos dependencies
-              if: ${{matrix.options.os}} == 'macos-10.15'
-              run: brew install mono-libgdiplus
+              shell: pwsh
+              #if: "${{matrix.options.os}}" == 'macos-10.15'
+              run: if ("${{matrix.options.os}}" -eq "macos-10.15") { brew install mono-libgdiplus } else { write-output "Not macOS" }
 
             - name: Build
               shell: pwsh


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Just noticed there is an available [virtual environment](https://github.com/actions/virtual-environments) for macOS. I think we should add it to the list of CI builds.
