### PR TITLE
Bump ChunkedMemoryStream buffer length

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,11 +52,6 @@ jobs:
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
 
-            - name: Setup DotNet SDK
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: "3.1.x"
-
             - name: Build
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
@@ -94,11 +89,6 @@ jobs:
                   git config --global core.longpaths true
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
-
-            - name: Setup DotNet SDK
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: "3.1.x"
 
             - name: Pack
               shell: pwsh

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Install stable releases via Nuget; development releases are available via MyGet.
 
 | Package Name                   | Release (NuGet) | Nightly (MyGet) |
 |--------------------------------|-----------------|-----------------|
-| `SixLabors.ImageSharp`         | [![NuGet](https://img.shields.io/nuget/v/SixLabors.ImageSharp.svg)](https://www.nuget.org/packages/SixLabors.ImageSharp/) | [![MyGet](https://img.shields.io/myget/sixlabors/v/SixLabors.ImageSharp.svg)](https://www.myget.org/feed/sixlabors/package/nuget/SixLabors.ImageSharp) |
+| `SixLabors.ImageSharp`         | [![NuGet](https://img.shields.io/nuget/v/SixLabors.ImageSharp.svg)](https://www.nuget.org/packages/SixLabors.ImageSharp/) | [![MyGet](https://img.shields.io/myget/sixlabors/vpre/SixLabors.ImageSharp.svg)](https://www.myget.org/feed/sixlabors/package/nuget/SixLabors.ImageSharp) |
 
 ## Manual build
 

--- a/src/ImageSharp/IO/ChunkedMemoryStream.cs
+++ b/src/ImageSharp/IO/ChunkedMemoryStream.cs
@@ -238,7 +238,9 @@ namespace SixLabors.ImageSharp.IO
             Guard.NotNull(buffer, nameof(buffer));
             Guard.MustBeGreaterThanOrEqualTo(offset, 0, nameof(offset));
             Guard.MustBeGreaterThanOrEqualTo(count, 0, nameof(count));
-            Guard.IsFalse(buffer.Length - offset < count, nameof(buffer), $"{offset} subtracted from the buffer length is less than {count}");
+
+            const string BufferMessage = "Offset subtracted from the buffer length is less than count.";
+            Guard.IsFalse(buffer.Length - offset < count, nameof(buffer), BufferMessage);
 
             return this.ReadImpl(buffer.AsSpan().Slice(offset, count));
         }
@@ -348,7 +350,16 @@ namespace SixLabors.ImageSharp.IO
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override void Write(byte[] buffer, int offset, int count)
-            => this.WriteImpl(buffer.AsSpan().Slice(offset, count));
+        {
+            Guard.NotNull(buffer, nameof(buffer));
+            Guard.MustBeGreaterThanOrEqualTo(offset, 0, nameof(offset));
+            Guard.MustBeGreaterThanOrEqualTo(count, 0, nameof(count));
+
+            const string BufferMessage = "Offset subtracted from the buffer length is less than count.";
+            Guard.IsFalse(buffer.Length - offset < count, nameof(buffer), BufferMessage);
+
+            this.WriteImpl(buffer.AsSpan().Slice(offset, count));
+        }
 
 #if SUPPORTS_SPAN_STREAM
         /// <inheritdoc/>

--- a/src/ImageSharp/IO/ChunkedMemoryStream.cs
+++ b/src/ImageSharp/IO/ChunkedMemoryStream.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.IO
         /// <summary>
         /// The default length in bytes of each buffer chunk.
         /// </summary>
-        public const int DefaultBufferLength = 81920;
+        public const int DefaultBufferLength = 128 * 1024;
 
         // The memory allocator.
         private readonly MemoryAllocator allocator;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Increase `ChunkedMemoryStream` chunk length to 128k inline with `RecycledMemoryStream`

<!-- Thanks for contributing to ImageSharp! -->
