### PR TITLE
Fix missing SDK version for test building it GitHub Workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,22 +18,27 @@ jobs:
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: false
+                      sdkVersion: "3.1.x"
                     - os: windows-latest
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: true
+                      sdkVersion: "3.1.x"
                     - os: windows-latest
                       framework: netcoreapp2.1
                       runtime: -x64
                       codecov: false
+                      sdkVersion: "2.1.x"
                     - os: windows-latest
                       framework: net472
                       runtime: -x64
                       codecov: false
+                      sdkVersion: "3.1.x"
                     - os: windows-latest
                       framework: net472
                       runtime: -x86
                       codecov: false
+                      sdkVersion: "3.1.x"
 
         runs-on: ${{matrix.options.os}}
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
@@ -55,7 +60,7 @@ jobs:
             - name: Setup DotNet SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "3.1.x"
+                  dotnet-version: ${{matrix.options.sdkVersion}}
 
             - name: Build
               shell: pwsh

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -8,4 +8,4 @@ dotnet clean -c Release
 $repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
 
 # Building for a specific framework.
-dotnet build -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl
+dotnet build tests/ImageSharp.Tests/ImageSharp.Tests.csproj -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl


### PR DESCRIPTION
See the build/test error in #1328 - this *might* patch around that neatly via using the matrix options. This PR is as much of a test of the concept.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Uses the options matrix to define the SDK version to install, thus hopefully guaranteeing the right version is installed for tests.

<!-- Thanks for contributing to ImageSharp! -->
