### PR TITLE
Bokeh blur constructor tweaks (input validation, tiny speedup)

### DIFF
--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
@@ -29,8 +29,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// Initializes a new instance of the <see cref="BokehBlurProcessor"/> class.
         /// </summary>
         public BokehBlurProcessor()
-            : this(DefaultRadius, DefaultComponents, DefaultGamma)
         {
+            this.Radius = DefaultRadius;
+            this.Components = DefaultComponents;
+            this.Gamma = DefaultGamma;
         }
 
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
@@ -47,6 +47,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Convolution
         /// </param>
         public BokehBlurProcessor(int radius, int components, float gamma)
         {
+            Guard.MustBeGreaterThan(radius, 0, nameof(radius));
+            Guard.MustBeBetweenOrEqualTo(components, 1, 6, nameof(components));
             Guard.MustBeGreaterThanOrEqualTo(gamma, 1, nameof(gamma));
 
             this.Radius = radius;

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/BokehBlurTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/BokehBlurTest.cs
@@ -35,6 +35,19 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
            0.02565295+0.01611732j  0.0153483+0.01605112j   0.00698622+0.01370844j
            0.00135338+0.00998296j -0.00152245+0.00604545j -0.00227282+0.002851j  ]]";
 
+        [Theory]
+        [InlineData(-10, 2, 3f)]
+        [InlineData(-1, 2, 3f)]
+        [InlineData(0, 2, 3f)]
+        [InlineData(20, -1, 3f)]
+        [InlineData(20, -0, 3f)]
+        [InlineData(20, 4, -10f)]
+        [InlineData(20, 4, 0f)]
+        public void VerifyBokehBlurProcessorArguments_Fail(int radius, int components, float gamma)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BokehBlurProcessor(radius, components, gamma));
+        }
+
         [Fact]
         public void VerifyComplexComponents()
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This PR does two things:

- Adds missing input validation for the blur radius and number of components (with tests)
- Reduces the overhead of the default constructor and skips the input validation there
