### PR TITLE
Add missing SaveAsync method

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,7 +64,7 @@ jobs:
                   XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
             - name: Update Codecov
-              uses: codecov/codecov-action@v1.0.7
+              uses: codecov/codecov-action@v1
               if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
               with:
                   flags: unittests

--- a/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
+++ b/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
@@ -23,7 +23,9 @@ namespace SixLabors.ImageSharp.Advanced
         /// </summary>
         /// <param name="source">The source image.</param>
         /// <param name="filePath">The target file path to save the image to.</param>
-        /// <returns>The matching encoder.</returns>
+        /// <exception cref="ArgumentNullException">The file path is null.</exception>
+        /// <exception cref="NotSupportedException">No encoder available for provided path.</exception>
+        /// <returns>The matching <see cref="IImageEncoder"/>.</returns>
         public static IImageEncoder DetectEncoder(this Image source, string filePath)
         {
             Guard.NotNull(filePath, nameof(filePath));

--- a/tests/ImageSharp.Tests/Image/ImageTests.SaveAsync.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.SaveAsync.cs
@@ -72,6 +72,37 @@ namespace SixLabors.ImageSharp.Tests
                 }
             }
 
+            [Theory]
+            [InlineData("test.png", "image/png")]
+            [InlineData("test.tga", "image/tga")]
+            [InlineData("test.bmp", "image/bmp")]
+            [InlineData("test.jpg", "image/jpeg")]
+            [InlineData("test.gif", "image/gif")]
+            public async Task SaveStreamWithMime(string filename, string mimeType)
+            {
+                using (var image = new Image<Rgba32>(5, 5))
+                {
+                    string ext = Path.GetExtension(filename);
+                    IImageFormat format = image.GetConfiguration().ImageFormatsManager.FindFormatByFileExtension(ext);
+                    Assert.Equal(mimeType, format.DefaultMimeType);
+
+                    using (var stream = new MemoryStream())
+                    {
+                        var asyncStream = new AsyncStreamWrapper(stream, () => false);
+                        await image.SaveAsync(asyncStream, format);
+
+                        stream.Position = 0;
+
+                        (Image Image, IImageFormat Format) imf = await Image.LoadWithFormatAsync(stream);
+
+                        Assert.Equal(format, imf.Format);
+                        Assert.Equal(mimeType, imf.Format.DefaultMimeType);
+
+                        imf.Image.Dispose();
+                    }
+                }
+            }
+
             [Fact]
             public async Task ThrowsWhenDisposed()
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Adds the missing `Image.SaveAsync(Stream, IImageformat, CancellationToken)` extension. 

See https://stackoverflow.com/q/63639644/427899

I also cleaned up some bad copy/paste in the extension method documentation.

<!-- Thanks for contributing to ImageSharp! -->
