### PR TITLE
Fixed typo in AdaptiveThreshold

### DIFF
--- a/src/ImageSharp/Processing/Processors/Binarization/AdaptiveThresholdProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/AdaptiveThresholdProcessor{TPixel}.cs
@@ -67,7 +67,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Binarization
                         ref TPixel color = ref Unsafe.Add(ref rowRef, x);
                         color.ToRgba32(ref rgb);
 
-                        sum += (ulong)(rgb.R + rgb.G + rgb.G);
+                        sum += (ulong)(rgb.R + rgb.G + rgb.B);
+
                         if (x - startX != 0)
                         {
                             intImage[x - startX, y - startY] = intImage[x - startX - 1, y - startY] + sum;

--- a/tests/ImageSharp.Tests/Processing/Binarization/AdaptiveThresholdTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Binarization/AdaptiveThresholdTests.cs
@@ -100,6 +100,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Binarization
         [Theory]
         [WithFile(TestImages.Png.Bradley01, PixelTypes.Rgba32)]
         [WithFile(TestImages.Png.Bradley02, PixelTypes.Rgba32)]
+        [WithFile(TestImages.Png.Ducky, PixelTypes.Rgba32)]
         public void AdaptiveThreshold_Works<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I saw a clear typo in the code. So I added a new test which would validate the change. All the images used in the tests were previously grayscale so that the typo would go unnoticed. That being said, using adaptive thresholding on a color image is not a usual use case.