### PR TITLE
Use Ubuntu for Code Coverage.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,11 +17,11 @@ jobs:
                     - os: ubuntu-latest
                       framework: netcoreapp3.1
                       runtime: -x64
-                      codecov: false
-                    - os: ubuntu-latest
+                      codecov: true
+                    - os: windows-latest
                       framework: netcoreapp3.1
                       runtime: -x64
-                      codecov: true
+                      codecov: false
                     - os: windows-latest
                       framework: netcoreapp2.1
                       runtime: -x64

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: false
-                    - os: windows-latest
+                    - os: ubuntu-latest
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -120,6 +120,7 @@
       https://api.nuget.org/v3/index.json;
       <!-- Contains RemoteExecutor. Taken from: https://github.com/dotnet/runtime/blob/master/NuGet.config -->
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
+      https://www.myget.org/F/coverlet-dev/api/v3/index.json;
     </RestoreSources>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)shared-infrastructure/SixLabors.snk</AssemblyOriginatorKeyFile>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,7 +18,7 @@
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
     <!--Global Dependencies-->
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" PrivateAssets="All" Version="3.3.1" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" PrivateAssets="All" Version="3.7.0" />
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Update="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
     

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,7 +18,7 @@
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
     <!--Global Dependencies-->
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" PrivateAssets="All" Version="3.7.0" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" PrivateAssets="All" Version="3.3.1" />
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Update="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
     

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -21,16 +21,25 @@
   </PropertyGroup>
 
   <!-- Workaround for running Coverlet with Determenistic builds -->
-  <!-- https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/DeterministicBuild.md -->
+  <PropertyGroup>
+    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+  </ItemGroup>
+  <ItemGroup>
+    <SourceRoot Include="$(NuGetPackageRoot)" />
+  </ItemGroup>
+
   <Target Name="CoverletGetPathMap"
-            DependsOnTargets="InitializeSourceRootMappedPaths"
-            Returns="@(_LocalTopLevelSourceRoot)"
-            Condition="'$(DeterministicSourcePaths)' == 'true'">
+          DependsOnTargets="InitializeSourceRootMappedPaths"
+          Returns="@(_LocalTopLevelSourceRoot)"
+          Condition="'$(DeterministicSourcePaths)' == 'true'">
     <ItemGroup>
       <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
     </ItemGroup>
   </Target>
-  
+
   <ItemDefinitionGroup>
     <InternalsVisibleTo>
       <Visible>false</Visible>
@@ -62,7 +71,7 @@
   <!-- Empty target so that `dotnet test` will work on the solution -->
   <!-- https://github.com/Microsoft/vstest/issues/411 -->
   <Target Name="VSTest" Condition="'$(IsTestProject)' == 'true'"/>
-  
+
   <ItemGroup>
     <!--Shared config files that have to exist at root level.-->
     <ConfigFilesToCopy Include="..\..\shared-infrastructure\.editorconfig;..\..\shared-infrastructure\.gitattributes" />
@@ -74,7 +83,7 @@
           SkipUnchangedFiles = "true"
           DestinationFolder="..\..\" />
   </Target>
-  
+
   <!-- Allows regenerating T4-generated files at build time using MsBuild -->
   <!-- Enable on Windows OS to build all T4 templates. TODO: XPlat
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TextTemplating\Microsoft.TextTemplating.targets" />
@@ -82,5 +91,5 @@
     <TransformOnBuild>true</TransformOnBuild>
   </PropertyGroup>
   -->
-  
+
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -28,7 +28,7 @@
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(OS)' == 'Windows_NT'" />    
     <PackageReference Update="Colourful" Version="2.0.5" />
-    <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All"/>
+    <PackageReference Update="coverlet.collector" Version="1.3.1-preview.27.gdd2237a3be" PrivateAssets="All"/>
     <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="7.15.5" />
     <PackageReference Update="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20069.1" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.7.1" />

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -31,7 +31,7 @@
     <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All"/>
     <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="7.15.5" />
     <PackageReference Update="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20069.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20200116-01" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Update="Moq" Version="4.14.5" />
     <PackageReference Update="Pfim" Version="0.9.1" />
     <PackageReference Update="SharpZipLib" Version="1.2.0" />

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -31,7 +31,7 @@
     <PackageReference Update="coverlet.collector" Version="1.3.1-preview.27.gdd2237a3be" PrivateAssets="All"/>
     <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="7.15.5" />
     <PackageReference Update="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20069.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Update="Moq" Version="4.14.5" />
     <PackageReference Update="Pfim" Version="0.9.1" />
     <PackageReference Update="SharpZipLib" Version="1.2.0" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
According to my [independent testing](https://github.com/dotnet/arcade/issues/6371#issuecomment-706291633) the RemoteExecutor still works with Ubuntu so we can use that OS as a workaround for #1376 for now.

<!-- Thanks for contributing to ImageSharp! -->
