### PR TITLE
Upgraded Magick.NET.

### DIFF
--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -29,7 +29,7 @@
     <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(OS)' == 'Windows_NT'" />    
     <PackageReference Update="Colourful" Version="2.0.5" />
     <PackageReference Update="coverlet.collector" Version="1.3.1-preview.27.gdd2237a3be" PrivateAssets="All"/>
-    <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="7.15.5" />
+    <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="7.22.0" />
     <PackageReference Update="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20069.1" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Update="Moq" Version="4.14.5" />

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaTestUtils.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaTestUtils.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
             Image<TPixel> image,
             bool useExactComparer = true,
             float compareTolerance = 0.01f)
-            where TPixel : unmanaged, IPixel<TPixel>
+            where TPixel : unmanaged, ImageSharp.PixelFormats.IPixel<TPixel>
         {
             string path = TestImageProvider<TPixel>.GetFilePathOrNull(provider);
             if (path == null)
@@ -39,7 +39,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
         }
 
         public static Image<TPixel> DecodeWithMagick<TPixel>(Configuration configuration, FileInfo fileInfo)
-            where TPixel : unmanaged, IPixel<TPixel>
+            where TPixel : unmanaged, ImageSharp.PixelFormats.IPixel<TPixel>
         {
             using (var magickImage = new MagickImage(fileInfo))
             {
@@ -48,7 +48,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
 
                 Assert.True(result.TryGetSinglePixelSpan(out Span<TPixel> resultPixels));
 
-                using (IPixelCollection pixels = magickImage.GetPixelsUnsafe())
+                using (IUnsafePixelCollection<ushort> pixels = magickImage.GetPixelsUnsafe())
                 {
                     byte[] data = pixels.ToByteArray(PixelMapping.RGBA);
 

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
             var settings = new MagickReadSettings();
             settings.SetDefines(bmpReadDefines);
 
-            using var magickImage = new MagickImage(stream);
+            using var magickImage = new MagickImage(stream, settings);
             var result = new Image<TPixel>(configuration, magickImage.Width, magickImage.Height);
             MemoryGroup<TPixel> resultPixels = result.GetRootFramePixelBuffer().FastMemoryGroup;
 

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -62,9 +62,6 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
                 // on all platforms.
                 IgnoreFileSize = !TestEnvironment.IsWindows
             };
-            {
-                IgnoreFileSize = true
-            };
 
             var settings = new MagickReadSettings();
             settings.SetDefines(bmpReadDefines);

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -57,6 +57,12 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         {
             var bmpReadDefines = new BmpReadDefines
             {
+                // See https://github.com/SixLabors/ImageSharp/issues/1380
+                // Validation fails on Ubuntu despite identical header generation
+                // on all platforms.
+                IgnoreFileSize = !TestEnvironment.IsWindows
+            };
+            {
                 IgnoreFileSize = true
             };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This updates Magick.NET and sets an option for the BMP coder that fixes #1380. This option was added because the BMP coder in ImageMagick is now stricter and you need to set it to be able to read all files.
