### PR TITLE
Fixed setting the file size when the BMP encoder has a color palette

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -171,7 +171,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
 
             var fileHeader = new BmpFileHeader(
                 type: BmpConstants.TypeMarkers.Bitmap,
-                fileSize: BmpFileHeader.Size + infoHeaderSize + infoHeader.ImageSize,
+                fileSize: BmpFileHeader.Size + infoHeaderSize + colorPaletteSize + infoHeader.ImageSize,
                 reserved: 0,
                 offset: BmpFileHeader.Size + infoHeaderSize + colorPaletteSize);
 

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -348,7 +348,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
                 image.DebugSave(provider);
-                image.CompareToOriginal(provider);
+
+                // Do not validate. Reference files will fail validation.
+                image.CompareToOriginal(provider, new MagickReferenceDecoder(false));
             }
         }
 

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -10,7 +10,7 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
-
+using SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -200,10 +200,18 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                     Quantizer = new WuQuantizer()
                 };
                 string actualOutputFile = provider.Utility.SaveTestOutputFile(image, "bmp", encoder, appendPixelTypeToFileName: false);
+
+                // Use the default decoder to test our encoded image. This verifies the content.
+                // We do not verify the reference image though as some are invalid.
                 IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(actualOutputFile);
                 using (var referenceImage = Image.Load<TPixel>(actualOutputFile, referenceDecoder))
                 {
-                    referenceImage.CompareToReferenceOutput(ImageComparer.TolerantPercentage(0.01f), provider, extension: "bmp", appendPixelTypeToFileName: false);
+                    referenceImage.CompareToReferenceOutput(
+                        ImageComparer.TolerantPercentage(0.01f),
+                        provider,
+                        extension: "bmp",
+                        appendPixelTypeToFileName: false,
+                        decoder: new MagickReferenceDecoder(false));
                 }
             }
         }
@@ -226,10 +234,18 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                     Quantizer = new OctreeQuantizer()
                 };
                 string actualOutputFile = provider.Utility.SaveTestOutputFile(image, "bmp", encoder, appendPixelTypeToFileName: false);
+
+                // Use the default decoder to test our encoded image. This verifies the content.
+                // We do not verify the reference image though as some are invalid.
                 IImageDecoder referenceDecoder = TestEnvironment.GetReferenceDecoder(actualOutputFile);
                 using (var referenceImage = Image.Load<TPixel>(actualOutputFile, referenceDecoder))
                 {
-                    referenceImage.CompareToReferenceOutput(ImageComparer.TolerantPercentage(0.01f), provider, extension: "bmp", appendPixelTypeToFileName: false);
+                    referenceImage.CompareToReferenceOutput(
+                        ImageComparer.TolerantPercentage(0.01f),
+                        provider,
+                        extension: "bmp",
+                        appendPixelTypeToFileName: false,
+                        decoder: new MagickReferenceDecoder(false));
                 }
             }
         }

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ImageMagick;
+using ImageMagick.Formats.Bmp;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
@@ -15,6 +16,18 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
 {
     public class MagickReferenceDecoder : IImageDecoder
     {
+        private readonly bool validate;
+
+        public MagickReferenceDecoder()
+            : this(true)
+        {
+        }
+
+        public MagickReferenceDecoder(bool validate)
+        {
+            this.validate = validate;
+        }
+
         public static MagickReferenceDecoder Instance { get; } = new MagickReferenceDecoder();
 
         private static void FromRgba32Bytes<TPixel>(Configuration configuration, Span<byte> rgbaBytes, IMemoryGroup<TPixel> destinationGroup)
@@ -54,7 +67,15 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
             where TPixel : unmanaged, ImageSharp.PixelFormats.IPixel<TPixel>
         {
-            using var magickImage = new MagickImage(stream);
+            var bmpReadDefines = new BmpReadDefines
+            {
+                IgnoreFileSize = !this.validate
+            };
+
+            var settings = new MagickReadSettings();
+            settings.SetDefines(bmpReadDefines);
+
+            using var magickImage = new MagickImage(stream, settings);
             var result = new Image<TPixel>(configuration, magickImage.Width, magickImage.Height);
             MemoryGroup<TPixel> resultPixels = result.GetRootFramePixelBuffer().FastMemoryGroup;
 

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -7,7 +7,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ImageMagick;
-using ImageMagick.Formats.Bmp;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
@@ -55,18 +54,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
             where TPixel : unmanaged, ImageSharp.PixelFormats.IPixel<TPixel>
         {
-            var bmpReadDefines = new BmpReadDefines
-            {
-                // See https://github.com/SixLabors/ImageSharp/issues/1380
-                // Validation fails on Ubuntu despite identical header generation
-                // on all platforms.
-                IgnoreFileSize = !TestEnvironment.IsWindows
-            };
-
-            var settings = new MagickReadSettings();
-            settings.SetDefines(bmpReadDefines);
-
-            using var magickImage = new MagickImage(stream, settings);
+            using var magickImage = new MagickImage(stream);
             var result = new Image<TPixel>(configuration, magickImage.Width, magickImage.Height);
             MemoryGroup<TPixel> resultPixels = result.GetRootFramePixelBuffer().FastMemoryGroup;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
The `colorPaletteSize` is also part of the file size.

Fixes #1380.
