### PR TITLE
Add 4 Channel Shuffle Intrinsics

### DIFF
--- a/src/ImageSharp/Common/Helpers/IComponentShuffle.cs
+++ b/src/ImageSharp/Common/Helpers/IComponentShuffle.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace SixLabors.ImageSharp
+{
+    /// <summary>
+    /// Defines the contract for methods that allow the shuffling of pixel components.
+    /// Used for shuffling on platforms that do not support Hardware Intrinsics.
+    /// </summary>
+    internal interface IComponentShuffle
+    {
+        /// <summary>
+        /// Gets the shuffle control.
+        /// </summary>
+        byte Control { get; }
+
+        /// <summary>
+        /// Shuffle 8-bit integers within 128-bit lanes in <paramref name="source"/>
+        /// using the control and store the results in <paramref name="dest"/>.
+        /// </summary>
+        /// <param name="source">The source span of bytes.</param>
+        /// <param name="dest">The destination span of bytes.</param>
+        void RunFallbackShuffle(ReadOnlySpan<byte> source, Span<byte> dest);
+    }
+
+    internal readonly struct DefaultShuffle4 : IComponentShuffle
+    {
+        public DefaultShuffle4(byte p3, byte p2, byte p1, byte p0)
+            : this(SimdUtils.Shuffle.MmShuffle(p3, p2, p1, p0))
+        {
+        }
+
+        public DefaultShuffle4(byte control) => this.Control = control;
+
+        public byte Control { get; }
+
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public void RunFallbackShuffle(ReadOnlySpan<byte> source, Span<byte> dest)
+        {
+            ref byte sBase = ref MemoryMarshal.GetReference(source);
+            ref byte dBase = ref MemoryMarshal.GetReference(dest);
+            SimdUtils.Shuffle.InverseMmShuffle(
+                this.Control,
+                out int p3,
+                out int p2,
+                out int p1,
+                out int p0);
+
+            for (int i = 0; i < source.Length; i += 4)
+            {
+                Unsafe.Add(ref dBase, i) = Unsafe.Add(ref sBase, p0 + i);
+                Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
+                Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
+                Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, p3 + i);
+            }
+        }
+    }
+
+    internal readonly struct WXYZShuffle4 : IComponentShuffle
+    {
+        public byte Control => SimdUtils.Shuffle.MmShuffle(2, 1, 0, 3);
+
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public void RunFallbackShuffle(ReadOnlySpan<byte> source, Span<byte> dest)
+        {
+            ReadOnlySpan<uint> s = MemoryMarshal.Cast<byte, uint>(source);
+            Span<uint> d = MemoryMarshal.Cast<byte, uint>(dest);
+            ref uint sBase = ref MemoryMarshal.GetReference(s);
+            ref uint dBase = ref MemoryMarshal.GetReference(d);
+
+            // The JIT can detect and optimize rotation idioms ROTL (Rotate Left)
+            // and ROTR (Rotate Right) emitting efficient CPU instructions:
+            // https://github.com/dotnet/coreclr/pull/1830
+            for (int i = 0; i < s.Length; i++)
+            {
+                uint packed = Unsafe.Add(ref sBase, i);
+
+                // packed          = [W Z Y X]
+                // ROTL(8, packed) = [Z Y X W]
+                Unsafe.Add(ref dBase, i) = (packed << 8) | (packed >> 24);
+            }
+        }
+    }
+
+    internal readonly struct WZYXShuffle4 : IComponentShuffle
+    {
+        public byte Control => SimdUtils.Shuffle.MmShuffle(0, 1, 2, 3);
+
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public void RunFallbackShuffle(ReadOnlySpan<byte> source, Span<byte> dest)
+        {
+            ReadOnlySpan<uint> s = MemoryMarshal.Cast<byte, uint>(source);
+            Span<uint> d = MemoryMarshal.Cast<byte, uint>(dest);
+            ref uint sBase = ref MemoryMarshal.GetReference(s);
+            ref uint dBase = ref MemoryMarshal.GetReference(d);
+
+            for (int i = 0; i < s.Length; i++)
+            {
+                uint packed = Unsafe.Add(ref sBase, i);
+
+                // packed              = [W Z Y X]
+                // REVERSE(packedArgb) = [X Y Z W]
+                Unsafe.Add(ref dBase, i) = BinaryPrimitives.ReverseEndianness(packed);
+            }
+        }
+    }
+
+    internal readonly struct YZWXShuffle4 : IComponentShuffle
+    {
+        public byte Control => SimdUtils.Shuffle.MmShuffle(0, 3, 2, 1);
+
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public void RunFallbackShuffle(ReadOnlySpan<byte> source, Span<byte> dest)
+        {
+            ReadOnlySpan<uint> s = MemoryMarshal.Cast<byte, uint>(source);
+            Span<uint> d = MemoryMarshal.Cast<byte, uint>(dest);
+            ref uint sBase = ref MemoryMarshal.GetReference(s);
+            ref uint dBase = ref MemoryMarshal.GetReference(d);
+
+            for (int i = 0; i < s.Length; i++)
+            {
+                uint packed = Unsafe.Add(ref sBase, i);
+
+                // packed              = [W Z Y X]
+                // ROTR(8, packedArgb) = [Y Z W X]
+                Unsafe.Add(ref dBase, i) = (packed >> 8) | (packed << 24);
+            }
+        }
+    }
+
+    internal readonly struct ZYXWShuffle4 : IComponentShuffle
+    {
+        public byte Control => SimdUtils.Shuffle.MmShuffle(3, 0, 1, 2);
+
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public void RunFallbackShuffle(ReadOnlySpan<byte> source, Span<byte> dest)
+        {
+            ReadOnlySpan<uint> s = MemoryMarshal.Cast<byte, uint>(source);
+            Span<uint> d = MemoryMarshal.Cast<byte, uint>(dest);
+            ref uint sBase = ref MemoryMarshal.GetReference(s);
+            ref uint dBase = ref MemoryMarshal.GetReference(d);
+
+            for (int i = 0; i < s.Length; i++)
+            {
+                uint packed = Unsafe.Add(ref sBase, i);
+
+                // packed              = [W Z Y X]
+                // tmp1                = [W 0 Y 0]
+                // tmp2                = [0 Z 0 X]
+                // tmp3=ROTL(16, tmp2) = [0 X 0 Z]
+                // tmp1 + tmp3         = [W X Y Z]
+                uint tmp1 = packed & 0xFF00FF00;
+                uint tmp2 = packed & 0x00FF00FF;
+                uint tmp3 = (tmp2 << 16) | (tmp2 >> 16);
+
+                Unsafe.Add(ref dBase, i) = tmp1 + tmp3;
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -148,24 +148,12 @@ namespace SixLabors.ImageSharp
                 {
                     int n = dest.Length / Vector256<byte>.Count;
 
-                    Vector256<byte> vcm;
-                    switch (control)
-                    {
-                        case Shuffle.WXYZ:
-                            vcm = Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(Shuffle.WXYZ_256));
-                            break;
-                        case Shuffle.XYZW:
-                            vcm = Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(Shuffle.XYZW_256));
-                            break;
-                        case Shuffle.ZYXW:
-                            vcm = Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(Shuffle.ZYXW_256));
-                            break;
-                        default:
-                            Span<byte> bytes = stackalloc byte[Vector256<byte>.Count];
-                            Shuffle.MmShuffleSpan(ref bytes, control);
-                            vcm = Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(bytes));
-                            break;
-                    }
+                    // I've chosen to do this for convenience while we determine what
+                    // shuffle controls to add to the library.
+                    // We can add static ROS instances if need be in the future.
+                    Span<byte> bytes = stackalloc byte[Vector256<byte>.Count];
+                    Shuffle.MmShuffleSpan(ref bytes, control);
+                    Vector256<byte> vcm = Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(bytes));
 
                     ref Vector256<byte> sourceBase =
                         ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(source));
@@ -183,24 +171,9 @@ namespace SixLabors.ImageSharp
                     // Ssse3
                     int n = dest.Length / Vector128<byte>.Count;
 
-                    Vector128<byte> vcm;
-                    switch (control)
-                    {
-                        case Shuffle.WXYZ:
-                            vcm = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(Shuffle.WXYZ_128));
-                            break;
-                        case Shuffle.XYZW:
-                            vcm = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(Shuffle.XYZW_128));
-                            break;
-                        case Shuffle.ZYXW:
-                            vcm = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(Shuffle.ZYXW_128));
-                            break;
-                        default:
-                            Span<byte> bytes = stackalloc byte[Vector128<byte>.Count];
-                            Shuffle.MmShuffleSpan(ref bytes, control);
-                            vcm = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(bytes));
-                            break;
-                    }
+                    Span<byte> bytes = stackalloc byte[Vector128<byte>.Count];
+                    Shuffle.MmShuffleSpan(ref bytes, control);
+                    Vector128<byte> vcm = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(bytes));
 
                     ref Vector128<byte> sourceBase =
                         ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(source));

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -74,7 +74,7 @@ namespace SixLabors.ImageSharp
                 if (Avx2.IsSupported || Ssse3.IsSupported)
                 {
                     int remainder;
-                    if (Avx.IsSupported)
+                    if (Avx2.IsSupported)
                     {
                         remainder = ImageMaths.ModuloP2(source.Length, Vector256<byte>.Count);
                     }

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -33,15 +33,9 @@ namespace SixLabors.ImageSharp
             {
                 if (Avx.IsSupported || Sse.IsSupported)
                 {
-                    int remainder;
-                    if (Avx.IsSupported)
-                    {
-                        remainder = ImageMaths.ModuloP2(source.Length, Vector256<float>.Count);
-                    }
-                    else
-                    {
-                        remainder = ImageMaths.ModuloP2(source.Length, Vector128<float>.Count);
-                    }
+                    int remainder = Avx.IsSupported
+                        ? ImageMaths.ModuloP2(source.Length, Vector256<float>.Count)
+                        : ImageMaths.ModuloP2(source.Length, Vector128<float>.Count);
 
                     int adjustedCount = source.Length - remainder;
 
@@ -73,15 +67,9 @@ namespace SixLabors.ImageSharp
             {
                 if (Avx2.IsSupported || Ssse3.IsSupported)
                 {
-                    int remainder;
-                    if (Avx2.IsSupported)
-                    {
-                        remainder = ImageMaths.ModuloP2(source.Length, Vector256<byte>.Count);
-                    }
-                    else
-                    {
-                        remainder = ImageMaths.ModuloP2(source.Length, Vector128<byte>.Count);
-                    }
+                    int remainder = Avx2.IsSupported
+                        ? ImageMaths.ModuloP2(source.Length, Vector256<byte>.Count)
+                        : ImageMaths.ModuloP2(source.Length, Vector128<byte>.Count);
 
                     int adjustedCount = source.Length - remainder;
 

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -40,34 +39,32 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Shuffle 8-bit integers in a within 128-bit lanes in <paramref name="source"/>
+        /// Shuffle 8-bit integers within 128-bit lanes in <paramref name="source"/>
         /// using the control and store the results in <paramref name="dest"/>.
         /// </summary>
         /// <param name="source">The source span of bytes.</param>
         /// <param name="dest">The destination span of bytes.</param>
-        /// <param name="control">The byte control.</param>
+        /// <param name="shuffle">The type of shuffle to perform.</param>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public static void Shuffle4Channel(
+        public static void Shuffle4Channel<TShuffle>(
             ReadOnlySpan<byte> source,
             Span<byte> dest,
-            byte control)
+            TShuffle shuffle)
+            where TShuffle : struct, IComponentShuffle
         {
             VerifyShuffleSpanInput(source, dest);
 
-            // TODO: There doesn't seem to be any APIs for
-            // System.Numerics that allow shuffling.
 #if SUPPORTS_RUNTIME_INTRINSICS
-            HwIntrinsics.Shuffle4ChannelReduce(ref source, ref dest, control);
+            HwIntrinsics.Shuffle4ChannelReduce(ref source, ref dest, shuffle.Control);
 #endif
 
             // Deal with the remainder:
             if (source.Length > 0)
             {
-                ShuffleRemainder4Channel(source, dest, control);
+                shuffle.RunFallbackShuffle(source, dest);
             }
         }
 
-        [MethodImpl(InliningOptions.ColdPath)]
         public static void ShuffleRemainder4Channel(
             ReadOnlySpan<float> source,
             Span<float> dest,
@@ -83,125 +80,6 @@ namespace SixLabors.ImageSharp
                 Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
                 Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
                 Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, p3 + i);
-            }
-        }
-
-        [MethodImpl(InliningOptions.ColdPath)]
-        public static void ShuffleRemainder4Channel(
-            ReadOnlySpan<byte> source,
-            Span<byte> dest,
-            byte control)
-        {
-#if NETCOREAPP
-            // The JIT can detect and optimize rotation idioms ROTL (Rotate Left)
-            // and ROTR (Rotate Right) emitting efficient CPU instructions:
-            // https://github.com/dotnet/coreclr/pull/1830
-            switch (control)
-            {
-                case Shuffle.WXYZ:
-                    WXYZ(source, dest);
-                    return;
-                case Shuffle.WZYX:
-                    WZYX(source, dest);
-                    return;
-                case Shuffle.YZWX:
-                    YZWX(source, dest);
-                    return;
-                case Shuffle.ZYXW:
-                    ZYXW(source, dest);
-                    return;
-            }
-#endif
-
-            ref byte sBase = ref MemoryMarshal.GetReference(source);
-            ref byte dBase = ref MemoryMarshal.GetReference(dest);
-            Shuffle.InverseMmShuffle(control, out int p3, out int p2, out int p1, out int p0);
-
-            for (int i = 0; i < source.Length; i += 4)
-            {
-                Unsafe.Add(ref dBase, i) = Unsafe.Add(ref sBase, p0 + i);
-                Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
-                Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
-                Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, p3 + i);
-            }
-        }
-
-        [MethodImpl(InliningOptions.ShortMethod)]
-        private static void WXYZ(ReadOnlySpan<byte> source, Span<byte> dest)
-        {
-            ReadOnlySpan<uint> s = MemoryMarshal.Cast<byte, uint>(source);
-            Span<uint> d = MemoryMarshal.Cast<byte, uint>(dest);
-            ref uint sBase = ref MemoryMarshal.GetReference(s);
-            ref uint dBase = ref MemoryMarshal.GetReference(d);
-
-            for (int i = 0; i < s.Length; i++)
-            {
-                uint packed = Unsafe.Add(ref sBase, i);
-
-                // packed          = [W Z Y X]
-                // ROTL(8, packed) = [Z Y X W]
-                Unsafe.Add(ref dBase, i) = (packed << 8) | (packed >> 24);
-            }
-        }
-
-        [MethodImpl(InliningOptions.ShortMethod)]
-        private static void ZYXW(ReadOnlySpan<byte> source, Span<byte> dest)
-        {
-            ReadOnlySpan<uint> s = MemoryMarshal.Cast<byte, uint>(source);
-            Span<uint> d = MemoryMarshal.Cast<byte, uint>(dest);
-            ref uint sBase = ref MemoryMarshal.GetReference(s);
-            ref uint dBase = ref MemoryMarshal.GetReference(d);
-
-            for (int i = 0; i < s.Length; i++)
-            {
-                uint packed = Unsafe.Add(ref sBase, i);
-
-                // packed              = [W Z Y X]
-                // tmp1                = [W 0 Y 0]
-                // tmp2                = [0 Z 0 X]
-                // tmp3=ROTL(16, tmp2) = [0 X 0 Z]
-                // tmp1 + tmp3         = [W X Y Z]
-                uint tmp1 = packed & 0xFF00FF00;
-                uint tmp2 = packed & 0x00FF00FF;
-                uint tmp3 = (tmp2 << 16) | (tmp2 >> 16);
-
-                Unsafe.Add(ref dBase, i) = tmp1 + tmp3;
-            }
-        }
-
-        [MethodImpl(InliningOptions.ShortMethod)]
-        private static void WZYX(ReadOnlySpan<byte> source, Span<byte> dest)
-        {
-            ReadOnlySpan<uint> s = MemoryMarshal.Cast<byte, uint>(source);
-            Span<uint> d = MemoryMarshal.Cast<byte, uint>(dest);
-            ref uint sBase = ref MemoryMarshal.GetReference(s);
-            ref uint dBase = ref MemoryMarshal.GetReference(d);
-
-            for (int i = 0; i < s.Length; i++)
-            {
-                uint packed = Unsafe.Add(ref sBase, i);
-
-                // packed              = [W Z Y X]
-                // REVERSE(packedArgb) = [X Y Z W]
-                Unsafe.Add(ref dBase, i) = BinaryPrimitives.ReverseEndianness(packed);
-            }
-        }
-
-        [MethodImpl(InliningOptions.ShortMethod)]
-        private static void YZWX(ReadOnlySpan<byte> source, Span<byte> dest)
-        {
-            ReadOnlySpan<uint> s = MemoryMarshal.Cast<byte, uint>(source);
-            Span<uint> d = MemoryMarshal.Cast<byte, uint>(dest);
-            ref uint sBase = ref MemoryMarshal.GetReference(s);
-            ref uint dBase = ref MemoryMarshal.GetReference(d);
-
-            for (int i = 0; i < s.Length; i++)
-            {
-                uint packed = Unsafe.Add(ref sBase, i);
-
-                // packed              = [W Z Y X]
-                // ROTR(8, packedArgb) = [Y Z W X]
-                Unsafe.Add(ref dBase, i) = (packed >> 8) | (packed << 24);
             }
         }
 
@@ -222,12 +100,6 @@ namespace SixLabors.ImageSharp
 
         public static class Shuffle
         {
-            public const byte WXYZ = (2 << 6) | (1 << 4) | (0 << 2) | 3;
-            public const byte WZYX = (0 << 6) | (1 << 4) | (2 << 2) | 3;
-            public const byte XYZW = (3 << 6) | (2 << 4) | (1 << 2) | 0;
-            public const byte YZWX = (0 << 6) | (3 << 4) | (2 << 2) | 1;
-            public const byte ZYXW = (3 << 6) | (0 << 4) | (1 << 2) | 2;
-
             [MethodImpl(InliningOptions.ShortMethod)]
             public static byte MmShuffle(byte p3, byte p2, byte p1, byte p0)
                 => (byte)((p3 << 6) | (p2 << 4) | (p1 << 2) | p0);

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
@@ -107,32 +107,6 @@ namespace SixLabors.ImageSharp
             public const byte XYZW = (3 << 6) | (2 << 4) | (1 << 2) | 0;
             public const byte ZYXW = (3 << 6) | (0 << 4) | (1 << 2) | 2;
 
-            public static ReadOnlySpan<byte> WXYZ_128 => MmShuffleSpan128(WXYZ);
-
-            public static ReadOnlySpan<byte> XYZW_128 => MmShuffleSpan128(XYZW);
-
-            public static ReadOnlySpan<byte> ZYXW_128 => MmShuffleSpan128(ZYXW);
-
-            public static ReadOnlySpan<byte> WXYZ_256 => MmShuffleSpan256(WXYZ);
-
-            public static ReadOnlySpan<byte> XYZW_256 => MmShuffleSpan256(XYZW);
-
-            public static ReadOnlySpan<byte> ZYXW_256 => MmShuffleSpan256(ZYXW);
-
-            private static ReadOnlySpan<byte> MmShuffleSpan128(byte control)
-            {
-                Span<byte> buffer = new byte[16];
-                MmShuffleSpan(ref buffer, control);
-                return buffer;
-            }
-
-            private static ReadOnlySpan<byte> MmShuffleSpan256(byte control)
-            {
-                Span<byte> buffer = new byte[32];
-                MmShuffleSpan(ref buffer, control);
-                return buffer;
-            }
-
             [MethodImpl(InliningOptions.ShortMethod)]
             public static byte MmShuffle(int p3, int p2, int p1, int p0)
                 => (byte)((p3 << 6) | (p2 << 4) | (p1 << 2) | p0);

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace SixLabors.ImageSharp
+{
+    internal static partial class SimdUtils
+    {
+        /// <summary>
+        /// Shuffle single-precision (32-bit) floating-point elements in <paramref name="source"/>
+        /// using the control and store the results in <paramref name="dest"/>.
+        /// </summary>
+        /// <param name="source">The source span of floats</param>
+        /// <param name="dest">The destination span of float</param>
+        /// <param name="control">The byte control.</param>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public static void Shuffle4Channel(
+            ReadOnlySpan<float> source,
+            Span<float> dest,
+            byte control)
+        {
+            VerifyShuffleSpanInput(source, dest);
+
+            // TODO: There doesn't seem to be any APIs for
+            // System.Numerics that allow shuffling.
+#if SUPPORTS_RUNTIME_INTRINSICS
+            HwIntrinsics.Shuffle4ChannelReduce(ref source, ref dest, control);
+#endif
+
+            // Deal with the remainder:
+            if (source.Length > 0)
+            {
+                ShuffleRemainder4Channel(source, dest, control);
+            }
+        }
+
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ShuffleRemainder4Channel(
+            ReadOnlySpan<float> source,
+            Span<float> dest,
+            byte control)
+        {
+            ref float sBase = ref MemoryMarshal.GetReference(source);
+            ref float dBase = ref MemoryMarshal.GetReference(dest);
+            Shuffle.InverseMmShuffle(control, out int p3, out int p2, out int p1, out int p0);
+
+            for (int i = 0; i < source.Length; i += 4)
+            {
+                Unsafe.Add(ref dBase, i) = Unsafe.Add(ref sBase, p0 + i);
+                Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
+                Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
+                Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, p3 + i);
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void VerifyShuffleSpanInput(ReadOnlySpan<float> source, Span<float> dest)
+        {
+            DebugGuard.IsTrue(
+                source.Length == dest.Length,
+                nameof(source),
+                "Input spans must be of same length!");
+
+            DebugGuard.IsTrue(
+                source.Length % 4 == 0,
+                nameof(source),
+                "Input spans must be divisiable by 4!");
+        }
+
+        public static class Shuffle
+        {
+            public const byte WXYZ = (2 << 6) | (1 << 4) | (0 << 2) | 3;
+            public const byte XYZW = (3 << 6) | (2 << 4) | (1 << 2) | 0;
+            public const byte ZYXW = (3 << 6) | (0 << 4) | (1 << 2) | 2;
+
+            public static ReadOnlySpan<byte> WXYZ_128 => MmShuffleByte128(2, 1, 0, 3);
+
+            public static ReadOnlySpan<byte> XYZW_128 => MmShuffleByte128(3, 2, 1, 0);
+
+            public static ReadOnlySpan<byte> ZYXW_128 => MmShuffleByte128(3, 0, 1, 2);
+
+            public static ReadOnlySpan<byte> WXYZ_256 => MmShuffleByte256(2, 1, 0, 3);
+
+            public static ReadOnlySpan<byte> XYZW_256 => MmShuffleByte256(3, 2, 1, 0);
+
+            public static ReadOnlySpan<byte> ZYXW_256 => MmShuffleByte256(3, 0, 1, 2);
+
+            private static byte[] MmShuffleByte128(int p3, int p2, int p1, int p0)
+            {
+                byte[] result = new byte[16];
+
+                for (int i = 0; i < result.Length; i += 4)
+                {
+                    result[i] = (byte)(p0 + i);
+                    result[i + 1] = (byte)(p1 + i);
+                    result[i + 2] = (byte)(p2 + i);
+                    result[i + 3] = (byte)(p3 + i);
+                }
+
+                return result;
+            }
+
+            private static byte[] MmShuffleByte256(int p3, int p2, int p1, int p0)
+            {
+                byte[] result = new byte[32];
+
+                for (int i = 0; i < result.Length; i += 4)
+                {
+                    result[i] = (byte)(p0 + i);
+                    result[i + 1] = (byte)(p1 + i);
+                    result[i + 2] = (byte)(p2 + i);
+                    result[i + 3] = (byte)(p3 + i);
+                }
+
+                return result;
+            }
+
+            public static void InverseMmShuffle(byte control, out int p3, out int p2, out int p1, out int p0)
+            {
+                p3 = control >> 6 & 0x3;
+                p2 = control >> 4 & 0x3;
+                p1 = control >> 2 & 0x3;
+                p0 = control >> 0 & 0x3;
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
@@ -25,8 +25,6 @@ namespace SixLabors.ImageSharp
         {
             VerifyShuffleSpanInput(source, dest);
 
-            // TODO: There doesn't seem to be any APIs for
-            // System.Numerics that allow shuffling.
 #if SUPPORTS_RUNTIME_INTRINSICS
             HwIntrinsics.Shuffle4ChannelReduce(ref source, ref dest, control);
 #endif

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
@@ -229,7 +229,7 @@ namespace SixLabors.ImageSharp
             public const byte ZYXW = (3 << 6) | (0 << 4) | (1 << 2) | 2;
 
             [MethodImpl(InliningOptions.ShortMethod)]
-            public static byte MmShuffle(int p3, int p2, int p1, int p0)
+            public static byte MmShuffle(byte p3, byte p2, byte p1, byte p0)
                 => (byte)((p3 << 6) | (p2 << 4) | (p1 << 2) | p0);
 
             [MethodImpl(InliningOptions.ShortMethod)]

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
@@ -14,8 +14,8 @@ namespace SixLabors.ImageSharp
         /// Shuffle single-precision (32-bit) floating-point elements in <paramref name="source"/>
         /// using the control and store the results in <paramref name="dest"/>.
         /// </summary>
-        /// <param name="source">The source span of floats</param>
-        /// <param name="dest">The destination span of float</param>
+        /// <param name="source">The source span of floats.</param>
+        /// <param name="dest">The destination span of floats.</param>
         /// <param name="control">The byte control.</param>
         [MethodImpl(InliningOptions.ShortMethod)]
         public static void Shuffle4Channel(
@@ -38,14 +38,43 @@ namespace SixLabors.ImageSharp
             }
         }
 
-        [MethodImpl(InliningOptions.ColdPath)]
-        public static void ShuffleRemainder4Channel(
-            ReadOnlySpan<float> source,
-            Span<float> dest,
+        /// <summary>
+        /// Shuffle 8-bit integers in a within 128-bit lanes in <paramref name="source"/>
+        /// using the control and store the results in <paramref name="dest"/>.
+        /// </summary>
+        /// <param name="source">The source span of bytes.</param>
+        /// <param name="dest">The destination span of bytes.</param>
+        /// <param name="control">The byte control.</param>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public static void Shuffle4Channel(
+            ReadOnlySpan<byte> source,
+            Span<byte> dest,
             byte control)
         {
-            ref float sBase = ref MemoryMarshal.GetReference(source);
-            ref float dBase = ref MemoryMarshal.GetReference(dest);
+            VerifyShuffleSpanInput(source, dest);
+
+            // TODO: There doesn't seem to be any APIs for
+            // System.Numerics that allow shuffling.
+#if SUPPORTS_RUNTIME_INTRINSICS
+            HwIntrinsics.Shuffle4ChannelReduce(ref source, ref dest, control);
+#endif
+
+            // Deal with the remainder:
+            if (source.Length > 0)
+            {
+                ShuffleRemainder4Channel(source, dest, control);
+            }
+        }
+
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ShuffleRemainder4Channel<T>(
+            ReadOnlySpan<T> source,
+            Span<T> dest,
+            byte control)
+            where T : struct
+        {
+            ref T sBase = ref MemoryMarshal.GetReference(source);
+            ref T dBase = ref MemoryMarshal.GetReference(dest);
             Shuffle.InverseMmShuffle(control, out int p3, out int p2, out int p1, out int p0);
 
             for (int i = 0; i < source.Length; i += 4)
@@ -58,7 +87,8 @@ namespace SixLabors.ImageSharp
         }
 
         [Conditional("DEBUG")]
-        private static void VerifyShuffleSpanInput(ReadOnlySpan<float> source, Span<float> dest)
+        private static void VerifyShuffleSpanInput<T>(ReadOnlySpan<T> source, Span<T> dest)
+            where T : struct
         {
             DebugGuard.IsTrue(
                 source.Length == dest.Length,
@@ -77,49 +107,64 @@ namespace SixLabors.ImageSharp
             public const byte XYZW = (3 << 6) | (2 << 4) | (1 << 2) | 0;
             public const byte ZYXW = (3 << 6) | (0 << 4) | (1 << 2) | 2;
 
-            public static ReadOnlySpan<byte> WXYZ_128 => MmShuffleByte128(2, 1, 0, 3);
+            public static ReadOnlySpan<byte> WXYZ_128 => MmShuffleSpan128(WXYZ);
 
-            public static ReadOnlySpan<byte> XYZW_128 => MmShuffleByte128(3, 2, 1, 0);
+            public static ReadOnlySpan<byte> XYZW_128 => MmShuffleSpan128(XYZW);
 
-            public static ReadOnlySpan<byte> ZYXW_128 => MmShuffleByte128(3, 0, 1, 2);
+            public static ReadOnlySpan<byte> ZYXW_128 => MmShuffleSpan128(ZYXW);
 
-            public static ReadOnlySpan<byte> WXYZ_256 => MmShuffleByte256(2, 1, 0, 3);
+            public static ReadOnlySpan<byte> WXYZ_256 => MmShuffleSpan256(WXYZ);
 
-            public static ReadOnlySpan<byte> XYZW_256 => MmShuffleByte256(3, 2, 1, 0);
+            public static ReadOnlySpan<byte> XYZW_256 => MmShuffleSpan256(XYZW);
 
-            public static ReadOnlySpan<byte> ZYXW_256 => MmShuffleByte256(3, 0, 1, 2);
+            public static ReadOnlySpan<byte> ZYXW_256 => MmShuffleSpan256(ZYXW);
 
-            private static byte[] MmShuffleByte128(int p3, int p2, int p1, int p0)
+            private static ReadOnlySpan<byte> MmShuffleSpan128(byte control)
             {
-                byte[] result = new byte[16];
-
-                for (int i = 0; i < result.Length; i += 4)
-                {
-                    result[i] = (byte)(p0 + i);
-                    result[i + 1] = (byte)(p1 + i);
-                    result[i + 2] = (byte)(p2 + i);
-                    result[i + 3] = (byte)(p3 + i);
-                }
-
-                return result;
+                Span<byte> buffer = new byte[16];
+                MmShuffleSpan(ref buffer, control);
+                return buffer;
             }
 
-            private static byte[] MmShuffleByte256(int p3, int p2, int p1, int p0)
+            private static ReadOnlySpan<byte> MmShuffleSpan256(byte control)
             {
-                byte[] result = new byte[32];
-
-                for (int i = 0; i < result.Length; i += 4)
-                {
-                    result[i] = (byte)(p0 + i);
-                    result[i + 1] = (byte)(p1 + i);
-                    result[i + 2] = (byte)(p2 + i);
-                    result[i + 3] = (byte)(p3 + i);
-                }
-
-                return result;
+                Span<byte> buffer = new byte[32];
+                MmShuffleSpan(ref buffer, control);
+                return buffer;
             }
 
-            public static void InverseMmShuffle(byte control, out int p3, out int p2, out int p1, out int p0)
+            [MethodImpl(InliningOptions.ShortMethod)]
+            public static byte MmShuffle(int p3, int p2, int p1, int p0)
+                => (byte)((p3 << 6) | (p2 << 4) | (p1 << 2) | p0);
+
+            [MethodImpl(InliningOptions.ShortMethod)]
+            public static void MmShuffleSpan(ref Span<byte> span, byte control)
+            {
+                InverseMmShuffle(
+                     control,
+                     out int p3,
+                     out int p2,
+                     out int p1,
+                     out int p0);
+
+                ref byte spanBase = ref MemoryMarshal.GetReference(span);
+
+                for (int i = 0; i < span.Length; i += 4)
+                {
+                    Unsafe.Add(ref spanBase, i) = (byte)(p0 + i);
+                    Unsafe.Add(ref spanBase, i + 1) = (byte)(p1 + i);
+                    Unsafe.Add(ref spanBase, i + 2) = (byte)(p2 + i);
+                    Unsafe.Add(ref spanBase, i + 3) = (byte)(p3 + i);
+                }
+            }
+
+            [MethodImpl(InliningOptions.ShortMethod)]
+            public static void InverseMmShuffle(
+                byte control,
+                out int p3,
+                out int p2,
+                out int p1,
+                out int p0)
             {
                 p3 = control >> 6 & 0x3;
                 p2 = control >> 4 & 0x3;

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Generated/Argb32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Generated/Argb32.PixelOperations.Generated.cs
@@ -53,66 +53,58 @@ namespace SixLabors.ImageSharp.PixelFormats
                 Vector4Converters.RgbaCompatible.ToVector4(configuration, this, sourcePixels, destVectors, modifiers.Remove(PixelConversionModifiers.Scale));
             }
             /// <inheritdoc />
-            public override void ToRgba32(Configuration configuration, ReadOnlySpan<Argb32> sourcePixels, Span<Rgba32> destinationPixels)
+            public override void ToRgba32(
+                Configuration configuration,
+                ReadOnlySpan<Argb32> sourcePixels,
+                Span<Rgba32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Argb32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Rgba32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromArgb32.ToRgba32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Argb32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
+                PixelConverter.FromArgb32.ToRgba32(source, dest);
             }
 
             /// <inheritdoc />
-            public override void FromRgba32(Configuration configuration, ReadOnlySpan<Rgba32> sourcePixels, Span<Argb32> destinationPixels)
+            public override void FromRgba32(
+                Configuration configuration,
+                ReadOnlySpan<Rgba32> sourcePixels,
+                Span<Argb32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Rgba32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Argb32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromRgba32.ToArgb32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgba32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
+                PixelConverter.FromRgba32.ToArgb32(source, dest);
             }
             /// <inheritdoc />
-            public override void ToBgra32(Configuration configuration, ReadOnlySpan<Argb32> sourcePixels, Span<Bgra32> destinationPixels)
+            public override void ToBgra32(
+                Configuration configuration,
+                ReadOnlySpan<Argb32> sourcePixels,
+                Span<Bgra32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Argb32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Bgra32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromArgb32.ToBgra32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Argb32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
+                PixelConverter.FromArgb32.ToBgra32(source, dest);
             }
 
             /// <inheritdoc />
-            public override void FromBgra32(Configuration configuration, ReadOnlySpan<Bgra32> sourcePixels, Span<Argb32> destinationPixels)
+            public override void FromBgra32(
+                Configuration configuration,
+                ReadOnlySpan<Bgra32> sourcePixels,
+                Span<Argb32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Bgra32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Argb32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromBgra32.ToArgb32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgra32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
+                PixelConverter.FromBgra32.ToArgb32(source, dest);
             }
 
             /// <inheritdoc />

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Generated/Bgra32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Generated/Bgra32.PixelOperations.Generated.cs
@@ -53,66 +53,58 @@ namespace SixLabors.ImageSharp.PixelFormats
                 Vector4Converters.RgbaCompatible.ToVector4(configuration, this, sourcePixels, destVectors, modifiers.Remove(PixelConversionModifiers.Scale));
             }
             /// <inheritdoc />
-            public override void ToRgba32(Configuration configuration, ReadOnlySpan<Bgra32> sourcePixels, Span<Rgba32> destinationPixels)
+            public override void ToRgba32(
+                Configuration configuration,
+                ReadOnlySpan<Bgra32> sourcePixels,
+                Span<Rgba32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Bgra32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Rgba32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromBgra32.ToRgba32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgra32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
+                PixelConverter.FromBgra32.ToRgba32(source, dest);
             }
 
             /// <inheritdoc />
-            public override void FromRgba32(Configuration configuration, ReadOnlySpan<Rgba32> sourcePixels, Span<Bgra32> destinationPixels)
+            public override void FromRgba32(
+                Configuration configuration,
+                ReadOnlySpan<Rgba32> sourcePixels,
+                Span<Bgra32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Rgba32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Bgra32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromRgba32.ToBgra32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgba32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
+                PixelConverter.FromRgba32.ToBgra32(source, dest);
             }
             /// <inheritdoc />
-            public override void ToArgb32(Configuration configuration, ReadOnlySpan<Bgra32> sourcePixels, Span<Argb32> destinationPixels)
+            public override void ToArgb32(
+                Configuration configuration,
+                ReadOnlySpan<Bgra32> sourcePixels,
+                Span<Argb32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Bgra32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Argb32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromBgra32.ToArgb32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgra32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
+                PixelConverter.FromBgra32.ToArgb32(source, dest);
             }
 
             /// <inheritdoc />
-            public override void FromArgb32(Configuration configuration, ReadOnlySpan<Argb32> sourcePixels, Span<Bgra32> destinationPixels)
+            public override void FromArgb32(
+                Configuration configuration,
+                ReadOnlySpan<Argb32> sourcePixels,
+                Span<Bgra32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Argb32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Bgra32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromArgb32.ToBgra32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Argb32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
+                PixelConverter.FromArgb32.ToBgra32(source, dest);
             }
 
             /// <inheritdoc />

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Generated/Rgba32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Generated/Rgba32.PixelOperations.Generated.cs
@@ -42,66 +42,58 @@ namespace SixLabors.ImageSharp.PixelFormats
             }
 
             /// <inheritdoc />
-            public override void ToArgb32(Configuration configuration, ReadOnlySpan<Rgba32> sourcePixels, Span<Argb32> destinationPixels)
+            public override void ToArgb32(
+                Configuration configuration,
+                ReadOnlySpan<Rgba32> sourcePixels,
+                Span<Argb32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Rgba32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Argb32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromRgba32.ToArgb32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgba32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
+                PixelConverter.FromRgba32.ToArgb32(source, dest);
             }
 
             /// <inheritdoc />
-            public override void FromArgb32(Configuration configuration, ReadOnlySpan<Argb32> sourcePixels, Span<Rgba32> destinationPixels)
+            public override void FromArgb32(
+                Configuration configuration,
+                ReadOnlySpan<Argb32> sourcePixels,
+                Span<Rgba32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Argb32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Rgba32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromArgb32.ToRgba32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Argb32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
+                PixelConverter.FromArgb32.ToRgba32(source, dest);
             }
             /// <inheritdoc />
-            public override void ToBgra32(Configuration configuration, ReadOnlySpan<Rgba32> sourcePixels, Span<Bgra32> destinationPixels)
+            public override void ToBgra32(
+                Configuration configuration,
+                ReadOnlySpan<Rgba32> sourcePixels,
+                Span<Bgra32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Rgba32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Bgra32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromRgba32.ToBgra32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgba32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
+                PixelConverter.FromRgba32.ToBgra32(source, dest);
             }
 
             /// <inheritdoc />
-            public override void FromBgra32(Configuration configuration, ReadOnlySpan<Bgra32> sourcePixels, Span<Rgba32> destinationPixels)
+            public override void FromBgra32(
+                Configuration configuration,
+                ReadOnlySpan<Bgra32> sourcePixels,
+                Span<Rgba32> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<Bgra32,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<Rgba32, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.FromBgra32.ToRgba32(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgra32, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
+                PixelConverter.FromBgra32.ToRgba32(source, dest);
             }
 
             /// <inheritdoc />

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Generated/_Common.ttinclude
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Generated/_Common.ttinclude
@@ -88,35 +88,31 @@ using System.Runtime.InteropServices;
     {
 #>
             /// <inheritdoc />
-            public override void To<#=otherPixelType#>(Configuration configuration, ReadOnlySpan<<#=thisPixelType#>> sourcePixels, Span<<#=otherPixelType#>> destinationPixels)
+            public override void To<#=otherPixelType#>(
+                Configuration configuration,
+                ReadOnlySpan<<#=thisPixelType#>> sourcePixels,
+                Span<<#=otherPixelType#>> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<<#=thisPixelType#>,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<<#=otherPixelType#>, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.From<#=thisPixelType#>.To<#=otherPixelType#>(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<<#=thisPixelType#>, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<<#=otherPixelType#>, byte>(destinationPixels);
+                PixelConverter.From<#=thisPixelType#>.To<#=otherPixelType#>(source, dest);
             }
 
             /// <inheritdoc />
-            public override void From<#=otherPixelType#>(Configuration configuration, ReadOnlySpan<<#=otherPixelType#>> sourcePixels, Span<<#=thisPixelType#>> destinationPixels)
+            public override void From<#=otherPixelType#>(
+                Configuration configuration,
+                ReadOnlySpan<<#=otherPixelType#>> sourcePixels,
+                Span<<#=thisPixelType#>> destinationPixels)
             {
                 Guard.NotNull(configuration, nameof(configuration));
                 Guard.DestinationShouldNotBeTooShort(sourcePixels, destinationPixels, nameof(destinationPixels));
 
-                ref uint sourceRef = ref Unsafe.As<<#=otherPixelType#>,uint>(ref MemoryMarshal.GetReference(sourcePixels));
-                ref uint destRef = ref Unsafe.As<<#=thisPixelType#>, uint>(ref MemoryMarshal.GetReference(destinationPixels));
-
-                for (int i = 0; i < sourcePixels.Length; i++)
-                {
-                    uint sp = Unsafe.Add(ref sourceRef, i);
-                    Unsafe.Add(ref destRef, i) = PixelConverter.From<#=otherPixelType#>.To<#=thisPixelType#>(sp);
-                }
+                ReadOnlySpan<byte> source = MemoryMarshal.Cast<<#=otherPixelType#>, byte>(sourcePixels);
+                Span<byte> dest = MemoryMarshal.Cast<<#=thisPixelType#>, byte>(destinationPixels);
+                PixelConverter.From<#=otherPixelType#>.To<#=thisPixelType#>(source, dest);
             }
 <#+
     }

--- a/src/ImageSharp/PixelFormats/Utils/PixelConverter.cs
+++ b/src/ImageSharp/PixelFormats/Utils/PixelConverter.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.PixelFormats.Utils
@@ -28,7 +27,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
             public static void ToArgb32(ReadOnlySpan<byte> source, Span<byte> dest)
-                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.WXYZ);
+                => SimdUtils.Shuffle4Channel<WXYZShuffle4>(source, dest, default);
 
             /// <summary>
             /// Converts a <see cref="ReadOnlySpan{Byte}"/> representing a collection of
@@ -37,7 +36,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
             public static void ToBgra32(ReadOnlySpan<byte> source, Span<byte> dest)
-                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.ZYXW);
+                => SimdUtils.Shuffle4Channel<ZYXWShuffle4>(source, dest, default);
         }
 
         public static class FromArgb32
@@ -49,7 +48,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
             public static void ToRgba32(ReadOnlySpan<byte> source, Span<byte> dest)
-                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.YZWX);
+                => SimdUtils.Shuffle4Channel<YZWXShuffle4>(source, dest, default);
 
             /// <summary>
             /// Converts a <see cref="ReadOnlySpan{Byte}"/> representing a collection of
@@ -58,7 +57,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
             public static void ToBgra32(ReadOnlySpan<byte> source, Span<byte> dest)
-                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.WZYX);
+                => SimdUtils.Shuffle4Channel<WZYXShuffle4>(source, dest, default);
         }
 
         public static class FromBgra32
@@ -70,7 +69,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
             public static void ToArgb32(ReadOnlySpan<byte> source, Span<byte> dest)
-                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.WZYX);
+                => SimdUtils.Shuffle4Channel<WZYXShuffle4>(source, dest, default);
 
             /// <summary>
             /// Converts a <see cref="ReadOnlySpan{Byte}"/> representing a collection of
@@ -79,7 +78,7 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
             public static void ToRgba32(ReadOnlySpan<byte> source, Span<byte> dest)
-                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.ZYXW);
+                => SimdUtils.Shuffle4Channel<ZYXWShuffle4>(source, dest, default);
         }
     }
 }

--- a/src/ImageSharp/PixelFormats/Utils/PixelConverter.cs
+++ b/src/ImageSharp/PixelFormats/Utils/PixelConverter.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
@@ -21,88 +22,64 @@ namespace SixLabors.ImageSharp.PixelFormats.Utils
         public static class FromRgba32
         {
             /// <summary>
-            /// Converts a packed <see cref="Rgba32"/> to <see cref="Argb32"/>.
+            /// Converts a <see cref="ReadOnlySpan{Byte}"/> representing a collection of
+            /// <see cref="Rgba32"/> pixels to a <see cref="Span{Byte}"/> representing
+            /// a collection of <see cref="Argb32"/> pixels.
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
-            public static uint ToArgb32(uint packedRgba)
-            {
-                // packedRgba          = [aa bb gg rr]
-                // ROTL(8, packedRgba) = [bb gg rr aa]
-                return (packedRgba << 8) | (packedRgba >> 24);
-            }
+            public static void ToArgb32(ReadOnlySpan<byte> source, Span<byte> dest)
+                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.WXYZ);
 
             /// <summary>
-            /// Converts a packed <see cref="Rgba32"/> to <see cref="Bgra32"/>.
+            /// Converts a <see cref="ReadOnlySpan{Byte}"/> representing a collection of
+            /// <see cref="Rgba32"/> pixels to a <see cref="Span{Byte}"/> representing
+            /// a collection of <see cref="Bgra32"/> pixels.
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
-            public static uint ToBgra32(uint packedRgba)
-            {
-                // packedRgba          = [aa bb gg rr]
-                // tmp1                = [aa 00 gg 00]
-                // tmp2                = [00 bb 00 rr]
-                // tmp3=ROTL(16, tmp2) = [00 rr 00 bb]
-                // tmp1 + tmp3         = [aa rr gg bb]
-                uint tmp1 = packedRgba & 0xFF00FF00;
-                uint tmp2 = packedRgba & 0x00FF00FF;
-                uint tmp3 = (tmp2 << 16) | (tmp2 >> 16);
-                return tmp1 + tmp3;
-            }
+            public static void ToBgra32(ReadOnlySpan<byte> source, Span<byte> dest)
+                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.ZYXW);
         }
 
         public static class FromArgb32
         {
             /// <summary>
-            /// Converts a packed <see cref="Argb32"/> to <see cref="Rgba32"/>.
+            /// Converts a <see cref="ReadOnlySpan{Byte}"/> representing a collection of
+            /// <see cref="Argb32"/> pixels to a <see cref="Span{Byte}"/> representing
+            /// a collection of <see cref="Rgba32"/> pixels.
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
-            public static uint ToRgba32(uint packedArgb)
-            {
-                // packedArgb          = [bb gg rr aa]
-                // ROTR(8, packedArgb) = [aa bb gg rr]
-                return (packedArgb >> 8) | (packedArgb << 24);
-            }
+            public static void ToRgba32(ReadOnlySpan<byte> source, Span<byte> dest)
+                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.YZWX);
 
             /// <summary>
-            /// Converts a packed <see cref="Argb32"/> to <see cref="Bgra32"/>.
+            /// Converts a <see cref="ReadOnlySpan{Byte}"/> representing a collection of
+            /// <see cref="Argb32"/> pixels to a <see cref="Span{Byte}"/> representing
+            /// a collection of <see cref="Bgra32"/> pixels.
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
-            public static uint ToBgra32(uint packedArgb)
-            {
-                // packedArgb          = [bb gg rr aa]
-                // REVERSE(packedArgb) = [aa rr gg bb]
-                return BinaryPrimitives.ReverseEndianness(packedArgb);
-            }
+            public static void ToBgra32(ReadOnlySpan<byte> source, Span<byte> dest)
+                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.WZYX);
         }
 
         public static class FromBgra32
         {
             /// <summary>
-            /// Converts a packed <see cref="Bgra32"/> to <see cref="Argb32"/>.
+            /// Converts a <see cref="ReadOnlySpan{Byte}"/> representing a collection of
+            /// <see cref="Bgra32"/> pixels to a <see cref="Span{Byte}"/> representing
+            /// a collection of <see cref="Argb32"/> pixels.
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
-            public static uint ToArgb32(uint packedBgra)
-            {
-                // packedBgra          = [aa rr gg bb]
-                // REVERSE(packedBgra) = [bb gg rr aa]
-                return BinaryPrimitives.ReverseEndianness(packedBgra);
-            }
+            public static void ToArgb32(ReadOnlySpan<byte> source, Span<byte> dest)
+                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.WZYX);
 
             /// <summary>
-            /// Converts a packed <see cref="Rgba32"/> to <see cref="Bgra32"/>.
+            /// Converts a <see cref="ReadOnlySpan{Byte}"/> representing a collection of
+            /// <see cref="Bgra32"/> pixels to a <see cref="Span{Byte}"/> representing
+            /// a collection of <see cref="Bgra32"/> pixels.
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
-            public static uint ToRgba32(uint packedBgra)
-            {
-                // packedRgba          = [aa rr gg bb]
-                // tmp1                = [aa 00 gg 00]
-                // tmp2                = [00 rr 00 bb]
-                // tmp3=ROTL(16, tmp2) = [00 bb 00 rr]
-                // tmp1 + tmp3         = [aa bb gg rr]
-                uint tmp1 = packedBgra & 0xFF00FF00;
-                uint tmp2 = packedBgra & 0x00FF00FF;
-                uint tmp3 = (tmp2 << 16) | (tmp2 >> 16);
-                return tmp1 + tmp3;
-            }
+            public static void ToRgba32(ReadOnlySpan<byte> source, Span<byte> dest)
+                => SimdUtils.Shuffle4Channel(source, dest, SimdUtils.Shuffle.ZYXW);
         }
     }
 }

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleByte4Channel.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleByte4Channel.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
+{
+    [Config(typeof(Config.HwIntrinsics_SSE_AVX))]
+    public class ShuffleByte4Channel
+    {
+        private byte[] source;
+        private byte[] destination;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.source = new byte[this.Count];
+            new Random(this.Count).NextBytes(this.source);
+            this.destination = new byte[this.Count];
+        }
+
+        [Params(128, 256, 512, 1024, 2048)]
+        public int Count { get; set; }
+
+        [Benchmark]
+        public void Shuffle4Channel()
+        {
+            SimdUtils.Shuffle4Channel(this.source, this.destination, SimdUtils.Shuffle.WXYZ);
+        }
+    }
+
+    // 2020-10-26
+    // ##########
+    //
+    // BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
+    // Intel Core i7-8650U CPU 1.90GHz(Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
+    // .NET Core SDK = 5.0.100-rc.2.20479.15
+    //
+    // [Host]          : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  AVX             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  No HwIntrinsics : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  SSE             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //
+    // Runtime=.NET Core 3.1
+    //
+    // |          Method |             Job |                              EnvironmentVariables | Count |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+    // |---------------- |---------------- |-------------------------------------------------- |------ |----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
+    // | Shuffle4Channel |             AVX |                                             Empty |   128 |  33.57 ns |  0.694 ns |  1.268 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |  63.97 ns |  0.940 ns |  1.045 ns |  1.94 |    0.10 |      - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   128 |  27.23 ns |  0.338 ns |  0.300 ns |  0.84 |    0.04 | 0.0095 |     - |     - |      40 B |
+    // |                 |                 |                                                   |       |           |           |           |       |         |        |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |   256 |  34.57 ns |  0.295 ns |  0.276 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 | 124.62 ns |  0.257 ns |  0.228 ns |  3.60 |    0.03 |      - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   256 |  32.22 ns |  0.106 ns |  0.099 ns |  0.93 |    0.01 | 0.0095 |     - |     - |      40 B |
+    // |                 |                 |                                                   |       |           |           |           |       |         |        |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |   512 |  40.41 ns |  0.826 ns |  0.848 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 | 251.65 ns |  0.440 ns |  0.412 ns |  6.23 |    0.13 |      - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   512 |  41.54 ns |  0.128 ns |  0.114 ns |  1.03 |    0.02 | 0.0095 |     - |     - |      40 B |
+    // |                 |                 |                                                   |       |           |           |           |       |         |        |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |  1024 |  51.54 ns |  0.156 ns |  0.121 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 | 493.66 ns |  1.316 ns |  1.231 ns |  9.58 |    0.04 |      - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  1024 |  61.45 ns |  0.216 ns |  0.181 ns |  1.19 |    0.00 | 0.0095 |     - |     - |      40 B |
+    // |                 |                 |                                                   |       |           |           |           |       |         |        |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |  2048 |  76.85 ns |  0.176 ns |  0.138 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 985.64 ns | 11.396 ns | 10.103 ns | 12.84 |    0.15 |      - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  2048 | 106.13 ns |  0.335 ns |  0.297 ns |  1.38 |    0.01 | 0.0095 |     - |     - |      40 B |
+}

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleByte4Channel.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleByte4Channel.cs
@@ -30,39 +30,38 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
         }
     }
 
-    // 2020-10-26
+    // 2020-10-29
     // ##########
     //
     // BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
-    // Intel Core i7-8650U CPU 1.90GHz(Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
-    // .NET Core SDK = 5.0.100-rc.2.20479.15
-    //
-    // [Host]          : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
-    //  AVX             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
-    //  No HwIntrinsics : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
-    //  SSE             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    // Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
+    // .NET Core SDK=3.1.403
+    //  [Host]             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  1. No HwIntrinsics : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  2. AVX             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  3. SSE             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
     //
     // Runtime=.NET Core 3.1
     //
-    // |          Method |             Job |                              EnvironmentVariables | Count |      Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
-    // |---------------- |---------------- |-------------------------------------------------- |------ |----------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
-    // | Shuffle4Channel |             AVX |                                             Empty |   128 |  20.51 ns | 0.270 ns | 0.211 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |  63.00 ns | 0.991 ns | 0.927 ns |  3.08 |    0.06 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   128 |  17.25 ns | 0.066 ns | 0.058 ns |  0.84 |    0.01 |     - |     - |     - |         - |
-    // |                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |   256 |  24.57 ns | 0.248 ns | 0.219 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 | 124.55 ns | 2.501 ns | 2.456 ns |  5.06 |    0.10 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   256 |  21.80 ns | 0.094 ns | 0.088 ns |  0.89 |    0.01 |     - |     - |     - |         - |
-    // |                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |   512 |  28.51 ns | 0.130 ns | 0.115 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 | 256.52 ns | 1.424 ns | 1.332 ns |  9.00 |    0.07 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   512 |  29.72 ns | 0.217 ns | 0.203 ns |  1.04 |    0.01 |     - |     - |     - |         - |
-    // |                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |  1024 |  36.40 ns | 0.357 ns | 0.334 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 | 492.71 ns | 1.498 ns | 1.251 ns | 13.52 |    0.12 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  1024 |  44.71 ns | 0.264 ns | 0.234 ns |  1.23 |    0.02 |     - |     - |     - |         - |
-    // |                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |  2048 |  59.38 ns | 0.180 ns | 0.159 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 975.05 ns | 2.043 ns | 1.811 ns | 16.42 |    0.05 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  2048 |  81.83 ns | 0.212 ns | 0.198 ns |  1.38 |    0.01 |     - |     - |     - |         - |
+    // |          Method |                Job |                              EnvironmentVariables | Count |      Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
+    // |---------------- |------------------- |-------------------------------------------------- |------ |----------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |  17.39 ns | 0.187 ns | 0.175 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |   128 |  21.72 ns | 0.299 ns | 0.279 ns |  1.25 |    0.02 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |   128 |  18.10 ns | 0.346 ns | 0.289 ns |  1.04 |    0.02 |     - |     - |     - |         - |
+    // |                 |                    |                                                   |       |           |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 |  35.51 ns | 0.711 ns | 0.790 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |   256 |  23.90 ns | 0.508 ns | 0.820 ns |  0.69 |    0.02 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |   256 |  20.40 ns | 0.133 ns | 0.111 ns |  0.57 |    0.01 |     - |     - |     - |         - |
+    // |                 |                    |                                                   |       |           |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 |  73.39 ns | 0.310 ns | 0.259 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |   512 |  26.10 ns | 0.418 ns | 0.391 ns |  0.36 |    0.01 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |   512 |  27.59 ns | 0.556 ns | 0.571 ns |  0.38 |    0.01 |     - |     - |     - |         - |
+    // |                 |                    |                                                   |       |           |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 | 150.64 ns | 2.903 ns | 2.716 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |  1024 |  38.67 ns | 0.801 ns | 1.889 ns |  0.24 |    0.02 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |  1024 |  47.13 ns | 0.948 ns | 1.054 ns |  0.31 |    0.01 |     - |     - |     - |         - |
+    // |                 |                    |                                                   |       |           |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 315.29 ns | 5.206 ns | 6.583 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |  2048 |  57.37 ns | 1.152 ns | 1.078 ns |  0.18 |    0.01 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |  2048 |  65.75 ns | 1.198 ns | 1.600 ns |  0.21 |    0.01 |     - |     - |     - |         - |
 }

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleByte4Channel.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleByte4Channel.cs
@@ -44,25 +44,25 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
     //
     // Runtime=.NET Core 3.1
     //
-    // |          Method |             Job |                              EnvironmentVariables | Count |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-    // |---------------- |---------------- |-------------------------------------------------- |------ |----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
-    // | Shuffle4Channel |             AVX |                                             Empty |   128 |  33.57 ns |  0.694 ns |  1.268 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |  63.97 ns |  0.940 ns |  1.045 ns |  1.94 |    0.10 |      - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   128 |  27.23 ns |  0.338 ns |  0.300 ns |  0.84 |    0.04 | 0.0095 |     - |     - |      40 B |
-    // |                 |                 |                                                   |       |           |           |           |       |         |        |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |   256 |  34.57 ns |  0.295 ns |  0.276 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 | 124.62 ns |  0.257 ns |  0.228 ns |  3.60 |    0.03 |      - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   256 |  32.22 ns |  0.106 ns |  0.099 ns |  0.93 |    0.01 | 0.0095 |     - |     - |      40 B |
-    // |                 |                 |                                                   |       |           |           |           |       |         |        |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |   512 |  40.41 ns |  0.826 ns |  0.848 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 | 251.65 ns |  0.440 ns |  0.412 ns |  6.23 |    0.13 |      - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   512 |  41.54 ns |  0.128 ns |  0.114 ns |  1.03 |    0.02 | 0.0095 |     - |     - |      40 B |
-    // |                 |                 |                                                   |       |           |           |           |       |         |        |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |  1024 |  51.54 ns |  0.156 ns |  0.121 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 | 493.66 ns |  1.316 ns |  1.231 ns |  9.58 |    0.04 |      - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  1024 |  61.45 ns |  0.216 ns |  0.181 ns |  1.19 |    0.00 | 0.0095 |     - |     - |      40 B |
-    // |                 |                 |                                                   |       |           |           |           |       |         |        |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |  2048 |  76.85 ns |  0.176 ns |  0.138 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 985.64 ns | 11.396 ns | 10.103 ns | 12.84 |    0.15 |      - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  2048 | 106.13 ns |  0.335 ns |  0.297 ns |  1.38 |    0.01 | 0.0095 |     - |     - |      40 B |
+    // |          Method |             Job |                              EnvironmentVariables | Count |      Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
+    // |---------------- |---------------- |-------------------------------------------------- |------ |----------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
+    // | Shuffle4Channel |             AVX |                                             Empty |   128 |  20.51 ns | 0.270 ns | 0.211 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |  63.00 ns | 0.991 ns | 0.927 ns |  3.08 |    0.06 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   128 |  17.25 ns | 0.066 ns | 0.058 ns |  0.84 |    0.01 |     - |     - |     - |         - |
+    // |                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |   256 |  24.57 ns | 0.248 ns | 0.219 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 | 124.55 ns | 2.501 ns | 2.456 ns |  5.06 |    0.10 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   256 |  21.80 ns | 0.094 ns | 0.088 ns |  0.89 |    0.01 |     - |     - |     - |         - |
+    // |                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |   512 |  28.51 ns | 0.130 ns | 0.115 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 | 256.52 ns | 1.424 ns | 1.332 ns |  9.00 |    0.07 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   512 |  29.72 ns | 0.217 ns | 0.203 ns |  1.04 |    0.01 |     - |     - |     - |         - |
+    // |                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |  1024 |  36.40 ns | 0.357 ns | 0.334 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 | 492.71 ns | 1.498 ns | 1.251 ns | 13.52 |    0.12 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  1024 |  44.71 ns | 0.264 ns | 0.234 ns |  1.23 |    0.02 |     - |     - |     - |         - |
+    // |                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |  2048 |  59.38 ns | 0.180 ns | 0.159 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 975.05 ns | 2.043 ns | 1.811 ns | 16.42 |    0.05 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  2048 |  81.83 ns | 0.212 ns | 0.198 ns |  1.38 |    0.01 |     - |     - |     - |         - |
 }

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleByte4Channel.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleByte4Channel.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
         [Benchmark]
         public void Shuffle4Channel()
         {
-            SimdUtils.Shuffle4Channel(this.source, this.destination, SimdUtils.Shuffle.WXYZ);
+            SimdUtils.Shuffle4Channel<WXYZShuffle4>(this.source, this.destination, default);
         }
     }
 

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleFloat4Channel.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleFloat4Channel.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using SixLabors.ImageSharp.Tests;
+
+namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
+{
+    [Config(typeof(Config.HwIntrinsics_SSE_AVX))]
+    public class ShuffleFloat4Channel
+    {
+        private float[] source;
+        private float[] destination;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.source = new Random(this.Count).GenerateRandomFloatArray(this.Count, 0, 256);
+            this.destination = new float[this.Count];
+        }
+
+        [Params(128, 256, 512, 1024, 2048)]
+        public int Count { get; set; }
+
+        [Benchmark]
+        public void Shuffle4Channel()
+        {
+            SimdUtils.Shuffle4Channel(this.source, this.destination, SimdUtils.Shuffle.WXYZ);
+        }
+    }
+
+    // 2020-10-26
+    // ##########
+    //
+    // BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
+    // Intel Core i7-8650U CPU 1.90GHz(Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
+    // .NET Core SDK = 5.0.100-rc.2.20479.15
+    //
+    // [Host]          : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  AVX             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  No HwIntrinsics : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  SSE             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //
+    // Runtime=.NET Core 3.1
+    //
+    // |          Method |             Job |                              EnvironmentVariables | Count |        Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
+    // |---------------- |---------------- |-------------------------------------------------- |------ |------------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
+    // | Shuffle4Channel |             AVX |                                             Empty |   128 |    14.49 ns | 0.244 ns | 0.217 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |    87.74 ns | 0.524 ns | 0.490 ns |  6.06 |    0.09 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   128 |    23.65 ns | 0.101 ns | 0.094 ns |  1.63 |    0.03 |     - |     - |     - |         - |
+    // |                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |   256 |    25.87 ns | 0.492 ns | 0.673 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 |   159.52 ns | 0.901 ns | 0.843 ns |  6.12 |    0.12 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   256 |    45.47 ns | 0.404 ns | 0.378 ns |  1.75 |    0.03 |     - |     - |     - |         - |
+    // |                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |   512 |    49.51 ns | 0.088 ns | 0.083 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 |   297.96 ns | 0.926 ns | 0.821 ns |  6.02 |    0.02 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   512 |    90.77 ns | 0.191 ns | 0.169 ns |  1.83 |    0.00 |     - |     - |     - |         - |
+    // |                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |  1024 |   113.09 ns | 1.913 ns | 3.090 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 |   604.58 ns | 1.464 ns | 1.298 ns |  5.29 |    0.18 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  1024 |   179.44 ns | 0.208 ns | 0.184 ns |  1.57 |    0.05 |     - |     - |     - |         - |
+    // |                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
+    // | Shuffle4Channel |             AVX |                                             Empty |  2048 |   217.95 ns | 1.314 ns | 1.165 ns |  1.00 |    0.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 1,152.04 ns | 3.941 ns | 3.494 ns |  5.29 |    0.03 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  2048 |   349.52 ns | 0.587 ns | 0.520 ns |  1.60 |    0.01 |     - |     - |     - |         - |
+}

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleFloat4Channel.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleFloat4Channel.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
         [Benchmark]
         public void Shuffle4Channel()
         {
-            SimdUtils.Shuffle4Channel(this.source, this.destination, SimdUtils.Shuffle.WXYZ);
+            SimdUtils.Shuffle4Channel(this.source, this.destination, default(WXYZShuffle4).Control);
         }
     }
 

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleFloat4Channel.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ShuffleFloat4Channel.cs
@@ -10,6 +10,7 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
     [Config(typeof(Config.HwIntrinsics_SSE_AVX))]
     public class ShuffleFloat4Channel
     {
+        private static readonly byte control = default(WXYZShuffle4).Control;
         private float[] source;
         private float[] destination;
 
@@ -26,43 +27,42 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces.Bulk
         [Benchmark]
         public void Shuffle4Channel()
         {
-            SimdUtils.Shuffle4Channel(this.source, this.destination, default(WXYZShuffle4).Control);
+            SimdUtils.Shuffle4Channel(this.source, this.destination, control);
         }
     }
 
-    // 2020-10-26
+    // 2020-10-29
     // ##########
     //
     // BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
-    // Intel Core i7-8650U CPU 1.90GHz(Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
-    // .NET Core SDK = 5.0.100-rc.2.20479.15
-    //
-    // [Host]          : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
-    //  AVX             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
-    //  No HwIntrinsics : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
-    //  SSE             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    // Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
+    // .NET Core SDK=3.1.403
+    //  [Host]             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  1. No HwIntrinsics : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  2. AVX             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+    //  3. SSE             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
     //
     // Runtime=.NET Core 3.1
     //
-    // |          Method |             Job |                              EnvironmentVariables | Count |        Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
-    // |---------------- |---------------- |-------------------------------------------------- |------ |------------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
-    // | Shuffle4Channel |             AVX |                                             Empty |   128 |    14.49 ns | 0.244 ns | 0.217 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |    87.74 ns | 0.524 ns | 0.490 ns |  6.06 |    0.09 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   128 |    23.65 ns | 0.101 ns | 0.094 ns |  1.63 |    0.03 |     - |     - |     - |         - |
-    // |                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |   256 |    25.87 ns | 0.492 ns | 0.673 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 |   159.52 ns | 0.901 ns | 0.843 ns |  6.12 |    0.12 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   256 |    45.47 ns | 0.404 ns | 0.378 ns |  1.75 |    0.03 |     - |     - |     - |         - |
-    // |                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |   512 |    49.51 ns | 0.088 ns | 0.083 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 |   297.96 ns | 0.926 ns | 0.821 ns |  6.02 |    0.02 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   512 |    90.77 ns | 0.191 ns | 0.169 ns |  1.83 |    0.00 |     - |     - |     - |         - |
-    // |                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |  1024 |   113.09 ns | 1.913 ns | 3.090 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 |   604.58 ns | 1.464 ns | 1.298 ns |  5.29 |    0.18 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  1024 |   179.44 ns | 0.208 ns | 0.184 ns |  1.57 |    0.05 |     - |     - |     - |         - |
-    // |                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
-    // | Shuffle4Channel |             AVX |                                             Empty |  2048 |   217.95 ns | 1.314 ns | 1.165 ns |  1.00 |    0.00 |     - |     - |     - |         - |
-    // | Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 1,152.04 ns | 3.941 ns | 3.494 ns |  5.29 |    0.03 |     - |     - |     - |         - |
-    // | Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  2048 |   349.52 ns | 0.587 ns | 0.520 ns |  1.60 |    0.01 |     - |     - |     - |         - |
+    // |          Method |                Job |                              EnvironmentVariables | Count |       Mean |     Error |    StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
+    // |---------------- |------------------- |-------------------------------------------------- |------ |-----------:|----------:|----------:|------:|------:|------:|------:|----------:|
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |  63.647 ns | 0.5475 ns | 0.4853 ns |  1.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |   128 |   9.818 ns | 0.1457 ns | 0.1292 ns |  0.15 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |   128 |  15.267 ns | 0.1005 ns | 0.0940 ns |  0.24 |     - |     - |     - |         - |
+    // |                 |                    |                                                   |       |            |           |           |       |       |       |       |           |
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 | 125.586 ns | 1.9312 ns | 1.8064 ns |  1.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |   256 |  15.878 ns | 0.1983 ns | 0.1758 ns |  0.13 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |   256 |  29.170 ns | 0.2925 ns | 0.2442 ns |  0.23 |     - |     - |     - |         - |
+    // |                 |                    |                                                   |       |            |           |           |       |       |       |       |           |
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 | 263.859 ns | 2.6660 ns | 2.3634 ns |  1.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |   512 |  29.452 ns | 0.3334 ns | 0.3118 ns |  0.11 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |   512 |  52.912 ns | 0.1932 ns | 0.1713 ns |  0.20 |     - |     - |     - |         - |
+    // |                 |                    |                                                   |       |            |           |           |       |       |       |       |           |
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 | 495.717 ns | 1.9850 ns | 1.8567 ns |  1.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |  1024 |  53.757 ns | 0.3212 ns | 0.2847 ns |  0.11 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |  1024 | 107.815 ns | 1.6201 ns | 1.3528 ns |  0.22 |     - |     - |     - |         - |
+    // |                 |                    |                                                   |       |            |           |           |       |       |       |       |           |
+    // | Shuffle4Channel | 1. No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 980.134 ns | 3.7407 ns | 3.1237 ns |  1.00 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             2. AVX |                                             Empty |  2048 | 105.120 ns | 0.6140 ns | 0.5443 ns |  0.11 |     - |     - |     - |         - |
+    // | Shuffle4Channel |             3. SSE |                               COMPlus_EnableAVX=0 |  2048 | 216.473 ns | 2.3268 ns | 2.0627 ns |  0.22 |     - |     - |     - |         - |
 }

--- a/tests/ImageSharp.Benchmarks/Config.HwIntrinsics.cs
+++ b/tests/ImageSharp.Benchmarks/Config.HwIntrinsics.cs
@@ -62,20 +62,20 @@ namespace SixLabors.ImageSharp.Benchmarks
                     .WithEnvironmentVariables(
                         new EnvironmentVariable(EnableHWIntrinsic, Off),
                         new EnvironmentVariable(FeatureSIMD, Off))
-                    .WithId("No HwIntrinsics"));
+                    .WithId("1. No HwIntrinsics").AsBaseline());
 
 #if SUPPORTS_RUNTIME_INTRINSICS
                 if (Avx.IsSupported)
                 {
                     this.AddJob(Job.Default.WithRuntime(CoreRuntime.Core31)
-                        .WithId("AVX").AsBaseline());
+                        .WithId("2. AVX"));
                 }
 
                 if (Sse.IsSupported)
                 {
                     this.AddJob(Job.Default.WithRuntime(CoreRuntime.Core31)
                         .WithEnvironmentVariables(new EnvironmentVariable(EnableAVX, Off))
-                        .WithId("SSE"));
+                        .WithId("3. SSE"));
                 }
 #endif
             }

--- a/tests/ImageSharp.Benchmarks/Config.HwIntrinsics.cs
+++ b/tests/ImageSharp.Benchmarks/Config.HwIntrinsics.cs
@@ -58,6 +58,12 @@ namespace SixLabors.ImageSharp.Benchmarks
         {
             public HwIntrinsics_SSE_AVX()
             {
+                this.AddJob(Job.Default.WithRuntime(CoreRuntime.Core31)
+                    .WithEnvironmentVariables(
+                        new EnvironmentVariable(EnableHWIntrinsic, Off),
+                        new EnvironmentVariable(FeatureSIMD, Off))
+                    .WithId("No HwIntrinsics"));
+
 #if SUPPORTS_RUNTIME_INTRINSICS
                 if (Avx.IsSupported)
                 {
@@ -72,11 +78,6 @@ namespace SixLabors.ImageSharp.Benchmarks
                         .WithId("SSE"));
                 }
 #endif
-                this.AddJob(Job.Default.WithRuntime(CoreRuntime.Core31)
-                    .WithEnvironmentVariables(
-                        new EnvironmentVariable(EnableHWIntrinsic, Off),
-                        new EnvironmentVariable(FeatureSIMD, Off))
-                    .WithId("No HwIntrinsics"));
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromRgba32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromRgba32.cs
@@ -168,49 +168,27 @@ namespace SixLabors.ImageSharp.Benchmarks.General.PixelConversion
         [Benchmark]
         public void PixelConverter_Rgba32_ToArgb32()
         {
-            ref uint sBase = ref Unsafe.As<Rgba32, uint>(ref this.PermutedRunnerRgbaToArgb.Source[0]);
-            ref uint dBase = ref Unsafe.As<TestArgb, uint>(ref this.PermutedRunnerRgbaToArgb.Dest[0]);
+            Span<byte> source = MemoryMarshal.Cast<Rgba32, byte>(this.PermutedRunnerRgbaToArgb.Source);
+            Span<byte> dest = MemoryMarshal.Cast<TestArgb, byte>(this.PermutedRunnerRgbaToArgb.Dest);
 
-            for (int i = 0; i < this.Count; i++)
-            {
-                uint s = Unsafe.Add(ref sBase, i);
-                Unsafe.Add(ref dBase, i) = PixelConverter.FromRgba32.ToArgb32(s);
-            }
-        }
-
-        [Benchmark]
-        public void PixelConverter_Rgba32_ToArgb32_CopyThenWorkOnSingleBuffer()
-        {
-            Span<uint> source = MemoryMarshal.Cast<Rgba32, uint>(this.PermutedRunnerRgbaToArgb.Source);
-            Span<uint> dest = MemoryMarshal.Cast<TestArgb, uint>(this.PermutedRunnerRgbaToArgb.Dest);
-            source.CopyTo(dest);
-
-            ref uint dBase = ref MemoryMarshal.GetReference(dest);
-
-            for (int i = 0; i < this.Count; i++)
-            {
-                uint s = Unsafe.Add(ref dBase, i);
-                Unsafe.Add(ref dBase, i) = PixelConverter.FromRgba32.ToArgb32(s);
-            }
+            PixelConverter.FromRgba32.ToArgb32(source, dest);
         }
 
         /*
         RESULTS:
-                                                            Method | Count |       Mean |      Error |     StdDev | Scaled | ScaledSD |
-        ---------------------------------------------------------- |------ |-----------:|-----------:|-----------:|-------:|---------:|
-                                                             ByRef |   256 |   328.7 ns |  6.6141 ns |  6.1868 ns |   1.00 |     0.00 |
-                                                             ByVal |   256 |   322.0 ns |  4.3541 ns |  4.0728 ns |   0.98 |     0.02 |
-                                                         FromBytes |   256 |   321.5 ns |  3.3499 ns |  3.1335 ns |   0.98 |     0.02 |
-                                                     InlineShuffle |   256 |   330.7 ns |  4.2525 ns |  3.9778 ns |   1.01 |     0.02 |
-                                    PixelConverter_Rgba32_ToArgb32 |   256 |   167.4 ns |  0.6357 ns |  0.5309 ns |   0.51 |     0.01 |
-         PixelConverter_Rgba32_ToArgb32_CopyThenWorkOnSingleBuffer |   256 |   196.6 ns |  0.8929 ns |  0.7915 ns |   0.60 |     0.01 |
-                                                                   |       |            |            |            |        |          |
-                                                             ByRef |  2048 | 2,534.4 ns |  8.2947 ns |  6.9265 ns |   1.00 |     0.00 |
-                                                             ByVal |  2048 | 2,638.5 ns | 52.6843 ns | 70.3320 ns |   1.04 |     0.03 |
-                                                         FromBytes |  2048 | 2,517.2 ns | 40.8055 ns | 38.1695 ns |   0.99 |     0.01 |
-                                                     InlineShuffle |  2048 | 2,546.5 ns | 21.2506 ns | 19.8778 ns |   1.00 |     0.01 |
-                                    PixelConverter_Rgba32_ToArgb32 |  2048 | 1,265.7 ns |  5.1397 ns |  4.5562 ns |   0.50 |     0.00 |
-         PixelConverter_Rgba32_ToArgb32_CopyThenWorkOnSingleBuffer |  2048 | 1,410.3 ns | 11.1939 ns |  9.9231 ns |   0.56 |     0.00 |
-         */
+        |                         Method | Count |        Mean |     Error |    StdDev |      Median | Ratio | RatioSD |
+        |------------------------------- |------ |------------:|----------:|----------:|------------:|------:|--------:|
+        |                          ByRef |   256 |   288.84 ns | 19.601 ns | 52.319 ns |   268.10 ns |  1.00 |    0.00 |
+        |                          ByVal |   256 |   267.97 ns |  1.831 ns |  1.713 ns |   267.85 ns |  0.77 |    0.18 |
+        |                      FromBytes |   256 |   266.81 ns |  2.427 ns |  2.270 ns |   266.47 ns |  0.76 |    0.18 |
+        |                  InlineShuffle |   256 |   291.41 ns |  5.820 ns |  5.444 ns |   290.17 ns |  0.83 |    0.19 |
+        | PixelConverter_Rgba32_ToArgb32 |   256 |    38.62 ns |  0.431 ns |  0.403 ns |    38.68 ns |  0.11 |    0.03 |
+        |                                |       |             |           |           |             |       |         |
+        |                          ByRef |  2048 | 2,197.69 ns | 15.826 ns | 14.804 ns | 2,197.25 ns |  1.00 |    0.00 |
+        |                          ByVal |  2048 | 2,226.81 ns | 44.266 ns | 62.054 ns | 2,197.17 ns |  1.03 |    0.04 |
+        |                      FromBytes |  2048 | 2,181.35 ns | 18.033 ns | 16.868 ns | 2,185.97 ns |  0.99 |    0.01 |
+        |                  InlineShuffle |  2048 | 2,233.10 ns | 27.673 ns | 24.531 ns | 2,229.78 ns |  1.02 |    0.01 |
+        | PixelConverter_Rgba32_ToArgb32 |  2048 |   139.90 ns |  2.152 ns |  3.825 ns |   138.70 ns |  0.06 |    0.00 |
+        */
     }
 }

--- a/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
+++ b/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <Compile Include="..\ImageSharp.Tests\TestImages.cs" Link="Tests\TestImages.cs" />
     <Compile Include="..\ImageSharp.Tests\TestUtilities\TestEnvironment.cs" Link="Tests\TestEnvironment.cs" />
+    <Compile Include="..\ImageSharp.Tests\TestUtilities\TestDataGenerator.cs" Link="Tests\TestDataGenerator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
+++ b/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
@@ -44,7 +44,7 @@ namespace SixLabors.ImageSharp.Tests.Common
             FeatureTestRunner.RunWithHwIntrinsicsFeature(
                 RunTest,
                 control,
-                HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE);
+                HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX | HwIntrinsics.DisableSSE);
         }
 
         [Theory]

--- a/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
+++ b/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
@@ -13,7 +13,9 @@ namespace SixLabors.ImageSharp.Tests.Common
             new TheoryData<byte>
             {
                 SimdUtils.Shuffle.WXYZ,
+                SimdUtils.Shuffle.WZYX,
                 SimdUtils.Shuffle.XYZW,
+                SimdUtils.Shuffle.YZWX,
                 SimdUtils.Shuffle.ZYXW,
                 SimdUtils.Shuffle.MmShuffle(2, 1, 3, 0),
                 SimdUtils.Shuffle.MmShuffle(1, 1, 1, 1),

--- a/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
+++ b/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.ImageSharp.Tests.TestUtilities;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Common
+{
+    public partial class SimdUtilsTests
+    {
+        public static readonly TheoryData<byte> ShuffleControls =
+            new TheoryData<byte>
+            {
+                SimdUtils.Shuffle.WXYZ,
+                SimdUtils.Shuffle.XYZW,
+                SimdUtils.Shuffle.ZYXW
+            };
+
+        [Theory]
+        [MemberData(nameof(ShuffleControls))]
+        public void BulkShuffleFloat4Channel(byte control)
+        {
+            static void RunTest(string serialized)
+            {
+                byte ctrl = FeatureTestRunner.Deserialize<byte>(serialized);
+                foreach (var item in ArraySizesDivisibleBy4)
+                {
+                    foreach (var count in item)
+                    {
+                        TestShuffle(
+                            (int)count,
+                            (s, d) => SimdUtils.Shuffle4Channel(s.Span, d.Span, ctrl),
+                            ctrl);
+                    }
+                }
+            }
+
+            FeatureTestRunner.RunWithHwIntrinsicsFeature(
+                RunTest,
+                control,
+                HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE);
+        }
+
+        private static void TestShuffle(
+            int count,
+            Action<Memory<float>, Memory<float>> convert,
+            byte control)
+        {
+            float[] source = new Random(count).GenerateRandomFloatArray(count, 0, 256);
+            var result = new float[count];
+
+            float[] expected = new float[count];
+
+            SimdUtils.Shuffle.InverseMmShuffle(
+                control,
+                out int p3,
+                out int p2,
+                out int p1,
+                out int p0);
+
+            for (int i = 0; i < expected.Length; i += 4)
+            {
+                expected[i] = source[p0 + i];
+                expected[i + 1] = source[p1 + i];
+                expected[i + 2] = source[p2 + i];
+                expected[i + 3] = source[p3 + i];
+            }
+
+            convert(source, result);
+
+            Assert.Equal(expected, result, new ApproximateFloatComparer(1e-5F));
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
+++ b/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
@@ -14,7 +14,10 @@ namespace SixLabors.ImageSharp.Tests.Common
             {
                 SimdUtils.Shuffle.WXYZ,
                 SimdUtils.Shuffle.XYZW,
-                SimdUtils.Shuffle.ZYXW
+                SimdUtils.Shuffle.ZYXW,
+                SimdUtils.Shuffle.MmShuffle(2, 1, 3, 0),
+                SimdUtils.Shuffle.MmShuffle(1, 1, 1, 1),
+                SimdUtils.Shuffle.MmShuffle(3, 3, 3, 3)
             };
 
         [Theory]
@@ -28,7 +31,7 @@ namespace SixLabors.ImageSharp.Tests.Common
                 {
                     foreach (var count in item)
                     {
-                        TestShuffle(
+                        TestShuffleFloat4Channel(
                             (int)count,
                             (s, d) => SimdUtils.Shuffle4Channel(s.Span, d.Span, ctrl),
                             ctrl);
@@ -42,7 +45,32 @@ namespace SixLabors.ImageSharp.Tests.Common
                 HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE);
         }
 
-        private static void TestShuffle(
+        [Theory]
+        [MemberData(nameof(ShuffleControls))]
+        public void BulkShuffleByte4Channel(byte control)
+        {
+            static void RunTest(string serialized)
+            {
+                byte ctrl = FeatureTestRunner.Deserialize<byte>(serialized);
+                foreach (var item in ArraySizesDivisibleBy4)
+                {
+                    foreach (var count in item)
+                    {
+                        TestShuffleByte4Channel(
+                            (int)count,
+                            (s, d) => SimdUtils.Shuffle4Channel(s.Span, d.Span, ctrl),
+                            ctrl);
+                    }
+                }
+            }
+
+            FeatureTestRunner.RunWithHwIntrinsicsFeature(
+                RunTest,
+                control,
+                HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE);
+        }
+
+        private static void TestShuffleFloat4Channel(
             int count,
             Action<Memory<float>, Memory<float>> convert,
             byte control)
@@ -70,6 +98,37 @@ namespace SixLabors.ImageSharp.Tests.Common
             convert(source, result);
 
             Assert.Equal(expected, result, new ApproximateFloatComparer(1e-5F));
+        }
+
+        private static void TestShuffleByte4Channel(
+            int count,
+            Action<Memory<byte>, Memory<byte>> convert,
+            byte control)
+        {
+            byte[] source = new byte[count];
+            new Random(count).NextBytes(source);
+            var result = new byte[count];
+
+            byte[] expected = new byte[count];
+
+            SimdUtils.Shuffle.InverseMmShuffle(
+                control,
+                out int p3,
+                out int p2,
+                out int p1,
+                out int p0);
+
+            for (int i = 0; i < expected.Length; i += 4)
+            {
+                expected[i] = source[p0 + i];
+                expected[i + 1] = source[p1 + i];
+                expected[i + 2] = source[p2 + i];
+                expected[i + 3] = source[p3 + i];
+            }
+
+            convert(source, result);
+
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Common/SimdUtilsTests.cs
+++ b/tests/ImageSharp.Tests/Common/SimdUtilsTests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.Common
 {
-    public class SimdUtilsTests
+    public partial class SimdUtilsTests
     {
         private ITestOutputHelper Output { get; }
 
@@ -212,14 +212,14 @@ namespace SixLabors.ImageSharp.Tests.Common
             static void RunTest(string serialized)
             {
                 TestImpl_BulkConvertByteToNormalizedFloat(
-                    FeatureTestRunner.Deserialize(serialized),
+                    FeatureTestRunner.Deserialize<int>(serialized),
                     (s, d) => SimdUtils.HwIntrinsics.ByteToNormalizedFloat(s.Span, d.Span));
             }
 
             FeatureTestRunner.RunWithHwIntrinsicsFeature(
                 RunTest,
-                HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE41,
-                count);
+                count,
+                HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE41);
         }
 #endif
 
@@ -305,14 +305,14 @@ namespace SixLabors.ImageSharp.Tests.Common
             static void RunTest(string serialized)
             {
                 TestImpl_BulkConvertNormalizedFloatToByteClampOverflows(
-                    FeatureTestRunner.Deserialize(serialized),
+                    FeatureTestRunner.Deserialize<int>(serialized),
                     (s, d) => SimdUtils.HwIntrinsics.NormalizedFloatToByteSaturate(s.Span, d.Span));
             }
 
             FeatureTestRunner.RunWithHwIntrinsicsFeature(
                 RunTest,
-                HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2,
-                count);
+                count,
+                HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2);
         }
 
 #endif

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -535,7 +535,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             static void RunTest(string serialized)
             {
                 TestImageProvider<Rgba32> provider =
-                    FeatureTestRunner.Deserialize<TestImageProvider<Rgba32>>(serialized);
+                    FeatureTestRunner.DeserializeForXunit<TestImageProvider<Rgba32>>(serialized);
 
                 foreach (PngInterlaceMode interlaceMode in InterlaceMode)
                 {

--- a/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
@@ -13,34 +13,49 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats
     {
         public static class ReferenceImplementations
         {
-            public static Rgba32 MakeRgba32(byte r, byte g, byte b, byte a)
+            public static byte[] MakeRgba32ByteArray(byte r, byte g, byte b, byte a)
             {
-                Rgba32 d = default;
-                d.R = r;
-                d.G = g;
-                d.B = b;
-                d.A = a;
-                return d;
+                var buffer = new byte[256];
+
+                for (int i = 0; i < buffer.Length; i += 4)
+                {
+                    buffer[i] = r;
+                    buffer[i + 1] = g;
+                    buffer[i + 2] = b;
+                    buffer[i + 3] = a;
+                }
+
+                return buffer;
             }
 
-            public static Argb32 MakeArgb32(byte r, byte g, byte b, byte a)
+            public static byte[] MakeArgb32ByteArray(byte r, byte g, byte b, byte a)
             {
-                Argb32 d = default;
-                d.R = r;
-                d.G = g;
-                d.B = b;
-                d.A = a;
-                return d;
+                var buffer = new byte[256];
+
+                for (int i = 0; i < buffer.Length; i += 4)
+                {
+                    buffer[i] = a;
+                    buffer[i + 1] = r;
+                    buffer[i + 2] = g;
+                    buffer[i + 3] = b;
+                }
+
+                return buffer;
             }
 
-            public static Bgra32 MakeBgra32(byte r, byte g, byte b, byte a)
+            public static byte[] MakeBgra32ByteArray(byte r, byte g, byte b, byte a)
             {
-                Bgra32 d = default;
-                d.R = r;
-                d.G = g;
-                d.B = b;
-                d.A = a;
-                return d;
+                var buffer = new byte[256];
+
+                for (int i = 0; i < buffer.Length; i += 4)
+                {
+                    buffer[i] = b;
+                    buffer[i + 1] = g;
+                    buffer[i + 2] = r;
+                    buffer[i + 3] = a;
+                }
+
+                return buffer;
             }
 
             internal static void To<TSourcePixel, TDestinationPixel>(
@@ -83,8 +98,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats
 
                 if (typeof(TDestinationPixel) == typeof(L8))
                 {
-                    ref L8 l8Ref = ref MemoryMarshal.GetReference(
-                                             MemoryMarshal.Cast<TDestinationPixel, L8>(destinationPixels));
+                    ref L8 l8Ref = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<TDestinationPixel, L8>(destinationPixels));
                     for (int i = 0; i < count; i++)
                     {
                         ref TSourcePixel sp = ref Unsafe.Add(ref sourceRef, i);

--- a/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.PixelFormats.Utils;
 
@@ -33,30 +34,28 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats
             [MemberData(nameof(RgbaData))]
             public void ToArgb32(byte r, byte g, byte b, byte a)
             {
-                Rgba32 s = ReferenceImplementations.MakeRgba32(r, g, b, a);
+                byte[] source = ReferenceImplementations.MakeRgba32ByteArray(r, g, b, a);
+                var actual = new byte[source.Length];
 
-                // Act:
-                uint actualPacked = PixelConverter.FromRgba32.ToArgb32(s.PackedValue);
+                PixelConverter.FromRgba32.ToArgb32(source, actual);
 
-                // Assert:
-                uint expectedPacked = ReferenceImplementations.MakeArgb32(r, g, b, a).PackedValue;
+                byte[] expected = ReferenceImplementations.MakeArgb32ByteArray(r, g, b, a);
 
-                Assert.Equal(expectedPacked, actualPacked);
+                Assert.Equal(expected, actual);
             }
 
             [Theory]
             [MemberData(nameof(RgbaData))]
             public void ToBgra32(byte r, byte g, byte b, byte a)
             {
-                Rgba32 s = ReferenceImplementations.MakeRgba32(r, g, b, a);
+                byte[] source = ReferenceImplementations.MakeRgba32ByteArray(r, g, b, a);
+                var actual = new byte[source.Length];
 
-                // Act:
-                uint actualPacked = PixelConverter.FromRgba32.ToBgra32(s.PackedValue);
+                PixelConverter.FromRgba32.ToBgra32(source, actual);
 
-                // Assert:
-                uint expectedPacked = ReferenceImplementations.MakeBgra32(r, g, b, a).PackedValue;
+                byte[] expected = ReferenceImplementations.MakeBgra32ByteArray(r, g, b, a);
 
-                Assert.Equal(expectedPacked, actualPacked);
+                Assert.Equal(expected, actual);
             }
         }
 
@@ -66,30 +65,28 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats
             [MemberData(nameof(RgbaData))]
             public void ToRgba32(byte r, byte g, byte b, byte a)
             {
-                Argb32 s = ReferenceImplementations.MakeArgb32(r, g, b, a);
+                byte[] source = ReferenceImplementations.MakeArgb32ByteArray(r, g, b, a);
+                var actual = new byte[source.Length];
 
-                // Act:
-                uint actualPacked = PixelConverter.FromArgb32.ToRgba32(s.PackedValue);
+                PixelConverter.FromArgb32.ToRgba32(source, actual);
 
-                // Assert:
-                uint expectedPacked = ReferenceImplementations.MakeRgba32(r, g, b, a).PackedValue;
+                byte[] expected = ReferenceImplementations.MakeRgba32ByteArray(r, g, b, a);
 
-                Assert.Equal(expectedPacked, actualPacked);
+                Assert.Equal(expected, actual);
             }
 
             [Theory]
             [MemberData(nameof(RgbaData))]
             public void ToBgra32(byte r, byte g, byte b, byte a)
             {
-                Argb32 s = ReferenceImplementations.MakeArgb32(r, g, b, a);
+                byte[] source = ReferenceImplementations.MakeArgb32ByteArray(r, g, b, a);
+                var actual = new byte[source.Length];
 
-                // Act:
-                uint actualPacked = PixelConverter.FromArgb32.ToBgra32(s.PackedValue);
+                PixelConverter.FromArgb32.ToBgra32(source, actual);
 
-                // Assert:
-                uint expectedPacked = ReferenceImplementations.MakeBgra32(r, g, b, a).PackedValue;
+                byte[] expected = ReferenceImplementations.MakeBgra32ByteArray(r, g, b, a);
 
-                Assert.Equal(expectedPacked, actualPacked);
+                Assert.Equal(expected, actual);
             }
         }
 
@@ -99,30 +96,28 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats
             [MemberData(nameof(RgbaData))]
             public void ToArgb32(byte r, byte g, byte b, byte a)
             {
-                Bgra32 s = ReferenceImplementations.MakeBgra32(r, g, b, a);
+                byte[] source = ReferenceImplementations.MakeBgra32ByteArray(r, g, b, a);
+                var actual = new byte[source.Length];
 
-                // Act:
-                uint actualPacked = PixelConverter.FromBgra32.ToArgb32(s.PackedValue);
+                PixelConverter.FromBgra32.ToArgb32(source, actual);
 
-                // Assert:
-                uint expectedPacked = ReferenceImplementations.MakeArgb32(r, g, b, a).PackedValue;
+                byte[] expected = ReferenceImplementations.MakeArgb32ByteArray(r, g, b, a);
 
-                Assert.Equal(expectedPacked, actualPacked);
+                Assert.Equal(expected, actual);
             }
 
             [Theory]
             [MemberData(nameof(RgbaData))]
             public void ToRgba32(byte r, byte g, byte b, byte a)
             {
-                Bgra32 s = ReferenceImplementations.MakeBgra32(r, g, b, a);
+                byte[] source = ReferenceImplementations.MakeBgra32ByteArray(r, g, b, a);
+                var actual = new byte[source.Length];
 
-                // Act:
-                uint actualPacked = PixelConverter.FromBgra32.ToRgba32(s.PackedValue);
+                PixelConverter.FromBgra32.ToRgba32(source, actual);
 
-                // Assert:
-                uint expectedPacked = ReferenceImplementations.MakeRgba32(r, g, b, a).PackedValue;
+                byte[] expected = ReferenceImplementations.MakeRgba32ByteArray(r, g, b, a);
 
-                Assert.Equal(expectedPacked, actualPacked);
+                Assert.Equal(expected, actual);
             }
         }
     }

--- a/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
@@ -29,17 +29,19 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities
         /// <typeparam name="T">The type to deserialize to.</typeparam>
         /// <param name="value">The string value to deserialize.</param>
         /// <returns>The <see cref="T"/> value.</returns>
-        public static T Deserialize<T>(string value)
+        public static T DeserializeForXunit<T>(string value)
             where T : IXunitSerializable
             => BasicSerializer.Deserialize<T>(value);
 
         /// <summary>
-        /// Allows the deserialization of integers passed to the feature test.
+        /// Allows the deserialization of types implementing <see cref="IConvertible"/>
+        /// passed to the feature test.
         /// </summary>
         /// <param name="value">The string value to deserialize.</param>
-        /// <returns>The <see cref="int"/> value.</returns>
-        public static int Deserialize(string value)
-            => Convert.ToInt32(value);
+        /// <returns>The <typeparamref name="T"/> value.</returns>
+        public static T Deserialize<T>(string value)
+            where T : IConvertible
+            => (T)Convert.ChangeType(value, typeof(T));
 
         /// <summary>
         /// Runs the given test <paramref name="action"/> within an environment
@@ -214,12 +216,13 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities
         /// where the given <paramref name="intrinsics"/> features.
         /// </summary>
         /// <param name="action">The test action to run.</param>
-        /// <param name="intrinsics">The intrinsics features.</param>
         /// <param name="serializable">The value to pass as a parameter to the test action.</param>
-        public static void RunWithHwIntrinsicsFeature(
+        /// <param name="intrinsics">The intrinsics features.</param>
+        public static void RunWithHwIntrinsicsFeature<T>(
             Action<string> action,
-            HwIntrinsics intrinsics,
-            int serializable)
+            T serializable,
+            HwIntrinsics intrinsics)
+            where T : IConvertible
         {
             if (!RemoteExecutor.IsSupported)
             {

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
@@ -183,7 +183,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
             static void AssertHwIntrinsicsFeatureDisabled(string serializable)
             {
                 Assert.NotNull(serializable);
-                Assert.NotNull(FeatureTestRunner.Deserialize<FakeSerializable>(serializable));
+                Assert.NotNull(FeatureTestRunner.DeserializeForXunit<FakeSerializable>(serializable));
 
 #if SUPPORTS_RUNTIME_INTRINSICS
                 Assert.False(Sse.IsSupported);
@@ -202,7 +202,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
             static void AssertHwIntrinsicsFeatureDisabled(string serializable, string intrinsic)
             {
                 Assert.NotNull(serializable);
-                Assert.NotNull(FeatureTestRunner.Deserialize<FakeSerializable>(serializable));
+                Assert.NotNull(FeatureTestRunner.DeserializeForXunit<FakeSerializable>(serializable));
 
                 switch ((HwIntrinsics)Enum.Parse(typeof(HwIntrinsics), intrinsic))
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds new `SimdUtils.Shuffle4Channel` methods with overloads for `float` and `byte`. This is the first part of a series of PRs that will complete #1354 

Methods are SIMD optimized on NET Core 3.1+

`public static void Shuffle4Channel(ReadOnlySpan<float> source, Span<float> dest, byte control)` Avx, Sse
`public static void Shuffle4Channel(ReadOnlySpan<byte> source, Span<byte> dest, byte control)` Avx2, Ssse3.

There don't appear to be any equivalent methods for [`System.Numerics`](https://github.com/dotnet/runtime/issues/14362) so I don't think we can add any optimization there.
 
Additional utility methods have also been added to `SimdUtils.Shuffle` which allow the generation of shuffle controls.

**Benchmarks**

**4 Channel Float**
```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-rc.2.20479.15
  [Host]          : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  AVX             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  No HwIntrinsics : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  SSE             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT

Runtime=.NET Core 3.1
```

|          Method |             Job |                              EnvironmentVariables | Count |        Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |---------------- |-------------------------------------------------- |------ |------------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
| Shuffle4Channel |             AVX |                                             Empty |   128 |    14.49 ns | 0.244 ns | 0.217 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |    87.74 ns | 0.524 ns | 0.490 ns |  6.06 |    0.09 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   128 |    23.65 ns | 0.101 ns | 0.094 ns |  1.63 |    0.03 |     - |     - |     - |         - |
|                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
| Shuffle4Channel |             AVX |                                             Empty |   256 |    25.87 ns | 0.492 ns | 0.673 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 |   159.52 ns | 0.901 ns | 0.843 ns |  6.12 |    0.12 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   256 |    45.47 ns | 0.404 ns | 0.378 ns |  1.75 |    0.03 |     - |     - |     - |         - |
|                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
| Shuffle4Channel |             AVX |                                             Empty |   512 |    49.51 ns | 0.088 ns | 0.083 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 |   297.96 ns | 0.926 ns | 0.821 ns |  6.02 |    0.02 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   512 |    90.77 ns | 0.191 ns | 0.169 ns |  1.83 |    0.00 |     - |     - |     - |         - |
|                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
| Shuffle4Channel |             AVX |                                             Empty |  1024 |   113.09 ns | 1.913 ns | 3.090 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 |   604.58 ns | 1.464 ns | 1.298 ns |  5.29 |    0.18 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  1024 |   179.44 ns | 0.208 ns | 0.184 ns |  1.57 |    0.05 |     - |     - |     - |         - |
|                 |                 |                                                   |       |             |          |          |       |         |       |       |       |           |
| Shuffle4Channel |             AVX |                                             Empty |  2048 |   217.95 ns | 1.314 ns | 1.165 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 1,152.04 ns | 3.941 ns | 3.494 ns |  5.29 |    0.03 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  2048 |   349.52 ns | 0.587 ns | 0.520 ns |  1.60 |    0.01 |     - |     - |     - |         - |


**4 Channel Byte**
```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-rc.2.20479.15
  [Host]          : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  AVX             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  No HwIntrinsics : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  SSE             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT

Runtime=.NET Core 3.1
```

|          Method |             Job |                              EnvironmentVariables | Count |      Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |---------------- |-------------------------------------------------- |------ |----------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
| Shuffle4Channel |             AVX |                                             Empty |   128 |  20.51 ns | 0.270 ns | 0.211 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   128 |  63.00 ns | 0.991 ns | 0.927 ns |  3.08 |    0.06 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   128 |  17.25 ns | 0.066 ns | 0.058 ns |  0.84 |    0.01 |     - |     - |     - |         - |
|                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
| Shuffle4Channel |             AVX |                                             Empty |   256 |  24.57 ns | 0.248 ns | 0.219 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   256 | 124.55 ns | 2.501 ns | 2.456 ns |  5.06 |    0.10 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   256 |  21.80 ns | 0.094 ns | 0.088 ns |  0.89 |    0.01 |     - |     - |     - |         - |
|                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
| Shuffle4Channel |             AVX |                                             Empty |   512 |  28.51 ns | 0.130 ns | 0.115 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |   512 | 256.52 ns | 1.424 ns | 1.332 ns |  9.00 |    0.07 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |   512 |  29.72 ns | 0.217 ns | 0.203 ns |  1.04 |    0.01 |     - |     - |     - |         - |
|                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
| Shuffle4Channel |             AVX |                                             Empty |  1024 |  36.40 ns | 0.357 ns | 0.334 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  1024 | 492.71 ns | 1.498 ns | 1.251 ns | 13.52 |    0.12 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  1024 |  44.71 ns | 0.264 ns | 0.234 ns |  1.23 |    0.02 |     - |     - |     - |         - |
|                 |                 |                                                   |       |           |          |          |       |         |       |       |       |           |
| Shuffle4Channel |             AVX |                                             Empty |  2048 |  59.38 ns | 0.180 ns | 0.159 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| Shuffle4Channel | No HwIntrinsics | COMPlus_EnableHWIntrinsic=0,COMPlus_FeatureSIMD=0 |  2048 | 975.05 ns | 2.043 ns | 1.811 ns | 16.42 |    0.05 |     - |     - |     - |         - |
| Shuffle4Channel |             SSE |                               COMPlus_EnableAVX=0 |  2048 |  81.83 ns | 0.212 ns | 0.198 ns |  1.38 |    0.01 |     - |     - |     - |         - |

<!-- Thanks for contributing to ImageSharp! -->
