### PR TITLE
Use bulk conversion in Write8BitColor

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -343,7 +343,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             Span<Rgba32> rgbColors = rgbColorsBuffer.GetSpan();
 
             ReadOnlySpan<TPixel> quantizedColors = quantized.Palette.Span;
-            PixelOperations<TPixel>.Instance.ToRgba32(Configuration.Default, quantizedColors, rgbColors);
+            PixelOperations<TPixel>.Instance.ToRgba32(this.configuration, quantizedColors, rgbColors);
 
             int idx = 0;
             foreach (Rgba32 color in rgbColors)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Just a small improvement in writing 8 bit bitmaps with a palette: Converting the quantized colors to rgb is now done as bulk convert.