### PR TITLE
PixelOperations<TPixel>.From<RgbaVector> speedup

### DIFF
--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/RgbaVector.PixelOperations.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/RgbaVector.PixelOperations.cs
@@ -27,6 +27,17 @@ namespace SixLabors.ImageSharp.PixelFormats
             public override PixelTypeInfo GetPixelTypeInfo() => LazyInfo.Value;
 
             /// <inheritdoc />
+            public override void From<TSourcePixel>(
+                Configuration configuration,
+                ReadOnlySpan<TSourcePixel> sourcePixels,
+                Span<RgbaVector> destinationPixels)
+            {
+                Span<Vector4> destinationVectors = MemoryMarshal.Cast<RgbaVector, Vector4>(destinationPixels);
+
+                PixelOperations<TSourcePixel>.Instance.ToVector4(configuration, sourcePixels, destinationVectors);
+            }
+
+            /// <inheritdoc />
             public override void FromVector4Destructive(
                 Configuration configuration,
                 Span<Vector4> sourceVectors,


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description

When using any of the generic [`Image.CloneAs<TPixel>` APIs](https://github.com/SixLabors/ImageSharp/blob/521fae35a14c7953f720a094d24b59b2f7d98555/src/ImageSharp/Image.cs#L124), if the target format was `RgbaVector`, the selected code paths was not optimized to take advantage of the fact that `RgbaVector` is blittable to `Vector4`. In particular, this `PixelOperations<TPixel>.To` method was called:

https://github.com/SixLabors/ImageSharp/blob/521fae35a14c7953f720a094d24b59b2f7d98555/src/ImageSharp/PixelFormats/PixelOperations%7BTPixel%7D.cs#L103-L134

You can see the method is virtual but was not overridden by `RgbaVector`, so this slower implementation was used, which required both chunking of the target span as well as doing an extra copy to a temporary buffer. This PR adds a new override for this method to `PixelOperations<RgbaVector>` that simply does a direct `ToVector4` copy on the reinterpreted target span.
