### PR TITLE
Add cache for Nuget packages

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,6 +56,14 @@ jobs:
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
 
+            - name: Setup nuget cache
+              uses: actions/cache@v2
+              id: nuget-cache
+              with:
+                  path: ~/.nuget
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/ImageSharp*.csproj') }}
+                  restore-keys: ${{ runner.os }}-nuget-
+
             - name: Build
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,7 +61,7 @@ jobs:
               id: nuget-cache
               with:
                   path: ~/.nuget
-                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/ImageSharp*.csproj') }}
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/ImageSharp*.csproj', '**/*.props', '**/*.targets') }}
                   restore-keys: ${{ runner.os }}-nuget-
 
             - name: Build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,7 +61,7 @@ jobs:
               id: nuget-cache
               with:
                   path: ~/.nuget
-                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/ImageSharp*.csproj', '**/*.props', '**/*.targets') }}
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
                   restore-keys: ${{ runner.os }}-nuget-
 
             - name: Build


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- Added cache action for Nuget packages for speedup Nuget restore before each CI builds
<!-- Thanks for contributing to ImageSharp! -->
