### PR TITLE
Added support for image integral computation.

### DIFF
--- a/src/ImageSharp/Processing/Extensions/Transforms/ImagingUtilities.cs
+++ b/src/ImageSharp/Processing/Extensions/Transforms/ImagingUtilities.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Processing
+{
+    /// <summary>
+    /// Defines extensions that allow the computation of image integrals on an <see cref="Image"/>
+    /// </summary>
+    public static class ImagingUtilities
+    {
+        /// <summary>
+        /// Apply an image integral. See https://en.wikipedia.org/wiki/Summed-area_table
+        /// </summary>
+        /// <param name="source">The image on which to apply the integral.</param>
+        /// <returns>The <see cref="Buffer2D{ulong}" containing all the sums</returns>
+        public static Buffer2D<ulong> CalculateIntegralImage(this Image<L8> source)
+        {
+            Configuration configuration = source.GetConfiguration();
+
+            int startY = 0;
+            int endY = source.Height;
+            int startX = 0;
+            int endX = source.Width;
+
+            Buffer2D<ulong> intImage = configuration.MemoryAllocator.Allocate2D<ulong>(source.Width, source.Height);
+
+            for (int x = startX; x < endX; x++)
+            {
+                ulong sum = 0;
+                for (int y = startY; y < endY; y++)
+                {
+                    Span<L8> row = source.GetPixelRowSpan(y);
+                    ref L8 rowRef = ref MemoryMarshal.GetReference(row);
+                    ref L8 color = ref Unsafe.Add(ref rowRef, x);
+
+                    sum += (ulong)color.PackedValue;
+
+                    if (x - startX != 0)
+                    {
+                        intImage[x - startX, y - startY] = intImage[x - startX - 1, y - startY] + sum;
+                    }
+                    else
+                    {
+                        intImage[x - startX, y - startY] = sum;
+                    }
+                }
+            }
+
+            return intImage;
+        }
+
+        /// <summary>
+        /// Apply an image integral. See https://en.wikipedia.org/wiki/Summed-area_table
+        /// </summary>
+        /// <param name="source">The image on which to apply the integral.</param>
+        /// <returns>The <see cref="Buffer2D{ulong}" containing all the sums</returns>
+        public static Buffer2D<ulong> CalculateIntegralImage(this Image<Rgba32> source)
+        {
+            Configuration configuration = source.GetConfiguration();
+
+            int startY = 0;
+            int endY = source.Height;
+            int startX = 0;
+            int endX = source.Width;
+
+            Buffer2D<ulong> intImage = configuration.MemoryAllocator.Allocate2D<ulong>(source.Width, source.Height);
+
+            for (int x = startX; x < endX; x++)
+            {
+                ulong sum = 0;
+                for (int y = startY; y < endY; y++)
+                {
+                    Span<Rgba32> row = source.GetPixelRowSpan(y);
+                    ref Rgba32 rowRef = ref MemoryMarshal.GetReference(row);
+                    ref Rgba32 color = ref Unsafe.Add(ref rowRef, x);
+
+                    sum += (ulong)(color.R + color.G + color.B);
+
+                    if (x - startX != 0)
+                    {
+                        intImage[x - startX, y - startY] = intImage[x - startX - 1, y - startY] + sum;
+                    }
+                    else
+                    {
+                        intImage[x - startX, y - startY] = sum;
+                    }
+                }
+            }
+
+            return intImage;
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Processing/Transforms/ImagingUtilitiesTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/ImagingUtilitiesTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Processing.Transforms
+{
+    public class ImagingUtilitiesTests : BaseImageOperationsExtensionTest
+    {
+        [Theory]
+        [WithFile(TestImages.Png.Bradley01, PixelTypes.Rgba32)]
+        [WithFile(TestImages.Png.Bradley02, PixelTypes.Rgba32)]
+        [WithFile(TestImages.Png.Ducky, PixelTypes.Rgba32)]
+        public void CalculateIntegralImage_Rgba32Works(TestImageProvider<Rgba32> provider)
+        {
+            using Image<Rgba32> image = provider.GetImage();
+
+            // Act:
+            Buffer2D<ulong> integralBuffer = image.CalculateIntegralImage();
+
+            // Assert:
+            VerifySumValues(provider, integralBuffer, (Rgba32 pixel) => { return (ulong)(pixel.R + pixel.G + pixel.B); });
+        }
+
+        [Theory]
+        [WithFile(TestImages.Png.Bradley01, PixelTypes.L8)]
+        [WithFile(TestImages.Png.Bradley02, PixelTypes.L8)]
+        public void CalculateIntegralImage_L8Works(TestImageProvider<L8> provider)
+        {
+            using Image<L8> image = provider.GetImage();
+
+            // Act:
+            Buffer2D<ulong> integralBuffer = image.CalculateIntegralImage();
+
+            // Assert:
+            VerifySumValues(provider, integralBuffer, (L8 pixel) => { return pixel.PackedValue; });
+        }
+
+        private static void VerifySumValues<TPixel>(
+            TestImageProvider<TPixel> provider,
+            Buffer2D<ulong> integralBuffer,
+            System.Func<TPixel, ulong> getPixel)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Image<TPixel> image = provider.GetImage();
+
+            // Check top-left corner
+            Assert.Equal(getPixel(image[0, 0]), integralBuffer[0, 0]);
+
+            ulong pixelValues = 0;
+
+            pixelValues += getPixel(image[0, 0]);
+            pixelValues += getPixel(image[1, 0]);
+            pixelValues += getPixel(image[0, 1]);
+            pixelValues += getPixel(image[1, 1]);
+
+            // Check top-left 2x2 pixels
+            Assert.Equal(pixelValues, integralBuffer[1, 1]);
+
+            pixelValues = 0;
+
+            pixelValues += getPixel(image[image.Width - 3, 0]);
+            pixelValues += getPixel(image[image.Width - 2, 0]);
+            pixelValues += getPixel(image[image.Width - 1, 0]);
+            pixelValues += getPixel(image[image.Width - 3, 1]);
+            pixelValues += getPixel(image[image.Width - 2, 1]);
+            pixelValues += getPixel(image[image.Width - 1, 1]);
+
+            // Check top-right 3x2 pixels
+            Assert.Equal(pixelValues, integralBuffer[image.Width - 1, 1] + 0 - 0 - integralBuffer[image.Width - 4, 1]);
+
+            pixelValues = 0;
+
+            pixelValues += getPixel(image[0, image.Height - 3]);
+            pixelValues += getPixel(image[0, image.Height - 2]);
+            pixelValues += getPixel(image[0, image.Height - 1]);
+            pixelValues += getPixel(image[1, image.Height - 3]);
+            pixelValues += getPixel(image[1, image.Height - 2]);
+            pixelValues += getPixel(image[1, image.Height - 1]);
+
+            // Check bottom-left 2x3 pixels
+            Assert.Equal(pixelValues, integralBuffer[1, image.Height - 1] + 0 - integralBuffer[1, image.Height - 4] - 0);
+
+            pixelValues = 0;
+
+            pixelValues += getPixel(image[image.Width - 3, image.Height - 3]);
+            pixelValues += getPixel(image[image.Width - 2, image.Height - 3]);
+            pixelValues += getPixel(image[image.Width - 1, image.Height - 3]);
+            pixelValues += getPixel(image[image.Width - 3, image.Height - 2]);
+            pixelValues += getPixel(image[image.Width - 2, image.Height - 2]);
+            pixelValues += getPixel(image[image.Width - 1, image.Height - 2]);
+            pixelValues += getPixel(image[image.Width - 3, image.Height - 1]);
+            pixelValues += getPixel(image[image.Width - 2, image.Height - 1]);
+            pixelValues += getPixel(image[image.Width - 1, image.Height - 1]);
+
+            // Check bottom-right 3x3 pixels
+            Assert.Equal(pixelValues, integralBuffer[image.Width - 1, image.Height - 1] + integralBuffer[image.Width - 4, image.Height - 4] - integralBuffer[image.Width - 1, image.Height - 4] - integralBuffer[image.Width - 4, image.Height - 1]);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x ] I have written a descriptive pull-request title
- [x ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x ] I have provided test coverage for my change (where applicable)

### Description
As discussed [here](https://github.com/SixLabors/ImageSharp/discussions/1370) I have implemented the image integral for Rgb32 and L8 formats based on the code in AdaptiveThreshold. I haven't integrated the code in AdaptiveThreshold, I prefer to do it as a separate PR.

As suggested by @antonfirsov [in his comment](https://github.com/SixLabors/ImageSharp/discussions/1370#discussioncomment-92932) I put the code inside a static class "ImagingUtilities", but I wasn't sure where to put it exactly in the code structure.

Also, I added a test to check all corners of the result buffer with different rectangle sizes. I'm not sure if a more thorough test is required.

<!-- Thanks for contributing to ImageSharp! -->
