### PR TITLE
Add action to save Output Images for failed tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,6 +75,13 @@ jobs:
                   CI: True
                   XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
+            - name: Store Output Images after failed tests
+              uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                  name: actual_output_${{ runner.os }}_${{ matrix.options.framework }}${{ matrix.options.runtime }}.zip
+                  path: tests/Images/ActualOutput/
+
             - name: Update Codecov
               uses: codecov/codecov-action@v1
               if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')


### PR DESCRIPTION
- Added action to store images `tests/Images/ActualOutput/*` as build artifacts