### PR TITLE
Add xunit trait attributes to tests

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.RemoteExecutor;
 
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests.TestUtilities;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
@@ -14,12 +15,12 @@ using SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs;
 
 using Xunit;
 
+using static SixLabors.ImageSharp.Tests.TestImages.Bmp;
+
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Bmp
 {
-    using SixLabors.ImageSharp.Metadata;
-    using static TestImages.Bmp;
-
+    [Trait("Format", "Bmp")]
     public class BmpDecoderTests
     {
         public const PixelTypes CommonNonDefaultPixelTypes = PixelTypes.Rgba32 | PixelTypes.Bgra32 | PixelTypes.RgbaVector;

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -11,14 +11,16 @@ using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 using SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs;
+
 using Xunit;
 using Xunit.Abstractions;
+
+using static SixLabors.ImageSharp.Tests.TestImages.Bmp;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Bmp
 {
-    using static TestImages.Bmp;
-
+    [Trait("Format", "Bmp")]
     public class BmpEncoderTests
     {
         public static readonly TheoryData<BmpBitsPerPixel> BitsPerPixel =

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpFileHeaderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpFileHeaderTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Bmp
 {
+    [Trait("Format", "Bmp")]
     public class BmpFileHeaderTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpMetadataTests.cs
@@ -4,13 +4,15 @@
 using System.IO;
 
 using SixLabors.ImageSharp.Formats.Bmp;
+
 using Xunit;
+
+using static SixLabors.ImageSharp.Tests.TestImages.Bmp;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Bmp
 {
-    using static TestImages.Bmp;
-
+    [Trait("Format", "Bmp")]
     public class BmpMetadataTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Gif
 {
+    [Trait("Format", "Gif")]
     public class GifDecoderTests
     {
         private const PixelTypes TestPixelTypes = PixelTypes.Rgba32 | PixelTypes.RgbaVector | PixelTypes.Argb32;

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -2,17 +2,19 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
-using SixLabors.ImageSharp.Formats;
+
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
+
 using Xunit;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Gif
 {
+    [Trait("Format", "Gif")]
     public class GifEncoderTests
     {
         private const PixelTypes TestPixelTypes = PixelTypes.Rgba32 | PixelTypes.RgbaVector | PixelTypes.Argb32;

--- a/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifFrameMetadataTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Gif
 {
+    [Trait("Format", "Gif")]
     public class GifFrameMetadataTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Gif/GifMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifMetadataTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Gif
 {
+    [Trait("Format", "Gif")]
     public class GifMetadataTests
     {
         public static readonly TheoryData<string, int, int, PixelResolutionUnit> RatioFiles =

--- a/tests/ImageSharp.Tests/Formats/Jpg/AdobeMarkerTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/AdobeMarkerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats.Jpeg;
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class AdobeMarkerTests
     {
         // Taken from actual test image

--- a/tests/ImageSharp.Tests/Formats/Jpg/Block8x8FTests.CopyToBufferArea.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/Block8x8FTests.CopyToBufferArea.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public partial class Block8x8FTests
     {
         public class CopyToBufferArea : JpegFixture

--- a/tests/ImageSharp.Tests/Formats/Jpg/Block8x8FTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/Block8x8FTests.cs
@@ -14,6 +14,7 @@ using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public partial class Block8x8FTests : JpegFixture
     {
 #if BENCHMARKING

--- a/tests/ImageSharp.Tests/Formats/Jpg/Block8x8Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/Block8x8Tests.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class Block8x8Tests : JpegFixture
     {
         public Block8x8Tests(ITestOutputHelper output)

--- a/tests/ImageSharp.Tests/Formats/Jpg/DCTTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/DCTTests.cs
@@ -12,6 +12,7 @@ using Xunit.Abstractions;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public static class DCTTests
     {
         public class FastFloatingPoint : JpegFixture

--- a/tests/ImageSharp.Tests/Formats/Jpg/GenericBlock8x8Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/GenericBlock8x8Tests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class GenericBlock8x8Tests
     {
         public static Image<TPixel> CreateTestImage<TPixel>()

--- a/tests/ImageSharp.Tests/Formats/Jpg/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ImageExtensionsTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class ImageExtensionsTest
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Jpg/JFifMarkerTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JFifMarkerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class JFifMarkerTests
     {
         // Taken from actual test image

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class JpegColorConverterTests
     {
         private const float Precision = 0.1F / 255;

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Baseline.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Baseline.cs
@@ -1,16 +1,15 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using Microsoft.DotNet.RemoteExecutor;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests.TestUtilities;
-using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
+
 using Xunit;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public partial class JpegDecoderTests
     {
         [Theory]

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
+using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public partial class JpegDecoderTests
     {
         public static string[] BaselineTestJpegs =

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
@@ -1,22 +1,23 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.IO;
+using System.Runtime.CompilerServices;
+
 using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using SixLabors.ImageSharp.PixelFormats;
+
 using Xunit;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
-    using System;
-    using System.Runtime.CompilerServices;
-
-    using SixLabors.ImageSharp.Formats.Jpeg;
-    using SixLabors.ImageSharp.Metadata;
-
+    [Trait("Format", "Jpg")]
     public partial class JpegDecoderTests
     {
         // TODO: A JPEGsnoop & metadata expert should review if the Exif/Icc expectations are correct.

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Progressive.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Progressive.cs
@@ -9,6 +9,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public partial class JpegDecoderTests
     {
         public const string DecodeProgressiveJpegOutputName = "DecodeProgressiveJpeg";

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -6,13 +6,12 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.RemoteExecutor;
+
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.IO;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests.Formats.Jpg.Utils;
-using SixLabors.ImageSharp.Tests.TestUtilities;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 
 using Xunit;
@@ -22,6 +21,7 @@ using Xunit.Abstractions;
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
     // TODO: Scatter test cases into multiple test classes
+    [Trait("Format", "Jpg")]
     public partial class JpegDecoderTests
     {
         public const PixelTypes CommonNonDefaultPixelTypes = PixelTypes.Rgba32 | PixelTypes.Argb32 | PixelTypes.RgbaVector;

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+
 using SixLabors.ImageSharp.Formats.Jpeg;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.Metadata.Profiles.Icc;
@@ -20,6 +19,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class JpegEncoderTests
     {
         public static readonly TheoryData<string, int> QualityFiles =

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegFileMarkerTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegFileMarkerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats.Jpeg;
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class JpegFileMarkerTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegImagePostProcessorTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegImagePostProcessorTests.cs
@@ -12,6 +12,7 @@ using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class JpegImagePostProcessorTests
     {
         public static string[] BaselineTestJpegs =

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegMetadataTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class JpegMetadataTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Jpg/LibJpegToolsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/LibJpegToolsTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class LibJpegToolsTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Jpg/ParseStreamTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ParseStreamTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class ParseStreamTests
     {
         private ITestOutputHelper Output { get; }

--- a/tests/ImageSharp.Tests/Formats/Jpg/ProfileResolverTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ProfileResolverTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class ProfileResolverTests
     {
         private static readonly byte[] JFifMarker = Encoding.ASCII.GetBytes("JFIF\0");

--- a/tests/ImageSharp.Tests/Formats/Jpg/ReferenceImplementationsTests.AccurateDCT.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ReferenceImplementationsTests.AccurateDCT.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public partial class ReferenceImplementationsTests
     {
         public class AccurateDCT : JpegFixture

--- a/tests/ImageSharp.Tests/Formats/Jpg/ReferenceImplementationsTests.FastFloatingPointDCT.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ReferenceImplementationsTests.FastFloatingPointDCT.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public partial class ReferenceImplementationsTests
     {
         public class FastFloatingPointDCT : JpegFixture

--- a/tests/ImageSharp.Tests/Formats/Jpg/ReferenceImplementationsTests.StandardIntegerDCT.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ReferenceImplementationsTests.StandardIntegerDCT.cs
@@ -12,6 +12,7 @@ using Xunit.Abstractions;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public partial class ReferenceImplementationsTests
     {
         public class StandardIntegerDCT : JpegFixture

--- a/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.IO;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests.Formats.Jpg.Utils;
 
@@ -17,6 +16,7 @@ using Xunit.Abstractions;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class SpectralJpegTests
     {
         public SpectralJpegTests(ITestOutputHelper output)

--- a/tests/ImageSharp.Tests/Formats/Jpg/ZigZagTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ZigZagTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
+    [Trait("Format", "Jpg")]
     public class ZigZagTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Png/Adler32Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/Adler32Tests.cs
@@ -8,6 +8,7 @@ using SharpAdler32 = ICSharpCode.SharpZipLib.Checksum.Adler32;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public class Adler32Tests
     {
         [Theory]

--- a/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
@@ -8,6 +8,7 @@ using SharpCrc32 = ICSharpCode.SharpZipLib.Checksum.Crc32;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public class Crc32Tests
     {
         [Theory]

--- a/tests/ImageSharp.Tests/Formats/Png/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/ImageExtensionsTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public class ImageExtensionsTest
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Png/PngChunkTypeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngChunkTypeTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public class PngChunkTypeTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.Chunks.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.Chunks.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
 using System.Buffers.Binary;
 using System.IO;
 using System.Text;
 
 using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.Formats.Png.Zlib;
 using SixLabors.ImageSharp.PixelFormats;
 
 using Xunit;
@@ -15,6 +13,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public partial class PngDecoderTests
     {
         // Represents ASCII string of "123456789"

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -16,6 +16,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public partial class PngDecoderTests
     {
         private const PixelTypes PixelTypes = Tests.PixelTypes.Rgba32 | Tests.PixelTypes.RgbaVector | Tests.PixelTypes.Argb32;

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.Chunks.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.Chunks.cs
@@ -4,15 +4,17 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
+
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
+
 using Xunit;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public partial class PngEncoderTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public partial class PngEncoderTests
     {
         private static PngEncoder PngEncoder => new PngEncoder();

--- a/tests/ImageSharp.Tests/Formats/Png/PngMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngMetadataTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public class PngMetadataTests
     {
         public static readonly TheoryData<string, int, int, PixelResolutionUnit> RatioFiles =

--- a/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
+    [Trait("Format", "Png")]
     public class PngSmokeTests
     {
         [Theory]

--- a/tests/ImageSharp.Tests/Formats/Png/PngTextDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngTextDataTests.cs
@@ -10,6 +10,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
     /// <summary>
     /// Tests the <see cref="PngTextData"/> class.
     /// </summary>
+    [Trait("Format", "Png")]
     public class PngTextDataTests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
@@ -6,16 +6,17 @@ using Microsoft.DotNet.RemoteExecutor;
 using SixLabors.ImageSharp.Formats.Tga;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Tests.TestUtilities;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
+
 using Xunit;
+
+using static SixLabors.ImageSharp.Tests.TestImages.Tga;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Tga
 {
-    using static TestImages.Tga;
-
+    [Trait("Format", "Tga")]
     public class TgaDecoderTests
     {
         private static TgaDecoder TgaDecoder => new TgaDecoder();

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaEncoderTests.cs
@@ -8,11 +8,12 @@ using SixLabors.ImageSharp.PixelFormats;
 
 using Xunit;
 
+using static SixLabors.ImageSharp.Tests.TestImages.Tga;
+
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Tga
 {
-    using static TestImages.Tga;
-
+    [Trait("Format", "Tga")]
     public class TgaEncoderTests
     {
         public static readonly TheoryData<TgaBitsPerPixel> BitsPerPixel =

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaFileHeaderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaFileHeaderTests.cs
@@ -1,15 +1,16 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Collections.Generic;
 using System.IO;
 
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Tga;
+
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Tga
 {
+    [Trait("Format", "Tga")]
     public class TgaFileHeaderTests
     {
         [Theory]

--- a/tests/ImageSharp.Tests/PixelFormats/A8Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/A8Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class A8Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/Argb32Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Argb32Tests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Argb32Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/Bgr24Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Bgr24Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Bgr24Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/Bgr565Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Bgr565Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Bgr565Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/Bgra32Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Bgra32Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Bgra32Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/Bgra4444Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Bgra4444Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Bgra4444Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/Bgra5551Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Bgra5551Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Bgra5551Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/Byte4Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Byte4Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Byte4Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/HalfSingleTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/HalfSingleTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class HalfSingleTests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/HalfVector2Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/HalfVector2Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class HalfVector2Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/HalfVector4Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/HalfVector4Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class HalfVector4Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/L16Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/L16Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class L16Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/L8Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/L8Tests.cs
@@ -9,6 +9,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class L8Tests
     {
         public static readonly TheoryData<byte> LuminanceData

--- a/tests/ImageSharp.Tests/PixelFormats/La16Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/La16Tests.cs
@@ -9,6 +9,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class La16Tests
     {
         public static readonly TheoryData<byte> LuminanceData

--- a/tests/ImageSharp.Tests/PixelFormats/La32Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/La32Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class La32Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/NormalizedByte2Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/NormalizedByte2Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class NormalizedByte2Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/NormalizedByte4Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/NormalizedByte4Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class NormalizedByte4Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/NormalizedShort2Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/NormalizedShort2Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class NormalizedShort2Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/NormalizedShort4Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/NormalizedShort4Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class NormalizedShort4Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/PixelBlenderTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelBlenderTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class PixelBlenderTests
     {
         public static TheoryData<object, Type, PixelColorBlendingMode> BlenderMappings = new TheoryData<object, Type, PixelColorBlendingMode>

--- a/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
@@ -7,8 +7,11 @@ using System.Runtime.InteropServices;
 
 using SixLabors.ImageSharp.PixelFormats;
 
+using Xunit;
+
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public abstract partial class PixelConverterTests
     {
         public static class ReferenceImplementations

--- a/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.cs
@@ -1,14 +1,13 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.PixelFormats.Utils;
 
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public abstract partial class PixelConverterTests
     {
         public static readonly TheoryData<byte, byte, byte, byte> RgbaData =

--- a/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelConversionModifiersExtensionsTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelConversionModifiersExtensionsTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelOperations
 {
+    [Trait("Category", "PixelFormats")]
     public class PixelConversionModifiersExtensionsTests
     {
         [Theory]

--- a/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.Rgba32OperationsTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.Rgba32OperationsTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelOperations
 {
+    [Trait("Category", "PixelFormats")]
     public partial class PixelOperationsTests
     {
         public partial class Rgba32_OperationsTests : PixelOperationsTests<Rgba32>

--- a/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats.PixelOperations
 {
+    [Trait("Category", "PixelFormats")]
     public partial class PixelOperationsTests
     {
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter

--- a/tests/ImageSharp.Tests/PixelFormats/Rg32Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Rg32Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Rg32Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/Rgb24Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Rgb24Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Rgb24Tests
     {
         public static readonly TheoryData<byte, byte, byte> ColorData =

--- a/tests/ImageSharp.Tests/PixelFormats/Rgb48Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Rgb48Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Rgb48Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/Rgba1010102Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Rgba1010102Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Rgba1010102Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/Rgba32Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Rgba32Tests.cs
@@ -11,6 +11,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats
     /// <summary>
     /// Tests the <see cref="Rgba32"/> struct.
     /// </summary>
+    [Trait("Category", "PixelFormats")]
     public class Rgba32Tests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/Rgba64Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Rgba64Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Rgba64Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/RgbaVectorTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/RgbaVectorTests.cs
@@ -11,6 +11,7 @@ namespace SixLabors.ImageSharp.Tests.PixelFormats
     /// <summary>
     /// Tests the <see cref="RgbaVector"/> struct.
     /// </summary>
+    [Trait("Category", "PixelFormats")]
     public class RgbaVectorTests
     {
         /// <summary>

--- a/tests/ImageSharp.Tests/PixelFormats/Short2Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Short2Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Short2Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/Short4Tests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/Short4Tests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.PixelFormats
 {
+    [Trait("Category", "PixelFormats")]
     public class Short4Tests
     {
         [Fact]

--- a/tests/ImageSharp.Tests/PixelFormats/UnPackedPixelTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/UnPackedPixelTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Colors
 {
+    [Trait("Category", "PixelFormats")]
     public class UnPackedPixelTests
     {
         [Fact]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

I have added xunit traits attribute to the tests. I think this makes it easier to filter for specific tests. For example to run only tests for a specific format:

`dotnet test -c Debug -f netcoreapp3.1 --filter "Format=Png"`

Also you can filter by traits in the test explorer:

![traits](https://user-images.githubusercontent.com/38701097/100972238-bf5e4880-3538-11eb-86be-34be35d53811.jpg)
