### PR TITLE
Filter processor should use scaled vectors.

### DIFF
--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessor{TPixel}.cs
@@ -72,11 +72,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Filters
             public void Invoke(int y, Span<Vector4> span)
             {
                 Span<TPixel> rowSpan = this.source.GetPixelRowSpan(y).Slice(this.startX, span.Length);
-                PixelOperations<TPixel>.Instance.ToVector4(this.configuration, rowSpan, span);
+                PixelOperations<TPixel>.Instance.ToVector4(this.configuration, rowSpan, span, PixelConversionModifiers.Scale);
 
                 ColorNumerics.Transform(span, ref Unsafe.AsRef(this.matrix));
 
-                PixelOperations<TPixel>.Instance.FromVector4Destructive(this.configuration, span, rowSpan);
+                PixelOperations<TPixel>.Instance.FromVector4Destructive(this.configuration, span, rowSpan, PixelConversionModifiers.Scale);
             }
         }
     }

--- a/tests/ImageSharp.Tests/Processing/Filters/BrightnessTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Filters/BrightnessTest.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Filters;
 using Xunit;
@@ -25,6 +26,34 @@ namespace SixLabors.ImageSharp.Tests.Processing.Effects
             BrightnessProcessor processor = this.Verify<BrightnessProcessor>(this.rect);
 
             Assert.Equal(1.5F, processor.Amount);
+        }
+
+        [Fact]
+        public void Brightness_scaled_vector()
+        {
+            var rgbImage = new Image<Rgb24>(Configuration.Default, 100, 100, new Rgb24(0, 0, 0));
+
+            rgbImage.Mutate(x => x.ApplyProcessor(new BrightnessProcessor(2)));
+
+            Assert.Equal(new Rgb24(0, 0, 0), rgbImage[0, 0]);
+
+            rgbImage = new Image<Rgb24>(Configuration.Default, 100, 100, new Rgb24(10, 10, 10));
+
+            rgbImage.Mutate(x => x.ApplyProcessor(new BrightnessProcessor(2)));
+
+            Assert.Equal(new Rgb24(20, 20, 20), rgbImage[0, 0]);
+
+            var halfSingleImage = new Image<HalfSingle>(Configuration.Default, 100, 100, new HalfSingle(-1));
+
+            halfSingleImage.Mutate(x => x.ApplyProcessor(new BrightnessProcessor(2)));
+
+            Assert.Equal(new HalfSingle(-1), halfSingleImage[0, 0]);
+
+            halfSingleImage = new Image<HalfSingle>(Configuration.Default, 100, 100, new HalfSingle(-0.5f));
+
+            halfSingleImage.Mutate(x => x.ApplyProcessor(new BrightnessProcessor(2)));
+
+            Assert.Equal(new HalfSingle(0), halfSingleImage[0, 0]);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Use scaled vectors in FilterProcessor to fix #1459.

<!-- Thanks for contributing to ImageSharp! -->
