### PR TITLE
Add PremultiplyAlpha to ResizeOptions

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
@@ -26,6 +26,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             this.DestinationHeight = size.Height;
             this.DestinationRectangle = rectangle;
             this.Compand = options.Compand;
+            this.PremultiplyAlpha = options.PremultiplyAlpha;
         }
 
         /// <summary>
@@ -52,6 +53,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// Gets a value indicating whether to compress or expand individual pixel color values on processing.
         /// </summary>
         public bool Compand { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether to premultiply the alpha (if it exists) during the resize operation.
+        /// </summary>
+        public bool PremultiplyAlpha { get; }
 
         /// <inheritdoc />
         public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
@@ -21,6 +21,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         private readonly IResampler resampler;
         private readonly Rectangle destinationRectangle;
         private readonly bool compand;
+        private readonly bool premultiplyAlpha;
         private Image<TPixel> destination;
 
         public ResizeProcessor(Configuration configuration, ResizeProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
@@ -30,6 +31,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             this.destinationHeight = definition.DestinationHeight;
             this.destinationRectangle = definition.DestinationRectangle;
             this.resampler = definition.Sampler;
+            this.premultiplyAlpha = definition.PremultiplyAlpha;
             this.compand = definition.Compand;
         }
 
@@ -60,6 +62,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             Rectangle sourceRectangle = this.SourceRectangle;
             Rectangle destinationRectangle = this.destinationRectangle;
             bool compand = this.compand;
+            bool premultiplyAlpha = this.premultiplyAlpha;
 
             // Handle resize dimensions identical to the original
             if (source.Width == destination.Width
@@ -128,7 +131,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                     sourceRectangle,
                     destinationRectangle,
                     interest,
-                    compand);
+                    compand,
+                    premultiplyAlpha);
             }
         }
 
@@ -168,10 +172,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             Rectangle sourceRectangle,
             Rectangle destinationRectangle,
             Rectangle interest,
-            bool compand)
+            bool compand,
+            bool premultiplyAlpha)
         {
-            PixelConversionModifiers conversionModifiers =
-                PixelConversionModifiers.Premultiply.ApplyCompanding(compand);
+            PixelConversionModifiers conversionModifiers = premultiplyAlpha ?
+                PixelConversionModifiers.Premultiply.ApplyCompanding(compand) :
+                PixelConversionModifiers.None.ApplyCompanding(compand);
 
             Buffer2DRegion<TPixel> sourceRegion = source.PixelBuffer.GetRegion(sourceRectangle);
 

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
@@ -163,6 +163,18 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 in operation);
         }
 
+        private static PixelConversionModifiers GetModifiers(bool compand, bool premultiplyAlpha)
+        {
+            if (premultiplyAlpha)
+            {
+                return PixelConversionModifiers.Premultiply.ApplyCompanding(compand);
+            }
+            else
+            {
+                return PixelConversionModifiers.None.ApplyCompanding(compand);
+            }
+        }
+
         private static void ApplyResizeFrameTransform(
             Configuration configuration,
             ImageFrame<TPixel> source,
@@ -175,9 +187,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             bool compand,
             bool premultiplyAlpha)
         {
-            PixelConversionModifiers conversionModifiers = premultiplyAlpha ?
-                PixelConversionModifiers.Premultiply.ApplyCompanding(compand) :
-                PixelConversionModifiers.None.ApplyCompanding(compand);
+            PixelConversionModifiers conversionModifiers = GetModifiers(compand, premultiplyAlpha);
 
             Buffer2DRegion<TPixel> sourceRegion = source.PixelBuffer.GetRegion(sourceRectangle);
 

--- a/src/ImageSharp/Processing/ResizeOptions.cs
+++ b/src/ImageSharp/Processing/ResizeOptions.cs
@@ -45,5 +45,11 @@ namespace SixLabors.ImageSharp.Processing
         /// Gets or sets the target rectangle to resize into.
         /// </summary>
         public Rectangle? TargetRectangle { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to premultiply
+        /// the alpha (if it exists) during the resize operation.
+        /// </summary>
+        public bool PremultiplyAlpha { get; set; } = true;
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -217,6 +217,32 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         }
 
         [Theory]
+        [WithFile(TestImages.Png.Kaboom, DefaultPixelType, false)]
+        [WithFile(TestImages.Png.Kaboom, DefaultPixelType, true)]
+        public void Resize_PremultiplyAlpha<TPixel>(TestImageProvider<TPixel> provider, bool premultiplyAlpha)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            string details = premultiplyAlpha ? "On" : "Off";
+
+            provider.RunValidatingProcessorTest(
+                x =>
+                {
+                    var resizeOptions = new ResizeOptions()
+                    {
+                        Size = x.GetCurrentSize() / 2,
+                        Mode = ResizeMode.Crop,
+                        Sampler = KnownResamplers.Bicubic,
+                        Compand = false,
+                        PremultiplyAlpha = premultiplyAlpha
+                    };
+                    x.Resize(resizeOptions);
+                },
+                details,
+                appendPixelTypeToFileName: false,
+                appendSourceFileOrDescription: false);
+        }
+
+        [Theory]
         [WithFile(TestImages.Gif.Giphy, DefaultPixelType)]
         public void Resize_IsAppliedToAllFrames<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Added PremultiplyAlpha to the ResizeOptions. This option was always on by default, but now the user has the ability to turn it off through the options.

Fixes #1498 