### PR TITLE
Vectorize Jpeg Encoder Color Conversion

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterLut.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterLut.cs
@@ -111,7 +111,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             // float cb = 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b));
             cbResult[i] = (this.CbRTable[r] + this.CbGTable[g] + this.CbBTable[b]) >> ScaleBits;
 
-            // float cr = 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b))
+            // float cr = 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b));
             crResult[i] = (this.CbBTable[r] + this.CrGTable[g] + this.CrBTable[b]) >> ScaleBits;
         }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterLut.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterLut.cs
@@ -1,16 +1,17 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Runtime.CompilerServices;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
 {
     /// <summary>
     /// Provides 8-bit lookup tables for converting from Rgb to YCbCr colorspace.
     /// Methods to build the tables are based on libjpeg implementation.
-    /// TODO: Replace this logic with SIMD conversion (similar to the one in the decoder)!
     /// </summary>
-    internal unsafe struct RgbToYCbCrTables
+    internal unsafe struct RgbToYCbCrConverterLut
     {
         /// <summary>
         /// The red luminance table
@@ -63,10 +64,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
         /// <summary>
         /// Initializes the YCbCr tables
         /// </summary>
-        /// <returns>The initialized <see cref="RgbToYCbCrTables"/></returns>
-        public static RgbToYCbCrTables Create()
+        /// <returns>The initialized <see cref="RgbToYCbCrConverterLut"/></returns>
+        public static RgbToYCbCrConverterLut Create()
         {
-            RgbToYCbCrTables tables = default;
+            RgbToYCbCrConverterLut tables = default;
 
             for (int i = 0; i <= 255; i++)
             {
@@ -92,11 +93,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
         }
 
         /// <summary>
-        /// TODO: Replace this logic with SIMD conversion (similar to the one in the decoder)!
         /// Optimized method to allocates the correct y, cb, and cr values to the DCT blocks from the given r, g, b values.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ConvertPixelInto(
+        private void ConvertPixelInto(
             int r,
             int g,
             int b,
@@ -111,8 +111,27 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             // float cb = 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b));
             cbResult[i] = (this.CbRTable[r] + this.CbGTable[g] + this.CbBTable[b]) >> ScaleBits;
 
-            // float cr = MathF.Round(y + (1.772F * cb), MidpointRounding.AwayFromZero);
+            // float cr = 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b))
             crResult[i] = (this.CbBTable[r] + this.CrGTable[g] + this.CrBTable[b]) >> ScaleBits;
+        }
+
+        public void Convert(Span<Rgb24> rgbSpan, ref Block8x8F yBlock, ref Block8x8F cbBlock, ref Block8x8F crBlock)
+        {
+            ref Rgb24 rgbStart = ref rgbSpan[0];
+
+            for (int i = 0; i < 64; i++)
+            {
+                ref Rgb24 c = ref Unsafe.Add(ref rgbStart, i);
+
+                this.ConvertPixelInto(
+                    c.R,
+                    c.G,
+                    c.B,
+                    ref yBlock,
+                    ref cbBlock,
+                    ref crBlock,
+                    i);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterVectorized.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterVectorized.cs
@@ -15,97 +15,43 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
 {
     internal static class RgbToYCbCrConverterVectorized
     {
-        private static ReadOnlySpan<byte> ExtractionMasks => new byte[]
-        {
-            0x0, 0xFF, 0xFF, 0xFF, 0x1, 0xFF, 0xFF, 0xFF, 0x2, 0xFF, 0xFF, 0xFF, 0x3, 0xFF, 0xFF, 0xFF,   0x10, 0xFF, 0xFF, 0xFF, 0x11, 0xFF, 0xFF, 0xFF, 0x12, 0xFF, 0xFF, 0xFF, 0x13, 0xFF, 0xFF, 0xFF,
-            0x4, 0xFF, 0xFF, 0xFF, 0x5, 0xFF, 0xFF, 0xFF, 0x6, 0xFF, 0xFF, 0xFF, 0x7, 0xFF, 0xFF, 0xFF,   0x14, 0xFF, 0xFF, 0xFF, 0x15, 0xFF, 0xFF, 0xFF, 0x16, 0xFF, 0xFF, 0xFF, 0x17, 0xFF, 0xFF, 0xFF,
-            0x8, 0xFF, 0xFF, 0xFF, 0x9, 0xFF, 0xFF, 0xFF, 0xA, 0xFF, 0xFF, 0xFF, 0xB, 0xFF, 0xFF, 0xFF,   0x18, 0xFF, 0xFF, 0xFF, 0x19, 0xFF, 0xFF, 0xFF, 0x1A, 0xFF, 0xFF, 0xFF, 0x1B, 0xFF, 0xFF, 0xFF,
-            0xC, 0xFF, 0xFF, 0xFF, 0xD, 0xFF, 0xFF, 0xFF, 0xE, 0xFF, 0xFF, 0xFF, 0xF, 0xFF, 0xFF, 0xFF,   0x1C, 0xFF, 0xFF, 0xFF, 0x1D, 0xFF, 0xFF, 0xFF, 0x1E, 0xFF, 0xFF, 0xFF, 0x1F, 0xFF, 0xFF, 0xFF,
-        };
-
         public static bool IsSupported
         {
             get
             {
 #if SUPPORTS_RUNTIME_INTRINSICS
-                return Avx2.IsSupported && Fma.IsSupported;
+                return Avx2.IsSupported;
 #else
                 return false;
 #endif
             }
         }
 
+#if SUPPORTS_RUNTIME_INTRINSICS
+        private static ReadOnlySpan<byte> MoveFirst24BytesToSeparateLanes => new byte[]
+        {
+            0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 6, 0, 0, 0,
+            3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 7, 0, 0, 0
+        };
+
+        private static ReadOnlySpan<byte> MoveLast24BytesToSeparateLanes => new byte[]
+        {
+            2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0,
+            5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0, 1, 0, 0, 0
+        };
+
+        private static ReadOnlySpan<byte> ExtractRgb => new byte[]
+        {
+            0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11, 0xFF, 0xFF, 0xFF, 0xFF,
+            0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11, 0xFF, 0xFF, 0xFF, 0xFF
+        };
+#endif
+
         public static void Convert(ReadOnlySpan<Rgb24> rgbSpan, ref Block8x8F yBlock, ref Block8x8F cbBlock, ref Block8x8F crBlock)
         {
-            Debug.Assert(IsSupported, "AVX2 and FMA are required to run this converter");
+            Debug.Assert(IsSupported, "AVX2 is required to run this converter");
 
 #if SUPPORTS_RUNTIME_INTRINSICS
-            SeparateRgb(rgbSpan);
-            ConvertInternal(rgbSpan, ref yBlock, ref cbBlock, ref crBlock);
-#endif
-        }
-
-#if SUPPORTS_RUNTIME_INTRINSICS
-        /// <summary>
-        /// Rearranges the provided <paramref name="rgbSpan"/> in-place
-        /// from { r00, g00, b00, ..., r63, g63, b63 }
-        /// to { r00, ... r31, g00, ..., g31, b00, ..., b31,
-        ///      r32, ... r63, g32, ..., g63, b31, ..., b63 }
-        /// </summary>
-        /// <remarks>
-        /// SSE is used for this operation as it is significantly faster than AVX in this specific case.
-        /// Solving this problem with AVX requires too many instructions that cross the 128-bit lanes of YMM registers.
-        /// </remarks>
-        [MethodImpl(InliningOptions.ShortMethod)]
-        private static void SeparateRgb(ReadOnlySpan<Rgb24> rgbSpan)
-        {
-            var selectRed0 = Vector128.Create(0x00, 0x03, 0x06, 0x09, 0x0C, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
-            var selectRed1 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02, 0x05, 0x08, 0x0B, 0x0E, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
-            var selectRed2 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x04, 0x07, 0x0A, 0x0D);
-
-            var selectGreen0 = Vector128.Create(0x01, 0x04, 0x07, 0x0A, 0x0D, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
-            var selectGreen1 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x03, 0x06, 0x09, 0x0C, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
-            var selectGreen2 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02, 0x05, 0x08, 0x0B, 0x0E);
-
-            var selectBlue0 = Vector128.Create(0x02, 0x05, 0x08, 0x0B, 0x0E, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
-            var selectBlue1 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x04, 0x07, 0x0A, 0x0D, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
-            var selectBlue2 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x03, 0x06, 0x09, 0x0C, 0x0F);
-
-            for (int i = 0; i < 2; i++)
-            {
-                ref Vector128<byte> inRef = ref Unsafe.Add(ref Unsafe.As<Rgb24, Vector128<byte>>(ref MemoryMarshal.GetReference(rgbSpan)), i * 6);
-
-                Vector128<byte> in0 = inRef;
-                Vector128<byte> in1 = Unsafe.Add(ref inRef, 1);
-                Vector128<byte> in2 = Unsafe.Add(ref inRef, 2);
-
-                Vector128<byte> r0 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectRed0), Ssse3.Shuffle(in1, selectRed1)), Ssse3.Shuffle(in2, selectRed2));
-                Vector128<byte> g0 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectGreen0), Ssse3.Shuffle(in1, selectGreen1)), Ssse3.Shuffle(in2, selectGreen2));
-                Vector128<byte> b0 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectBlue0), Ssse3.Shuffle(in1, selectBlue1)), Ssse3.Shuffle(in2, selectBlue2));
-
-                in0 = Unsafe.Add(ref inRef, 3);
-                in1 = Unsafe.Add(ref inRef, 4);
-                in2 = Unsafe.Add(ref inRef, 5);
-
-                Vector128<byte> r1 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectRed0), Ssse3.Shuffle(in1, selectRed1)), Ssse3.Shuffle(in2, selectRed2));
-                Vector128<byte> g1 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectGreen0), Ssse3.Shuffle(in1, selectGreen1)), Ssse3.Shuffle(in2, selectGreen2));
-                Vector128<byte> b1 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectBlue0), Ssse3.Shuffle(in1, selectBlue1)), Ssse3.Shuffle(in2, selectBlue2));
-
-                inRef = r0;
-                Unsafe.Add(ref inRef, 1) = r1;
-                Unsafe.Add(ref inRef, 2) = g0;
-                Unsafe.Add(ref inRef, 3) = g1;
-                Unsafe.Add(ref inRef, 4) = b0;
-                Unsafe.Add(ref inRef, 5) = b1;
-            }
-        }
-
-        /// <summary>
-        /// Converts the previously separated (see <see cref="SeparateRgb"/>) RGB values to YCbCr using AVX2 and FMA.
-        /// </summary>
-        [MethodImpl(InliningOptions.ShortMethod)]
-        private static void ConvertInternal(ReadOnlySpan<Rgb24> rgbSpan, ref Block8x8F yBlock, ref Block8x8F cbBlock, ref Block8x8F crBlock)
-        {
             var f0299 = Vector256.Create(0.299f);
             var f0587 = Vector256.Create(0.587f);
             var f0114 = Vector256.Create(0.114f);
@@ -115,68 +61,60 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             var fn0418688 = Vector256.Create(-0.418688f);
             var fn0081312F = Vector256.Create(-0.081312F);
             var f05 = Vector256.Create(0.5f);
+            var zero = Vector256.Create(0).AsByte();
 
             ref Vector256<byte> inRef = ref Unsafe.As<Rgb24, Vector256<byte>>(ref MemoryMarshal.GetReference(rgbSpan));
+            ref Vector256<float> destYRef = ref Unsafe.As<Block8x8F, Vector256<float>>(ref yBlock);
+            ref Vector256<float> destCbRef = ref Unsafe.As<Block8x8F, Vector256<float>>(ref cbBlock);
+            ref Vector256<float> destCrRef = ref Unsafe.As<Block8x8F, Vector256<float>>(ref crBlock);
 
-            for (int i = 0; i < 2; i++)
+            var extractToLanesMask = Unsafe.As<byte, Vector256<uint>>(ref MemoryMarshal.GetReference(MoveFirst24BytesToSeparateLanes));
+            var extractRgbMask = Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(ExtractRgb));
+            Vector256<byte> rgb, rg, bx;
+            Vector256<float> r, g, b;
+            for (int i = 0; i < 7; i++)
             {
-                ref Vector256<float> destYRef = ref Unsafe.Add(ref Unsafe.As<Block8x8F, Vector256<float>>(ref yBlock), i * 4);
-                ref Vector256<float> destCbRef = ref Unsafe.Add(ref Unsafe.As<Block8x8F, Vector256<float>>(ref cbBlock), i * 4);
-                ref Vector256<float> destCrRef = ref Unsafe.Add(ref Unsafe.As<Block8x8F, Vector256<float>>(ref crBlock), i * 4);
+                rgb = Avx2.PermuteVar8x32(Unsafe.AddByteOffset(ref inRef, (IntPtr)(24 * i)).AsUInt32(), extractToLanesMask).AsByte();
 
-                Vector256<byte> red = Unsafe.Add(ref inRef, i * 3);
-                Vector256<byte> green = Unsafe.Add(ref inRef, (i * 3) + 1);
-                Vector256<byte> blue = Unsafe.Add(ref inRef, (i * 3) + 2);
+                rgb = Avx2.Shuffle(rgb, extractRgbMask);
 
-                for (int j = 0; j < 2; j++)
-                {
-                    // 1st part of unrolled loop
-                    Vector256<byte> mask = Unsafe.Add(ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(ExtractionMasks)), j * 2);
+                rg = Avx2.UnpackLow(rgb, zero);
+                bx = Avx2.UnpackHigh(rgb, zero);
 
-                    Vector256<float> r = Avx.ConvertToVector256Single(Avx2.Shuffle(red, mask).AsInt32());
-                    Vector256<float> g = Avx.ConvertToVector256Single(Avx2.Shuffle(green, mask).AsInt32());
-                    Vector256<float> b = Avx.ConvertToVector256Single(Avx2.Shuffle(blue, mask).AsInt32());
+                r = Avx.ConvertToVector256Single(Avx2.UnpackLow(rg, zero).AsInt32());
+                g = Avx.ConvertToVector256Single(Avx2.UnpackHigh(rg, zero).AsInt32());
+                b = Avx.ConvertToVector256Single(Avx2.UnpackLow(bx, zero).AsInt32());
 
-                    // (0.299F * r) + (0.587F * g) + (0.114F * b);
-                    Vector256<float> yy0 = Fma.MultiplyAdd(f0299, r, Fma.MultiplyAdd(f0587, g, Avx.Multiply(f0114, b)));
+                // (0.299F * r) + (0.587F * g) + (0.114F * b);
+                Unsafe.Add(ref destYRef, i) = SimdUtils.HwIntrinsics.MultiplyAdd(SimdUtils.HwIntrinsics.MultiplyAdd(Avx.Multiply(f0114, b), f0587, g), f0299, r);
 
-                    // 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b))
-                    Vector256<float> cb0 = Avx.Add(f128, Fma.MultiplyAdd(fn0168736, r, Fma.MultiplyAdd(fn0331264, g, Avx.Multiply(f05, b))));
+                // 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b))
+                Unsafe.Add(ref destCbRef, i) = Avx.Add(f128, SimdUtils.HwIntrinsics.MultiplyAdd(SimdUtils.HwIntrinsics.MultiplyAdd(Avx.Multiply(f05, b), fn0331264, g), fn0168736, r));
 
-                    // 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b))
-                    Vector256<float> cr0 = Avx.Add(f128, Fma.MultiplyAdd(f05, r, Fma.MultiplyAdd(fn0418688, g, Avx.Multiply(fn0081312F, b))));
-
-                    // 2nd part of unrolled loop
-                    mask = Unsafe.Add(ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(ExtractionMasks)), (j * 2) + 1);
-
-                    r = Avx.ConvertToVector256Single(Avx2.Shuffle(red, mask).AsInt32());
-                    g = Avx.ConvertToVector256Single(Avx2.Shuffle(green, mask).AsInt32());
-                    b = Avx.ConvertToVector256Single(Avx2.Shuffle(blue, mask).AsInt32());
-
-                    // (0.299F * r) + (0.587F * g) + (0.114F * b);
-                    Vector256<float> yy1 = Fma.MultiplyAdd(f0299, r, Fma.MultiplyAdd(f0587, g, Avx.Multiply(f0114, b)));
-
-                    // 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b))
-                    Vector256<float> cb1 = Avx.Add(f128, Fma.MultiplyAdd(fn0168736, r, Fma.MultiplyAdd(fn0331264, g, Avx.Multiply(f05, b))));
-
-                    // 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b))
-                    Vector256<float> cr1 = Avx.Add(f128, Fma.MultiplyAdd(f05, r, Fma.MultiplyAdd(fn0418688, g, Avx.Multiply(fn0081312F, b))));
-
-                    // store results from 1st and 2nd part
-                    Vector256<float> tmpY = Avx.Permute2x128(yy0, yy1, 0b0010_0001);
-                    Unsafe.Add(ref destYRef, j) = Avx.Blend(yy0, tmpY, 0b1111_0000);
-                    Unsafe.Add(ref destYRef, j + 2) = Avx.Blend(yy1, tmpY, 0b0000_1111);
-
-                    Vector256<float> tmpCb = Avx.Permute2x128(cb0, cb1, 0b0010_0001);
-                    Unsafe.Add(ref destCbRef, j) = Avx.Blend(cb0, tmpCb, 0b1111_0000);
-                    Unsafe.Add(ref destCbRef, j + 2) = Avx.Blend(cb1, tmpCb, 0b0000_1111);
-
-                    Vector256<float> tmpCr = Avx.Permute2x128(cr0, cr1, 0b0010_0001);
-                    Unsafe.Add(ref destCrRef, j) = Avx.Blend(cr0, tmpCr, 0b1111_0000);
-                    Unsafe.Add(ref destCrRef, j + 2) = Avx.Blend(cr1, tmpCr, 0b0000_1111);
-                }
+                // 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b))
+                Unsafe.Add(ref destCrRef, i) = Avx.Add(f128, SimdUtils.HwIntrinsics.MultiplyAdd(SimdUtils.HwIntrinsics.MultiplyAdd(Avx.Multiply(fn0081312F, b), fn0418688, g), f05, r));
             }
-        }
+
+            extractToLanesMask = Unsafe.As<byte, Vector256<uint>>(ref MemoryMarshal.GetReference(MoveLast24BytesToSeparateLanes));
+            rgb = Avx2.PermuteVar8x32(Unsafe.AddByteOffset(ref inRef, (IntPtr)160).AsUInt32(), extractToLanesMask).AsByte();
+            rgb = Avx2.Shuffle(rgb, extractRgbMask);
+
+            rg = Avx2.UnpackLow(rgb, zero);
+            bx = Avx2.UnpackHigh(rgb, zero);
+
+            r = Avx.ConvertToVector256Single(Avx2.UnpackLow(rg, zero).AsInt32());
+            g = Avx.ConvertToVector256Single(Avx2.UnpackHigh(rg, zero).AsInt32());
+            b = Avx.ConvertToVector256Single(Avx2.UnpackLow(bx, zero).AsInt32());
+
+            // (0.299F * r) + (0.587F * g) + (0.114F * b);
+            Unsafe.Add(ref destYRef, 7) = SimdUtils.HwIntrinsics.MultiplyAdd(SimdUtils.HwIntrinsics.MultiplyAdd(Avx.Multiply(f0114, b), f0587, g), f0299, r);
+
+            // 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b))
+            Unsafe.Add(ref destCbRef, 7) = Avx.Add(f128, SimdUtils.HwIntrinsics.MultiplyAdd(SimdUtils.HwIntrinsics.MultiplyAdd(Avx.Multiply(f05, b), fn0331264, g), fn0168736, r));
+
+            // 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b))
+            Unsafe.Add(ref destCrRef, 7) = Avx.Add(f128, SimdUtils.HwIntrinsics.MultiplyAdd(SimdUtils.HwIntrinsics.MultiplyAdd(Avx.Multiply(fn0081312F, b), fn0418688, g), f05, r));
 #endif
+        }
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterVectorized.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterVectorized.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Diagnostics;
+#if SUPPORTS_RUNTIME_INTRINSICS
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
+{
+    internal static class RgbToYCbCrConverterVectorized
+    {
+        private static ReadOnlySpan<byte> ExtractionMasks => new byte[]
+        {
+            0x0, 0xFF, 0xFF, 0xFF, 0x1, 0xFF, 0xFF, 0xFF, 0x2, 0xFF, 0xFF, 0xFF, 0x3, 0xFF, 0xFF, 0xFF,   0x10, 0xFF, 0xFF, 0xFF, 0x11, 0xFF, 0xFF, 0xFF, 0x12, 0xFF, 0xFF, 0xFF, 0x13, 0xFF, 0xFF, 0xFF,
+            0x4, 0xFF, 0xFF, 0xFF, 0x5, 0xFF, 0xFF, 0xFF, 0x6, 0xFF, 0xFF, 0xFF, 0x7, 0xFF, 0xFF, 0xFF,   0x14, 0xFF, 0xFF, 0xFF, 0x15, 0xFF, 0xFF, 0xFF, 0x16, 0xFF, 0xFF, 0xFF, 0x17, 0xFF, 0xFF, 0xFF,
+            0x8, 0xFF, 0xFF, 0xFF, 0x9, 0xFF, 0xFF, 0xFF, 0xA, 0xFF, 0xFF, 0xFF, 0xB, 0xFF, 0xFF, 0xFF,   0x18, 0xFF, 0xFF, 0xFF, 0x19, 0xFF, 0xFF, 0xFF, 0x1A, 0xFF, 0xFF, 0xFF, 0x1B, 0xFF, 0xFF, 0xFF,
+            0xC, 0xFF, 0xFF, 0xFF, 0xD, 0xFF, 0xFF, 0xFF, 0xE, 0xFF, 0xFF, 0xFF, 0xF, 0xFF, 0xFF, 0xFF,   0x1C, 0xFF, 0xFF, 0xFF, 0x1D, 0xFF, 0xFF, 0xFF, 0x1E, 0xFF, 0xFF, 0xFF, 0x1F, 0xFF, 0xFF, 0xFF,
+        };
+
+        public static bool IsSupported
+        {
+            get
+            {
+#if SUPPORTS_RUNTIME_INTRINSICS
+                return Avx2.IsSupported && Fma.IsSupported;
+#else
+                return false;
+#endif
+            }
+        }
+
+        public static void Convert(ReadOnlySpan<Rgb24> rgbSpan, ref Block8x8F yBlock, ref Block8x8F cbBlock, ref Block8x8F crBlock)
+        {
+            Debug.Assert(IsSupported, "AVX2 and FMA are required to run this converter");
+
+#if SUPPORTS_RUNTIME_INTRINSICS
+            SeparateRgb(rgbSpan);
+            ConvertInternal(rgbSpan, ref yBlock, ref cbBlock, ref crBlock);
+#endif
+        }
+
+#if SUPPORTS_RUNTIME_INTRINSICS
+        /// <summary>
+        /// Rearranges the provided <paramref name="rgbSpan"/> in-place
+        /// from { r00, g00, b00, ..., r63, g63, b63 }
+        /// to { r00, ... r31, g00, ..., g31, b00, ..., b31,
+        ///      r32, ... r63, g32, ..., g63, b31, ..., b63 }
+        /// </summary>
+        /// <remarks>
+        /// SSE is used for this operation as it is significantly faster than AVX in this specific case.
+        /// Solving this problem with AVX requires too many instructions that cross the 128-bit lanes of YMM registers.
+        /// </remarks>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        private static void SeparateRgb(ReadOnlySpan<Rgb24> rgbSpan)
+        {
+            var selectRed0 = Vector128.Create(0x00, 0x03, 0x06, 0x09, 0x0C, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
+            var selectRed1 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02, 0x05, 0x08, 0x0B, 0x0E, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
+            var selectRed2 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x04, 0x07, 0x0A, 0x0D);
+
+            var selectGreen0 = Vector128.Create(0x01, 0x04, 0x07, 0x0A, 0x0D, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
+            var selectGreen1 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x03, 0x06, 0x09, 0x0C, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
+            var selectGreen2 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02, 0x05, 0x08, 0x0B, 0x0E);
+
+            var selectBlue0 = Vector128.Create(0x02, 0x05, 0x08, 0x0B, 0x0E, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
+            var selectBlue1 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x04, 0x07, 0x0A, 0x0D, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
+            var selectBlue2 = Vector128.Create(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x03, 0x06, 0x09, 0x0C, 0x0F);
+
+            for (int i = 0; i < 2; i++)
+            {
+                ref Vector128<byte> inRef = ref Unsafe.Add(ref Unsafe.As<Rgb24, Vector128<byte>>(ref MemoryMarshal.GetReference(rgbSpan)), i * 6);
+
+                Vector128<byte> in0 = inRef;
+                Vector128<byte> in1 = Unsafe.Add(ref inRef, 1);
+                Vector128<byte> in2 = Unsafe.Add(ref inRef, 2);
+
+                Vector128<byte> r0 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectRed0), Ssse3.Shuffle(in1, selectRed1)), Ssse3.Shuffle(in2, selectRed2));
+                Vector128<byte> g0 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectGreen0), Ssse3.Shuffle(in1, selectGreen1)), Ssse3.Shuffle(in2, selectGreen2));
+                Vector128<byte> b0 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectBlue0), Ssse3.Shuffle(in1, selectBlue1)), Ssse3.Shuffle(in2, selectBlue2));
+
+                in0 = Unsafe.Add(ref inRef, 3);
+                in1 = Unsafe.Add(ref inRef, 4);
+                in2 = Unsafe.Add(ref inRef, 5);
+
+                Vector128<byte> r1 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectRed0), Ssse3.Shuffle(in1, selectRed1)), Ssse3.Shuffle(in2, selectRed2));
+                Vector128<byte> g1 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectGreen0), Ssse3.Shuffle(in1, selectGreen1)), Ssse3.Shuffle(in2, selectGreen2));
+                Vector128<byte> b1 = Sse2.Or(Sse2.Or(Ssse3.Shuffle(in0, selectBlue0), Ssse3.Shuffle(in1, selectBlue1)), Ssse3.Shuffle(in2, selectBlue2));
+
+                inRef = r0;
+                Unsafe.Add(ref inRef, 1) = r1;
+                Unsafe.Add(ref inRef, 2) = g0;
+                Unsafe.Add(ref inRef, 3) = g1;
+                Unsafe.Add(ref inRef, 4) = b0;
+                Unsafe.Add(ref inRef, 5) = b1;
+            }
+        }
+
+        /// <summary>
+        /// Converts the previously separated (see <see cref="SeparateRgb"/>) RGB values to YCbCr using AVX2 and FMA.
+        /// </summary>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        private static void ConvertInternal(ReadOnlySpan<Rgb24> rgbSpan, ref Block8x8F yBlock, ref Block8x8F cbBlock, ref Block8x8F crBlock)
+        {
+            var f0299 = Vector256.Create(0.299f);
+            var f0587 = Vector256.Create(0.587f);
+            var f0114 = Vector256.Create(0.114f);
+            var fn0168736 = Vector256.Create(-0.168736f);
+            var fn0331264 = Vector256.Create(-0.331264f);
+            var f128 = Vector256.Create(128f);
+            var fn0418688 = Vector256.Create(-0.418688f);
+            var fn0081312F = Vector256.Create(-0.081312F);
+            var f05 = Vector256.Create(0.5f);
+
+            ref Vector256<byte> inRef = ref Unsafe.As<Rgb24, Vector256<byte>>(ref MemoryMarshal.GetReference(rgbSpan));
+
+            for (int i = 0; i < 2; i++)
+            {
+                ref Vector256<float> destYRef = ref Unsafe.Add(ref Unsafe.As<Block8x8F, Vector256<float>>(ref yBlock), i * 4);
+                ref Vector256<float> destCbRef = ref Unsafe.Add(ref Unsafe.As<Block8x8F, Vector256<float>>(ref cbBlock), i * 4);
+                ref Vector256<float> destCrRef = ref Unsafe.Add(ref Unsafe.As<Block8x8F, Vector256<float>>(ref crBlock), i * 4);
+
+                Vector256<byte> red = Unsafe.Add(ref inRef, i * 3);
+                Vector256<byte> green = Unsafe.Add(ref inRef, (i * 3) + 1);
+                Vector256<byte> blue = Unsafe.Add(ref inRef, (i * 3) + 2);
+
+                for (int j = 0; j < 2; j++)
+                {
+                    // 1st part of unrolled loop
+                    Vector256<byte> mask = Unsafe.Add(ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(ExtractionMasks)), j * 2);
+
+                    Vector256<float> r = Avx.ConvertToVector256Single(Avx2.Shuffle(red, mask).AsInt32());
+                    Vector256<float> g = Avx.ConvertToVector256Single(Avx2.Shuffle(green, mask).AsInt32());
+                    Vector256<float> b = Avx.ConvertToVector256Single(Avx2.Shuffle(blue, mask).AsInt32());
+
+                    // (0.299F * r) + (0.587F * g) + (0.114F * b);
+                    Vector256<float> yy0 = Fma.MultiplyAdd(f0299, r, Fma.MultiplyAdd(f0587, g, Avx.Multiply(f0114, b)));
+
+                    // 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b))
+                    Vector256<float> cb0 = Avx.Add(f128, Fma.MultiplyAdd(fn0168736, r, Fma.MultiplyAdd(fn0331264, g, Avx.Multiply(f05, b))));
+
+                    // 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b))
+                    Vector256<float> cr0 = Avx.Add(f128, Fma.MultiplyAdd(f05, r, Fma.MultiplyAdd(fn0418688, g, Avx.Multiply(fn0081312F, b))));
+
+                    // 2nd part of unrolled loop
+                    mask = Unsafe.Add(ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(ExtractionMasks)), (j * 2) + 1);
+
+                    r = Avx.ConvertToVector256Single(Avx2.Shuffle(red, mask).AsInt32());
+                    g = Avx.ConvertToVector256Single(Avx2.Shuffle(green, mask).AsInt32());
+                    b = Avx.ConvertToVector256Single(Avx2.Shuffle(blue, mask).AsInt32());
+
+                    // (0.299F * r) + (0.587F * g) + (0.114F * b);
+                    Vector256<float> yy1 = Fma.MultiplyAdd(f0299, r, Fma.MultiplyAdd(f0587, g, Avx.Multiply(f0114, b)));
+
+                    // 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b))
+                    Vector256<float> cb1 = Avx.Add(f128, Fma.MultiplyAdd(fn0168736, r, Fma.MultiplyAdd(fn0331264, g, Avx.Multiply(f05, b))));
+
+                    // 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b))
+                    Vector256<float> cr1 = Avx.Add(f128, Fma.MultiplyAdd(f05, r, Fma.MultiplyAdd(fn0418688, g, Avx.Multiply(fn0081312F, b))));
+
+                    // store results from 1st and 2nd part
+                    Vector256<float> tmpY = Avx.Permute2x128(yy0, yy1, 0b0010_0001);
+                    Unsafe.Add(ref destYRef, j) = Avx.Blend(yy0, tmpY, 0b1111_0000);
+                    Unsafe.Add(ref destYRef, j + 2) = Avx.Blend(yy1, tmpY, 0b0000_1111);
+
+                    Vector256<float> tmpCb = Avx.Permute2x128(cb0, cb1, 0b0010_0001);
+                    Unsafe.Add(ref destCbRef, j) = Avx.Blend(cb0, tmpCb, 0b1111_0000);
+                    Unsafe.Add(ref destCbRef, j + 2) = Avx.Blend(cb0, tmpCb, 0b0000_1111);
+
+                    Vector256<float> tmpCr = Avx.Permute2x128(cr0, cr1, 0b0010_0001);
+                    Unsafe.Add(ref destCrRef, j) = Avx.Blend(cr0, tmpCr, 0b1111_0000);
+                    Unsafe.Add(ref destCrRef, j + 2) = Avx.Blend(cr0, tmpCr, 0b0000_1111);
+                }
+            }
+        }
+#endif
+    }
+}

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterVectorized.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterVectorized.cs
@@ -169,11 +169,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
 
                     Vector256<float> tmpCb = Avx.Permute2x128(cb0, cb1, 0b0010_0001);
                     Unsafe.Add(ref destCbRef, j) = Avx.Blend(cb0, tmpCb, 0b1111_0000);
-                    Unsafe.Add(ref destCbRef, j + 2) = Avx.Blend(cb0, tmpCb, 0b0000_1111);
+                    Unsafe.Add(ref destCbRef, j + 2) = Avx.Blend(cb1, tmpCb, 0b0000_1111);
 
                     Vector256<float> tmpCr = Avx.Permute2x128(cr0, cr1, 0b0010_0001);
                     Unsafe.Add(ref destCrRef, j) = Avx.Blend(cr0, tmpCr, 0b1111_0000);
-                    Unsafe.Add(ref destCrRef, j + 2) = Avx.Blend(cr0, tmpCr, 0b0000_1111);
+                    Unsafe.Add(ref destCrRef, j + 2) = Avx.Blend(cr1, tmpCr, 0b0000_1111);
                 }
             }
         }

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/YCbCrForwardConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/YCbCrForwardConverter{TPixel}.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -33,7 +32,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
         /// <summary>
         /// The color conversion tables
         /// </summary>
-        private RgbToYCbCrTables colorTables;
+        private RgbToYCbCrConverterLut colorTables;
 
         /// <summary>
         /// Temporal 8x8 block to hold TPixel data
@@ -48,7 +47,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
         public static YCbCrForwardConverter<TPixel> Create()
         {
             var result = default(YCbCrForwardConverter<TPixel>);
-            result.colorTables = RgbToYCbCrTables.Create();
+            if (RgbToYCbCrConverterVectorized.IsSupported)
+            {
+                // Avoid creating lookup tables, when vectorized converter is supported
+                result.colorTables = RgbToYCbCrConverterLut.Create();
+            }
+
             return result;
         }
 
@@ -65,20 +69,14 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             ref Block8x8F yBlock = ref this.Y;
             ref Block8x8F cbBlock = ref this.Cb;
             ref Block8x8F crBlock = ref this.Cr;
-            ref Rgb24 rgbStart = ref rgbSpan[0];
 
-            for (int i = 0; i < 64; i++)
+            if (RgbToYCbCrConverterVectorized.IsSupported)
             {
-                ref Rgb24 c = ref Unsafe.Add(ref rgbStart, i);
-
-                this.colorTables.ConvertPixelInto(
-                    c.R,
-                    c.G,
-                    c.B,
-                    ref yBlock,
-                    ref cbBlock,
-                    ref crBlock,
-                    i);
+                RgbToYCbCrConverterVectorized.Convert(rgbSpan, ref yBlock, ref cbBlock, ref crBlock);
+            }
+            else
+            {
+                this.colorTables.Convert(rgbSpan,  ref yBlock, ref cbBlock, ref crBlock);
             }
         }
     }

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/YCbCrForwardConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/YCbCrForwardConverter{TPixel}.cs
@@ -47,7 +47,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
         public static YCbCrForwardConverter<TPixel> Create()
         {
             var result = default(YCbCrForwardConverter<TPixel>);
-            if (RgbToYCbCrConverterVectorized.IsSupported)
+            if (!RgbToYCbCrConverterVectorized.IsSupported)
             {
                 // Avoid creating lookup tables, when vectorized converter is supported
                 result.colorTables = RgbToYCbCrConverterLut.Create();

--- a/tests/ImageSharp.Benchmarks/Format/Jpeg/Components/Encoder/YCbCrForwardConverterBenchmark.cs
+++ b/tests/ImageSharp.Benchmarks/Format/Jpeg/Components/Encoder/YCbCrForwardConverterBenchmark.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using SixLabors.ImageSharp.Formats.Jpeg.Components;
+using SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Benchmarks.Format.Jpeg.Components.Encoder
+{
+    public class YCbCrForwardConverterBenchmark
+    {
+        private RgbToYCbCrConverterLut converter;
+        private Rgb24[] data;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.converter = RgbToYCbCrConverterLut.Create();
+
+            var r = new Random(42);
+            this.data = new Rgb24[64];
+
+            var d = new byte[3];
+            for (int i = 0; i < this.data.Length; i++)
+            {
+                r.NextBytes(d);
+                this.data[i] = new Rgb24(d[0], d[1], d[2]);
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ConvertLut()
+        {
+            Block8x8F y = default;
+            Block8x8F cb = default;
+            Block8x8F cr = default;
+
+            this.converter.Convert(this.data.AsSpan(), ref y, ref cb, ref cr);
+        }
+
+        [Benchmark]
+        public void ConvertVectorized()
+        {
+            Block8x8F y = default;
+            Block8x8F cb = default;
+            Block8x8F cr = default;
+
+            if (RgbToYCbCrConverterVectorized.IsSupported)
+            {
+                RgbToYCbCrConverterVectorized.Convert(this.data.AsSpan(), ref y, ref cb, ref cr);
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Jpg/RgbToYCbCrConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/RgbToYCbCrConverterTests.cs
@@ -48,17 +48,13 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
             Rgb24[] data = CreateTestData();
 
-            // RgbToYCbCrConverterVectorized uses `data` as working memory so we need a copy for verification below
-            Rgb24[] dataCopy = new Rgb24[data.Length];
-            data.CopyTo(dataCopy, 0);
-
             Block8x8F y = default;
             Block8x8F cb = default;
             Block8x8F cr = default;
 
             RgbToYCbCrConverterVectorized.Convert(data.AsSpan(), ref y, ref cb, ref cr);
 
-            Verify(dataCopy, ref y, ref cb, ref cr, new ApproximateColorSpaceComparer(0.0001F));
+            Verify(data, ref y, ref cb, ref cr, new ApproximateColorSpaceComparer(0.0001F));
         }
 
         private static void Verify(ReadOnlySpan<Rgb24> data, ref Block8x8F yResult, ref Block8x8F cbResult, ref Block8x8F crResult, ApproximateColorSpaceComparer comparer)
@@ -73,7 +69,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 float cb = 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b));
                 float cr = 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b));
 
-                Assert.Equal(new YCbCr(y, cb, cr), new YCbCr(yResult[i], cbResult[i], crResult[i]), comparer);
+                Assert.True(comparer.Equals(new YCbCr(y, cb, cr), new YCbCr(yResult[i], cbResult[i], crResult[i])), $"Pos {i}, Expected {y} == {yResult[i]}, {cb} == {cbResult[i]}, {cr} == {crResult[i]}");
             }
         }
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/RgbToYCbCrConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/RgbToYCbCrConverterTests.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.ImageSharp.ColorSpaces;
+using SixLabors.ImageSharp.Formats.Jpeg.Components;
+using SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.Colorspaces.Conversion;
+using Xunit;
+using Xunit.Abstractions;
+
+// ReSharper disable InconsistentNaming
+namespace SixLabors.ImageSharp.Tests.Formats.Jpg
+{
+    public class RgbToYCbCrConverterTests
+    {
+        private const float Epsilon = .5F;
+        private static readonly ApproximateColorSpaceComparer Comparer = new ApproximateColorSpaceComparer(Epsilon);
+
+        public RgbToYCbCrConverterTests(ITestOutputHelper output)
+        {
+            this.Output = output;
+        }
+
+        private ITestOutputHelper Output { get; }
+
+        [Fact]
+        public void TestLutConverter()
+        {
+            Rgb24[] data = CreateTestData();
+            var target = RgbToYCbCrConverterLut.Create();
+
+            Block8x8F y = default;
+            Block8x8F cb = default;
+            Block8x8F cr = default;
+
+            target.Convert(data.AsSpan(), ref y, ref cb, ref cr);
+
+            Verify(data, ref y, ref cb, ref cr);
+        }
+
+        [Fact]
+        public void TestVectorizedConverter()
+        {
+            if (!RgbToYCbCrConverterVectorized.IsSupported)
+            {
+                this.Output.WriteLine("No AVX and/or FMA present, skipping test!");
+                return;
+            }
+
+            Rgb24[] data = CreateTestData();
+
+            // RgbToYCbCrConverterVectorized uses `data` as working memory so we need a copy for verification below
+            Rgb24[] dataCopy = new Rgb24[data.Length];
+            data.CopyTo(dataCopy, 0);
+
+            Block8x8F y = default;
+            Block8x8F cb = default;
+            Block8x8F cr = default;
+
+            RgbToYCbCrConverterVectorized.Convert(data.AsSpan(), ref y, ref cb, ref cr);
+
+            Verify(dataCopy, ref y, ref cb, ref cr);
+        }
+
+        private static void Verify(ReadOnlySpan<Rgb24> data, ref Block8x8F yResult, ref Block8x8F cbResult, ref Block8x8F crResult)
+        {
+            for (int i = 0; i < data.Length; i++)
+            {
+                int r = data[i].R;
+                int g = data[i].G;
+                int b = data[i].B;
+
+                float y = (0.299F * r) + (0.587F * g) + (0.114F * b);
+                float cb = 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b));
+                float cr = 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b));
+
+                Assert.Equal(new YCbCr(y, cb, cr), new YCbCr(yResult[i], cbResult[i], crResult[i]), Comparer);
+            }
+        }
+
+        private static Rgb24[] CreateTestData()
+        {
+            var data = new Rgb24[64];
+            var r = new Random();
+
+            var random = new byte[3];
+            for (int i = 0; i < data.Length; i++)
+            {
+                r.NextBytes(random);
+                data[i] = new Rgb24(random[0], random[1], random[2]);
+            }
+
+            return data;
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Jpg/RgbToYCbCrConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/RgbToYCbCrConverterTests.cs
@@ -15,9 +15,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
     public class RgbToYCbCrConverterTests
     {
-        private const float Epsilon = .5F;
-        private static readonly ApproximateColorSpaceComparer Comparer = new ApproximateColorSpaceComparer(Epsilon);
-
         public RgbToYCbCrConverterTests(ITestOutputHelper output)
         {
             this.Output = output;
@@ -37,7 +34,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
             target.Convert(data.AsSpan(), ref y, ref cb, ref cr);
 
-            Verify(data, ref y, ref cb, ref cr);
+            Verify(data, ref y, ref cb, ref cr, new ApproximateColorSpaceComparer(1F));
         }
 
         [Fact]
@@ -61,10 +58,10 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
             RgbToYCbCrConverterVectorized.Convert(data.AsSpan(), ref y, ref cb, ref cr);
 
-            Verify(dataCopy, ref y, ref cb, ref cr);
+            Verify(dataCopy, ref y, ref cb, ref cr, new ApproximateColorSpaceComparer(0.0001F));
         }
 
-        private static void Verify(ReadOnlySpan<Rgb24> data, ref Block8x8F yResult, ref Block8x8F cbResult, ref Block8x8F crResult)
+        private static void Verify(ReadOnlySpan<Rgb24> data, ref Block8x8F yResult, ref Block8x8F cbResult, ref Block8x8F crResult, ApproximateColorSpaceComparer comparer)
         {
             for (int i = 0; i < data.Length; i++)
             {
@@ -76,7 +73,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 float cb = 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b));
                 float cr = 128F + ((0.5F * r) - (0.418688F * g) - (0.081312F * b));
 
-                Assert.Equal(new YCbCr(y, cb, cr), new YCbCr(yResult[i], cbResult[i], crResult[i]), Comparer);
+                Assert.Equal(new YCbCr(y, cb, cr), new YCbCr(yResult[i], cbResult[i], crResult[i]), comparer);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Touches #1476 with a vectorized implementation of the RGB -> YCbCr conversions.

It is worth noting, that the following benchmarks don't show the entire picture. The current lookup table converter uses 3kB of lookup tables that pollute the cache and likely negatively impact subsequent operations in the encoding chain.

### Benchmark 🚀 

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.102
  [Host]     : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  DefaultJob : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT


```
|            Method |      Mean |    Error |   StdDev | Ratio |
|------------------ |----------:|---------:|---------:|------:|
|        ConvertLut | 224.68 ns | 1.059 ns | 0.938 ns |  1.00 |
| ConvertVectorized |  81.07 ns | 0.404 ns | 0.337 ns |  0.36 |
