### PR TITLE
Speed improvements to resize kernel (w/ SIMD)

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 #if SUPPORTS_RUNTIME_INTRINSICS
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -77,7 +78,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 float* bufferEnd = bufferStart + (this.Length & ~3);
                 Vector256<float> result256_0 = Vector256<float>.Zero;
                 Vector256<float> result256_1 = Vector256<float>.Zero;
-                var mask = Vector256.Create(0, 0, 0, 0, 1, 1, 1, 1);
+                ReadOnlySpan<byte> maskBytes = new byte[]
+                {
+                    0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0,
+                    1, 0, 0, 0, 1, 0, 0, 0,
+                    1, 0, 0, 0, 1, 0, 0, 0,
+                };
+                Vector256<int> mask = Unsafe.ReadUnaligned<Vector256<int>>(ref MemoryMarshal.GetReference(maskBytes));
 
                 while (bufferStart < bufferEnd)
                 {

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
@@ -76,11 +76,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 float* bufferStart = this.bufferPtr;
                 float* bufferEnd = bufferStart + (this.Length & ~1);
                 Vector256<float> result256 = Vector256<float>.Zero;
+                var mask = Vector256.Create(0, 0, 0, 0, 1, 1, 1, 1);
 
                 while (bufferStart < bufferEnd)
                 {
                     Vector256<float> rowItem256 = Unsafe.As<Vector4, Vector256<float>>(ref rowStartRef);
-                    var bufferItem256 = Vector256.Create(Vector128.Create(bufferStart[0]), Vector128.Create(bufferStart[1]));
+                    Vector256<float> bufferItem256 = Avx2.PermuteVar8x32(Vector256.Create(*(double*)bufferStart).AsSingle(), mask);
 
                     result256 = Fma.MultiplyAdd(rowItem256, bufferItem256, result256);
 

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
@@ -115,6 +115,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                         Unsafe.As<Vector4, Vector256<float>>(ref rowStartRef),
                         Avx2.PermuteVar8x32(Vector256.CreateScalarUnsafe(*(double*)bufferStart).AsSingle(), mask),
                         result256_0);
+
+                    bufferStart += 2;
+                    rowStartRef = ref Unsafe.Add(ref rowStartRef, 2);
                 }
 
                 Vector128<float> result128 = Sse.Add(result256_0.GetLower(), result256_0.GetUpper());

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -139,7 +139,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
                         testOutputDetails: workingBufferLimitInRows,
                         appendPixelTypeToFileName: false);
                     image.CompareToReferenceOutput(
-                        ImageComparer.TolerantPercentage(0.001f),
+                        ImageComparer.TolerantPercentage(0.004f),
                         provider,
                         testOutputDetails: workingBufferLimitInRows,
                         appendPixelTypeToFileName: false);


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
Related to #1476, this PR includes some speed improvements to the resize kernels.
In particular, it introduces a new vectorized path using AVX2/FMA operations to perform the convolutions.
For those interested, [here is](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABABgAJiBGAOgDkBXfGKASzFwG4BYAKDMq0ASgwB2GVsxoBhCPgAOrADYsAyiwBu7GFz4DqNEeMkwaASXFtRudrv4UDRiVIsYrNjjQAaADiQ9ePlZxFlFsJXJYbAATCFElAE9yMVxsADMYclw3BjAMciEdVgAvGABpUJglPgBvPnIG8nk2DWwMTKjY+KS0pQg2gCpyYAY0jKgABTcAxvJ6xuIAZnJg/IAZGFEAcwwAC3mGut5Z2YBtAFkYPYhoswUlAApL69v7gHl5CTjcGgBBLa2sFwNg0MAsSmCwS2AEoALoHE5bK4zRoAXwRCKW5AAajA8tAUORZKINBAlKDZLAHrA0ji8RgCZEIAB3VQYbBQDCFNLQhFHE6NXr9DBDEZjNTsznkAC85D2rB+YvGUygKIFQsGw1G4wAoqJojKteKoGyOfkANTkB7yn4bbZ7cgAMnIAD9FtC1SdcfioAAmACsSAAPBqMAA+SI6BhKDABpAAfQosu9DL9gZDfTaYZoAC0WBBPbMU9A4xnhRGgdHY4H41RDcW08HQ9m81ACwjZq0oOR8HgANb1+klwMyKLtB6kNDkSfTqczqhThfkJdUD18DuNZm7ZSZB5KiVm8hBo26/W844C8j8y+zSsxuOJw0AMV7NHOVdY8kSv2i0QeG5vBoAFVrHSUxflwIMG3QOkfVLZsw2pGBaTbVlJS5ZDoTQADAN+DQEF9GgJhYfAGHabEOR8BBFl9B4GzjUcYDaGBVDAcIORA1IMgeAYHliBhgBUAZoX3E10OhP5cFUKEVAeLCe37LCcJvO9qwTUg10CC9AMjXAqwfOtZRfbA3w/L8Eh/P9lMvTiwMkqChygGD6PTBCkNpWyMj+X93KZNCzW5KdfWhJTtJ0xo8IIoiSLImAKKgKiaLoxyGOkMcWLYpQONA7jeP4wSYGEvdtQPKVLWCiSIOk7ZZPk3tcD7ULwpOVSDM06yGlE00ytlFBC0vVDuow2lZRpchPPAnyxsG9DAvIFBNJvdEtJUqN7xrJNyEi7y/1ajapz2hNVwCHDWFpB5rW3W1Nh2XYnXId1yDDWVgpw68dMOx8jNfd8Y0/b8fI6k4Jvs6CpxcptM3DRDppZIbuSa5qIvwwjiKgUjyMo6jaIhxjmNY9ioAmni+IgAShJEkqxLNSqpJkmA5KnerGuwsLms+jSTrZy8uvQ8hzRe/qBRmgLkMNMaQcs3yRc5ObgqF8hlpwhsqF9HwyyzXSq1VnxDVUXBJt2ta1MTGgAHErjWFkWEZrX1vU82riA+R5BtkKuZvM6rUuhUaDtW77tXcgAEJZQ0t6gdUnXnx+syAas7mdMlyCwdg1MdY16Hpbh2bMNZpHGhVtW8fHAZeZp/OC7tjAdcWy8lcTygAHZyF46DhMdKO1c9ZblqAA=) a sharplab link with the current codegen for the `ConvolveCore` method, when using SIMD operations.

Still running benchmarks and work in progress...
