### PR TITLE
Vectorize Scale16X16To8X8

### DIFF
--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -19,6 +19,8 @@ namespace SixLabors.ImageSharp
 
             public static ReadOnlySpan<byte> PermuteMaskEvenOdd8x32 => new byte[] { 0, 0, 0, 0, 2, 0, 0, 0, 4, 0, 0, 0, 6, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, 5, 0, 0, 0, 7, 0, 0, 0 };
 
+            public static ReadOnlySpan<byte> PermuteMaskSwitchInnerDWords8x32 => new byte[] { 0, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0 };
+
             private static ReadOnlySpan<byte> ShuffleMaskPad4Nx16 => new byte[] { 0, 1, 2, 0x80, 3, 4, 5, 0x80, 6, 7, 8, 0x80, 9, 10, 11, 0x80 };
 
             private static ReadOnlySpan<byte> ShuffleMaskSlice4Nx16 => new byte[] { 0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14, 0x80, 0x80, 0x80, 0x80 };

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_Scale16X16To8X8.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_Scale16X16To8X8.cs
@@ -1,0 +1,35 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using SixLabors.ImageSharp.Formats.Jpeg.Components;
+
+namespace SixLabors.ImageSharp.Benchmarks.Format.Jpeg.Components
+{
+    [Config(typeof(Config.HwIntrinsics_SSE_AVX))]
+    public class Block8x8F_Scale16X16To8X8
+    {
+        private Block8x8F source;
+        private readonly Block8x8F[] target = new Block8x8F[4];
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var random = new Random();
+
+            float[] f = new float[8*8];
+            for (int i = 0; i < f.Length; i++)
+            {
+                f[i] = (float)random.NextDouble();
+            }
+
+            for (int i = 0; i < 4; i++)
+            {
+                this.target[i] = Block8x8F.Load(f);
+            }
+
+            this.source = Block8x8F.Load(f);
+        }
+
+        [Benchmark]
+        public void Scale16X16To8X8() => Block8x8F.Scale16X16To8X8(ref this.source, this.target);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

In the context of #1476 I looked for low hanging fruit on the hot path of the JPEG encoding pipeline.
Using a benchmark (encoding a 4K image) with the ETW Profiler attached, I've noticed that `Block8x8F.Scale16X16To8X8` is responsible for 9.8% of the total time taken. I've noticed that the method is the optimal candidate for vectorization (AVX2) and went for it. 

* The benchmarks below show a **12x improvement** in `Block8x8F.Scale16X16To8X8` 🚀
* This reduces the total encoding time of my sample image by **~9%** from 475.9 ms to 434.1 ms

### Benchmarks

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.102
  [Host] : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  main   : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  PR     : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT

Runtime=.NET Core 3.1  

```
|          Method |  Job |      Mean |    Error |   StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated | Allocated native memory | Native memory leak |
|---------------- |----- |----------:|---------:|---------:|------:|------:|------:|------:|----------:|------------------------:|-------------------:|
| Scale16X16To8X8 | main | 189.83 ns | 2.875 ns | 2.689 ns |  1.00 |     - |     - |     - |         - |                       - |                  - |
| Scale16X16To8X8 |   PR |  14.97 ns | 0.179 ns | 0.159 ns |  0.08 |     - |     - |     - |         - |                       - |                  - |
