### PR TITLE
Change size guards for WrapMemory to allow Memory/IMemoryOwner blocks to be larger than the image size

### DIFF
--- a/src/ImageSharp/Image.WrapMemory.cs
+++ b/src/ImageSharp/Image.WrapMemory.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp
     {
         /// <summary>
         /// <para>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels allowing viewing/manipulation as
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels allowing viewing/manipulation as
         /// an <see cref="Image{TPixel}"/> instance.
         /// </para>
         /// <para>
@@ -52,7 +52,7 @@ namespace SixLabors.ImageSharp
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(metadata, nameof(metadata));
-            Guard.IsTrue(pixelMemory.Length == width * height, nameof(pixelMemory), "The length of the input memory doesn't match the specified image size");
+            Guard.IsTrue(pixelMemory.Length >= width * height, nameof(pixelMemory), "The length of the input memory is less than the specified image size");
 
             var memorySource = MemoryGroup<TPixel>.Wrap(pixelMemory);
             return new Image<TPixel>(configuration, memorySource, width, height, metadata);
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// <para>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels allowing viewing/manipulation as
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels allowing viewing/manipulation as
         /// an <see cref="Image{TPixel}"/> instance.
         /// </para>
         /// <para>
@@ -93,7 +93,7 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// <para>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels allowing viewing/manipulation as
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels allowing viewing/manipulation as
         /// an <see cref="Image{TPixel}"/> instance.
         /// </para>
         /// <para>
@@ -122,7 +122,7 @@ namespace SixLabors.ImageSharp
             => WrapMemory(Configuration.Default, pixelMemory, width, height);
 
         /// <summary>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels,
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels,
         /// allowing to view/manipulate it as an <see cref="Image{TPixel}"/> instance.
         /// The ownership of the <paramref name="pixelMemoryOwner"/> is being transferred to the new <see cref="Image{TPixel}"/> instance,
         /// meaning that the caller is not allowed to dispose <paramref name="pixelMemoryOwner"/>.
@@ -147,14 +147,14 @@ namespace SixLabors.ImageSharp
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(metadata, nameof(metadata));
-            Guard.IsTrue(pixelMemoryOwner.Memory.Length == width * height, nameof(pixelMemoryOwner), "The length of the input memory doesn't match the specified image size");
+            Guard.IsTrue(pixelMemoryOwner.Memory.Length >= width * height, nameof(pixelMemoryOwner), "The length of the input memory is less than the specified image size");
 
             var memorySource = MemoryGroup<TPixel>.Wrap(pixelMemoryOwner);
             return new Image<TPixel>(configuration, memorySource, width, height, metadata);
         }
 
         /// <summary>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels,
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels,
         /// allowing to view/manipulate it as an <see cref="Image{TPixel}"/> instance.
         /// The ownership of the <paramref name="pixelMemoryOwner"/> is being transferred to the new <see cref="Image{TPixel}"/> instance,
         /// meaning that the caller is not allowed to dispose <paramref name="pixelMemoryOwner"/>.
@@ -176,7 +176,7 @@ namespace SixLabors.ImageSharp
             => WrapMemory(configuration, pixelMemoryOwner, width, height, new ImageMetadata());
 
         /// <summary>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels,
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels,
         /// allowing to view/manipulate it as an <see cref="Image{TPixel}"/> instance.
         /// The ownership of the <paramref name="pixelMemoryOwner"/> is being transferred to the new <see cref="Image{TPixel}"/> instance,
         /// meaning that the caller is not allowed to dispose <paramref name="pixelMemoryOwner"/>.
@@ -196,7 +196,7 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// <para>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels allowing viewing/manipulation as
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels allowing viewing/manipulation as
         /// an <see cref="Image{TPixel}"/> instance.
         /// </para>
         /// <para>
@@ -234,7 +234,7 @@ namespace SixLabors.ImageSharp
 
             var memoryManager = new ByteMemoryManager<TPixel>(byteMemory);
 
-            Guard.IsTrue(memoryManager.Memory.Length == width * height, nameof(byteMemory), "The length of the input memory doesn't match the specified image size");
+            Guard.IsTrue(memoryManager.Memory.Length >= width * height, nameof(byteMemory), "The length of the input memory is less than the specified image size");
 
             var memorySource = MemoryGroup<TPixel>.Wrap(memoryManager.Memory);
             return new Image<TPixel>(configuration, memorySource, width, height, metadata);
@@ -242,7 +242,7 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// <para>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels allowing viewing/manipulation as
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels allowing viewing/manipulation as
         /// an <see cref="Image{TPixel}"/> instance.
         /// </para>
         /// <para>
@@ -275,7 +275,7 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// <para>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels allowing viewing/manipulation as
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels allowing viewing/manipulation as
         /// an <see cref="Image{TPixel}"/> instance.
         /// </para>
         /// <para>
@@ -305,7 +305,7 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// <para>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels allowing viewing/manipulation as
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels allowing viewing/manipulation as
         /// an <see cref="Image{TPixel}"/> instance.
         /// </para>
         /// <para>
@@ -355,7 +355,7 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// <para>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels allowing viewing/manipulation as
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels allowing viewing/manipulation as
         /// an <see cref="Image{TPixel}"/> instance.
         /// </para>
         /// <para>
@@ -393,7 +393,7 @@ namespace SixLabors.ImageSharp
 
         /// <summary>
         /// <para>
-        /// Wraps an existing contiguous memory area of 'width' x 'height' pixels allowing viewing/manipulation as
+        /// Wraps an existing contiguous memory area of at least 'width' x 'height' pixels allowing viewing/manipulation as
         /// an <see cref="Image{TPixel}"/> instance.
         /// </para>
         /// <para>

--- a/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
@@ -355,8 +355,6 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [InlineData(0, 5, 5)]
             [InlineData(20, 5, 5)]
-            [InlineData(26, 5, 5)]
-            [InlineData(2, 1, 1)]
             [InlineData(1023, 32, 32)]
             public void WrapMemory_MemoryOfT_InvalidSize(int size, int height, int width)
             {
@@ -364,6 +362,20 @@ namespace SixLabors.ImageSharp.Tests
                 var memory = new Memory<Rgba32>(array);
 
                 Assert.Throws<ArgumentException>(() => Image.WrapMemory(memory, height, width));
+            }
+
+            [Theory]
+            [InlineData(25, 5, 5)]
+            [InlineData(26, 5, 5)]
+            [InlineData(2, 1, 1)]
+            [InlineData(1024, 32, 32)]
+            [InlineData(2048, 32, 32)]
+            public void WrapMemory_MemoryOfT_ValidSize(int size, int height, int width)
+            {
+                var array = new Rgba32[size];
+                var memory = new Memory<Rgba32>(array);
+
+               Image.WrapMemory(memory, height, width);
             }
 
             private class TestMemoryOwner<T> : IMemoryOwner<T>
@@ -378,8 +390,6 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [InlineData(0, 5, 5)]
             [InlineData(20, 5, 5)]
-            [InlineData(26, 5, 5)]
-            [InlineData(2, 1, 1)]
             [InlineData(1023, 32, 32)]
             public void WrapMemory_IMemoryOwnerOfT_InvalidSize(int size, int height, int width)
             {
@@ -390,10 +400,22 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Theory]
-            [InlineData(0, 5, 5)]
-            [InlineData(20, 5, 5)]
+            [InlineData(25, 5, 5)]
             [InlineData(26, 5, 5)]
             [InlineData(2, 1, 1)]
+            [InlineData(1024, 32, 32)]
+            [InlineData(2048, 32, 32)]
+            public void WrapMemory_IMemoryOwnerOfT_ValidSize(int size, int height, int width)
+            {
+                var array = new Rgba32[size];
+                var memory = new TestMemoryOwner<Rgba32> { Memory = array };
+
+                Image.WrapMemory(memory, height, width);
+            }
+
+            [Theory]
+            [InlineData(0, 5, 5)]
+            [InlineData(20, 5, 5)]
             [InlineData(1023, 32, 32)]
             public void WrapMemory_MemoryOfByte_InvalidSize(int size, int height, int width)
             {
@@ -401,6 +423,20 @@ namespace SixLabors.ImageSharp.Tests
                 var memory = new Memory<byte>(array);
 
                 Assert.Throws<ArgumentException>(() => Image.WrapMemory<Rgba32>(memory, height, width));
+            }
+
+            [Theory]
+            [InlineData(25, 5, 5)]
+            [InlineData(26, 5, 5)]
+            [InlineData(2, 1, 1)]
+            [InlineData(1024, 32, 32)]
+            [InlineData(2048, 32, 32)]
+            public void WrapMemory_MemoryOfByte_ValidSize(int size, int height, int width)
+            {
+                var array = new byte[size * Unsafe.SizeOf<Rgba32>()];
+                var memory = new Memory<byte>(array);
+
+                Image.WrapMemory<Rgba32>(memory, height, width);
             }
 
             [Theory]


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
Changes memory length guards in Image.WrapMemory() methods to allow passing blocks that are larger than the image size. Fixes #1522.

<!-- Thanks for contributing to ImageSharp! -->
