### PR TITLE
Better JpegEncoder profiling & benchmarks

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
         /// <returns>The float value at the specified index</returns>
         public float this[int idx]
         {
-            [MethodImpl(InliningOptions.ShortMethod)]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 GuardBlockIndex(idx);
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
                 return Unsafe.Add(ref selfRef, idx);
             }
 
-            [MethodImpl(InliningOptions.ShortMethod)]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
                 GuardBlockIndex(idx);

--- a/src/ImageSharp/Formats/Jpeg/Components/RowOctet.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/RowOctet.cs
@@ -75,7 +75,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(InliningOptions.ShortMethod)]
         public void Update(Buffer2D<T> buffer, int startY)
         {
             // We don't actually have to assign values outside of the

--- a/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
@@ -315,7 +315,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <param name="bits">The packed bits.</param>
         /// <param name="count">The number of bits</param>
         /// <param name="emitBufferBase">The reference to the emitBuffer.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(InliningOptions.ShortMethod)]
         private void Emit(uint bits, uint count, ref byte emitBufferBase)
         {
             count += this.bitCount;
@@ -356,7 +356,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <param name="index">The index of the Huffman encoder</param>
         /// <param name="value">The value to encode.</param>
         /// <param name="emitBufferBase">The reference to the emit buffer.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(InliningOptions.ShortMethod)]
         private void EmitHuff(HuffIndex index, int value, ref byte emitBufferBase)
         {
             uint x = HuffmanLut.TheHuffmanLut[(int)index].Values[value];
@@ -370,7 +370,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <param name="runLength">The number of copies to encode.</param>
         /// <param name="value">The value to encode.</param>
         /// <param name="emitBufferBase">The reference to the emit buffer.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(InliningOptions.ShortMethod)]
         private void EmitHuffRLE(HuffIndex index, int runLength, int value, ref byte emitBufferBase)
         {
             int a = value;

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/EncodeJpeg.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/EncodeJpeg.cs
@@ -16,17 +16,20 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs.Jpeg
         private Stream bmpStream;
         private SDImage bmpDrawing;
         private Image<Rgba32> bmpCore;
+        private MemoryStream destinationStream;
 
         [GlobalSetup]
         public void ReadImages()
         {
             if (this.bmpStream == null)
             {
-                const string TestImage = TestImages.Bmp.NegHeight;
+                const string TestImage = TestImages.Jpeg.BenchmarkSuite.Jpeg420Exif_MidSizeYCbCr;
                 this.bmpStream = File.OpenRead(Path.Combine(TestEnvironment.InputImagesDirectoryFullPath, TestImage));
                 this.bmpCore = Image.Load<Rgba32>(this.bmpStream);
+                this.bmpCore.Metadata.ExifProfile = null;
                 this.bmpStream.Position = 0;
                 this.bmpDrawing = SDImage.FromStream(this.bmpStream);
+                this.destinationStream = new MemoryStream();
             }
         }
 
@@ -42,15 +45,15 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs.Jpeg
         [Benchmark(Baseline = true, Description = "System.Drawing Jpeg")]
         public void JpegSystemDrawing()
         {
-            using var stream = new MemoryStream();
-            this.bmpDrawing.Save(stream, ImageFormat.Jpeg);
+            this.bmpDrawing.Save(this.destinationStream, ImageFormat.Jpeg);
+            this.destinationStream.Seek(0, SeekOrigin.Begin);
         }
 
         [Benchmark(Description = "ImageSharp Jpeg")]
         public void JpegCore()
         {
-            using var stream = new MemoryStream();
-            this.bmpCore.SaveAsJpeg(stream);
+            this.bmpCore.SaveAsJpeg(this.destinationStream);
+            this.destinationStream.Seek(0, SeekOrigin.Begin);
         }
     }
 }

--- a/tests/ImageSharp.Tests.ProfilingSandbox/Program.cs
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/Program.cs
@@ -31,12 +31,19 @@ namespace SixLabors.ImageSharp.Tests.ProfilingSandbox
         /// </param>
         public static void Main(string[] args)
         {
+            RunJpegEncoderProfilingTests();
             // RunJpegColorProfilingTests();
-            RunDecodeJpegProfilingTests();
+            // RunDecodeJpegProfilingTests();
             // RunToVector4ProfilingTest();
             // RunResizeProfilingTest();
 
             Console.ReadLine();
+        }
+
+        private static void RunJpegEncoderProfilingTests()
+        {
+            var benchmarks = new JpegProfilingBenchmarks(new ConsoleOutput());
+            benchmarks.EncodeJpeg_SingleMidSize();
         }
 
         private static void RunJpegColorProfilingTests()

--- a/tests/ImageSharp.Tests/ProfilingBenchmarks/JpegProfilingBenchmarks.cs
+++ b/tests/ImageSharp.Tests/ProfilingBenchmarks/JpegProfilingBenchmarks.cs
@@ -75,6 +75,21 @@ namespace SixLabors.ImageSharp.Tests.ProfilingBenchmarks
 #pragma warning restore SA1515 // Single-line comment should be preceded by blank line
         }
 
+        [Fact(Skip = ProfilingSetup.SkipProfilingTests)]
+        public void EncodeJpeg_SingleMidSize()
+        {
+            string path = TestFile.GetInputFileFullPath(TestImages.Jpeg.BenchmarkSuite.Jpeg420Exif_MidSizeYCbCr);
+            using var image = Image.Load(path);
+            image.Metadata.ExifProfile = null;
+
+            using var ms = new MemoryStream();
+            for (int i = 0; i < 30; i++)
+            {
+                image.SaveAsJpeg(ms);
+                ms.Seek(0, SeekOrigin.Begin);
+            }
+        }
+
         // Benchmark, enable manually!
         [Theory(Skip = ProfilingSetup.SkipProfilingTests)]
         [InlineData(1, 75, JpegSubsample.Ratio420)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This is a test/benchmark only change.

Been playing around with `JpegEncoder` to get some detailed data about our current performance numbers. In order to have proper profiler results (with `PROFILING` constant enabled), I had to change some of the `[MethodImpl]` attributes. Namely: switch to conditional inlining (`[MethodImpl(InliningOptions.ShortMethod)]`) in huffmann methods, and always inline in `Block8x8F` indexer.

Additionally:
- Changed the `EncodeJpeg`  benchmark to work with a bigger image, and move `MemoryStream` creation to GlobalSetup
- Added `JpegProfilingBenchmarks.EncodeJpeg_SingleMidSize`


### Current perf characteristics

#### (Updated) JpegEncoder benchmark results on my machine

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.200-preview.20614.14
  [Host]     : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  DefaultJob : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  
|                Method |      Mean |     Error |    StdDev | Ratio | RatioSD |
|---------------------- |----------:|----------:|----------:|------:|--------:|
| 'System.Drawing Jpeg' |  5.735 ms | 0.1122 ms | 0.2292 ms |  1.00 |    0.00 |
|     'ImageSharp Jpeg' | 73.348 ms | 1.9322 ms | 5.4498 ms | 13.06 |    1.17 |
```

#### Profiler results on my Surface Book

Running `EncodeJpeg_SingleMidSize` which stresses encoding of the same image with default quality settings results in the following profile using dotTrace:

```
100.00%   Encode420  •  2,185 ms  •  SixLabors.ImageSharp.Formats.Jpeg.JpegEncoderCore.Encode420(Image, CancellationToken, ref Byte)
  66.78%   WriteBlock  •  1,459 ms  •  SixLabors.ImageSharp.Formats.Jpeg.JpegEncoderCore.WriteBlock(QuantIndex, Int32, ref Block8x8F, ref Block8x8F, ref Block8x8F, ref Block8x8F, ref ZigZag, ref Byte)
    35.16%   EmitHuffRLE  •  768 ms  •  SixLabors.ImageSharp.Formats.Jpeg.JpegEncoderCore.EmitHuffRLE(HuffIndex, Int32, Int32, ref Byte)
      18.96%   EmitHuff  •  414 ms  •  SixLabors.ImageSharp.Formats.Jpeg.JpegEncoderCore.EmitHuff(HuffIndex, Int32, ref Byte)
        12.10%   Emit  •  264 ms  •  SixLabors.ImageSharp.Formats.Jpeg.JpegEncoderCore.Emit(UInt32, UInt32, ref Byte)
           4.67%   Write  •  102 ms  •  System.IO.MemoryStream.Write(Byte[], Int32, Int32)
      9.05%   Emit  •  198 ms  •  SixLabors.ImageSharp.Formats.Jpeg.JpegEncoderCore.Emit(UInt32, UInt32, ref Byte)
         4.11%   Write  •  90 ms  •  System.IO.MemoryStream.Write(Byte[], Int32, Int32)
       0.27%   get_Item  •  6 ms  •  System.ReadOnlySpan`1.get_Item(Int32)
      ►0.27%   get_BitCountLut  •  6 ms  •  SixLabors.ImageSharp.Formats.Jpeg.JpegEncoderCore.get_BitCountLut
    ►6.59%   TransformFDCT  •  144 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.FastFloatingPointDCT.TransformFDCT(ref Block8x8F, ref Block8x8F, ref Block8x8F, Boolean)
     5.22%   Quantize  •  114 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.Block8x8F.Quantize(ref Block8x8F, ref Block8x8F, ref Block8x8F, ref ZigZag)
     2.47%   DivideRoundAll  •  54 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.Block8x8F.DivideRoundAll(ref Block8x8F, ref Block8x8F)
     1.10%   MultiplyInPlace  •  24 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.Block8x8F.MultiplyInPlace(Single)
    ►0.54%   EmitHuff  •  12 ms  •  SixLabors.ImageSharp.Formats.Jpeg.JpegEncoderCore.EmitHuff(HuffIndex, Int32, ref Byte)
  21.17%   Convert  •  463 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.YCbCrForwardConverter`1.Convert(ImageFrame, Int32, Int32, ref RowOctet)
    9.63%   Convert  •  211 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.RgbToYCbCrConverterVectorized.Convert(ReadOnlySpan, ref Block8x8F, ref Block8x8F, ref Block8x8F)
       2.74%   MultiplyAdd  •  60 ms  •  SixLabors.ImageSharp.SimdUtils+HwIntrinsics.MultiplyAdd(ref Vector256, ref Vector256, ref Vector256)
    5.22%   LoadAndStretchEdges  •  114 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.GenericBlock8x8`1.LoadAndStretchEdges(Buffer2D, Int32, Int32, ref RowOctet)
       1.65%   get_Item  •  36 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.RowOctet`1.get_Item(Int32)
    ►4.94%   ToRgb24  •  108 ms  •  SixLabors.ImageSharp.PixelFormats.Rgba32+PixelOperations.ToRgb24(Configuration, ReadOnlySpan, Span)
    ►0.27%   AsSpanUnsafe  •  6 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.GenericBlock8x8`1.AsSpanUnsafe
  7.66%   Update  •  167 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.RowOctet`1.Update(Buffer2D, Int32)
    ►6.29%   GetRowSpan  •  137 ms  •  SixLabors.ImageSharp.Memory.Buffer2D`1.GetRowSpan(Int32)
     0.27%   set_Item  •  6 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.RowOctet`1.set_Item(Int32, Span)
   1.10%   Scale16X16To8X8Vectorized  •  24 ms  •  SixLabors.ImageSharp.Formats.Jpeg.Components.Block8x8F.Scale16X16To8X8Vectorized(ref Block8x8F, ReadOnlySpan)

```

This means that our current primary bottleneck is Huffmann encoding.
