### PR TITLE
Add check for Avx2 in ResizeKernel

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernel.cs
@@ -72,7 +72,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Vector4 ConvolveCore(ref Vector4 rowStartRef)
         {
 #if SUPPORTS_RUNTIME_INTRINSICS
-            if (Fma.IsSupported)
+            if (Avx2.IsSupported && Fma.IsSupported)
             {
                 float* bufferStart = this.bufferPtr;
                 float* bufferEnd = bufferStart + (this.Length & ~3);

--- a/tests/ImageSharp.Tests/Processing/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/ResizeTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Processing.Transforms
@@ -85,5 +87,24 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
             Assert.Equal(compand, resizeOptions.Compand);
             Assert.Equal(mode, resizeOptions.Mode);
         }
+
+#if SUPPORTS_RUNTIME_INTRINSICS
+        [Fact]
+        public void HwIntrinsics_Resize()
+        {
+            static void RunTest()
+            {
+                using var image = new Image<Rgba32>(50, 50);
+                image.Mutate(img => img.Resize(25, 25));
+
+                Assert.Equal(25, image.Width);
+                Assert.Equal(25, image.Height);
+            }
+
+            FeatureTestRunner.RunWithHwIntrinsicsFeature(
+                RunTest,
+                HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableFMA);
+        }
+#endif
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
@@ -25,9 +25,9 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
 
         [Theory]
         [MemberData(nameof(Intrinsics))]
-        public void ToFeatureCollectionReturnsExpectedResult(HwIntrinsics expectedItrinsics, string[] expectedValues)
+        public void ToFeatureCollectionReturnsExpectedResult(HwIntrinsics expectedIntrinsics, string[] expectedValues)
         {
-            Dictionary<HwIntrinsics, string> features = expectedItrinsics.ToFeatureKeyValueCollection();
+            Dictionary<HwIntrinsics, string> features = expectedIntrinsics.ToFeatureKeyValueCollection();
             HwIntrinsics[] keys = features.Keys.ToArray();
 
             HwIntrinsics actualIntrinsics = keys[0];
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
                 actualIntrinsics |= keys[i];
             }
 
-            Assert.Equal(expectedItrinsics, actualIntrinsics);
+            Assert.Equal(expectedIntrinsics, actualIntrinsics);
 
             IEnumerable<string> actualValues = features.Select(x => x.Value);
             Assert.Equal(expectedValues, actualValues);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Adds a check for Avx2 in ResizeKernel, fix for #1546