### PR TITLE
Fix vectorized 4:2:0 subsampling

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
@@ -494,32 +494,35 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
             var f2 = Vector256.Create(2f);
             var f025 = Vector256.Create(0.25f);
             Vector256<int> switchInnerDoubleWords = Unsafe.As<byte, Vector256<int>>(ref MemoryMarshal.GetReference(SimdUtils.HwIntrinsics.PermuteMaskSwitchInnerDWords8x32));
-
-            ref Vector256<float> in1 = ref Unsafe.As<Block8x8F, Vector256<float>>(ref MemoryMarshal.GetReference(source));
-            ref Vector256<float> in2 = ref Unsafe.As<Block8x8F, Vector256<float>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(source), 1));
             ref Vector256<float> destRef = ref Unsafe.As<Block8x8F, Vector256<float>>(ref destination);
 
-            for (int i = 0; i < 8; i++)
+            for (int i = 0; i < 2; i++)
             {
-                Vector256<float> a = in1;
-                Vector256<float> b = Unsafe.Add(ref in1, 1);
-                Vector256<float> c = in2;
-                Vector256<float> d = Unsafe.Add(ref in2, 1);
+                ref Vector256<float> in1 = ref Unsafe.As<Block8x8F, Vector256<float>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(source), 2 * i));
+                ref Vector256<float> in2 = ref Unsafe.As<Block8x8F, Vector256<float>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(source), (2 * i) + 1));
 
-                Vector256<float> calc1 = Avx.Shuffle(a, c, 0b10_00_10_00);
-                Vector256<float> calc2 = Avx.Shuffle(a, c, 0b11_01_11_01);
-                Vector256<float> calc3 = Avx.Shuffle(b, d, 0b10_00_10_00);
-                Vector256<float> calc4 = Avx.Shuffle(b, d, 0b11_01_11_01);
+                for (int j = 0; j < 4; j++)
+                {
+                    Vector256<float> a = in1;
+                    Vector256<float> b = Unsafe.Add(ref in1, 1);
+                    Vector256<float> c = in2;
+                    Vector256<float> d = Unsafe.Add(ref in2, 1);
 
-                Vector256<float> sum = Avx.Add(Avx.Add(calc1, calc2), Avx.Add(calc3, calc4));
-                Vector256<float> add = Avx.Add(sum, f2);
-                Vector256<float> res = Avx.Multiply(add, f025);
+                    Vector256<float> calc1 = Avx.Shuffle(a, c, 0b10_00_10_00);
+                    Vector256<float> calc2 = Avx.Shuffle(a, c, 0b11_01_11_01);
+                    Vector256<float> calc3 = Avx.Shuffle(b, d, 0b10_00_10_00);
+                    Vector256<float> calc4 = Avx.Shuffle(b, d, 0b11_01_11_01);
 
-                destRef = Avx2.PermuteVar8x32(res, switchInnerDoubleWords);
-                destRef = ref Unsafe.Add(ref destRef, 1);
+                    Vector256<float> sum = Avx.Add(Avx.Add(calc1, calc2), Avx.Add(calc3, calc4));
+                    Vector256<float> add = Avx.Add(sum, f2);
+                    Vector256<float> res = Avx.Multiply(add, f025);
 
-                in1 = ref Unsafe.Add(ref in1, 2);
-                in2 = ref Unsafe.Add(ref in2, 2);
+                    destRef = Avx2.PermuteVar8x32(res, switchInnerDoubleWords);
+                    destRef = ref Unsafe.Add(ref destRef, 1);
+
+                    in1 = ref Unsafe.Add(ref in1, 2);
+                    in2 = ref Unsafe.Add(ref in2, 2);
+                }
             }
 #endif
         }

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
@@ -501,12 +501,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
                 ref Vector256<float> in1 = ref Unsafe.As<Block8x8F, Vector256<float>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(source), 2 * i));
                 ref Vector256<float> in2 = ref Unsafe.As<Block8x8F, Vector256<float>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(source), (2 * i) + 1));
 
-                for (int j = 0; j < 4; j++)
+                for (int j = 0; j < 8; j += 2)
                 {
-                    Vector256<float> a = in1;
-                    Vector256<float> b = Unsafe.Add(ref in1, 1);
-                    Vector256<float> c = in2;
-                    Vector256<float> d = Unsafe.Add(ref in2, 1);
+                    Vector256<float> a = Unsafe.Add(ref in1, j);
+                    Vector256<float> b = Unsafe.Add(ref in1, j + 1);
+                    Vector256<float> c = Unsafe.Add(ref in2, j);
+                    Vector256<float> d = Unsafe.Add(ref in2, j + 1);
 
                     Vector256<float> calc1 = Avx.Shuffle(a, c, 0b10_00_10_00);
                     Vector256<float> calc2 = Avx.Shuffle(a, c, 0b11_01_11_01);
@@ -519,9 +519,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
 
                     destRef = Avx2.PermuteVar8x32(res, switchInnerDoubleWords);
                     destRef = ref Unsafe.Add(ref destRef, 1);
-
-                    in1 = ref Unsafe.Add(ref in1, 2);
-                    in2 = ref Unsafe.Add(ref in2, 2);
                 }
             }
 #endif


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes the bug reported by @jrdiver and @JimBobSquarePants in #1547/#1549 introduced in #1517.

<!-- Thanks for contributing to ImageSharp! -->
