### PR TITLE
Image.Load(byte[]) should return non-generic Image

### DIFF
--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp
         /// <param name="data">The byte array containing image data.</param>
         /// <exception cref="ArgumentNullException">The configuration is null.</exception>
         /// <exception cref="ArgumentNullException">The data is null.</exception>
-        /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>
+        /// <returns>A new <see cref="Image"/>.</returns>
         public static Image Load(byte[] data)
             => Load(Configuration.Default, data);
 

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -92,8 +92,8 @@ namespace SixLabors.ImageSharp
         /// <exception cref="ArgumentNullException">The configuration is null.</exception>
         /// <exception cref="ArgumentNullException">The data is null.</exception>
         /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>
-        public static Image<Rgba32> Load(byte[] data)
-            => Load<Rgba32>(Configuration.Default, data);
+        public static Image Load(byte[] data)
+            => Load(Configuration.Default, data);
 
         /// <summary>
         /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte array.

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -155,9 +155,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         [Fact]
         public void CanDecodeIntermingledImages()
         {
-            using (var kumin1 = Image.Load(TestFile.Create(TestImages.Gif.Kumin).Bytes))
+            using (var kumin1 = Image.Load<Rgba32>(TestFile.Create(TestImages.Gif.Kumin).Bytes))
             using (Image.Load(TestFile.Create(TestImages.Png.Icon).Bytes))
-            using (var kumin2 = Image.Load(TestFile.Create(TestImages.Gif.Kumin).Bytes))
+            using (var kumin2 = Image.Load<Rgba32>(TestFile.Create(TestImages.Gif.Kumin).Bytes))
             {
                 for (int i = 0; i < kumin1.Frames.Count; i++)
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Discovered an API bug while answering #1571. The fix is a breaking change, but very scoped one.