### PR TITLE
Add support for encoding 4 bit per pixel bitmaps

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpBitsPerPixel.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpBitsPerPixel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.ImageSharp.Formats.Bmp
@@ -8,6 +8,11 @@ namespace SixLabors.ImageSharp.Formats.Bmp
     /// </summary>
     public enum BmpBitsPerPixel : short
     {
+        /// <summary>
+        /// 4 bits per pixel.
+        /// </summary>
+        Pixel4 = 4,
+
         /// <summary>
         /// 8 bits per pixel. Each pixel consists of 1 byte.
         /// </summary>

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -1304,8 +1304,9 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             this.bmpMetadata = this.metadata.GetBmpMetadata();
             this.bmpMetadata.InfoHeaderType = infoHeaderType;
 
-            // We can only encode at these bit rates so far (1 bit and 4 bit are still missing).
-            if (bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel8)
+            // We can only encode at these bit rates so far (1 bit per pixel is still missing).
+            if (bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel4)
+                || bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel8)
                 || bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel16)
                 || bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel24)
                 || bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel32))

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -40,6 +40,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         public static readonly TheoryData<string, BmpBitsPerPixel> BmpBitsPerPixelFiles =
         new TheoryData<string, BmpBitsPerPixel>
         {
+            { Bit4, BmpBitsPerPixel.Pixel4 },
+            { Bit8, BmpBitsPerPixel.Pixel8 },
             { Rgb16, BmpBitsPerPixel.Pixel16 },
             { Car, BmpBitsPerPixel.Pixel24 },
             { Bit32Rgb, BmpBitsPerPixel.Pixel32 }

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -13,7 +13,6 @@ using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 using SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs;
 
 using Xunit;
-using Xunit.Abstractions;
 
 using static SixLabors.ImageSharp.Tests.TestImages.Bmp;
 
@@ -41,13 +40,10 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         public static readonly TheoryData<string, BmpBitsPerPixel> BmpBitsPerPixelFiles =
         new TheoryData<string, BmpBitsPerPixel>
         {
+            { Rgb16, BmpBitsPerPixel.Pixel16 },
             { Car, BmpBitsPerPixel.Pixel24 },
             { Bit32Rgb, BmpBitsPerPixel.Pixel32 }
         };
-
-        public BmpEncoderTests(ITestOutputHelper output) => this.Output = output;
-
-        private ITestOutputHelper Output { get; }
 
         [Theory]
         [MemberData(nameof(RatioFiles))]
@@ -174,6 +170,16 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                 provider,
                 bitsPerPixel,
                 supportTransparency: false);
+
+        [Theory]
+        [WithFile(Bit4, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel4)]
+        public void Encode_4Bit_WithV3Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
+
+        [Theory]
+        [WithFile(Bit4, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel4)]
+        public void Encode_4Bit_WithV4Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
 
         [Theory]
         [WithFile(Bit8Gs, PixelTypes.L8, BmpBitsPerPixel.Pixel8)]

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -175,13 +175,31 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
 
         [Theory]
         [WithFile(Bit4, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel4)]
-        public void Encode_4Bit_WithV3Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
+        public void Encode_4Bit_WithV3Header_Works<TPixel>(
+            TestImageProvider<TPixel> provider,
+            BmpBitsPerPixel bitsPerPixel)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // The Magick Reference Decoder can not decode 4-Bit bitmaps, so only execute this on windows.
+            if (TestEnvironment.IsWindows)
+            {
+                TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
+            }
+        }
 
         [Theory]
         [WithFile(Bit4, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel4)]
-        public void Encode_4Bit_WithV4Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
-            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
+        public void Encode_4Bit_WithV4Header_Works<TPixel>(
+            TestImageProvider<TPixel> provider,
+            BmpBitsPerPixel bitsPerPixel)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // The Magick Reference Decoder can not decode 4-Bit bitmaps, so only execute this on windows.
+            if (TestEnvironment.IsWindows)
+            {
+                TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
+            }
+        }
 
         [Theory]
         [WithFile(Bit8Gs, PixelTypes.L8, BmpBitsPerPixel.Pixel8)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

As the title says, this will change the bitmap encoder to support encoding 4 bits per pixel bitmaps.
