### PR TITLE
Add support for encoding 1 bit per pixel bitmaps

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpBitsPerPixel.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpBitsPerPixel.cs
@@ -9,6 +9,11 @@ namespace SixLabors.ImageSharp.Formats.Bmp
     public enum BmpBitsPerPixel : short
     {
         /// <summary>
+        /// 1 bit per pixel.
+        /// </summary>
+        Pixel1 = 1,
+
+        /// <summary>
         /// 4 bits per pixel.
         /// </summary>
         Pixel4 = 4,

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -1303,16 +1303,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             short bitsPerPixel = this.infoHeader.BitsPerPixel;
             this.bmpMetadata = this.metadata.GetBmpMetadata();
             this.bmpMetadata.InfoHeaderType = infoHeaderType;
-
-            // We can only encode at these bit rates so far (1 bit per pixel is still missing).
-            if (bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel4)
-                || bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel8)
-                || bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel16)
-                || bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel24)
-                || bitsPerPixel.Equals((short)BmpBitsPerPixel.Pixel32))
-            {
-                this.bmpMetadata.BitsPerPixel = (BmpBitsPerPixel)bitsPerPixel;
-            }
+            this.bmpMetadata.BitsPerPixel = (BmpBitsPerPixel)bitsPerPixel;
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Bmp/BmpEncoder.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoder.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
 
         /// <summary>
         /// Gets or sets the quantizer for reducing the color count for 8-Bit images.
-        /// Defaults to OctreeQuantizer.
+        /// Defaults to Wu Quantizer.
         /// </summary>
         public IQuantizer Quantizer { get; set; }
 

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             this.memoryAllocator = memoryAllocator;
             this.bitsPerPixel = options.BitsPerPixel;
             this.writeV4Header = options.SupportTransparency;
-            this.quantizer = options.Quantizer ?? KnownQuantizers.Octree;
+            this.quantizer = options.Quantizer ?? KnownQuantizers.Wu;
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Bmp/IBmpEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Bmp/IBmpEncoderOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
@@ -24,7 +24,8 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         bool SupportTransparency { get; }
 
         /// <summary>
-        /// Gets the quantizer for reducing the color count for 8-Bit images.
+        /// Gets the quantizer for reducing the color count for 8-Bit, 4-Bit, and 1-Bit images.
+        /// Defaults to the Octree Quantizer.
         /// </summary>
         IQuantizer Quantizer { get; }
     }

--- a/src/ImageSharp/Formats/Bmp/IBmpEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Bmp/IBmpEncoderOptions.cs
@@ -25,7 +25,6 @@ namespace SixLabors.ImageSharp.Formats.Bmp
 
         /// <summary>
         /// Gets the quantizer for reducing the color count for 8-Bit, 4-Bit, and 1-Bit images.
-        /// Defaults to the Octree Quantizer.
         /// </summary>
         IQuantizer Quantizer { get; }
     }

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -40,6 +40,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         public static readonly TheoryData<string, BmpBitsPerPixel> BmpBitsPerPixelFiles =
         new TheoryData<string, BmpBitsPerPixel>
         {
+            { Bit1, BmpBitsPerPixel.Pixel1 },
             { Bit4, BmpBitsPerPixel.Pixel4 },
             { Bit8, BmpBitsPerPixel.Pixel8 },
             { Rgb16, BmpBitsPerPixel.Pixel16 },
@@ -202,6 +203,42 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         }
 
         [Theory]
+        [WithFile(Bit1, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel1)]
+        public void Encode_1Bit_WithV3Header_Works<TPixel>(
+            TestImageProvider<TPixel> provider,
+            BmpBitsPerPixel bitsPerPixel)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // The Magick Reference Decoder can not decode 1-Bit bitmaps, so only execute this on windows.
+            if (TestEnvironment.IsWindows)
+            {
+                TestBmpEncoderCore(
+                    provider,
+                    bitsPerPixel,
+                    supportTransparency: false,
+                    quantizer: KnownQuantizers.Wu);  // using the wu quantizer, because the octree seems to have problems with just two colors.
+            }
+        }
+
+        [Theory]
+        [WithFile(Bit1, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel1)]
+        public void Encode_1Bit_WithV4Header_Works<TPixel>(
+            TestImageProvider<TPixel> provider,
+            BmpBitsPerPixel bitsPerPixel)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // The Magick Reference Decoder can not decode 1-Bit bitmaps, so only execute this on windows.
+            if (TestEnvironment.IsWindows)
+            {
+                TestBmpEncoderCore(
+                    provider,
+                    bitsPerPixel,
+                    supportTransparency: true,
+                    quantizer: KnownQuantizers.Wu); // using the wu quantizer, because the octree seems to have problems with just two colors.
+            }
+        }
+
+        [Theory]
         [WithFile(Bit8Gs, PixelTypes.L8, BmpBitsPerPixel.Pixel8)]
         public void Encode_8BitGray_WithV4Header_Works<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
             where TPixel : unmanaged, IPixel<TPixel> =>
@@ -297,7 +334,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         private static void TestBmpEncoderCore<TPixel>(
             TestImageProvider<TPixel> provider,
             BmpBitsPerPixel bitsPerPixel,
-            bool supportTransparency = true,
+            bool supportTransparency = true, // if set to true, will write a V4 header, otherwise a V3 header.
+            IQuantizer quantizer = null,
             ImageComparer customComparer = null)
             where TPixel : unmanaged, IPixel<TPixel>
         {
@@ -309,7 +347,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                     image.Mutate(c => c.MakeOpaque());
                 }
 
-                var encoder = new BmpEncoder { BitsPerPixel = bitsPerPixel, SupportTransparency = supportTransparency };
+                var encoder = new BmpEncoder
+                {
+                    BitsPerPixel = bitsPerPixel,
+                    SupportTransparency = supportTransparency,
+                    Quantizer = quantizer ?? KnownQuantizers.Octree
+                };
 
                 // Does DebugSave & load reference CompareToReferenceInput():
                 image.VerifyEncoder(provider, "bmp", bitsPerPixel, encoder, customComparer);

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -212,11 +212,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
             // The Magick Reference Decoder can not decode 1-Bit bitmaps, so only execute this on windows.
             if (TestEnvironment.IsWindows)
             {
-                TestBmpEncoderCore(
-                    provider,
-                    bitsPerPixel,
-                    supportTransparency: false,
-                    quantizer: KnownQuantizers.Wu);  // using the wu quantizer, because the octree seems to have problems with just two colors.
+                TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
             }
         }
 
@@ -230,11 +226,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
             // The Magick Reference Decoder can not decode 1-Bit bitmaps, so only execute this on windows.
             if (TestEnvironment.IsWindows)
             {
-                TestBmpEncoderCore(
-                    provider,
-                    bitsPerPixel,
-                    supportTransparency: true,
-                    quantizer: KnownQuantizers.Wu); // using the wu quantizer, because the octree seems to have problems with just two colors.
+                TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
             }
         }
 
@@ -351,7 +343,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                 {
                     BitsPerPixel = bitsPerPixel,
                     SupportTransparency = supportTransparency,
-                    Quantizer = quantizer ?? KnownQuantizers.Octree
+                    Quantizer = quantizer ?? KnownQuantizers.Wu
                 };
 
                 // Does DebugSave & load reference CompareToReferenceInput():


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Add support for encoding 1 bit per pixel bitmaps.

@JimBobSquarePants: The bitmap encoder uses Octree Quantizer as a default. This quantizer does seem to have problems with just 2 colors. Im not so familiar with the Octree Quantizer. Is not possible to quantize with just to colors or is it maybe an issue we should look into? All indices seem to be 0.
If i change it to Wu quantizer it works with two colors.