### PR TITLE
Update ImageSharp.Tests.ProfilingSandbox.csproj

### DIFF
--- a/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
@@ -13,6 +13,7 @@
     <IsTestProject>false</IsTestProject>
     <EnsureNETCoreAppRuntime>false</EnsureNETCoreAppRuntime>
     <Configurations>Debug;Release;Release-InnerLoop;Debug-InnerLoop</Configurations>
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 
   <Choose>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

There's a breaking change in the .NET SDK 5.300 that affects our sandbox reference. This PR disables the check so we can build the solution. (_I would like to delete the sandbox one day, we can profile using our Rider licenses_)

See https://github.com/dotnet/docs/issues/24231 for more info.

<!-- Thanks for contributing to ImageSharp! -->
