### PR TITLE
Make sure encoding 4bit paletted tiff rows are byte aligned

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -202,7 +202,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
 
             if (this.PlanarConfiguration == TiffPlanarConfiguration.Chunky)
             {
-                DebugGuard.IsTrue(plane == -1, "Excepted Chunky planar.");
+                DebugGuard.IsTrue(plane == -1, "Expected Chunky planar.");
                 bitsPerPixel = this.BitsPerPixel;
             }
             else

--- a/src/ImageSharp/Formats/Tiff/Writers/TiffPaletteWriter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/Writers/TiffPaletteWriter{TPixel}.cs
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Writers
             {
                 int width = this.Image.Width;
                 int excess = (width % 2) * height;
-                int rows4BitBufferLength = indexedPixels.Length + excess;
+                int rows4BitBufferLength = (width / 2 * height) + excess;
                 using IMemoryOwner<byte> rows4bitBuffer = this.MemoryAllocator.Allocate<byte>(rows4BitBufferLength);
                 Span<byte> rows4bit = rows4bitBuffer.GetSpan();
                 int idxPixels = 0;

--- a/src/ImageSharp/Formats/Tiff/Writers/TiffPaletteWriter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/Writers/TiffPaletteWriter{TPixel}.cs
@@ -59,13 +59,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Writers
             if (this.BitsPerPixel == 4)
             {
                 int width = this.Image.Width;
-                int excess = (width % 2) * height;
-                int rows4BitBufferLength = (width / 2 * height) + excess;
+                int halfWidth = width >> 1;
+                int excess = (width & 1) * height; // (width % 2) * height
+                int rows4BitBufferLength = (halfWidth * height) + excess;
                 using IMemoryOwner<byte> rows4bitBuffer = this.MemoryAllocator.Allocate<byte>(rows4BitBufferLength);
                 Span<byte> rows4bit = rows4bitBuffer.GetSpan();
                 int idxPixels = 0;
                 int idx4bitRows = 0;
-                int halfWidth = width / 2;
                 for (int row = 0; row < height; row++)
                 {
                     for (int x = 0; x < halfWidth; x++)

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -4,7 +4,7 @@
 // ReSharper disable InconsistentNaming
 using System;
 using System.IO;
-
+using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Tiff;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
@@ -37,6 +37,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [InlineData(RgbUncompressed, 24, 256, 256, 300, 300, PixelResolutionUnit.PixelsPerInch)]
         [InlineData(SmallRgbDeflate, 24, 32, 32, 96, 96, PixelResolutionUnit.PixelsPerInch)]
         [InlineData(Calliphora_GrayscaleUncompressed, 8, 804, 1198, 96, 96, PixelResolutionUnit.PixelsPerInch)]
+        [InlineData(Flower4BitPalette, 4, 73, 43, 72, 72, PixelResolutionUnit.PixelsPerInch)]
         public void Identify(string imagePath, int expectedPixelSize, int expectedWidth, int expectedHeight, double expectedHResolution, double expectedVResolution, PixelResolutionUnit expectedResolutionUnit)
         {
             var testFile = TestFile.Create(imagePath);
@@ -90,6 +91,19 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [WithFile(PaletteUncompressed, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_WithPalette<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(Rgb4BitPalette, PixelTypes.Rgba32)]
+        [WithFile(Flower4BitPalette, PixelTypes.Rgba32)]
+        [WithFile(Flower4BitPaletteGray, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_4Bit_WithPalette<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            if (TestEnvironment.IsWindows)
+            {
+                TestTiffDecoder(provider, new SystemDrawingReferenceDecoder(), useExactComparer: false, 0.01f);
+            }
+        }
 
         [Theory]
         [WithFile(GrayscaleDeflateMultistrip, PixelTypes.Rgba32)]
@@ -155,12 +169,15 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             image.CompareToOriginalMultiFrame(provider, ImageComparer.Exact, ReferenceDecoder);
         }
 
-        private static void TestTiffDecoder<TPixel>(TestImageProvider<TPixel> provider)
+        private static void TestTiffDecoder<TPixel>(TestImageProvider<TPixel> provider, IImageDecoder referenceDecoder = null, bool useExactComparer = true, float compareTolerance = 0.001f)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using Image<TPixel> image = provider.GetImage(TiffDecoder);
             image.DebugSave(provider);
-            image.CompareToOriginal(provider, ImageComparer.Exact, ReferenceDecoder);
+            image.CompareToOriginal(
+                provider,
+                useExactComparer ? ImageComparer.Exact : ImageComparer.Tolerant(compareTolerance),
+                referenceDecoder ?? ReferenceDecoder);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -296,10 +296,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
 
         [Theory]
         [WithFile(Rgb4BitPalette, PixelTypes.Rgba32)]
+        [WithFile(Flower4BitPalette, PixelTypes.Rgba32)]
+        [WithFile(Flower4BitPaletteGray, PixelTypes.Rgba32)]
         public void TiffEncoder_EncodeColorPalette_With4Bit_Works<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> =>
             //// Note: The magick reference decoder does not support 4 bit tiff's, so we use our TIFF decoder instead.
-            TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit4, TiffPhotometricInterpretation.PaletteColor, useExactComparer: false, compareTolerance: 0.001f, imageDecoder: new TiffDecoder());
+            TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit4, TiffPhotometricInterpretation.PaletteColor, useExactComparer: false, compareTolerance: 0.003f, imageDecoder: new TiffDecoder());
 
         [Theory]
         [WithFile(Calliphora_PaletteUncompressed, PixelTypes.Rgba32)]
@@ -460,7 +462,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             TiffCompression compression = TiffCompression.None,
             TiffPredictor predictor = TiffPredictor.None,
             bool useExactComparer = true,
-            float compareTolerance = 0.01f,
+            float compareTolerance = 0.001f,
             IImageDecoder imageDecoder = null)
             where TPixel : unmanaged, IPixel<TPixel>
         {

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -558,6 +558,8 @@ namespace SixLabors.ImageSharp.Tests
             public const string RgbPalette = "Tiff/rgb_palette.tiff";
             public const string Rgb4BitPalette = "Tiff/bike_colorpalette_4bit.tiff";
             public const string RgbPaletteDeflate = "Tiff/rgb_palette_deflate.tiff";
+            public const string Flower4BitPalette = "Tiff/flower-palette-04.tiff";
+            public const string Flower4BitPaletteGray = "Tiff/flower-minisblack-04.tiff";
 
             public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
             public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/Images/Input/Tiff/flower-minisblack-04.tiff
+++ b/tests/Images/Input/Tiff/flower-minisblack-04.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18991fca75a89b3d15c7f93dee0454e3943920b595ba16145ebc1fd8bd45b1f5
+size 1905

--- a/tests/Images/Input/Tiff/flower-palette-04.tiff
+++ b/tests/Images/Input/Tiff/flower-palette-04.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:700ec8103b4197c415ba90d983a7d5f471f155fd5b1c952d86ee9becba898a1a
+size 2010


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This **PR** makes sure to write padding when encoding 4-bit paletted tiff's with uneven width.