### PR TITLE
Add support for decoding 6, 12, 30, 42 bits per pixel tiff's

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Constants/TiffConstants.cs
+++ b/src/ImageSharp/Formats/Tiff/Constants/TiffConstants.cs
@@ -96,14 +96,19 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Constants
         public static readonly ushort[] BitsPerSample8Bit = { 8 };
 
         /// <summary>
-        /// The bits per sample for color images with 8 bits for each color channel.
+        /// The bits per sample for color images with 2 bits for each color channel.
         /// </summary>
-        public static readonly ushort[] BitsPerSampleRgb8Bit = { 8, 8, 8 };
+        public static readonly ushort[] BitsPerSampleRgb2Bit = { 2, 2, 2 };
 
         /// <summary>
         /// The bits per sample for color images with 4 bits for each color channel.
         /// </summary>
         public static readonly ushort[] BitsPerSampleRgb4Bit = { 4, 4, 4 };
+
+        /// <summary>
+        /// The bits per sample for color images with 8 bits for each color channel.
+        /// </summary>
+        public static readonly ushort[] BitsPerSampleRgb8Bit = { 8, 8, 8 };
 
         /// <summary>
         /// The list of mimetypes that equate to a tiff.

--- a/src/ImageSharp/Formats/Tiff/Constants/TiffConstants.cs
+++ b/src/ImageSharp/Formats/Tiff/Constants/TiffConstants.cs
@@ -111,6 +111,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Constants
         public static readonly ushort[] BitsPerSampleRgb8Bit = { 8, 8, 8 };
 
         /// <summary>
+        /// The bits per sample for color images with 10 bits for each color channel.
+        /// </summary>
+        public static readonly ushort[] BitsPerSampleRgb10Bit = { 10, 10, 10 };
+
+        /// <summary>
         /// The list of mimetypes that equate to a tiff.
         /// </summary>
         public static readonly IEnumerable<string> MimeTypes = new[] { "image/tiff", "image/tiff-fx" };

--- a/src/ImageSharp/Formats/Tiff/Constants/TiffConstants.cs
+++ b/src/ImageSharp/Formats/Tiff/Constants/TiffConstants.cs
@@ -96,9 +96,14 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Constants
         public static readonly ushort[] BitsPerSample8Bit = { 8 };
 
         /// <summary>
-        /// The bits per sample for images with 8 bits for each color channel.
+        /// The bits per sample for color images with 8 bits for each color channel.
         /// </summary>
         public static readonly ushort[] BitsPerSampleRgb8Bit = { 8, 8, 8 };
+
+        /// <summary>
+        /// The bits per sample for color images with 4 bits for each color channel.
+        /// </summary>
+        public static readonly ushort[] BitsPerSampleRgb4Bit = { 4, 4, 4 };
 
         /// <summary>
         /// The list of mimetypes that equate to a tiff.

--- a/src/ImageSharp/Formats/Tiff/Constants/TiffConstants.cs
+++ b/src/ImageSharp/Formats/Tiff/Constants/TiffConstants.cs
@@ -116,6 +116,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Constants
         public static readonly ushort[] BitsPerSampleRgb10Bit = { 10, 10, 10 };
 
         /// <summary>
+        /// The bits per sample for color images with 14 bits for each color channel.
+        /// </summary>
+        public static readonly ushort[] BitsPerSampleRgb14Bit = { 14, 14, 14 };
+
+        /// <summary>
         /// The list of mimetypes that equate to a tiff.
         /// </summary>
         public static readonly IEnumerable<string> MimeTypes = new[] { "image/tiff", "image/tiff-fx" };

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgb444TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgb444TiffColor{TPixel}.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
+{
+    /// <summary>
+    /// Implements the 'RGB' photometric interpretation for 4 bits per color channel images.
+    /// </summary>
+    internal class Rgb444TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        /// <inheritdoc/>
+        public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
+        {
+            var color = default(TPixel);
+
+            int offset = 0;
+
+            var bgra = default(Bgra4444);
+            for (int y = top; y < top + height; y++)
+            {
+                Span<TPixel> pixelRow = pixels.GetRowSpan(y);
+
+                for (int x = left; x < left + width; x += 2)
+                {
+                    byte r = (byte)((data[offset] & 0xF0) >> 4);
+                    byte g = (byte)(data[offset] & 0xF);
+                    offset++;
+                    byte b = (byte)((data[offset] & 0xF0) >> 4);
+
+                    bgra.PackedValue = ToBgraPackedValue(b, g, r);
+                    color.FromScaledVector4(bgra.ToScaledVector4());
+                    pixelRow[x] = color;
+                    if (x + 1 >= pixelRow.Length)
+                    {
+                        offset++;
+                        break;
+                    }
+
+                    r = (byte)(data[offset] & 0xF);
+                    offset++;
+                    g = (byte)((data[offset] & 0xF0) >> 4);
+                    b = (byte)(data[offset] & 0xF);
+                    offset++;
+
+                    bgra.PackedValue = ToBgraPackedValue(b, g, r);
+                    color.FromScaledVector4(bgra.ToScaledVector4());
+                    pixelRow[x + 1] = color;
+                }
+            }
+        }
+
+        private static ushort ToBgraPackedValue(byte b, byte g, byte r) => (ushort)(b | (g << 4) | (r << 8) | (0xF << 12));
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/RgbPlanarTiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/RgbPlanarTiffColor{TPixel}.cs
@@ -27,7 +27,6 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         private readonly ushort bitsPerSampleB;
 
         public RgbPlanarTiffColor(ushort[] bitsPerSample)
-        /* : base(bitsPerSample, null) */
         {
             this.bitsPerSampleR = bitsPerSample[0];
             this.bitsPerSampleG = bitsPerSample[1];

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
@@ -60,9 +60,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                 case TiffColorType.Rgb222:
                     DebugGuard.IsTrue(
                         bitsPerSample.Length == 3
-                        && bitsPerSample[0] == 2
+                        && bitsPerSample[2] == 2
                         && bitsPerSample[1] == 2
-                        && bitsPerSample[2] == 2,
+                        && bitsPerSample[0] == 2,
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);
@@ -70,9 +70,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                 case TiffColorType.Rgb444:
                     DebugGuard.IsTrue(
                         bitsPerSample.Length == 3
-                        && bitsPerSample[0] == 4
+                        && bitsPerSample[2] == 4
                         && bitsPerSample[1] == 4
-                        && bitsPerSample[2] == 4,
+                        && bitsPerSample[0] == 4,
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new Rgb444TiffColor<TPixel>();
@@ -80,9 +80,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                 case TiffColorType.Rgb888:
                     DebugGuard.IsTrue(
                         bitsPerSample.Length == 3
-                        && bitsPerSample[0] == 8
+                        && bitsPerSample[2] == 8
                         && bitsPerSample[1] == 8
-                        && bitsPerSample[2] == 8,
+                        && bitsPerSample[0] == 8,
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new Rgb888TiffColor<TPixel>();
@@ -90,9 +90,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                 case TiffColorType.Rgb101010:
                     DebugGuard.IsTrue(
                         bitsPerSample.Length == 3
-                        && bitsPerSample[0] == 10
+                        && bitsPerSample[2] == 10
                         && bitsPerSample[1] == 10
-                        && bitsPerSample[2] == 10,
+                        && bitsPerSample[0] == 10,
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);
@@ -100,9 +100,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                 case TiffColorType.Rgb141414:
                     DebugGuard.IsTrue(
                         bitsPerSample.Length == 3
-                        && bitsPerSample[0] == 14
+                        && bitsPerSample[2] == 14
                         && bitsPerSample[1] == 14
-                        && bitsPerSample[2] == 14,
+                        && bitsPerSample[0] == 14,
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
@@ -97,6 +97,16 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);
 
+                case TiffColorType.Rgb141414:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Length == 3
+                        && bitsPerSample[0] == 14
+                        && bitsPerSample[1] == 14
+                        && bitsPerSample[2] == 14,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbTiffColor<TPixel>(bitsPerSample);
+
                 case TiffColorType.PaletteColor:
                     DebugGuard.NotNull(bitsPerSample, "bitsPerSample");
                     DebugGuard.NotNull(colorMap, "colorMap");

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
@@ -57,6 +57,16 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);
 
+                case TiffColorType.Rgb444:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Length == 3
+                        && bitsPerSample[0] == 4
+                        && bitsPerSample[1] == 4
+                        && bitsPerSample[2] == 4,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new Rgb444TiffColor<TPixel>();
+
                 case TiffColorType.Rgb888:
                     DebugGuard.IsTrue(
                         bitsPerSample.Length == 3

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
@@ -87,6 +87,16 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new Rgb888TiffColor<TPixel>();
 
+                case TiffColorType.Rgb101010:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Length == 3
+                        && bitsPerSample[0] == 10
+                        && bitsPerSample[1] == 10
+                        && bitsPerSample[2] == 10,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbTiffColor<TPixel>(bitsPerSample);
+
                 case TiffColorType.PaletteColor:
                     DebugGuard.NotNull(bitsPerSample, "bitsPerSample");
                     DebugGuard.NotNull(colorMap, "colorMap");

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
@@ -57,6 +57,16 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);
 
+                case TiffColorType.Rgb222:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Length == 3
+                        && bitsPerSample[0] == 2
+                        && bitsPerSample[1] == 2
+                        && bitsPerSample[2] == 2,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbTiffColor<TPixel>(bitsPerSample);
+
                 case TiffColorType.Rgb444:
                     DebugGuard.IsTrue(
                         bitsPerSample.Length == 3

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
@@ -64,6 +64,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         Rgb888,
 
         /// <summary>
+        /// RGB color image with 4 bits for each channel.
+        /// </summary>
+        Rgb444,
+
+        /// <summary>
         /// RGB Full Color. Planar configuration of data.
         /// </summary>
         RgbPlanar,

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
@@ -74,6 +74,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         Rgb888,
 
         /// <summary>
+        /// RGB color image with 10 bits for each channel.
+        /// </summary>
+        Rgb101010,
+
+        /// <summary>
         /// RGB Full Color. Planar configuration of data.
         /// </summary>
         RgbPlanar,

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
@@ -79,6 +79,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         Rgb101010,
 
         /// <summary>
+        /// RGB color image with 14 bits for each channel.
+        /// </summary>
+        Rgb141414,
+
+        /// <summary>
         /// RGB Full Color. Planar configuration of data.
         /// </summary>
         RgbPlanar,

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
@@ -59,14 +59,19 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         Rgb,
 
         /// <summary>
-        /// RGB Full Color. Optimized implementation for 8-bit images.
+        /// RGB color image with 2 bits for each channel.
         /// </summary>
-        Rgb888,
+        Rgb222,
 
         /// <summary>
         /// RGB color image with 4 bits for each channel.
         /// </summary>
         Rgb444,
+
+        /// <summary>
+        /// RGB Full Color. Optimized implementation for 8-bit images.
+        /// </summary>
+        Rgb888,
 
         /// <summary>
         /// RGB Full Color. Planar configuration of data.

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
@@ -19,6 +19,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         Bit4 = 4,
 
         /// <summary>
+        /// 6 bits per pixel. 2 bit for each color channel.
+        ///
+        /// Note: The TiffEncoder does not yet support 2 bits per color channel and will default to 24 bits per pixel instead.
+        /// </summary>
+        Bit6 = 6,
+
+        /// <summary>
         /// 8 bits per pixel, grayscale or color palette images.
         /// </summary>
         Bit8 = 8,
@@ -26,7 +33,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         /// <summary>
         /// 12 bits per pixel. 4 bit for each color channel.
         ///
-        /// Note: The TiffEncoder does not yet support 4 bits per color channel and will default to 24 bits per pixel.
+        /// Note: The TiffEncoder does not yet support 4 bits per color channel and will default to 24 bits per pixel instead.
         /// </summary>
         Bit12 = 12,
 

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
@@ -48,5 +48,12 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         /// Note: The TiffEncoder does not yet support 10 bits per color channel and will default to 24 bits per pixel instead.
         /// </summary>
         Bit30 = 30,
+
+        /// <summary>
+        /// 42 bits per pixel. 14 bit for each color channel.
+        ///
+        /// Note: The TiffEncoder does not yet support 14 bits per color channel and will default to 24 bits per pixel instead.
+        /// </summary>
+        Bit42 = 42,
     }
 }

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         Bit8 = 8,
 
         /// <summary>
-        /// 14 bits per pixel. 4 bit for each color channel.
+        /// 12 bits per pixel. 4 bit for each color channel.
         ///
         /// Note: The TiffEncoder does not yet support 4 bits per color channel and will default to 24 bits per pixel.
         /// </summary>

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
@@ -41,5 +41,12 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         /// 24 bits per pixel. One byte for each color channel.
         /// </summary>
         Bit24 = 24,
+
+        /// <summary>
+        /// 30 bits per pixel. 10 bit for each color channel.
+        ///
+        /// Note: The TiffEncoder does not yet support 10 bits per color channel and will default to 24 bits per pixel instead.
+        /// </summary>
+        Bit30 = 30,
     }
 }

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerPixel.cs
@@ -24,6 +24,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         Bit8 = 8,
 
         /// <summary>
+        /// 14 bits per pixel. 4 bit for each color channel.
+        ///
+        /// Note: The TiffEncoder does not yet support 4 bits per color channel and will default to 24 bits per pixel.
+        /// </summary>
+        Bit12 = 12,
+
+        /// <summary>
         /// 24 bits per pixel. One byte for each color channel.
         /// </summary>
         Bit24 = 24,

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
@@ -42,5 +42,10 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         /// 24 bits per sample, each color channel has 8 Bits.
         /// </summary>
         Bit24 = 24,
+
+        /// <summary>
+        /// Thirty bits per sample, each channel has 10 bits.
+        /// </summary>
+        Bit30 = 30,
     }
 }

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
@@ -47,5 +47,10 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         /// Thirty bits per sample, each channel has 10 bits.
         /// </summary>
         Bit30 = 30,
+
+        /// <summary>
+        /// Forty two bits per sample, each channel has 14 bits.
+        /// </summary>
+        Bit42 = 42,
     }
 }

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
@@ -29,6 +29,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         Bit8 = 8,
 
         /// <summary>
+        /// Twelve bits per sample, each channel has 4 bits.
+        /// </summary>
+        Bit12 = 12,
+
+        /// <summary>
         /// 24 bits per sample, each color channel has 8 Bits.
         /// </summary>
         Bit24 = 24,

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
@@ -29,6 +29,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         Bit8 = 8,
 
         /// <summary>
+        /// Six bits per sample, each channel has 2 bits.
+        /// </summary>
+        Bit6 = 6,
+
+        /// <summary>
         /// Twelve bits per sample, each channel has 4 bits.
         /// </summary>
         Bit12 = 12,

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
@@ -23,6 +23,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     return TiffConstants.BitsPerSample4Bit;
                 case TiffBitsPerSample.Bit8:
                     return TiffConstants.BitsPerSample8Bit;
+                case TiffBitsPerSample.Bit12:
+                    return TiffConstants.BitsPerSampleRgb4Bit;
                 case TiffBitsPerSample.Bit24:
                     return TiffConstants.BitsPerSampleRgb8Bit;
 
@@ -46,6 +48,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                         bitsPerSample[2] == TiffConstants.BitsPerSampleRgb8Bit[2])
                     {
                         return TiffBitsPerSample.Bit24;
+                    }
+
+                    if (bitsPerSample[0] == TiffConstants.BitsPerSampleRgb4Bit[0] &&
+                        bitsPerSample[1] == TiffConstants.BitsPerSampleRgb4Bit[1] &&
+                        bitsPerSample[2] == TiffConstants.BitsPerSampleRgb4Bit[2])
+                    {
+                        return TiffBitsPerSample.Bit12;
                     }
 
                     break;

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
@@ -50,9 +50,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                         return TiffBitsPerSample.Bit24;
                     }
 
-                    if (bitsPerSample[0] == TiffConstants.BitsPerSampleRgb4Bit[0] &&
+                    if (bitsPerSample[2] == TiffConstants.BitsPerSampleRgb4Bit[2] &&
                         bitsPerSample[1] == TiffConstants.BitsPerSampleRgb4Bit[1] &&
-                        bitsPerSample[2] == TiffConstants.BitsPerSampleRgb4Bit[2])
+                        bitsPerSample[0] == TiffConstants.BitsPerSampleRgb4Bit[0])
                     {
                         return TiffBitsPerSample.Bit12;
                     }

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
@@ -43,9 +43,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             switch (bitsPerSample.Length)
             {
                 case 3:
-                    if (bitsPerSample[0] == TiffConstants.BitsPerSampleRgb8Bit[0] &&
+                    if (bitsPerSample[2] == TiffConstants.BitsPerSampleRgb8Bit[2] &&
                         bitsPerSample[1] == TiffConstants.BitsPerSampleRgb8Bit[1] &&
-                        bitsPerSample[2] == TiffConstants.BitsPerSampleRgb8Bit[2])
+                        bitsPerSample[0] == TiffConstants.BitsPerSampleRgb8Bit[0])
                     {
                         return TiffBitsPerSample.Bit24;
                     }

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
@@ -31,6 +31,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     return TiffConstants.BitsPerSampleRgb8Bit;
                 case TiffBitsPerSample.Bit30:
                     return TiffConstants.BitsPerSampleRgb10Bit;
+                case TiffBitsPerSample.Bit42:
+                    return TiffConstants.BitsPerSampleRgb14Bit;
 
                 default:
                     return Array.Empty<ushort>();
@@ -47,6 +49,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             switch (bitsPerSample.Length)
             {
                 case 3:
+                    if (bitsPerSample[2] == TiffConstants.BitsPerSampleRgb14Bit[2] &&
+                        bitsPerSample[1] == TiffConstants.BitsPerSampleRgb14Bit[1] &&
+                        bitsPerSample[0] == TiffConstants.BitsPerSampleRgb14Bit[0])
+                    {
+                        return TiffBitsPerSample.Bit42;
+                    }
+
                     if (bitsPerSample[2] == TiffConstants.BitsPerSampleRgb10Bit[2] &&
                         bitsPerSample[1] == TiffConstants.BitsPerSampleRgb10Bit[1] &&
                         bitsPerSample[0] == TiffConstants.BitsPerSampleRgb10Bit[0])

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
@@ -21,6 +21,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     return TiffConstants.BitsPerSample1Bit;
                 case TiffBitsPerSample.Bit4:
                     return TiffConstants.BitsPerSample4Bit;
+                case TiffBitsPerSample.Bit6:
+                    return TiffConstants.BitsPerSampleRgb2Bit;
                 case TiffBitsPerSample.Bit8:
                     return TiffConstants.BitsPerSample8Bit;
                 case TiffBitsPerSample.Bit12:
@@ -55,6 +57,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                         bitsPerSample[0] == TiffConstants.BitsPerSampleRgb4Bit[0])
                     {
                         return TiffBitsPerSample.Bit12;
+                    }
+
+                    if (bitsPerSample[2] == TiffConstants.BitsPerSampleRgb2Bit[2] &&
+                        bitsPerSample[1] == TiffConstants.BitsPerSampleRgb2Bit[1] &&
+                        bitsPerSample[0] == TiffConstants.BitsPerSampleRgb2Bit[0])
+                    {
+                        return TiffBitsPerSample.Bit6;
                     }
 
                     break;

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSampleExtensions.cs
@@ -29,6 +29,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     return TiffConstants.BitsPerSampleRgb4Bit;
                 case TiffBitsPerSample.Bit24:
                     return TiffConstants.BitsPerSampleRgb8Bit;
+                case TiffBitsPerSample.Bit30:
+                    return TiffConstants.BitsPerSampleRgb10Bit;
 
                 default:
                     return Array.Empty<ushort>();
@@ -45,6 +47,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             switch (bitsPerSample.Length)
             {
                 case 3:
+                    if (bitsPerSample[2] == TiffConstants.BitsPerSampleRgb10Bit[2] &&
+                        bitsPerSample[1] == TiffConstants.BitsPerSampleRgb10Bit[1] &&
+                        bitsPerSample[0] == TiffConstants.BitsPerSampleRgb10Bit[0])
+                    {
+                        return TiffBitsPerSample.Bit30;
+                    }
+
                     if (bitsPerSample[2] == TiffConstants.BitsPerSampleRgb8Bit[2] &&
                         bitsPerSample[1] == TiffConstants.BitsPerSampleRgb8Bit[1] &&
                         bitsPerSample[0] == TiffConstants.BitsPerSampleRgb8Bit[0])

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -294,7 +294,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                 int top = rowsPerStrip * stripIndex;
                 if (top + stripHeight > frame.Height)
                 {
-                    // Make sure we ignore any strips that are not needed for the image (if too many are present)
+                    // Make sure we ignore any strips that are not needed for the image (if too many are present).
                     break;
                 }
 

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
@@ -189,7 +189,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                                 options.ColorType = TiffColorType.Rgb444;
                                 break;
                             default:
-                                TiffThrowHelper.ThrowNotSupported("Bits per sample is nut supported.");
+                                TiffThrowHelper.ThrowNotSupported("Bits per sample is not supported.");
                                 break;
                         }
                     }

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
@@ -182,6 +182,10 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     {
                         switch (options.BitsPerSample)
                         {
+                            case TiffBitsPerSample.Bit42:
+                                options.ColorType = TiffColorType.Rgb141414;
+                                break;
+
                             case TiffBitsPerSample.Bit30:
                                 options.ColorType = TiffColorType.Rgb101010;
                                 break;
@@ -297,6 +301,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             TiffBitsPerPixel.Bit12 => TiffBitsPerSample.Bit12,
             TiffBitsPerPixel.Bit24 => TiffBitsPerSample.Bit24,
             TiffBitsPerPixel.Bit30 => TiffBitsPerSample.Bit30,
+            TiffBitsPerPixel.Bit42 => TiffBitsPerSample.Bit42,
             _ => throw new NotSupportedException("The bits per pixel are not supported"),
         };
     }

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Linq;
 using SixLabors.ImageSharp.Formats.Tiff.Compression;
 using SixLabors.ImageSharp.Formats.Tiff.Constants;
@@ -179,7 +180,18 @@ namespace SixLabors.ImageSharp.Formats.Tiff
 
                     if (options.PlanarConfiguration == TiffPlanarConfiguration.Chunky)
                     {
-                        options.ColorType = options.BitsPerSample == TiffBitsPerSample.Bit24 ? TiffColorType.Rgb888 : TiffColorType.Rgb;
+                        switch (options.BitsPerSample)
+                        {
+                            case TiffBitsPerSample.Bit24:
+                                options.ColorType = TiffColorType.Rgb888;
+                                break;
+                            case TiffBitsPerSample.Bit12:
+                                options.ColorType = TiffColorType.Rgb444;
+                                break;
+                            default:
+                                TiffThrowHelper.ThrowNotSupported("Bits per sample is nut supported.");
+                                break;
+                        }
                     }
                     else
                     {
@@ -274,8 +286,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             TiffBitsPerPixel.Bit1 => TiffBitsPerSample.Bit1,
             TiffBitsPerPixel.Bit4 => TiffBitsPerSample.Bit4,
             TiffBitsPerPixel.Bit8 => TiffBitsPerSample.Bit8,
+            TiffBitsPerPixel.Bit12 => TiffBitsPerSample.Bit12,
             TiffBitsPerPixel.Bit24 => TiffBitsPerSample.Bit24,
-            _ => TiffBitsPerSample.Bit24,
+            _ => throw new NotSupportedException("The bits per pixel are not supported"),
         };
     }
 }

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
@@ -188,6 +188,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                             case TiffBitsPerSample.Bit12:
                                 options.ColorType = TiffColorType.Rgb444;
                                 break;
+                            case TiffBitsPerSample.Bit6:
+                                options.ColorType = TiffColorType.Rgb222;
+                                break;
                             default:
                                 TiffThrowHelper.ThrowNotSupported("Bits per sample is not supported.");
                                 break;
@@ -285,6 +288,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         {
             TiffBitsPerPixel.Bit1 => TiffBitsPerSample.Bit1,
             TiffBitsPerPixel.Bit4 => TiffBitsPerSample.Bit4,
+            TiffBitsPerPixel.Bit6 => TiffBitsPerSample.Bit6,
             TiffBitsPerPixel.Bit8 => TiffBitsPerSample.Bit8,
             TiffBitsPerPixel.Bit12 => TiffBitsPerSample.Bit12,
             TiffBitsPerPixel.Bit24 => TiffBitsPerSample.Bit24,

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
@@ -182,6 +182,10 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     {
                         switch (options.BitsPerSample)
                         {
+                            case TiffBitsPerSample.Bit30:
+                                options.ColorType = TiffColorType.Rgb101010;
+                                break;
+
                             case TiffBitsPerSample.Bit24:
                                 options.ColorType = TiffColorType.Rgb888;
                                 break;
@@ -292,6 +296,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             TiffBitsPerPixel.Bit8 => TiffBitsPerSample.Bit8,
             TiffBitsPerPixel.Bit12 => TiffBitsPerSample.Bit12,
             TiffBitsPerPixel.Bit24 => TiffBitsPerSample.Bit24,
+            TiffBitsPerPixel.Bit30 => TiffBitsPerSample.Bit30,
             _ => throw new NotSupportedException("The bits per pixel are not supported"),
         };
     }

--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -306,7 +306,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     case TiffBitsPerPixel.Bit1:
                         if (compression == TiffCompression.Ccitt1D || compression == TiffCompression.CcittGroup3Fax || compression == TiffCompression.CcittGroup4Fax)
                         {
-                            // The ìnormalî PhotometricInterpretation for bilevel CCITT compressed data is WhiteIsZero.
+                            // The ‚Äúnormal‚Äù PhotometricInterpretation for bilevel CCITT compressed data is WhiteIsZero.
                             this.SetEncoderOptions(bitsPerPixel, TiffPhotometricInterpretation.WhiteIsZero, compression, TiffPredictor.None);
                             break;
                         }
@@ -318,6 +318,10 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                         break;
                     case TiffBitsPerPixel.Bit8:
                         this.SetEncoderOptions(bitsPerPixel, photometricInterpretation ?? TiffPhotometricInterpretation.BlackIsZero, compression, predictor);
+                        break;
+                    case TiffBitsPerPixel.Bit12:
+                        // Encoding 12 bits per pixel is not yet supported. Default to 24 bits.
+                        this.SetEncoderOptions(TiffBitsPerPixel.Bit24, TiffPhotometricInterpretation.Rgb, compression, TiffPredictor.None);
                         break;
                     default:
                         this.SetEncoderOptions(bitsPerPixel, TiffPhotometricInterpretation.Rgb, compression, predictor);

--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -321,7 +321,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                         break;
                     case TiffBitsPerPixel.Bit6:
                     case TiffBitsPerPixel.Bit12:
-                        // Encoding 12 and 6 bits per pixel is not yet supported. Default to 24 bits.
+                    case TiffBitsPerPixel.Bit30:
+                        // Encoding 30, 12 and 6 bits per pixel is not yet supported. Default to 24 bits.
                         this.SetEncoderOptions(TiffBitsPerPixel.Bit24, TiffPhotometricInterpretation.Rgb, compression, TiffPredictor.None);
                         break;
                     default:

--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -319,8 +319,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     case TiffBitsPerPixel.Bit8:
                         this.SetEncoderOptions(bitsPerPixel, photometricInterpretation ?? TiffPhotometricInterpretation.BlackIsZero, compression, predictor);
                         break;
+                    case TiffBitsPerPixel.Bit6:
                     case TiffBitsPerPixel.Bit12:
-                        // Encoding 12 bits per pixel is not yet supported. Default to 24 bits.
+                        // Encoding 12 and 6 bits per pixel is not yet supported. Default to 24 bits.
                         this.SetEncoderOptions(TiffBitsPerPixel.Bit24, TiffPhotometricInterpretation.Rgb, compression, TiffPredictor.None);
                         break;
                     default:

--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -322,7 +322,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     case TiffBitsPerPixel.Bit6:
                     case TiffBitsPerPixel.Bit12:
                     case TiffBitsPerPixel.Bit30:
-                        // Encoding 30, 12 and 6 bits per pixel is not yet supported. Default to 24 bits.
+                    case TiffBitsPerPixel.Bit42:
+                        // Encoding 42, 30, 12 and 6 bits per pixel is not yet supported. Default to 24 bits.
                         this.SetEncoderOptions(TiffBitsPerPixel.Bit24, TiffPhotometricInterpretation.Rgb, compression, TiffPredictor.None);
                         break;
                     default:

--- a/src/ImageSharp/Formats/Tiff/TiffEncoderEntriesCollector.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderEntriesCollector.cs
@@ -66,8 +66,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     Value = SoftwareValue
                 };
 
-                this.collector.Add(width);
-                this.collector.Add(height);
+                this.collector.AddOrReplace(width);
+                this.collector.AddOrReplace(height);
 
                 this.ProcessResolution(image.Metadata, rootFrameExifProfile);
                 this.ProcessProfiles(image.Metadata, rootFrameExifProfile, rootFrameXmpBytes);
@@ -227,7 +227,6 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     exifProfile.RemoveValue(ExifTag.IccProfile);
                 }
 
-                TiffMetadata tiffMetadata = imageMetadata.GetTiffMetadata();
                 if (xmpProfile != null)
                 {
                     var xmp = new ExifByteArray(ExifTagValue.XMP, ExifDataType.Byte)
@@ -252,6 +251,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff
 
             public void Process(TiffEncoderCore encoder)
             {
+                var planarConfig = new ExifShort(ExifTagValue.PlanarConfiguration)
+                {
+                    Value = (ushort)TiffPlanarConfiguration.Chunky
+                };
+
                 var samplesPerPixel = new ExifLong(ExifTagValue.SamplesPerPixel)
                 {
                     Value = GetSamplesPerPixel(encoder)
@@ -274,6 +278,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     Value = (ushort)encoder.PhotometricInterpretation
                 };
 
+                this.collector.AddOrReplace(planarConfig);
                 this.collector.AddOrReplace(samplesPerPixel);
                 this.collector.AddOrReplace(bitPerSample);
                 this.collector.AddOrReplace(compression);

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -97,25 +97,13 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [WithFile(Flower4BitPalette, PixelTypes.Rgba32)]
         [WithFile(Flower4BitPaletteGray, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_4Bit_WithPalette<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : unmanaged, IPixel<TPixel>
-        {
-            if (TestEnvironment.IsWindows)
-            {
-                TestTiffDecoder(provider, new SystemDrawingReferenceDecoder(), useExactComparer: false, 0.01f);
-            }
-        }
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, ReferenceDecoder, useExactComparer: false, 0.01f);
 
         [Theory]
         [WithFile(FlowerRgb444Contiguous, PixelTypes.Rgba32)]
         [WithFile(FlowerRgb444Planar, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_12Bit<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : unmanaged, IPixel<TPixel>
-        {
-            if (TestEnvironment.IsWindows)
-            {
-                TestTiffDecoder(provider, new SystemDrawingReferenceDecoder());
-            }
-        }
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
         [WithFile(GrayscaleDeflateMultistrip, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -118,6 +118,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
+        [WithFile(FlowerRgb141414Contiguous, PixelTypes.Rgba32)]
+        [WithFile(FlowerRgb141414Planar, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_42Bit<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
         [WithFile(GrayscaleDeflateMultistrip, PixelTypes.Rgba32)]
         [WithFile(RgbDeflateMultistrip, PixelTypes.Rgba32)]
         [WithFile(Calliphora_GrayscaleDeflate, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -112,6 +112,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
+        [WithFile(FlowerRgb101010Contiguous, PixelTypes.Rgba32)]
+        [WithFile(FlowerRgb101010Planar, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_30Bit<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
         [WithFile(GrayscaleDeflateMultistrip, PixelTypes.Rgba32)]
         [WithFile(RgbDeflateMultistrip, PixelTypes.Rgba32)]
         [WithFile(Calliphora_GrayscaleDeflate, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -106,6 +106,18 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         }
 
         [Theory]
+        [WithFile(FlowerRgb444Contiguous, PixelTypes.Rgba32)]
+        [WithFile(FlowerRgb444Planar, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_12Bit<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            if (TestEnvironment.IsWindows)
+            {
+                TestTiffDecoder(provider, new SystemDrawingReferenceDecoder());
+            }
+        }
+
+        [Theory]
         [WithFile(GrayscaleDeflateMultistrip, PixelTypes.Rgba32)]
         [WithFile(RgbDeflateMultistrip, PixelTypes.Rgba32)]
         [WithFile(Calliphora_GrayscaleDeflate, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -100,6 +100,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, ReferenceDecoder, useExactComparer: false, 0.01f);
 
         [Theory]
+        [WithFile(FlowerRgb222Contiguous, PixelTypes.Rgba32)]
+        [WithFile(FlowerRgb222Planar, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_6Bit<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
         [WithFile(FlowerRgb444Contiguous, PixelTypes.Rgba32)]
         [WithFile(FlowerRgb444Planar, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_12Bit<TPixel>(TestImageProvider<TPixel> provider)

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -248,6 +248,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             Assert.Equal(expectedCompression, frameMetaData.Compression);
         }
 
+        // This makes sure, that when decoding a planar tiff, the planar configuration is not carried over to the encoded image.
+        [Theory]
+        [WithFile(FlowerRgb444Planar, PixelTypes.Rgba32)]
+        public void TiffEncoder_EncodePlanar_AndReload_Works<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit24, TiffPhotometricInterpretation.Rgb, imageDecoder: new TiffDecoder());
+
         [Theory]
         [WithFile(Calliphora_RgbUncompressed, PixelTypes.Rgba32)]
         public void TiffEncoder_EncodeRgb_Works<TPixel>(TestImageProvider<TPixel> provider)

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -79,6 +79,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
 
         [Theory]
         [InlineData(TiffBitsPerPixel.Bit12)]
+        [InlineData(TiffBitsPerPixel.Bit6)]
         public void EncoderOptions_UnsupportedBitPerPixel_DefaultTo24Bits(TiffBitsPerPixel bitsPerPixel)
         {
             // arrange

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -78,6 +78,26 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         }
 
         [Theory]
+        [InlineData(TiffBitsPerPixel.Bit12)]
+        public void EncoderOptions_UnsupportedBitPerPixel_DefaultTo24Bits(TiffBitsPerPixel bitsPerPixel)
+        {
+            // arrange
+            var tiffEncoder = new TiffEncoder { BitsPerPixel = bitsPerPixel };
+            using Image input = new Image<Rgb24>(10, 10);
+            using var memStream = new MemoryStream();
+
+            // act
+            input.Save(memStream, tiffEncoder);
+
+            // assert
+            memStream.Position = 0;
+            using var output = Image.Load<Rgba32>(memStream);
+
+            TiffFrameMetadata frameMetaData = output.Frames.RootFrame.Metadata.GetTiffMetadata();
+            Assert.Equal(TiffBitsPerPixel.Bit24, frameMetaData.BitsPerPixel);
+        }
+
+        [Theory]
         [InlineData(null, TiffCompression.Deflate, TiffBitsPerPixel.Bit24, TiffCompression.Deflate)]
         [InlineData(TiffPhotometricInterpretation.Rgb, TiffCompression.Deflate, TiffBitsPerPixel.Bit24, TiffCompression.Deflate)]
         [InlineData(TiffPhotometricInterpretation.BlackIsZero, TiffCompression.Deflate, TiffBitsPerPixel.Bit8, TiffCompression.Deflate)]
@@ -300,8 +320,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [WithFile(Flower4BitPaletteGray, PixelTypes.Rgba32)]
         public void TiffEncoder_EncodeColorPalette_With4Bit_Works<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> =>
-            //// Note: The magick reference decoder does not support 4 bit tiff's, so we use our TIFF decoder instead.
-            TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit4, TiffPhotometricInterpretation.PaletteColor, useExactComparer: false, compareTolerance: 0.003f, imageDecoder: new TiffDecoder());
+            TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit4, TiffPhotometricInterpretation.PaletteColor, useExactComparer: false, compareTolerance: 0.003f);
 
         [Theory]
         [WithFile(Calliphora_PaletteUncompressed, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -78,6 +78,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         }
 
         [Theory]
+        [InlineData(TiffBitsPerPixel.Bit30)]
         [InlineData(TiffBitsPerPixel.Bit12)]
         [InlineData(TiffBitsPerPixel.Bit6)]
         public void EncoderOptions_UnsupportedBitPerPixel_DefaultTo24Bits(TiffBitsPerPixel bitsPerPixel)

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -78,6 +78,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         }
 
         [Theory]
+        [InlineData(TiffBitsPerPixel.Bit42)]
         [InlineData(TiffBitsPerPixel.Bit30)]
         [InlineData(TiffBitsPerPixel.Bit12)]
         [InlineData(TiffBitsPerPixel.Bit6)]

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
@@ -288,10 +288,13 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             Assert.Equal("This is Изготовитель камеры", exifProfileInput.GetValue(ExifTag.Make).Value);
             Assert.Equal("This is Авторские права", exifProfileInput.GetValue(ExifTag.Copyright).Value);
 
-            Assert.Equal(exifProfileInput.Values.Count, encodedImageExifProfile.Values.Count);
             Assert.Equal(exifProfileInput.GetValue(ExifTag.ImageDescription).Value, encodedImageExifProfile.GetValue(ExifTag.ImageDescription).Value);
             Assert.Equal(exifProfileInput.GetValue(ExifTag.Make).Value, encodedImageExifProfile.GetValue(ExifTag.Make).Value);
             Assert.Equal(exifProfileInput.GetValue(ExifTag.Copyright).Value, encodedImageExifProfile.GetValue(ExifTag.Copyright).Value);
+
+            // Note that the encoded profile has PlanarConfiguration explicitly set, which is missing in the original image profile.
+            Assert.Equal((ushort)TiffPlanarConfiguration.Chunky, encodedImageExifProfile.GetValue(ExifTag.PlanarConfiguration).Value);
+            Assert.Equal(exifProfileInput.Values.Count + 1, encodedImageExifProfile.Values.Count);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
@@ -293,7 +293,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             Assert.Equal(exifProfileInput.GetValue(ExifTag.Copyright).Value, encodedImageExifProfile.GetValue(ExifTag.Copyright).Value);
 
             // Note that the encoded profile has PlanarConfiguration explicitly set, which is missing in the original image profile.
-            Assert.Equal((ushort)TiffPlanarConfiguration.Chunky, encodedImageExifProfile.GetValue(ExifTag.PlanarConfiguration).Value);
+            Assert.Equal((ushort)TiffPlanarConfiguration.Chunky, encodedImageExifProfile.GetValue(ExifTag.PlanarConfiguration)?.Value);
             Assert.Equal(exifProfileInput.Values.Count + 1, encodedImageExifProfile.Values.Count);
         }
     }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -562,6 +562,8 @@ namespace SixLabors.ImageSharp.Tests
             public const string Flower4BitPaletteGray = "Tiff/flower-minisblack-04.tiff";
             public const string FlowerRgb444Contiguous = "Tiff/flower-rgb-contig-04.tiff";
             public const string FlowerRgb444Planar = "Tiff/flower-rgb-planar-04.tiff";
+            public const string FlowerRgb222Contiguous = "Tiff/flower-rgb-contig-02.tiff";
+            public const string FlowerRgb222Planar = "Tiff/flower-rgb-planar-02.tiff";
 
             public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
             public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -560,6 +560,8 @@ namespace SixLabors.ImageSharp.Tests
             public const string RgbPaletteDeflate = "Tiff/rgb_palette_deflate.tiff";
             public const string Flower4BitPalette = "Tiff/flower-palette-04.tiff";
             public const string Flower4BitPaletteGray = "Tiff/flower-minisblack-04.tiff";
+            public const string FlowerRgb101010Contiguous = "Tiff/flower-rgb-contig-10.tiff";
+            public const string FlowerRgb101010Planar = "Tiff/flower-rgb-planar-10.tiff";
             public const string FlowerRgb444Contiguous = "Tiff/flower-rgb-contig-04.tiff";
             public const string FlowerRgb444Planar = "Tiff/flower-rgb-planar-04.tiff";
             public const string FlowerRgb222Contiguous = "Tiff/flower-rgb-contig-02.tiff";

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -560,6 +560,8 @@ namespace SixLabors.ImageSharp.Tests
             public const string RgbPaletteDeflate = "Tiff/rgb_palette_deflate.tiff";
             public const string Flower4BitPalette = "Tiff/flower-palette-04.tiff";
             public const string Flower4BitPaletteGray = "Tiff/flower-minisblack-04.tiff";
+            public const string FlowerRgb141414Contiguous = "Tiff/flower-rgb-contig-14.tiff";
+            public const string FlowerRgb141414Planar = "Tiff/flower-rgb-planar-14.tiff";
             public const string FlowerRgb101010Contiguous = "Tiff/flower-rgb-contig-10.tiff";
             public const string FlowerRgb101010Planar = "Tiff/flower-rgb-planar-10.tiff";
             public const string FlowerRgb444Contiguous = "Tiff/flower-rgb-contig-04.tiff";

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -560,6 +560,8 @@ namespace SixLabors.ImageSharp.Tests
             public const string RgbPaletteDeflate = "Tiff/rgb_palette_deflate.tiff";
             public const string Flower4BitPalette = "Tiff/flower-palette-04.tiff";
             public const string Flower4BitPaletteGray = "Tiff/flower-minisblack-04.tiff";
+            public const string FlowerRgb444Contiguous = "Tiff/flower-rgb-contig-04.tiff";
+            public const string FlowerRgb444Planar = "Tiff/flower-rgb-planar-04.tiff";
 
             public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
             public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -87,7 +87,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
                 MemoryGroup<TPixel> framePixels = frame.PixelBuffer.FastMemoryGroup;
 
                 using IUnsafePixelCollection<ushort> pixels = magicFrame.GetPixelsUnsafe();
-                if (magicFrame.Depth == 8 || magicFrame.Depth == 1)
+                if (magicFrame.Depth == 8 || magicFrame.Depth == 4 || magicFrame.Depth == 2 || magicFrame.Depth == 1)
                 {
                     byte[] data = pixels.ToByteArray(PixelMapping.RGBA);
 

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -25,10 +25,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         {
         }
 
-        public MagickReferenceDecoder(bool validate)
-        {
-            this.validate = validate;
-        }
+        public MagickReferenceDecoder(bool validate) => this.validate = validate;
 
         public static MagickReferenceDecoder Instance { get; } = new MagickReferenceDecoder();
 
@@ -93,7 +90,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
 
                     FromRgba32Bytes(configuration, data, framePixels);
                 }
-                else if (magicFrame.Depth == 16)
+                else if (magicFrame.Depth == 16 || magicFrame.Depth == 14)
                 {
                     ushort[] data = pixels.ToShortArray(PixelMapping.RGBA);
                     Span<byte> bytes = MemoryMarshal.Cast<ushort, byte>(data.AsSpan());

--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -87,7 +87,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
                 MemoryGroup<TPixel> framePixels = frame.PixelBuffer.FastMemoryGroup;
 
                 using IUnsafePixelCollection<ushort> pixels = magicFrame.GetPixelsUnsafe();
-                if (magicFrame.Depth == 8 || magicFrame.Depth == 4 || magicFrame.Depth == 2 || magicFrame.Depth == 1)
+                if (magicFrame.Depth == 8 || magicFrame.Depth == 4 || magicFrame.Depth == 2 || magicFrame.Depth == 1 || magicFrame.Depth == 10)
                 {
                     byte[] data = pixels.ToByteArray(PixelMapping.RGBA);
 

--- a/tests/Images/Input/Tiff/flower-rgb-contig-02.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-contig-02.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbcd225c0db343f0cc984c35609b81f6413ebc1ba2ce2494d3607db375e969ff
+size 2685

--- a/tests/Images/Input/Tiff/flower-rgb-contig-04.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-contig-04.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96c4c1dfc23a0d9e5c6189717647fa117b08aac9a40c63e3945d3e674df4c3c6
+size 5049

--- a/tests/Images/Input/Tiff/flower-rgb-contig-10.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-contig-10.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68168ea1c2e50e674a7c5c41e5b055c881adf8cb940d0fd033a927a7ebdd7b6f
+size 12117

--- a/tests/Images/Input/Tiff/flower-rgb-contig-14.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-contig-14.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a419a8e2f89321501ca8ad70d2a19d37a7bf3a8c2f45c809acc30be59139ae29
+size 16855

--- a/tests/Images/Input/Tiff/flower-rgb-planar-02.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-planar-02.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21c4ede6382d8c72cb8e6f7939203d5111b362646a9727d95a2f63310ec8e5b3
+size 2795

--- a/tests/Images/Input/Tiff/flower-rgb-planar-04.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-planar-04.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca4434aa1a8c52654b20596c7c428c9016e089de75c29dc6ddcd32708874005c
+size 5117

--- a/tests/Images/Input/Tiff/flower-rgb-planar-10.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-planar-10.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f53948d4a36c80f45d70a315d2e76514ec41cabe982c06dbbd0d47e671120e2
+size 12211

--- a/tests/Images/Input/Tiff/flower-rgb-planar-14.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-planar-14.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d28f021d40f53a011053f9644400fee2d29c02f97b4101fec899251125dbb18e
+size 16855


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This **PR** adds support for decoding:
- 12 bit (4 bits per channel, RGB chunky) TIFF images.
- 6 bit (2 bits per channel, RGB chunky) TIFF images.
- 30 bit (10 bits per channel, RGB chunky) TIFF images.
- 42 bit (14 bits per channel, RGB chunky) TIFF images.

/cc @IldarKhayrutdinov 