### PR TITLE
Use GreatestCommonDivisor to prevent overflow

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
@@ -130,9 +130,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             int radius = (int)TolerantMath.Ceiling(scale * sampler.Radius);
 
             // 'ratio' is a rational number.
-            // Multiplying it by LCM(sourceSize, destSize)/sourceSize will result in a whole number "again".
+            // Multiplying it by destSize/GCD(sourceSize, destSize) will result in a whole number "again".
             // This value is determining the length of the periods in repeating kernel map rows.
-            int period = Numerics.LeastCommonMultiple(sourceSize, destinationSize) / sourceSize;
+            int period = destinationSize / Numerics.GreatestCommonDivisor(sourceSize, destinationSize);
 
             // the center position at i == 0:
             double center0 = (ratio - 1) * 0.5;

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeKernelMapTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeKernelMapTests.cs
@@ -80,6 +80,9 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
             { KnownResamplers.Bicubic, 1680, 1200 },
             { KnownResamplers.Box, 13, 299 },
             { KnownResamplers.Lanczos5, 3032, 600 },
+
+            // Large number. https://github.com/SixLabors/ImageSharp/issues/1616
+            { KnownResamplers.Bicubic, 207773, 51943 }
         };
 
         public static TheoryData<string, int, int> GeneratedImageResizeData =


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #1616
Updates the period calculation to use `GreatestCommonDivisor` as per issue.

<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
