### PR TITLE
Update RemoteExecutor

### DIFF
--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -22,8 +22,8 @@
     <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(IsWindows)'=='true'" />
     <PackageReference Update="Colourful" Version="2.0.5" />
     <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="7.23.2.1" />
-    <PackageReference Update="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.20513.1" />
-    <PackageReference Update="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.20513.1" />
+    <PackageReference Update="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.21311.3" />
+    <PackageReference Update="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21311.3" />
     <PackageReference Update="Moq" Version="4.14.6" />
     <PackageReference Update="Pfim" Version="0.9.1" />
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" Condition="'$(IsOSX)'=='true'" />

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/BokehBlurTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/BokehBlurTest.cs
@@ -11,6 +11,7 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Convolution;
 using SixLabors.ImageSharp.Tests.TestUtilities;
+using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -154,8 +155,9 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
                 appendSourceFileOrDescription: false);
 
         [Theory]
-        [WithFileCollection(nameof(TestFiles), nameof(BokehBlurValues), PixelTypes.Rgba32)]
-        public void BokehBlurFilterProcessor_Bounded(TestImageProvider<Rgba32> provider, BokehBlurInfo value)
+        [WithFileCollection(nameof(TestFiles), nameof(BokehBlurValues), PixelTypes.Rgba32, HwIntrinsics.AllowAll)]
+        [WithFileCollection(nameof(TestFiles), nameof(BokehBlurValues), PixelTypes.Rgba32, HwIntrinsics.DisableSSE41)]
+        public void BokehBlurFilterProcessor_Bounded(TestImageProvider<Rgba32> provider, BokehBlurInfo value, HwIntrinsics intrinsicsFilter)
         {
             static void RunTest(string arg1, string arg2)
             {
@@ -173,12 +175,13 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution
                     x.BokehBlur(value.Radius, value.Components, value.Gamma, bounds);
                 },
                 testOutputDetails: value.ToString(),
+                ImageComparer.TolerantPercentage(0.05f),
                 appendPixelTypeToFileName: false);
             }
 
             FeatureTestRunner.RunWithHwIntrinsicsFeature(
                 RunTest,
-                HwIntrinsics.DisableSSE41,
+                intrinsicsFilter,
                 provider,
                 value);
         }

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestEnvironmentTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestEnvironmentTests.cs
@@ -115,8 +115,7 @@ namespace SixLabors.ImageSharp.Tests
             Assert.IsType(expectedDecoderType, decoder);
         }
 
-        // The RemoteExecutor fix does not work well with the "dotnet xunit" call
-        // we use with Framework on 32 bit:
+        // RemoteExecutor does not work with "dotnet xunit" used to run tests on 32 bit .NET Framework:
         // https://github.com/SixLabors/ImageSharp/blob/381dff8640b721a34b1227c970fcf6ad6c5e3e72/ci-test.ps1#L30
         public static bool IsNot32BitNetFramework = !TestEnvironment.IsFramework || TestEnvironment.Is64BitProcess;
 

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestEnvironmentTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestEnvironmentTests.cs
@@ -118,6 +118,14 @@ namespace SixLabors.ImageSharp.Tests
         [Fact]
         public void RemoteExecutor_FailingRemoteTestShouldFailLocalTest()
         {
+            if (TestEnvironment.IsFramework && !TestEnvironment.Is64BitProcess)
+            {
+                // The RemoteExecutor fix does not work well with the "dotnet xunit" call
+                // we use with Framework on 32 bit:
+                // https://github.com/SixLabors/ImageSharp/blob/381dff8640b721a34b1227c970fcf6ad6c5e3e72/ci-test.ps1#L30
+                return;
+            }
+
             static void FailingCode()
             {
                 Assert.False(true);

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestEnvironmentTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestEnvironmentTests.cs
@@ -115,17 +115,14 @@ namespace SixLabors.ImageSharp.Tests
             Assert.IsType(expectedDecoderType, decoder);
         }
 
-        [Fact]
+        // The RemoteExecutor fix does not work well with the "dotnet xunit" call
+        // we use with Framework on 32 bit:
+        // https://github.com/SixLabors/ImageSharp/blob/381dff8640b721a34b1227c970fcf6ad6c5e3e72/ci-test.ps1#L30
+        public static bool IsNot32BitNetFramework = !TestEnvironment.IsFramework || TestEnvironment.Is64BitProcess;
+
+        [ConditionalFact(nameof(IsNot32BitNetFramework))]
         public void RemoteExecutor_FailingRemoteTestShouldFailLocalTest()
         {
-            if (TestEnvironment.IsFramework && !TestEnvironment.Is64BitProcess)
-            {
-                // The RemoteExecutor fix does not work well with the "dotnet xunit" call
-                // we use with Framework on 32 bit:
-                // https://github.com/SixLabors/ImageSharp/blob/381dff8640b721a34b1227c970fcf6ad6c5e3e72/ci-test.ps1#L30
-                return;
-            }
-
             static void FailingCode()
             {
                 Assert.False(true);

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestEnvironmentTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestEnvironmentTests.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.IO;
-
+using Microsoft.DotNet.RemoteExecutor;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Gif;
@@ -113,6 +113,17 @@ namespace SixLabors.ImageSharp.Tests
 
             IImageDecoder decoder = TestEnvironment.GetReferenceDecoder(fileName);
             Assert.IsType(expectedDecoderType, decoder);
+        }
+
+        [Fact]
+        public void RemoteExecutor_FailingRemoteTestShouldFailLocalTest()
+        {
+            static void FailingCode()
+            {
+                Assert.False(true);
+            }
+
+            Assert.ThrowsAny<RemoteExecutionException>(() => RemoteExecutor.Invoke(FailingCode).Dispose());
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Since https://github.com/dotnet/arcade/pull/7443 and dotnet/arcade#7426 got merged, we just need to update RemoteExecutor to fix #1376.

**Update:** Looks like dotnet/arcade#7426 doesn't work with the legacy xunit console host we use for running 32 bit tests on .NET Framework, disabled the test for that case, will open an issue for the gap.

~WIP:~
- [x] Add a test for false positives (curious about current CI results)
- [x] Update RemoteExecutor version
- [x] Fix test failures