### PR TITLE
Allow clearing and reusing a pixel map.

### DIFF
--- a/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
@@ -194,7 +194,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
             }
 
             /// <summary>
-            /// Clears the cahe resetting each entry to empty.
+            /// Clears the cache resetting each entry to empty.
             /// </summary>
             [MethodImpl(InliningOptions.ShortMethod)]
             public void Clear() => this.table.GetSpan().Fill(-1);

--- a/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
@@ -18,20 +18,21 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// This class is not threadsafe and should not be accessed in parallel.
     /// Doing so will result in non-idempotent results.
     /// </para>
-    internal readonly struct EuclideanPixelMap<TPixel> : IDisposable
+    internal sealed class EuclideanPixelMap<TPixel> : IDisposable
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        private readonly Rgba32[] rgbaPalette;
+        private Rgba32[] rgbaPalette;
         private readonly ColorDistanceCache cache;
+        private readonly Configuration configuration;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EuclideanPixelMap{TPixel}"/> struct.
+        /// Initializes a new instance of the <see cref="EuclideanPixelMap{TPixel}"/> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="palette">The color palette to map from.</param>
-        [MethodImpl(InliningOptions.ShortMethod)]
         public EuclideanPixelMap(Configuration configuration, ReadOnlyMemory<TPixel> palette)
         {
+            this.configuration = configuration;
             this.Palette = palette;
             this.rgbaPalette = new Rgba32[palette.Length];
             this.cache = new ColorDistanceCache(configuration.MemoryAllocator);
@@ -46,6 +47,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         {
             [MethodImpl(InliningOptions.ShortMethod)]
             get;
+
+            [MethodImpl(InliningOptions.ShortMethod)]
+            private set;
         }
 
         /// <summary>
@@ -70,6 +74,18 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
 
             match = Unsafe.Add(ref paletteRef, index);
             return index;
+        }
+
+        /// <summary>
+        /// Clears the map, resetting it to use the given palette.
+        /// </summary>
+        /// <param name="palette">The color palette to map from.</param>
+        public void Clear(ReadOnlyMemory<TPixel> palette)
+        {
+            this.Palette = palette;
+            this.rgbaPalette = new Rgba32[palette.Length];
+            PixelOperations<TPixel>.Instance.ToRgba32(this.configuration, this.Palette.Span, this.rgbaPalette);
+            this.cache.Clear();
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]
@@ -176,6 +192,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
                 match = this.tablePointer[idx];
                 return match > -1;
             }
+
+            /// <summary>
+            /// Clears the cahe resetting each entry to empty.
+            /// </summary>
+            [MethodImpl(InliningOptions.ShortMethod)]
+            public void Clear() => this.table.GetSpan().Fill(-1);
 
             [MethodImpl(InliningOptions.ShortMethod)]
             private static int GetPaletteIndex(int r, int g, int b, int a)

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer.cs
@@ -58,9 +58,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
             var palette = new TPixel[length];
 
             Color.ToPixel(configuration, this.colorPalette.Span, palette.AsSpan());
-
-            var pixelMap = new EuclideanPixelMap<TPixel>(configuration, palette);
-            return new PaletteQuantizer<TPixel>(configuration, options, pixelMap, false);
+            return new PaletteQuantizer<TPixel>(configuration, options, palette);
         }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer{TPixel}.cs
@@ -16,32 +16,23 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     internal struct PaletteQuantizer<TPixel> : IQuantizer<TPixel>
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        private readonly EuclideanPixelMap<TPixel> pixelMap;
-        private readonly bool leaveMap;
+        private EuclideanPixelMap<TPixel> pixelMap;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PaletteQuantizer{TPixel}"/> struct.
         /// </summary>
         /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
         /// <param name="options">The quantizer options defining quantization rules.</param>
-        /// <param name="pixelMap">The pixel map for looking up color matches from a predefined palette.</param>
-        /// <param name="leaveMap">
-        /// <see langword="true"/> to leave the pixel map undisposed after disposing the <see cref="PaletteQuantizer{TPixel}"/> object; otherwise, <see langword="false"/>.
-        /// </param>
+        /// <param name="palette">The palette to use.</param>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public PaletteQuantizer(
-            Configuration configuration,
-            QuantizerOptions options,
-            EuclideanPixelMap<TPixel> pixelMap,
-            bool leaveMap)
+        public PaletteQuantizer(Configuration configuration, QuantizerOptions options, ReadOnlyMemory<TPixel> palette)
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(options, nameof(options));
 
             this.Configuration = configuration;
             this.Options = options;
-            this.pixelMap = pixelMap;
-            this.leaveMap = leaveMap;
+            this.pixelMap = new EuclideanPixelMap<TPixel>(configuration, palette);
         }
 
         /// <inheritdoc/>
@@ -72,10 +63,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         /// <inheritdoc/>
         public void Dispose()
         {
-            if (!this.leaveMap)
-            {
-                this.pixelMap.Dispose();
-            }
+            this.pixelMap?.Dispose();
+            this.pixelMap = null;
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Disposing and recreating a pixel map puts pressure on the allocator when processing multi-frame gifs. By clearing the map we can avoid this. 

<!-- Thanks for contributing to ImageSharp! -->
