### PR TITLE
Rename unsafe memory methods to use Dangerous prefix.

### DIFF
--- a/src/ImageSharp/Memory/Buffer2DExtensions.cs
+++ b/src/ImageSharp/Memory/Buffer2DExtensions.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Memory
         /// Copy <paramref name="columnCount"/> columns of <paramref name="buffer"/> inplace,
         /// from positions starting at <paramref name="sourceIndex"/> to positions at <paramref name="destIndex"/>.
         /// </summary>
-        internal static unsafe void CopyColumns<T>(
+        internal static unsafe void DangerousCopyColumns<T>(
             this Buffer2D<T> buffer,
             int sourceIndex,
             int destIndex,
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Memory
             int dOffset = destIndex * elementSize;
             long count = columnCount * elementSize;
 
-            Span<byte> span = MemoryMarshal.AsBytes(buffer.GetSingleMemory().Span);
+            Span<byte> span = MemoryMarshal.AsBytes(buffer.DangerousGetSingleMemory().Span);
 
             fixed (byte* ptr = span)
             {

--- a/src/ImageSharp/Memory/Buffer2D{T}.cs
+++ b/src/ImageSharp/Memory/Buffer2D{T}.cs
@@ -168,10 +168,10 @@ namespace SixLabors.ImageSharp.Memory
         /// Thrown when the backing group is discontiguous.
         /// </exception>
         [MethodImpl(InliningOptions.ShortMethod)]
-        internal Span<T> GetSingleSpan()
+        internal Span<T> DangerousGetSingleSpan()
         {
             // TODO: If we need a public version of this method, we need to cache the non-fast Memory<T> of this.MemoryGroup
-            return this.cachedMemory.Length != 0 ? this.cachedMemory.Span : this.GetSingleSpanSlow();
+            return this.cachedMemory.Length != 0 ? this.cachedMemory.Span : this.DangerousGetSingleSpanSlow();
         }
 
         /// <summary>
@@ -183,10 +183,10 @@ namespace SixLabors.ImageSharp.Memory
         /// Thrown when the backing group is discontiguous.
         /// </exception>
         [MethodImpl(InliningOptions.ShortMethod)]
-        internal Memory<T> GetSingleMemory()
+        internal Memory<T> DangerousGetSingleMemory()
         {
             // TODO: If we need a public version of this method, we need to cache the non-fast Memory<T> of this.MemoryGroup
-            return this.cachedMemory.Length != 0 ? this.cachedMemory : this.GetSingleMemorySlow();
+            return this.cachedMemory.Length != 0 ? this.cachedMemory : this.DangerousGetSingleMemorySlow();
         }
 
         /// <summary>
@@ -203,10 +203,10 @@ namespace SixLabors.ImageSharp.Memory
         private Memory<T> GetRowMemorySlow(int y) => this.FastMemoryGroup.GetBoundedSlice(y * (long)this.Width, this.Width);
 
         [MethodImpl(InliningOptions.ColdPath)]
-        private Memory<T> GetSingleMemorySlow() => this.FastMemoryGroup.Single();
+        private Memory<T> DangerousGetSingleMemorySlow() => this.FastMemoryGroup.Single();
 
         [MethodImpl(InliningOptions.ColdPath)]
-        private Span<T> GetSingleSpanSlow() => this.FastMemoryGroup.Single().Span;
+        private Span<T> DangerousGetSingleSpanSlow() => this.FastMemoryGroup.Single().Span;
 
         [MethodImpl(InliningOptions.ColdPath)]
         private ref T GetElementSlow(int x, int y)

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
@@ -52,7 +52,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             this.DestinationLength = destinationLength;
             this.MaxDiameter = (radius * 2) + 1;
             this.data = memoryAllocator.Allocate2D<float>(this.MaxDiameter, bufferHeight, AllocationOptions.Clean);
-            this.pinHandle = this.data.GetSingleMemory().Pin();
+            this.pinHandle = this.data.DangerousGetSingleMemory().Pin();
             this.kernels = new ResizeKernel[destinationLength];
             this.tempValues = new double[this.MaxDiameter];
         }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
@@ -115,7 +115,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             Span<Vector4> tempColSpan = this.tempColumnBuffer.GetSpan();
 
             // When creating transposedFirstPassBuffer, we made sure it's contiguous:
-            Span<Vector4> transposedFirstPassBufferSpan = this.transposedFirstPassBuffer.GetSingleSpan();
+            Span<Vector4> transposedFirstPassBufferSpan = this.transposedFirstPassBuffer.DangerousGetSingleSpan();
 
             for (int y = rowInterval.Min; y < rowInterval.Max; y++)
             {
@@ -153,7 +153,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             // Copy previous bottom band to the new top:
             // (rows <--> columns, because the buffer is transposed)
-            this.transposedFirstPassBuffer.CopyColumns(
+            this.transposedFirstPassBuffer.DangerousCopyColumns(
                 this.workerHeight - this.windowBandHeight,
                 0,
                 this.windowBandHeight);
@@ -167,7 +167,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         private void CalculateFirstPassValues(RowInterval calculationInterval)
         {
             Span<Vector4> tempRowSpan = this.tempRowBuffer.GetSpan();
-            Span<Vector4> transposedFirstPassBufferSpan = this.transposedFirstPassBuffer.GetSingleSpan();
+            Span<Vector4> transposedFirstPassBufferSpan = this.transposedFirstPassBuffer.DangerousGetSingleSpan();
 
             for (int y = calculationInterval.Min; y < calculationInterval.Max; y++)
             {

--- a/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
@@ -113,7 +113,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 this.Output.WriteLine($"Component{i}: {diff}");
                 averageDifference += diff.average;
                 totalDifference += diff.total;
-                tolerance += libJpegComponent.SpectralBlocks.GetSingleSpan().Length;
+                tolerance += libJpegComponent.SpectralBlocks.DangerousGetSingleSpan().Length;
             }
 
             averageDifference /= componentCount;

--- a/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
+++ b/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
@@ -361,7 +361,7 @@ namespace SixLabors.ImageSharp.Tests.Helpers
                     in operation);
 
                 // Assert:
-                TestImageExtensions.CompareBuffers(expected.GetSingleSpan(), actual.GetSingleSpan());
+                TestImageExtensions.CompareBuffers(expected.DangerousGetSingleSpan(), actual.DangerousGetSingleSpan());
             }
         }
 

--- a/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.WrapMemory.cs
@@ -160,7 +160,7 @@ namespace SixLabors.ImageSharp.Tests
 
                         using (var image = Image.WrapMemory(memory, bmp.Width, bmp.Height))
                         {
-                            Assert.Equal(memory, image.GetRootFramePixelBuffer().GetSingleMemory());
+                            Assert.Equal(memory, image.GetRootFramePixelBuffer().DangerousGetSingleMemory());
                             Assert.True(image.TryGetSinglePixelSpan(out Span<Bgra32> imageSpan));
                             imageSpan.Fill(bg);
                             for (var i = 10; i < 20; i++)
@@ -196,7 +196,7 @@ namespace SixLabors.ImageSharp.Tests
 
                     using (var image = Image.WrapMemory(memoryManager, bmp.Width, bmp.Height))
                     {
-                        Assert.Equal(memoryManager.Memory, image.GetRootFramePixelBuffer().GetSingleMemory());
+                        Assert.Equal(memoryManager.Memory, image.GetRootFramePixelBuffer().DangerousGetSingleMemory());
                         Assert.True(image.TryGetSinglePixelSpan(out Span<Bgra32> imageSpan));
                         imageSpan.Fill(bg);
                         for (var i = 10; i < 20; i++)
@@ -255,7 +255,7 @@ namespace SixLabors.ImageSharp.Tests
                         using (var image = Image.WrapMemory<Bgra32>(byteMemory, bmp.Width, bmp.Height))
                         {
                             Span<Bgra32> pixelSpan = pixelMemory.Span;
-                            Span<Bgra32> imageSpan = image.GetRootFramePixelBuffer().GetSingleMemory().Span;
+                            Span<Bgra32> imageSpan = image.GetRootFramePixelBuffer().DangerousGetSingleMemory().Span;
 
                             // We can't compare the two Memory<T> instances directly as they wrap different memory managers.
                             // To check that the underlying data matches, we can just manually check their lenth, and the
@@ -327,7 +327,7 @@ namespace SixLabors.ImageSharp.Tests
                             using (var image = Image.WrapMemory<Bgra32>(p, bmp.Width, bmp.Height))
                             {
                                 Span<Bgra32> pixelSpan = pixelMemory.Span;
-                                Span<Bgra32> imageSpan = image.GetRootFramePixelBuffer().GetSingleMemory().Span;
+                                Span<Bgra32> imageSpan = image.GetRootFramePixelBuffer().DangerousGetSingleMemory().Span;
 
                                 Assert.Equal(pixelSpan.Length, imageSpan.Length);
                                 Assert.True(Unsafe.AreSame(ref pixelSpan.GetPinnableReference(), ref imageSpan.GetPinnableReference()));

--- a/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
@@ -65,7 +65,7 @@ namespace SixLabors.ImageSharp.Tests.Memory
                 Assert.Equal(width, buffer.Width);
                 Assert.Equal(height, buffer.Height);
                 Assert.Equal(0, buffer.FastMemoryGroup.TotalLength);
-                Assert.Equal(0, buffer.GetSingleSpan().Length);
+                Assert.Equal(0, buffer.DangerousGetSingleSpan().Length);
             }
         }
 
@@ -87,7 +87,7 @@ namespace SixLabors.ImageSharp.Tests.Memory
         {
             using (Buffer2D<int> buffer = this.MemoryAllocator.Allocate2D<int>(42, 42, AllocationOptions.Clean))
             {
-                Span<int> span = buffer.GetSingleSpan();
+                Span<int> span = buffer.DangerousGetSingleSpan();
                 for (int j = 0; j < span.Length; j++)
                 {
                     Assert.Equal(0, span[j]);
@@ -249,9 +249,9 @@ namespace SixLabors.ImageSharp.Tests.Memory
             var rnd = new Random(123);
             using (Buffer2D<float> b = this.MemoryAllocator.Allocate2D<float>(width, height))
             {
-                rnd.RandomFill(b.GetSingleSpan(), 0, 1);
+                rnd.RandomFill(b.DangerousGetSingleSpan(), 0, 1);
 
-                b.CopyColumns(startIndex, destIndex, columnCount);
+                b.DangerousCopyColumns(startIndex, destIndex, columnCount);
 
                 for (int y = 0; y < b.Height; y++)
                 {
@@ -271,10 +271,10 @@ namespace SixLabors.ImageSharp.Tests.Memory
             var rnd = new Random(123);
             using (Buffer2D<float> b = this.MemoryAllocator.Allocate2D<float>(100, 100))
             {
-                rnd.RandomFill(b.GetSingleSpan(), 0, 1);
+                rnd.RandomFill(b.DangerousGetSingleSpan(), 0, 1);
 
-                b.CopyColumns(0, 50, 22);
-                b.CopyColumns(0, 50, 22);
+                b.DangerousCopyColumns(0, 50, 22);
+                b.DangerousCopyColumns(0, 50, 22);
 
                 for (int y = 0; y < b.Height; y++)
                 {

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -672,7 +672,7 @@ namespace SixLabors.ImageSharp.Tests
             var image = new Image<Rgba32>(buffer.Width, buffer.Height);
 
             Assert.True(image.Frames.RootFrame.TryGetSinglePixelSpan(out Span<Rgba32> pixels));
-            Span<float> bufferSpan = buffer.GetSingleSpan();
+            Span<float> bufferSpan = buffer.DangerousGetSingleSpan();
 
             for (int i = 0; i < bufferSpan.Length; i++)
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
We need to ensure we don't incorrectly use the single memory/span methods and prevent having to do work like #1662 
Should also help with refactoring #1625  

<!-- Thanks for contributing to ImageSharp! -->
