### PR TITLE
Update AllocatePaddedPixelRowBuffer to use IMemoryOwner<byte>

### DIFF
--- a/src/ImageSharp/Common/Extensions/StreamExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/StreamExtensions.cs
@@ -72,12 +72,6 @@ namespace SixLabors.ImageSharp
             }
         }
 
-        public static void Read(this Stream stream, IManagedByteBuffer buffer)
-            => stream.Read(buffer.Array, 0, buffer.Length());
-
-        public static void Write(this Stream stream, IManagedByteBuffer buffer)
-            => stream.Write(buffer.Array, 0, buffer.Length());
-
 #if !SUPPORTS_SPAN_STREAM
         // This is a port of the CoreFX implementation and is MIT Licensed:
         // https://github.com/dotnet/corefx/blob/17300169760c61a90cab8d913636c1058a30a8c1/src/Common/src/CoreLib/System/IO/Stream.cs#L742

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -257,7 +257,8 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             }
         }
 
-        private IManagedByteBuffer AllocateRow(int width, int bytesPerPixel) => this.memoryAllocator.AllocatePaddedPixelRowBuffer(width, bytesPerPixel, this.padding);
+        private IMemoryOwner<byte> AllocateRow(int width, int bytesPerPixel)
+            => this.memoryAllocator.AllocatePaddedPixelRowBuffer(width, bytesPerPixel, this.padding);
 
         /// <summary>
         /// Writes the 32bit color palette to the stream.
@@ -268,18 +269,18 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         private void Write32Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 4))
+            using IMemoryOwner<byte> row = this.AllocateRow(pixels.Width, 4);
+            Span<byte> rowSpan = row.GetSpan();
+
+            for (int y = pixels.Height - 1; y >= 0; y--)
             {
-                for (int y = pixels.Height - 1; y >= 0; y--)
-                {
-                    Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
-                    PixelOperations<TPixel>.Instance.ToBgra32Bytes(
-                        this.configuration,
-                        pixelSpan,
-                        row.GetSpan(),
-                        pixelSpan.Length);
-                    stream.Write(row.Array, 0, row.Length());
-                }
+                Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
+                PixelOperations<TPixel>.Instance.ToBgra32Bytes(
+                    this.configuration,
+                    pixelSpan,
+                    rowSpan,
+                    pixelSpan.Length);
+                stream.Write(rowSpan);
             }
         }
 
@@ -294,18 +295,18 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         {
             int width = pixels.Width;
             int rowBytesWithoutPadding = width * 3;
-            using (IManagedByteBuffer row = this.AllocateRow(width, 3))
+            using IMemoryOwner<byte> row = this.AllocateRow(width, 3);
+            Span<byte> rowSpan = row.GetSpan();
+
+            for (int y = pixels.Height - 1; y >= 0; y--)
             {
-                for (int y = pixels.Height - 1; y >= 0; y--)
-                {
-                    Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
-                    PixelOperations<TPixel>.Instance.ToBgr24Bytes(
-                        this.configuration,
-                        pixelSpan,
-                        row.Slice(0, rowBytesWithoutPadding),
-                        width);
-                    stream.Write(row.Array, 0, row.Length());
-                }
+                Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
+                PixelOperations<TPixel>.Instance.ToBgr24Bytes(
+                    this.configuration,
+                    pixelSpan,
+                    row.Slice(0, rowBytesWithoutPadding),
+                    width);
+                stream.Write(rowSpan);
             }
         }
 
@@ -320,20 +321,20 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         {
             int width = pixels.Width;
             int rowBytesWithoutPadding = width * 2;
-            using (IManagedByteBuffer row = this.AllocateRow(width, 2))
+            using IMemoryOwner<byte> row = this.AllocateRow(width, 2);
+            Span<byte> rowSpan = row.GetSpan();
+
+            for (int y = pixels.Height - 1; y >= 0; y--)
             {
-                for (int y = pixels.Height - 1; y >= 0; y--)
-                {
-                    Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
+                Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
 
-                    PixelOperations<TPixel>.Instance.ToBgra5551Bytes(
-                        this.configuration,
-                        pixelSpan,
-                        row.Slice(0, rowBytesWithoutPadding),
-                        pixelSpan.Length);
+                PixelOperations<TPixel>.Instance.ToBgra5551Bytes(
+                    this.configuration,
+                    pixelSpan,
+                    row.Slice(0, rowBytesWithoutPadding),
+                    pixelSpan.Length);
 
-                    stream.Write(row.Array, 0, row.Length());
-                }
+                stream.Write(rowSpan);
             }
         }
 

--- a/src/ImageSharp/Formats/Tga/TgaEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tga/TgaEncoderCore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -258,7 +259,8 @@ namespace SixLabors.ImageSharp.Formats.Tga
             return equalPixelCount;
         }
 
-        private IManagedByteBuffer AllocateRow(int width, int bytesPerPixel) => this.memoryAllocator.AllocatePaddedPixelRowBuffer(width, bytesPerPixel, 0);
+        private IMemoryOwner<byte> AllocateRow(int width, int bytesPerPixel)
+            => this.memoryAllocator.AllocatePaddedPixelRowBuffer(width, bytesPerPixel, 0);
 
         /// <summary>
         /// Writes the 8bit pixels uncompressed to the stream.
@@ -269,18 +271,18 @@ namespace SixLabors.ImageSharp.Formats.Tga
         private void Write8Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 1))
+            using IMemoryOwner<byte> row = this.AllocateRow(pixels.Width, 1);
+            Span<byte> rowSpan = row.GetSpan();
+
+            for (int y = pixels.Height - 1; y >= 0; y--)
             {
-                for (int y = pixels.Height - 1; y >= 0; y--)
-                {
-                    Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
-                    PixelOperations<TPixel>.Instance.ToL8Bytes(
-                        this.configuration,
-                        pixelSpan,
-                        row.GetSpan(),
-                        pixelSpan.Length);
-                    stream.Write(row.Array, 0, row.Length());
-                }
+                Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
+                PixelOperations<TPixel>.Instance.ToL8Bytes(
+                    this.configuration,
+                    pixelSpan,
+                    rowSpan,
+                    pixelSpan.Length);
+                stream.Write(rowSpan);
             }
         }
 
@@ -293,18 +295,18 @@ namespace SixLabors.ImageSharp.Formats.Tga
         private void Write16Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 2))
+            using IMemoryOwner<byte> row = this.AllocateRow(pixels.Width, 2);
+            Span<byte> rowSpan = row.GetSpan();
+
+            for (int y = pixels.Height - 1; y >= 0; y--)
             {
-                for (int y = pixels.Height - 1; y >= 0; y--)
-                {
-                    Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
-                    PixelOperations<TPixel>.Instance.ToBgra5551Bytes(
-                        this.configuration,
-                        pixelSpan,
-                        row.GetSpan(),
-                        pixelSpan.Length);
-                    stream.Write(row.Array, 0, row.Length());
-                }
+                Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
+                PixelOperations<TPixel>.Instance.ToBgra5551Bytes(
+                    this.configuration,
+                    pixelSpan,
+                    rowSpan,
+                    pixelSpan.Length);
+                stream.Write(rowSpan);
             }
         }
 
@@ -317,18 +319,18 @@ namespace SixLabors.ImageSharp.Formats.Tga
         private void Write24Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 3))
+            using IMemoryOwner<byte> row = this.AllocateRow(pixels.Width, 3);
+            Span<byte> rowSpan = row.GetSpan();
+
+            for (int y = pixels.Height - 1; y >= 0; y--)
             {
-                for (int y = pixels.Height - 1; y >= 0; y--)
-                {
-                    Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
-                    PixelOperations<TPixel>.Instance.ToBgr24Bytes(
-                        this.configuration,
-                        pixelSpan,
-                        row.GetSpan(),
-                        pixelSpan.Length);
-                    stream.Write(row.Array, 0, row.Length());
-                }
+                Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
+                PixelOperations<TPixel>.Instance.ToBgr24Bytes(
+                    this.configuration,
+                    pixelSpan,
+                    rowSpan,
+                    pixelSpan.Length);
+                stream.Write(rowSpan);
             }
         }
 
@@ -341,18 +343,18 @@ namespace SixLabors.ImageSharp.Formats.Tga
         private void Write32Bit<TPixel>(Stream stream, Buffer2D<TPixel> pixels)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            using (IManagedByteBuffer row = this.AllocateRow(pixels.Width, 4))
+            using IMemoryOwner<byte> row = this.AllocateRow(pixels.Width, 4);
+            Span<byte> rowSpan = row.GetSpan();
+
+            for (int y = pixels.Height - 1; y >= 0; y--)
             {
-                for (int y = pixels.Height - 1; y >= 0; y--)
-                {
-                    Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
-                    PixelOperations<TPixel>.Instance.ToBgra32Bytes(
-                        this.configuration,
-                        pixelSpan,
-                        row.GetSpan(),
-                        pixelSpan.Length);
-                    stream.Write(row.Array, 0, row.Length());
-                }
+                Span<TPixel> pixelSpan = pixels.GetRowSpan(y);
+                PixelOperations<TPixel>.Instance.ToBgra32Bytes(
+                    this.configuration,
+                    pixelSpan,
+                    rowSpan,
+                    pixelSpan.Length);
+                stream.Write(rowSpan);
             }
         }
 

--- a/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
+++ b/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
@@ -67,21 +67,21 @@ namespace SixLabors.ImageSharp.Memory
         }
 
         /// <summary>
-        /// Allocates padded buffers for BMP encoder/decoder. (Replacing old PixelRow/PixelArea).
+        /// Allocates padded buffers. Generally used by encoder/decoders.
         /// </summary>
         /// <param name="memoryAllocator">The <see cref="MemoryAllocator"/>.</param>
         /// <param name="width">Pixel count in the row</param>
         /// <param name="pixelSizeInBytes">The pixel size in bytes, eg. 3 for RGB.</param>
         /// <param name="paddingInBytes">The padding.</param>
-        /// <returns>A <see cref="IManagedByteBuffer"/>.</returns>
-        internal static IManagedByteBuffer AllocatePaddedPixelRowBuffer(
+        /// <returns>A <see cref="IMemoryOwner{Byte}"/>.</returns>
+        internal static IMemoryOwner<byte> AllocatePaddedPixelRowBuffer(
             this MemoryAllocator memoryAllocator,
             int width,
             int pixelSizeInBytes,
             int paddingInBytes)
         {
             int length = (width * pixelSizeInBytes) + paddingInBytes;
-            return memoryAllocator.AllocateManagedByteBuffer(length);
+            return memoryAllocator.Allocate<byte>(length);
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Refactors `MemeoryAllocatorExtensions.AllocatePaddedPixelRowBuffer` to return `IMemoryOwner<byte>`.

Touches #1675 

<!-- Thanks for contributing to ImageSharp! -->
