### PR TITLE
Do not skip 4-bit and 1-bit bmp tests on linux

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -138,12 +138,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
             using (Image<TPixel> image = provider.GetImage(BmpDecoder))
             {
                 image.DebugSave(provider);
-
-                // The Magick Reference Decoder can not decode 4-Bit bitmaps, so only execute this on windows.
-                if (TestEnvironment.IsWindows)
-                {
-                    image.CompareToOriginal(provider);
-                }
+                image.CompareToOriginal(provider);
             }
         }
 
@@ -202,15 +197,11 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         public void BmpDecoder_CanDecode_RunLengthEncoded_4Bit_WithDelta<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            using (Image<TPixel> image = provider.GetImage(new BmpDecoder { RleSkippedPixelHandling = RleSkippedPixelHandling.Black }))
+            RleSkippedPixelHandling skippedPixelHandling = TestEnvironment.IsWindows ? RleSkippedPixelHandling.Black : RleSkippedPixelHandling.FirstColorOfPalette;
+            using (Image<TPixel> image = provider.GetImage(new BmpDecoder { RleSkippedPixelHandling = skippedPixelHandling }))
             {
                 image.DebugSave(provider);
-
-                // The Magick Reference Decoder can not decode 4-Bit bitmaps, so only execute this on windows.
-                if (TestEnvironment.IsWindows)
-                {
-                    image.CompareToOriginal(provider);
-                }
+                image.CompareToOriginal(provider);
             }
         }
 
@@ -219,15 +210,11 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         public void BmpDecoder_CanDecode_RunLengthEncoded_4Bit<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            using (Image<TPixel> image = provider.GetImage(new BmpDecoder { RleSkippedPixelHandling = RleSkippedPixelHandling.Black }))
+            RleSkippedPixelHandling skippedPixelHandling = TestEnvironment.IsWindows ? RleSkippedPixelHandling.Black : RleSkippedPixelHandling.FirstColorOfPalette;
+            using (Image<TPixel> image = provider.GetImage(new BmpDecoder { RleSkippedPixelHandling = skippedPixelHandling }))
             {
                 image.DebugSave(provider);
-
-                // The Magick Reference Decoder can not decode 4-Bit bitmaps, so only execute this on windows.
-                if (TestEnvironment.IsWindows)
-                {
-                    image.CompareToOriginal(provider);
-                }
+                image.CompareToOriginal(provider);
             }
         }
 

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -179,56 +179,28 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         public void Encode_4Bit_WithV3Header_Works<TPixel>(
             TestImageProvider<TPixel> provider,
             BmpBitsPerPixel bitsPerPixel)
-            where TPixel : unmanaged, IPixel<TPixel>
-        {
-            // The Magick Reference Decoder can not decode 4-Bit bitmaps, so only execute this on windows.
-            if (TestEnvironment.IsWindows)
-            {
-                TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
-            }
-        }
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
 
         [Theory]
         [WithFile(Bit4, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel4)]
         public void Encode_4Bit_WithV4Header_Works<TPixel>(
             TestImageProvider<TPixel> provider,
             BmpBitsPerPixel bitsPerPixel)
-            where TPixel : unmanaged, IPixel<TPixel>
-        {
-            // The Magick Reference Decoder can not decode 4-Bit bitmaps, so only execute this on windows.
-            if (TestEnvironment.IsWindows)
-            {
-                TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
-            }
-        }
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
 
         [Theory]
         [WithFile(Bit1, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel1)]
         public void Encode_1Bit_WithV3Header_Works<TPixel>(
             TestImageProvider<TPixel> provider,
             BmpBitsPerPixel bitsPerPixel)
-            where TPixel : unmanaged, IPixel<TPixel>
-        {
-            // The Magick Reference Decoder can not decode 1-Bit bitmaps, so only execute this on windows.
-            if (TestEnvironment.IsWindows)
-            {
-                TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
-            }
-        }
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: false);
 
         [Theory]
         [WithFile(Bit1, PixelTypes.Rgba32, BmpBitsPerPixel.Pixel1)]
         public void Encode_1Bit_WithV4Header_Works<TPixel>(
             TestImageProvider<TPixel> provider,
             BmpBitsPerPixel bitsPerPixel)
-            where TPixel : unmanaged, IPixel<TPixel>
-        {
-            // The Magick Reference Decoder can not decode 1-Bit bitmaps, so only execute this on windows.
-            if (TestEnvironment.IsWindows)
-            {
-                TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
-            }
-        }
+            where TPixel : unmanaged, IPixel<TPixel> => TestBmpEncoderCore(provider, bitsPerPixel, supportTransparency: true);
 
         [Theory]
         [WithFile(Bit8Gs, PixelTypes.L8, BmpBitsPerPixel.Pixel8)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

There is no need anymore to skip the 4 bit and 1 bit bitmap tests on linux. This ****PR**** removes skipping those tests.