### PR TITLE
Added Image<TPixel> constructor from single ImageFrame

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Writers/TiffBiColorWriter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/Writers/TiffBiColorWriter{TPixel}.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Writers
             : base(image, memoryAllocator, configuration, entriesCollector)
         {
             // Convert image to black and white.
-            this.imageBlackWhite = new Image<TPixel>(configuration, new ImageMetadata(), new[] { image.Clone() });
+            this.imageBlackWhite = new Image<TPixel>(configuration, new ImageMetadata(), image.Clone());
             this.imageBlackWhite.Mutate(img => img.BinaryDither(KnownDitherings.FloydSteinberg));
         }
 

--- a/src/ImageSharp/ImageFrameCollection{TPixel}.cs
+++ b/src/ImageSharp/ImageFrameCollection{TPixel}.cs
@@ -285,7 +285,7 @@ namespace SixLabors.ImageSharp
 
             this.frames.Remove(frame);
 
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.Metadata.DeepClone(), new[] { frame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.Metadata.DeepClone(), frame);
         }
 
         /// <summary>
@@ -300,7 +300,7 @@ namespace SixLabors.ImageSharp
 
             ImageFrame<TPixel> frame = this[index];
             ImageFrame<TPixel> clonedFrame = frame.Clone();
-            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.Metadata.DeepClone(), new[] { clonedFrame });
+            return new Image<TPixel>(this.parent.GetConfiguration(), this.parent.Metadata.DeepClone(), clonedFrame);
         }
 
         /// <summary>

--- a/src/ImageSharp/ImageFrameCollection{TPixel}.cs
+++ b/src/ImageSharp/ImageFrameCollection{TPixel}.cs
@@ -38,6 +38,18 @@ namespace SixLabors.ImageSharp
             this.frames.Add(new ImageFrame<TPixel>(parent.GetConfiguration(), width, height, memorySource));
         }
 
+        internal ImageFrameCollection(Image<TPixel> parent, ImageFrame<TPixel> frame)
+        {
+            Guard.NotNull(parent, nameof(parent));
+            Guard.NotNull(frame, nameof(frame));
+
+            this.parent = parent;
+
+            // Frame is already cloned by the caller
+            // this.ValidateFrame call can be omitted as it's the only frame
+            this.frames.Add(frame);
+        }
+
         internal ImageFrameCollection(Image<TPixel> parent, IEnumerable<ImageFrame<TPixel>> frames)
         {
             Guard.NotNull(parent, nameof(parent));

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -140,6 +140,19 @@ namespace SixLabors.ImageSharp
             this.frames = new ImageFrameCollection<TPixel>(this, frames);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Image{TPixel}" /> class
+        /// with the height and the width of the image.
+        /// </summary>
+        /// <param name="configuration">The configuration providing initialization code which allows extending the library.</param>
+        /// <param name="metadata">The images metadata.</param>
+        /// <param name="frame">The frame that will be owned by this image instance.</param>
+        internal Image(Configuration configuration, ImageMetadata metadata, ImageFrame<TPixel> frame)
+            : base(configuration, PixelTypeInfo.Create<TPixel>(), metadata, frame.Size())
+        {
+            this.frames = new ImageFrameCollection<TPixel>(this, frame);
+        }
+
         /// <inheritdoc />
         protected override ImageFrameCollection NonGenericFrameCollection => this.Frames;
 

--- a/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
@@ -39,7 +39,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             // TODO: This is clunky. We should add behavior enum to ExtractFrame.
             // All frames have be the same size so we only need to calculate the correct dimensions for the first frame
-            using (var temp = new Image<TPixel>(this.Configuration, this.Source.Metadata.DeepClone(), new[] { this.Source.Frames.RootFrame.Clone() }))
+            using (var temp = new Image<TPixel>(this.Configuration, this.Source.Metadata.DeepClone(), this.Source.Frames.RootFrame.Clone()))
             {
                 Configuration configuration = this.Source.GetConfiguration();
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Added contructor from single frame used in some cases (and will be used in new version of jpeg decoder). Replaced multi-frame ctors with single-frame ctors where applicable.