### PR TITLE
Migrate ManagedByteBuffer 3

### DIFF
--- a/src/ImageSharp/Common/Extensions/StreamExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/StreamExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Buffers;
 using System.IO;
-using SixLabors.ImageSharp.Memory;
 
 namespace SixLabors.ImageSharp
 {

--- a/src/ImageSharp/Common/Helpers/DebugGuard.cs
+++ b/src/ImageSharp/Common/Helpers/DebugGuard.cs
@@ -37,7 +37,7 @@ namespace SixLabors
         /// <paramref name="target"/> has a different size than <paramref name="other"/>
         /// </exception>
         [Conditional("DEBUG")]
-        public static void MustBeSameSized<T>(Span<T> target, Span<T> other, string parameterName)
+        public static void MustBeSameSized<T>(ReadOnlySpan<T> target, ReadOnlySpan<T> other, string parameterName)
             where T : struct
         {
             if (target.Length != other.Length)
@@ -57,7 +57,7 @@ namespace SixLabors
         /// <paramref name="target"/> has less items than <paramref name="minSpan"/>
         /// </exception>
         [Conditional("DEBUG")]
-        public static void MustBeSizedAtLeast<T>(Span<T> target, Span<T> minSpan, string parameterName)
+        public static void MustBeSizedAtLeast<T>(ReadOnlySpan<T> target, ReadOnlySpan<T> minSpan, string parameterName)
             where T : struct
         {
             if (target.Length < minSpan.Length)

--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(Span<byte> scanline, Span<byte> previousScanline, int bytesPerPixel)
         {
-            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSameSized<byte>(scanline, previousScanline, nameof(scanline));
 
             ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
             ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         /// <param name="sum">The sum of the total variance of the filtered row</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(Span<byte> scanline, Span<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
+        public static void Encode(ReadOnlySpan<byte> scanline, ReadOnlySpan<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
         {
             DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
             DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));

--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -30,7 +30,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(Span<byte> scanline, Span<byte> previousScanline, int bytesPerPixel)
         {
-            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSameSized<byte>(scanline, previousScanline, nameof(scanline));
 
             ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
             ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
@@ -64,7 +64,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         /// <param name="sum">The sum of the total variance of the filtered row</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(Span<byte> scanline, Span<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
+        public static void Encode(ReadOnlySpan<byte> scanline, ReadOnlySpan<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
         {
             DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
             DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         /// <param name="sum">The sum of the total variance of the filtered row</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(Span<byte> scanline, Span<byte> result, int bytesPerPixel, out int sum)
+        public static void Encode(ReadOnlySpan<byte> scanline, ReadOnlySpan<byte> result, int bytesPerPixel, out int sum)
         {
             DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
 

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(Span<byte> scanline, Span<byte> previousScanline)
         {
-            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSameSized<byte>(scanline, previousScanline, nameof(scanline));
 
             ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
             ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         /// <param name="result">The filtered scanline result.</param>
         /// <param name="sum">The sum of the total variance of the filtered row</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(Span<byte> scanline, Span<byte> previousScanline, Span<byte> result, out int sum)
+        public static void Encode(ReadOnlySpan<byte> scanline, ReadOnlySpan<byte> previousScanline, Span<byte> result, out int sum)
         {
             DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
             DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));

--- a/src/ImageSharp/Formats/Png/PngChunk.cs
+++ b/src/ImageSharp/Formats/Png/PngChunk.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.Memory;
+using System.Buffers;
 
 namespace SixLabors.ImageSharp.Formats.Png
 {
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Formats.Png
     /// </summary>
     internal readonly struct PngChunk
     {
-        public PngChunk(int length, PngChunkType type, IManagedByteBuffer data = null)
+        public PngChunk(int length, PngChunkType type, IMemoryOwner<byte> data = null)
         {
             this.Length = length;
             this.Type = type;
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// Gets the data bytes appropriate to the chunk type, if any.
         /// This field can be of zero length or null.
         /// </summary>
-        public IManagedByteBuffer Data { get; }
+        public IMemoryOwner<byte> Data { get; }
 
         /// <summary>
         /// Gets a value indicating whether the given chunk is critical to decoding

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -746,78 +746,88 @@ namespace SixLabors.ImageSharp.Formats.Png
             ReadOnlySpan<byte> trimmed = defilteredScanline.Slice(1, defilteredScanline.Length - 1);
 
             // Convert 1, 2, and 4 bit pixel data into the 8 bit equivalent.
-            ReadOnlySpan<byte> scanlineSpan = this.TryScaleUpTo8BitArray(trimmed, this.bytesPerScanline, this.header.BitDepth, out IMemoryOwner<byte> buffer)
-            ? buffer.GetSpan()
-            : trimmed;
-
-            switch (this.pngColorType)
+            IMemoryOwner<byte> buffer = null;
+            try
             {
-                case PngColorType.Grayscale:
-                    PngScanlineProcessor.ProcessInterlacedGrayscaleScanline(
-                        this.header,
-                        scanlineSpan,
-                        rowSpan,
-                        pixelOffset,
-                        increment,
-                        pngMetadata.HasTransparency,
-                        pngMetadata.TransparentL16.GetValueOrDefault(),
-                        pngMetadata.TransparentL8.GetValueOrDefault());
+                ReadOnlySpan<byte> scanlineSpan = this.TryScaleUpTo8BitArray(
+                    trimmed,
+                    this.bytesPerScanline,
+                    this.header.BitDepth,
+                    out buffer)
+                ? buffer.GetSpan()
+                : trimmed;
 
-                    break;
+                switch (this.pngColorType)
+                {
+                    case PngColorType.Grayscale:
+                        PngScanlineProcessor.ProcessInterlacedGrayscaleScanline(
+                            this.header,
+                            scanlineSpan,
+                            rowSpan,
+                            pixelOffset,
+                            increment,
+                            pngMetadata.HasTransparency,
+                            pngMetadata.TransparentL16.GetValueOrDefault(),
+                            pngMetadata.TransparentL8.GetValueOrDefault());
 
-                case PngColorType.GrayscaleWithAlpha:
-                    PngScanlineProcessor.ProcessInterlacedGrayscaleWithAlphaScanline(
-                        this.header,
-                        scanlineSpan,
-                        rowSpan,
-                        pixelOffset,
-                        increment,
-                        this.bytesPerPixel,
-                        this.bytesPerSample);
+                        break;
 
-                    break;
+                    case PngColorType.GrayscaleWithAlpha:
+                        PngScanlineProcessor.ProcessInterlacedGrayscaleWithAlphaScanline(
+                            this.header,
+                            scanlineSpan,
+                            rowSpan,
+                            pixelOffset,
+                            increment,
+                            this.bytesPerPixel,
+                            this.bytesPerSample);
 
-                case PngColorType.Palette:
-                    PngScanlineProcessor.ProcessInterlacedPaletteScanline(
-                        this.header,
-                        scanlineSpan,
-                        rowSpan,
-                        pixelOffset,
-                        increment,
-                        this.palette,
-                        this.paletteAlpha);
+                        break;
 
-                    break;
+                    case PngColorType.Palette:
+                        PngScanlineProcessor.ProcessInterlacedPaletteScanline(
+                            this.header,
+                            scanlineSpan,
+                            rowSpan,
+                            pixelOffset,
+                            increment,
+                            this.palette,
+                            this.paletteAlpha);
 
-                case PngColorType.Rgb:
-                    PngScanlineProcessor.ProcessInterlacedRgbScanline(
-                        this.header,
-                        scanlineSpan,
-                        rowSpan,
-                        pixelOffset,
-                        increment,
-                        this.bytesPerPixel,
-                        this.bytesPerSample,
-                        pngMetadata.HasTransparency,
-                        pngMetadata.TransparentRgb48.GetValueOrDefault(),
-                        pngMetadata.TransparentRgb24.GetValueOrDefault());
+                        break;
 
-                    break;
+                    case PngColorType.Rgb:
+                        PngScanlineProcessor.ProcessInterlacedRgbScanline(
+                            this.header,
+                            scanlineSpan,
+                            rowSpan,
+                            pixelOffset,
+                            increment,
+                            this.bytesPerPixel,
+                            this.bytesPerSample,
+                            pngMetadata.HasTransparency,
+                            pngMetadata.TransparentRgb48.GetValueOrDefault(),
+                            pngMetadata.TransparentRgb24.GetValueOrDefault());
 
-                case PngColorType.RgbWithAlpha:
-                    PngScanlineProcessor.ProcessInterlacedRgbaScanline(
-                        this.header,
-                        scanlineSpan,
-                        rowSpan,
-                        pixelOffset,
-                        increment,
-                        this.bytesPerPixel,
-                        this.bytesPerSample);
+                        break;
 
-                    break;
+                    case PngColorType.RgbWithAlpha:
+                        PngScanlineProcessor.ProcessInterlacedRgbaScanline(
+                            this.header,
+                            scanlineSpan,
+                            rowSpan,
+                            pixelOffset,
+                            increment,
+                            this.bytesPerPixel,
+                            this.bytesPerSample);
+
+                        break;
+                }
             }
-
-            buffer?.Dispose();
+            finally
+            {
+                buffer?.Dispose();
+            }
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
@@ -84,12 +85,12 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <summary>
         /// Previous scanline processed.
         /// </summary>
-        private IManagedByteBuffer previousScanline;
+        private IMemoryOwner<byte> previousScanline;
 
         /// <summary>
         /// The current scanline that is being processed.
         /// </summary>
-        private IManagedByteBuffer scanline;
+        private IMemoryOwner<byte> scanline;
 
         /// <summary>
         /// The index of the current scanline being processed.
@@ -149,7 +150,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                         switch (chunk.Type)
                         {
                             case PngChunkType.Header:
-                                this.ReadHeaderChunk(pngMetadata, chunk.Data.Array);
+                                this.ReadHeaderChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.Physical:
                                 this.ReadPhysicalChunk(metadata, chunk.Data.GetSpan());
@@ -168,29 +169,29 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 break;
                             case PngChunkType.Palette:
                                 var pal = new byte[chunk.Length];
-                                Buffer.BlockCopy(chunk.Data.Array, 0, pal, 0, chunk.Length);
+                                chunk.Data.GetSpan().CopyTo(pal);
                                 this.palette = pal;
                                 break;
                             case PngChunkType.Transparency:
                                 var alpha = new byte[chunk.Length];
-                                Buffer.BlockCopy(chunk.Data.Array, 0, alpha, 0, chunk.Length);
+                                chunk.Data.GetSpan().CopyTo(alpha);
                                 this.paletteAlpha = alpha;
                                 this.AssignTransparentMarkers(alpha, pngMetadata);
                                 break;
                             case PngChunkType.Text:
-                                this.ReadTextChunk(pngMetadata, chunk.Data.Array.AsSpan(0, chunk.Length));
+                                this.ReadTextChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.CompressedText:
-                                this.ReadCompressedTextChunk(pngMetadata, chunk.Data.Array.AsSpan(0, chunk.Length));
+                                this.ReadCompressedTextChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.InternationalText:
-                                this.ReadInternationalTextChunk(pngMetadata, chunk.Data.Array.AsSpan(0, chunk.Length));
+                                this.ReadInternationalTextChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.Exif:
                                 if (!this.ignoreMetadata)
                                 {
                                     var exifData = new byte[chunk.Length];
-                                    Buffer.BlockCopy(chunk.Data.Array, 0, exifData, 0, chunk.Length);
+                                    chunk.Data.GetSpan().CopyTo(exifData);
                                     metadata.ExifProfile = new ExifProfile(exifData);
                                 }
 
@@ -239,7 +240,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                         switch (chunk.Type)
                         {
                             case PngChunkType.Header:
-                                this.ReadHeaderChunk(pngMetadata, chunk.Data.Array);
+                                this.ReadHeaderChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.Physical:
                                 this.ReadPhysicalChunk(metadata, chunk.Data.GetSpan());
@@ -251,19 +252,19 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 this.SkipChunkDataAndCrc(chunk);
                                 break;
                             case PngChunkType.Text:
-                                this.ReadTextChunk(pngMetadata, chunk.Data.Array.AsSpan(0, chunk.Length));
+                                this.ReadTextChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.CompressedText:
-                                this.ReadCompressedTextChunk(pngMetadata, chunk.Data.Array.AsSpan(0, chunk.Length));
+                                this.ReadCompressedTextChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.InternationalText:
-                                this.ReadInternationalTextChunk(pngMetadata, chunk.Data.Array.AsSpan(0, chunk.Length));
+                                this.ReadInternationalTextChunk(pngMetadata, chunk.Data.GetSpan());
                                 break;
                             case PngChunkType.Exif:
                                 if (!this.ignoreMetadata)
                                 {
                                     var exifData = new byte[chunk.Length];
-                                    Buffer.BlockCopy(chunk.Data.Array, 0, exifData, 0, chunk.Length);
+                                    chunk.Data.GetSpan().CopyTo(exifData);
                                     metadata.ExifProfile = new ExifProfile(exifData);
                                 }
 
@@ -312,7 +313,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="bits">The number of bits per value.</param>
         /// <param name="buffer">The new array.</param>
         /// <returns>The resulting <see cref="ReadOnlySpan{Byte}"/> array.</returns>
-        private bool TryScaleUpTo8BitArray(ReadOnlySpan<byte> source, int bytesPerScanline, int bits, out IManagedByteBuffer buffer)
+        private bool TryScaleUpTo8BitArray(ReadOnlySpan<byte> source, int bytesPerScanline, int bits, out IMemoryOwner<byte> buffer)
         {
             if (bits >= 8)
             {
@@ -320,9 +321,9 @@ namespace SixLabors.ImageSharp.Formats.Png
                 return false;
             }
 
-            buffer = this.memoryAllocator.AllocateManagedByteBuffer(bytesPerScanline * 8 / bits, AllocationOptions.Clean);
+            buffer = this.memoryAllocator.Allocate<byte>(bytesPerScanline * 8 / bits, AllocationOptions.Clean);
             ref byte sourceRef = ref MemoryMarshal.GetReference(source);
-            ref byte resultRef = ref buffer.Array[0];
+            ref byte resultRef = ref buffer.GetReference();
             int mask = 0xFF >> (8 - bits);
             int resultOffset = 0;
 
@@ -504,7 +505,8 @@ namespace SixLabors.ImageSharp.Formats.Png
         {
             while (this.currentRow < this.header.Height)
             {
-                int bytesRead = compressedStream.Read(this.scanline.Array, this.currentRowBytesRead, this.bytesPerScanline - this.currentRowBytesRead);
+                Span<byte> scanlineSpan = this.scanline.GetSpan();
+                int bytesRead = compressedStream.Read(scanlineSpan, this.currentRowBytesRead, this.bytesPerScanline - this.currentRowBytesRead);
                 this.currentRowBytesRead += bytesRead;
                 if (this.currentRowBytesRead < this.bytesPerScanline)
                 {
@@ -512,7 +514,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                 }
 
                 this.currentRowBytesRead = 0;
-                Span<byte> scanlineSpan = this.scanline.GetSpan();
 
                 switch ((FilterType)scanlineSpan[0])
                 {
@@ -576,7 +577,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
                 while (this.currentRow < this.header.Height)
                 {
-                    int bytesRead = compressedStream.Read(this.scanline.Array, this.currentRowBytesRead, bytesPerInterlaceScanline - this.currentRowBytesRead);
+                    int bytesRead = compressedStream.Read(this.scanline.GetSpan(), this.currentRowBytesRead, bytesPerInterlaceScanline - this.currentRowBytesRead);
                     this.currentRowBytesRead += bytesRead;
                     if (this.currentRowBytesRead < bytesPerInterlaceScanline)
                     {
@@ -653,7 +654,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             ReadOnlySpan<byte> trimmed = defilteredScanline.Slice(1, defilteredScanline.Length - 1);
 
             // Convert 1, 2, and 4 bit pixel data into the 8 bit equivalent.
-            ReadOnlySpan<byte> scanlineSpan = this.TryScaleUpTo8BitArray(trimmed, this.bytesPerScanline - 1, this.header.BitDepth, out IManagedByteBuffer buffer)
+            ReadOnlySpan<byte> scanlineSpan = this.TryScaleUpTo8BitArray(trimmed, this.bytesPerScanline - 1, this.header.BitDepth, out IMemoryOwner<byte> buffer)
             ? buffer.GetSpan()
             : trimmed;
 
@@ -735,7 +736,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             ReadOnlySpan<byte> trimmed = defilteredScanline.Slice(1, defilteredScanline.Length - 1);
 
             // Convert 1, 2, and 4 bit pixel data into the 8 bit equivalent.
-            ReadOnlySpan<byte> scanlineSpan = this.TryScaleUpTo8BitArray(trimmed, this.bytesPerScanline, this.header.BitDepth, out IManagedByteBuffer buffer)
+            ReadOnlySpan<byte> scanlineSpan = this.TryScaleUpTo8BitArray(trimmed, this.bytesPerScanline, this.header.BitDepth, out IMemoryOwner<byte> buffer)
             ? buffer.GetSpan()
             : trimmed;
 
@@ -1189,12 +1190,12 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// </summary>
         /// <param name="length">The length of the chunk data to read.</param>
         [MethodImpl(InliningOptions.ShortMethod)]
-        private IManagedByteBuffer ReadChunkData(int length)
+        private IMemoryOwner<byte> ReadChunkData(int length)
         {
             // We rent the buffer here to return it afterwards in Decode()
-            IManagedByteBuffer buffer = this.Configuration.MemoryAllocator.AllocateManagedByteBuffer(length, AllocationOptions.Clean);
+            IMemoryOwner<byte> buffer = this.Configuration.MemoryAllocator.Allocate<byte>(length, AllocationOptions.Clean);
 
-            this.currentStream.Read(buffer.Array, 0, length);
+            this.currentStream.Read(buffer.GetSpan(), 0, length);
 
             return buffer;
         }
@@ -1274,7 +1275,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
         private void SwapBuffers()
         {
-            IManagedByteBuffer temp = this.previousScanline;
+            IMemoryOwner<byte> temp = this.previousScanline;
             this.previousScanline = this.scanline;
             this.scanline = temp;
         }

--- a/tests/ImageSharp.Tests/Formats/Png/ReferenceImplementations.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/ReferenceImplementations.cs
@@ -22,9 +22,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         /// <param name="sum">The sum of the total variance of the filtered row</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void EncodePaethFilter(Span<byte> scanline, Span<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
+        public static void EncodePaethFilter(ReadOnlySpan<byte> scanline, Span<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
         {
-            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSameSized<byte>(scanline, previousScanline, nameof(scanline));
             DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
 
             ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
@@ -69,7 +69,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         /// <param name="sum">The sum of the total variance of the filtered row</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void EncodeSubFilter(Span<byte> scanline, Span<byte> result, int bytesPerPixel, out int sum)
+        public static void EncodeSubFilter(ReadOnlySpan<byte> scanline, Span<byte> result, int bytesPerPixel, out int sum)
         {
             DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
 
@@ -111,7 +111,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         /// <param name="result">The filtered scanline result.</param>
         /// <param name="sum">The sum of the total variance of the filtered row</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void EncodeUpFilter(Span<byte> scanline, Span<byte> previousScanline, Span<byte> result, out int sum)
+        public static void EncodeUpFilter(ReadOnlySpan<byte> scanline, Span<byte> previousScanline, Span<byte> result, out int sum)
         {
             DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
             DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
@@ -148,7 +148,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         /// <param name="sum">The sum of the total variance of the filtered row</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void EncodeAverageFilter(Span<byte> scanline, Span<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
+        public static void EncodeAverageFilter(ReadOnlySpan<byte> scanline, ReadOnlySpan<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
         {
             DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
             DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Migration to `IMemoryOwner<byte>` for png decoder/encoder

<!-- Thanks for contributing to ImageSharp! -->
