### PR TITLE
Migrate ManagedByteBuffer 4

### DIFF
--- a/src/ImageSharp/Compression/Zlib/Deflater.cs
+++ b/src/ImageSharp/Compression/Zlib/Deflater.cs
@@ -222,7 +222,7 @@ namespace SixLabors.ImageSharp.Compression.Zlib
         /// The number of compressed bytes added to the output, or 0 if either
         /// <see cref="IsNeedingInput"/> or <see cref="IsFinished"/> returns true or length is zero.
         /// </returns>
-        public int Deflate(byte[] output, int offset, int length)
+        public int Deflate(Span<byte> output, int offset, int length)
         {
             int origLength = length;
 

--- a/src/ImageSharp/Compression/Zlib/DeflaterOutputStream.cs
+++ b/src/ImageSharp/Compression/Zlib/DeflaterOutputStream.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Buffers;
 using System.IO;
 using SixLabors.ImageSharp.Memory;
 
@@ -14,8 +15,8 @@ namespace SixLabors.ImageSharp.Compression.Zlib
     internal sealed class DeflaterOutputStream : Stream
     {
         private const int BufferLength = 512;
-        private IManagedByteBuffer memoryOwner;
-        private readonly byte[] buffer;
+        private IMemoryOwner<byte> memoryOwner;
+        private readonly Memory<byte> buffer;
         private Deflater deflater;
         private readonly Stream rawStream;
         private bool isDisposed;
@@ -29,8 +30,8 @@ namespace SixLabors.ImageSharp.Compression.Zlib
         public DeflaterOutputStream(MemoryAllocator memoryAllocator, Stream rawStream, int compressionLevel)
         {
             this.rawStream = rawStream;
-            this.memoryOwner = memoryAllocator.AllocateManagedByteBuffer(BufferLength);
-            this.buffer = this.memoryOwner.Array;
+            this.memoryOwner = memoryAllocator.Allocate<byte>(BufferLength);
+            this.buffer = this.memoryOwner.Memory;
             this.deflater = new Deflater(memoryAllocator, compressionLevel);
         }
 
@@ -49,15 +50,9 @@ namespace SixLabors.ImageSharp.Compression.Zlib
         /// <inheritdoc/>
         public override long Position
         {
-            get
-            {
-                return this.rawStream.Position;
-            }
+            get => this.rawStream.Position;
 
-            set
-            {
-                throw new NotSupportedException();
-            }
+            set => throw new NotSupportedException();
         }
 
         /// <inheritdoc/>
@@ -93,14 +88,14 @@ namespace SixLabors.ImageSharp.Compression.Zlib
         {
             while (flushing || !this.deflater.IsNeedingInput)
             {
-                int deflateCount = this.deflater.Deflate(this.buffer, 0, BufferLength);
+                int deflateCount = this.deflater.Deflate(this.buffer.Span, 0, BufferLength);
 
                 if (deflateCount <= 0)
                 {
                     break;
                 }
 
-                this.rawStream.Write(this.buffer, 0, deflateCount);
+                this.rawStream.Write(this.buffer.Span.Slice(0, deflateCount));
             }
 
             if (!this.deflater.IsNeedingInput)
@@ -114,13 +109,13 @@ namespace SixLabors.ImageSharp.Compression.Zlib
             this.deflater.Finish();
             while (!this.deflater.IsFinished)
             {
-                int len = this.deflater.Deflate(this.buffer, 0, BufferLength);
+                int len = this.deflater.Deflate(this.buffer.Span, 0, BufferLength);
                 if (len <= 0)
                 {
                     break;
                 }
 
-                this.rawStream.Write(this.buffer, 0, len);
+                this.rawStream.Write(this.buffer.Span.Slice(0, len));
             }
 
             if (!this.deflater.IsFinished)

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -348,17 +348,16 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             where TPixel : unmanaged, IPixel<TPixel>
         {
             bool isL8 = typeof(TPixel) == typeof(L8);
-            using (IMemoryOwner<byte> colorPaletteBuffer = this.memoryAllocator.AllocateManagedByteBuffer(ColorPaletteSize8Bit, AllocationOptions.Clean))
+            using IMemoryOwner<byte> colorPaletteBuffer = this.memoryAllocator.Allocate<byte>(ColorPaletteSize8Bit, AllocationOptions.Clean);
+            Span<byte> colorPalette = colorPaletteBuffer.GetSpan();
+
+            if (isL8)
             {
-                Span<byte> colorPalette = colorPaletteBuffer.GetSpan();
-                if (isL8)
-                {
-                    this.Write8BitGray(stream, image, colorPalette);
-                }
-                else
-                {
-                    this.Write8BitColor(stream, image, colorPalette);
-                }
+                this.Write8BitGray(stream, image, colorPalette);
+            }
+            else
+            {
+                this.Write8BitColor(stream, image, colorPalette);
             }
         }
 
@@ -442,7 +441,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
                 MaxColors = 16
             });
             using IndexedImageFrame<TPixel> quantized = frameQuantizer.BuildPaletteAndQuantizeFrame(image, image.Bounds());
-            using IMemoryOwner<byte> colorPaletteBuffer = this.memoryAllocator.AllocateManagedByteBuffer(ColorPaletteSize4Bit, AllocationOptions.Clean);
+            using IMemoryOwner<byte> colorPaletteBuffer = this.memoryAllocator.Allocate<byte>(ColorPaletteSize4Bit, AllocationOptions.Clean);
 
             Span<byte> colorPalette = colorPaletteBuffer.GetSpan();
             ReadOnlySpan<TPixel> quantizedColorPalette = quantized.Palette.Span;
@@ -486,7 +485,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
                 MaxColors = 2
             });
             using IndexedImageFrame<TPixel> quantized = frameQuantizer.BuildPaletteAndQuantizeFrame(image, image.Bounds());
-            using IMemoryOwner<byte> colorPaletteBuffer = this.memoryAllocator.AllocateManagedByteBuffer(ColorPaletteSize1Bit, AllocationOptions.Clean);
+            using IMemoryOwner<byte> colorPaletteBuffer = this.memoryAllocator.Allocate<byte>(ColorPaletteSize1Bit, AllocationOptions.Clean);
 
             Span<byte> colorPalette = colorPaletteBuffer.GetSpan();
             ReadOnlySpan<TPixel> quantizedColorPalette = quantized.Palette.Span;

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -393,8 +393,8 @@ namespace SixLabors.ImageSharp.Formats.Png
                 this.bytesPerSample = this.header.BitDepth / 8;
             }
 
-            this.previousScanline = this.memoryAllocator.AllocateManagedByteBuffer(this.bytesPerScanline, AllocationOptions.Clean);
-            this.scanline = this.Configuration.MemoryAllocator.AllocateManagedByteBuffer(this.bytesPerScanline, AllocationOptions.Clean);
+            this.previousScanline = this.memoryAllocator.Allocate<byte>(this.bytesPerScanline, AllocationOptions.Clean);
+            this.scanline = this.Configuration.MemoryAllocator.Allocate<byte>(this.bytesPerScanline, AllocationOptions.Clean);
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Tiff/Writers/TiffBiColorWriter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/Writers/TiffBiColorWriter{TPixel}.cs
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Writers
             {
                 // Write uncompressed image.
                 int bytesPerStrip = this.BytesPerRow * height;
-                this.bitStrip ??= this.MemoryAllocator.AllocateManagedByteBuffer(bytesPerStrip);
+                this.bitStrip ??= this.MemoryAllocator.Allocate<byte>(bytesPerStrip);
                 this.pixelsAsGray ??= this.MemoryAllocator.Allocate<byte>(width);
                 Span<byte> pixelAsGraySpan = this.pixelsAsGray.GetSpan();
 

--- a/src/ImageSharp/Formats/Tiff/Writers/TiffPaletteWriter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/Writers/TiffPaletteWriter{TPixel}.cs
@@ -89,7 +89,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Writers
             else
             {
                 int stripPixels = width * height;
-                this.indexedPixelsBuffer ??= this.MemoryAllocator.AllocateManagedByteBuffer(stripPixels);
+                this.indexedPixelsBuffer ??= this.MemoryAllocator.Allocate<byte>(stripPixels);
                 Span<byte> indexedPixels = this.indexedPixelsBuffer.GetSpan();
                 int lastRow = y + height;
                 int indexedPixelsRowIdx = 0;
@@ -113,7 +113,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Writers
 
         private void AddColorMapTag()
         {
-            using IMemoryOwner<byte> colorPaletteBuffer = this.MemoryAllocator.AllocateManagedByteBuffer(this.colorPaletteBytes);
+            using IMemoryOwner<byte> colorPaletteBuffer = this.MemoryAllocator.Allocate<byte>(this.colorPaletteBytes);
             Span<byte> colorPalette = colorPaletteBuffer.GetSpan();
 
             ReadOnlySpan<TPixel> quantizedColors = this.quantizedImage.Palette.Span;

--- a/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Memory
         protected internal abstract int GetBufferCapacityInBytes();
 
         /// <summary>
-        /// Allocates an <see cref="IMemoryOwner{T}" />, holding a <see cref="System.Memory{T}"/> of length <paramref name="length"/>.
+        /// Allocates an <see cref="IMemoryOwner{T}" />, holding a <see cref="Memory{T}"/> of length <paramref name="length"/>.
         /// </summary>
         /// <typeparam name="T">Type of the data stored in the buffer.</typeparam>
         /// <param name="length">Size of the buffer to allocate.</param>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Removes the last usage outside of tests for `IManagedByteBuffer` and `MemoryAllocator.AllocateManagedByteBuffer(...)` to make it easier to refactor the memory allocator.

<!-- Thanks for contributing to ImageSharp! -->
