### PR TITLE
Updated Colourful from 2.0.5 to 3.0.0 (only benchmarks affected)

### DIFF
--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -20,7 +20,7 @@
     <!-- Test Dependencies -->
     <PackageReference Update="BenchmarkDotNet" Version="0.13.0" />
     <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0" Condition="'$(IsWindows)'=='true'" />
-    <PackageReference Update="Colourful" Version="2.0.5" />
+    <PackageReference Update="Colourful" Version="3.0.0" />
     <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="8.0.1" />
     <PackageReference Update="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.21311.3" />
     <PackageReference Update="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21311.3" />

--- a/tests/ImageSharp.Benchmarks/Color/ColorspaceCieXyzToCieLabConvert.cs
+++ b/tests/ImageSharp.Benchmarks/Color/ColorspaceCieXyzToCieLabConvert.cs
@@ -4,10 +4,10 @@
 using BenchmarkDotNet.Attributes;
 
 using Colourful;
-using Colourful.Conversion;
 
 using SixLabors.ImageSharp.ColorSpaces;
 using SixLabors.ImageSharp.ColorSpaces.Conversion;
+using Illuminants = Colourful.Illuminants;
 
 namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces
 {
@@ -19,12 +19,12 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces
 
         private static readonly ColorSpaceConverter ColorSpaceConverter = new ColorSpaceConverter();
 
-        private static readonly ColourfulConverter ColourfulConverter = new ColourfulConverter();
+        private static readonly IColorConverter<XYZColor, LabColor> ColourfulConverter = new ConverterBuilder().FromXYZ(Illuminants.D50).ToLab(Illuminants.D50).Build();
 
         [Benchmark(Baseline = true, Description = "Colourful Convert")]
         public double ColourfulConvert()
         {
-            return ColourfulConverter.ToLab(XYZColor).L;
+            return ColourfulConverter.Convert(XYZColor).L;
         }
 
         [Benchmark(Description = "ImageSharp Convert")]

--- a/tests/ImageSharp.Benchmarks/Color/ColorspaceCieXyzToHunterLabConvert.cs
+++ b/tests/ImageSharp.Benchmarks/Color/ColorspaceCieXyzToHunterLabConvert.cs
@@ -4,10 +4,10 @@
 using BenchmarkDotNet.Attributes;
 
 using Colourful;
-using Colourful.Conversion;
 
 using SixLabors.ImageSharp.ColorSpaces;
 using SixLabors.ImageSharp.ColorSpaces.Conversion;
+using Illuminants = Colourful.Illuminants;
 
 namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces
 {
@@ -19,12 +19,12 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces
 
         private static readonly ColorSpaceConverter ColorSpaceConverter = new ColorSpaceConverter();
 
-        private static readonly ColourfulConverter ColourfulConverter = new ColourfulConverter();
+        private static readonly IColorConverter<XYZColor, HunterLabColor> ColourfulConverter = new ConverterBuilder().FromXYZ(Illuminants.C).ToHunterLab(Illuminants.C).Build();
 
         [Benchmark(Baseline = true, Description = "Colourful Convert")]
         public double ColourfulConvert()
         {
-            return ColourfulConverter.ToHunterLab(XYZColor).L;
+            return ColourfulConverter.Convert(XYZColor).L;
         }
 
         [Benchmark(Description = "ImageSharp Convert")]

--- a/tests/ImageSharp.Benchmarks/Color/ColorspaceCieXyzToLmsConvert.cs
+++ b/tests/ImageSharp.Benchmarks/Color/ColorspaceCieXyzToLmsConvert.cs
@@ -4,7 +4,6 @@
 using BenchmarkDotNet.Attributes;
 
 using Colourful;
-using Colourful.Conversion;
 
 using SixLabors.ImageSharp.ColorSpaces;
 using SixLabors.ImageSharp.ColorSpaces.Conversion;
@@ -19,12 +18,12 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces
 
         private static readonly ColorSpaceConverter ColorSpaceConverter = new ColorSpaceConverter();
 
-        private static readonly ColourfulConverter ColourfulConverter = new ColourfulConverter();
+        private static readonly IColorConverter<XYZColor, LMSColor> ColourfulConverter = new ConverterBuilder().FromXYZ().ToLMS().Build();
 
         [Benchmark(Baseline = true, Description = "Colourful Convert")]
         public double ColourfulConvert()
         {
-            return ColourfulConverter.ToLMS(XYZColor).L;
+            return ColourfulConverter.Convert(XYZColor).L;
         }
 
         [Benchmark(Description = "ImageSharp Convert")]

--- a/tests/ImageSharp.Benchmarks/Color/ColorspaceCieXyzToRgbConvert.cs
+++ b/tests/ImageSharp.Benchmarks/Color/ColorspaceCieXyzToRgbConvert.cs
@@ -4,7 +4,6 @@
 using BenchmarkDotNet.Attributes;
 
 using Colourful;
-using Colourful.Conversion;
 
 using SixLabors.ImageSharp.ColorSpaces;
 using SixLabors.ImageSharp.ColorSpaces.Conversion;
@@ -19,12 +18,12 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces
 
         private static readonly ColorSpaceConverter ColorSpaceConverter = new ColorSpaceConverter();
 
-        private static readonly ColourfulConverter ColourfulConverter = new ColourfulConverter();
+        private static readonly IColorConverter<XYZColor, RGBColor> ColourfulConverter = new ConverterBuilder().FromXYZ(RGBWorkingSpaces.sRGB.WhitePoint).ToRGB(RGBWorkingSpaces.sRGB).Build();
 
         [Benchmark(Baseline = true, Description = "Colourful Convert")]
         public double ColourfulConvert()
         {
-            return ColourfulConverter.ToRGB(XYZColor).R;
+            return ColourfulConverter.Convert(XYZColor).R;
         }
 
         [Benchmark(Description = "ImageSharp Convert")]

--- a/tests/ImageSharp.Benchmarks/Color/RgbWorkingSpaceAdapt.cs
+++ b/tests/ImageSharp.Benchmarks/Color/RgbWorkingSpaceAdapt.cs
@@ -4,7 +4,6 @@
 using BenchmarkDotNet.Attributes;
 
 using Colourful;
-using Colourful.Conversion;
 
 using SixLabors.ImageSharp.ColorSpaces;
 using SixLabors.ImageSharp.ColorSpaces.Conversion;
@@ -15,20 +14,20 @@ namespace SixLabors.ImageSharp.Benchmarks.ColorSpaces
     {
         private static readonly Rgb Rgb = new Rgb(0.206162F, 0.260277F, 0.746717F, RgbWorkingSpaces.WideGamutRgb);
 
-        private static readonly RGBColor RGBColor = new RGBColor(0.206162, 0.260277, 0.746717, RGBWorkingSpaces.WideGamutRGB);
+        private static readonly RGBColor RGBColor = new RGBColor(0.206162, 0.260277, 0.746717);
 
         private static readonly ColorSpaceConverter ColorSpaceConverter = new ColorSpaceConverter(new ColorSpaceConverterOptions { TargetRgbWorkingSpace = RgbWorkingSpaces.SRgb });
 
-        private static readonly ColourfulConverter ColourfulConverter = new ColourfulConverter { TargetRGBWorkingSpace = RGBWorkingSpaces.sRGB };
+        private static readonly IColorConverter<RGBColor, RGBColor> ColourfulConverter = new ConverterBuilder().FromRGB(RGBWorkingSpaces.WideGamutRGB).ToRGB(RGBWorkingSpaces.sRGB).Build();
 
         [Benchmark(Baseline = true, Description = "Colourful Adapt")]
         public RGBColor ColourfulConvert()
         {
-            return ColourfulConverter.Adapt(RGBColor);
+            return ColourfulConverter.Convert(RGBColor);
         }
 
         [Benchmark(Description = "ImageSharp Adapt")]
-        internal Rgb ColorSpaceConvert()
+        public Rgb ColorSpaceConvert()
         {
             return ColorSpaceConverter.Adapt(Rgb);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

The Colourful library is used in the benchmarks, and recently, there was a [version 3.0.0](https://github.com/tompazourek/Colourful/releases/tag/3.0.0) released. I updated the package reference, and the converter code to reflect the new API.