### PR TITLE
Jpeg decoder refactoring, fixed 1693

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
@@ -22,7 +22,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         private JpegFrame frame;
         private JpegComponent[] components;
 
-        // The restart interval.
+        /// <summary>
+        /// The reset interval determined by RST markers.
+        /// </summary>
         private int restartInterval;
 
         // How many mcu's are left to do.
@@ -72,7 +74,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             this.acHuffmanTables = new HuffmanTable[maxTables];
         }
 
-        // Reset interval
+        /// <summary>
+        /// Sets reset interval determined by RST markers.
+        /// </summary>
         public int ResetInterval
         {
             set

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
@@ -18,11 +18,19 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
     {
         private readonly BufferedReadStream stream;
 
-        // Frame related
+        /// <summary>
+        /// <see cref="JpegFrame"/> instance containing decoding-related information.
+        /// </summary>
         private JpegFrame frame;
+
+        /// <summary>
+        /// Shortcut for <see cref="frame"/>.Components.
+        /// </summary>
         private JpegComponent[] components;
 
-        // The number of interleaved components.
+        /// <summary>
+        /// Number of component in the current scan.
+        /// </summary>
         private int componentsCount;
 
         /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/IRawJpegData.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/IRawJpegData.cs
@@ -17,11 +17,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         Size ImageSizeInPixels { get; }
 
         /// <summary>
-        /// Gets the number of components.
-        /// </summary>
-        int ComponentCount { get; }
-
-        /// <summary>
         /// Gets the color space
         /// </summary>
         JpegColorSpace ColorSpace { get; }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/IRawJpegData.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/IRawJpegData.cs
@@ -27,11 +27,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         JpegColorSpace ColorSpace { get; }
 
         /// <summary>
-        /// Gets the number of bits used for precision.
-        /// </summary>
-        int Precision { get; }
-
-        /// <summary>
         /// Gets the components.
         /// </summary>
         IJpegComponent[] Components { get; }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/IRawJpegData.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/IRawJpegData.cs
@@ -12,11 +12,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
     internal interface IRawJpegData : IDisposable
     {
         /// <summary>
-        /// Gets the image size in pixels.
-        /// </summary>
-        Size ImageSizeInPixels { get; }
-
-        /// <summary>
         /// Gets the color space
         /// </summary>
         JpegColorSpace ColorSpace { get; }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBlockPostProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBlockPostProcessor.cs
@@ -39,11 +39,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         private Size subSamplingDivisors;
 
         /// <summary>
-        /// Defines the maximum value derived from the bitdepth.
-        /// </summary>
-        private readonly int maximumValue;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="JpegBlockPostProcessor"/> struct.
         /// </summary>
         /// <param name="decoder">The raw jpeg data.</param>
@@ -53,7 +48,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             int qtIndex = component.QuantizationTableIndex;
             this.DequantiazationTable = ZigZag.CreateDequantizationTable(ref decoder.QuantizationTables[qtIndex]);
             this.subSamplingDivisors = component.SubSamplingDivisors;
-            this.maximumValue = (int)MathF.Pow(2, decoder.Precision) - 1;
 
             this.SourceBlock = default;
             this.WorkspaceBlock1 = default;

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponent.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponent.cs
@@ -123,8 +123,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             int blocksPerColumnForMcu = this.Frame.McusPerColumn * this.VerticalSamplingFactor;
             this.SizeInBlocks = new Size(blocksPerLineForMcu, blocksPerColumnForMcu);
 
-            JpegComponent c0 = this.Frame.Components[0];
-            this.SubSamplingDivisors = c0.SamplingFactors.DivideBy(this.SamplingFactors);
+            this.SubSamplingDivisors = new Size(maxSubFactorH, maxSubFactorV).DivideBy(this.SamplingFactors);
 
             if (this.SubSamplingDivisors.Width == 0 || this.SubSamplingDivisors.Height == 0)
             {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponent.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponent.cs
@@ -106,13 +106,18 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             this.SpectralBlocks = null;
         }
 
-        public void Init()
+        /// <summary>
+        /// Initializes component for future buffers initialization.
+        /// </summary>
+        /// <param name="maxSubFactorH">Maximal horizontal subsampling factor among all the components.</param>
+        /// <param name="maxSubFactorV">Maximal vertical subsampling factor among all the components.</param>
+        public void Init(int maxSubFactorH, int maxSubFactorV)
         {
             this.WidthInBlocks = (int)MathF.Ceiling(
-                MathF.Ceiling(this.Frame.PixelWidth / 8F) * this.HorizontalSamplingFactor / this.Frame.MaxHorizontalFactor);
+                MathF.Ceiling(this.Frame.PixelWidth / 8F) * this.HorizontalSamplingFactor / maxSubFactorH);
 
             this.HeightInBlocks = (int)MathF.Ceiling(
-                MathF.Ceiling(this.Frame.PixelHeight / 8F) * this.VerticalSamplingFactor / this.Frame.MaxVerticalFactor);
+                MathF.Ceiling(this.Frame.PixelHeight / 8F) * this.VerticalSamplingFactor / maxSubFactorV);
 
             int blocksPerLineForMcu = this.Frame.McusPerLine * this.HorizontalSamplingFactor;
             int blocksPerColumnForMcu = this.Frame.McusPerColumn * this.VerticalSamplingFactor;

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponentPostProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponentPostProcessor.cs
@@ -78,8 +78,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 
             var blockPp = new JpegBlockPostProcessor(this.RawJpeg, this.Component);
 
-            // TODO: this is a constant value for ALL components
-            float maximumValue = MathF.Pow(2, this.frame.Precision) - 1;
+            float maximumValue = this.frame.MaxColorChannelValue;
 
             int destAreaStride = this.ColorBuffer.Width;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponentPostProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponentPostProcessor.cs
@@ -22,10 +22,17 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         private readonly Size blockAreaSize;
 
         /// <summary>
+        /// Jpeg frame instance containing required decoding metadata.
+        /// </summary>
+        private readonly JpegFrame frame;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JpegComponentPostProcessor"/> class.
         /// </summary>
-        public JpegComponentPostProcessor(MemoryAllocator memoryAllocator, IRawJpegData rawJpeg, Size postProcessorBufferSize, IJpegComponent component)
+        public JpegComponentPostProcessor(MemoryAllocator memoryAllocator, JpegFrame frame, IRawJpegData rawJpeg, Size postProcessorBufferSize, IJpegComponent component)
         {
+            this.frame = frame;
+
             this.Component = component;
             this.RawJpeg = rawJpeg;
             this.blockAreaSize = this.Component.SubSamplingDivisors * 8;
@@ -70,7 +77,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             Buffer2D<Block8x8> spectralBuffer = this.Component.SpectralBlocks;
 
             var blockPp = new JpegBlockPostProcessor(this.RawJpeg, this.Component);
-            float maximumValue = MathF.Pow(2, this.RawJpeg.Precision) - 1;
+
+            // TODO: this is a constant value for ALL components
+            float maximumValue = MathF.Pow(2, this.frame.Precision) - 1;
 
             int destAreaStride = this.ColorBuffer.Width;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
@@ -90,6 +90,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         public int McusPerColumn { get; set; }
 
         /// <summary>
+        /// Gets the mcu size of the image.
+        /// </summary>
+        public Size McuSize => new Size(this.McusPerLine, this.McusPerColumn);
+
+        /// <summary>
         /// Gets the color depth, in number of bits per pixel.
         /// </summary>
         public int BitsPerPixel => this.ComponentCount * this.Precision;

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
@@ -10,15 +10,29 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
     /// </summary>
     internal sealed class JpegFrame : IDisposable
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether the frame uses the extended specification.
-        /// </summary>
-        public bool Extended { get; set; }
+        public JpegFrame(JpegFileMarker sofMarker, byte precision, int width, int height, byte componentCount)
+        {
+            this.Extended = sofMarker.Marker == JpegConstants.Markers.SOF1;
+            this.Progressive = sofMarker.Marker == JpegConstants.Markers.SOF2;
+
+            this.Precision = precision;
+            this.MaxColorChannelValue = MathF.Pow(2, precision) - 1;
+
+            this.PixelWidth = width;
+            this.PixelHeight = height;
+
+            this.ComponentCount = componentCount;
+        }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the frame uses the progressive specification.
+        /// Gets a value indicating whether the frame uses the extended specification.
         /// </summary>
-        public bool Progressive { get; set; }
+        public bool Extended { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the frame uses the progressive specification.
+        /// </summary>
+        public bool Progressive { get; private set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the frame is encoded using multiple scans (SOS markers).
@@ -29,19 +43,24 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         public bool MultiScan { get; set; }
 
         /// <summary>
-        /// Gets or sets the precision.
+        /// Gets the precision.
         /// </summary>
-        public byte Precision { get; set; }
+        public byte Precision { get; private set; }
 
         /// <summary>
-        /// Gets or sets the number of scanlines within the frame.
+        /// Gets the maximum color value derived from <see cref="Precision"/>.
         /// </summary>
-        public int PixelHeight { get; set; }
+        public float MaxColorChannelValue { get; private set; }
 
         /// <summary>
-        /// Gets or sets the number of samples per scanline.
+        /// Gets the number of pixel per row.
         /// </summary>
-        public int PixelWidth { get; set; }
+        public int PixelHeight { get; private set; }
+
+        /// <summary>
+        /// Gets the number of pixels per line.
+        /// </summary>
+        public int PixelWidth { get; private set; }
 
         /// <summary>
         /// Gets the pixel size of the image.
@@ -49,9 +68,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         public Size PixelSize => new Size(this.PixelWidth, this.PixelHeight);
 
         /// <summary>
-        /// Gets or sets the number of components within a frame. In progressive frames this value can range from only 1 to 4.
+        /// Gets the number of components within a frame. In progressive frames this value can range from only 1 to 4.
         /// </summary>
-        public byte ComponentCount { get; set; }
+        public byte ComponentCount { get; private set; }
 
         /// <summary>
         /// Gets or sets the component id collection.

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
@@ -70,16 +70,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         public JpegComponent[] Components { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum horizontal sampling factor.
-        /// </summary>
-        public int MaxHorizontalFactor { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum vertical sampling factor.
-        /// </summary>
-        public int MaxVerticalFactor { get; set; }
-
-        /// <summary>
         /// Gets or sets the number of MCU's per line.
         /// </summary>
         public int McusPerLine { get; set; }
@@ -116,15 +106,17 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <summary>
         /// Allocates the frame component blocks.
         /// </summary>
-        public void InitComponents()
+        /// <param name="maxSubFactorH">Maximal horizontal subsampling factor among all the components.</param>
+        /// <param name="maxSubFactorV">Maximal vertical subsampling factor among all the components.</param>
+        public void Init(int maxSubFactorH, int maxSubFactorV)
         {
-            this.McusPerLine = (int)Numerics.DivideCeil((uint)this.PixelWidth, (uint)this.MaxHorizontalFactor * 8);
-            this.McusPerColumn = (int)Numerics.DivideCeil((uint)this.PixelHeight, (uint)this.MaxVerticalFactor * 8);
+            this.McusPerLine = (int)Numerics.DivideCeil((uint)this.PixelWidth, (uint)maxSubFactorH * 8);
+            this.McusPerColumn = (int)Numerics.DivideCeil((uint)this.PixelHeight, (uint)maxSubFactorV * 8);
 
             for (int i = 0; i < this.ComponentCount; i++)
             {
                 JpegComponent component = this.Components[i];
-                component.Init();
+                component.Init(maxSubFactorH, maxSubFactorV);
             }
         }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
@@ -44,6 +44,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         public int PixelWidth { get; set; }
 
         /// <summary>
+        /// Gets the pixel size of the image.
+        /// </summary>
+        public Size PixelSize => new Size(this.PixelWidth, this.PixelHeight);
+
+        /// <summary>
         /// Gets or sets the number of components within a frame. In progressive frames this value can range from only 1 to 4.
         /// </summary>
         public byte ComponentCount { get; set; }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
@@ -84,6 +84,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// </summary>
         public int McusPerColumn { get; set; }
 
+        /// <summary>
+        /// Gets the color depth, in number of bits per pixel.
+        /// </summary>
+        public int BitsPerPixel => this.ComponentCount * this.Precision;
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegFrame.cs
@@ -68,7 +68,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         public Size PixelSize => new Size(this.PixelWidth, this.PixelHeight);
 
         /// <summary>
-        /// Gets the number of components within a frame. In progressive frames this value can range from only 1 to 4.
+        /// Gets the number of components within a frame.
         /// </summary>
         public byte ComponentCount { get; private set; }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
@@ -78,7 +78,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             this.componentProcessors = new JpegComponentPostProcessor[frame.Components.Length];
             for (int i = 0; i < this.componentProcessors.Length; i++)
             {
-                this.componentProcessors[i] = new JpegComponentPostProcessor(allocator, jpegData, postProcessorBufferSize, frame.Components[i]);
+                this.componentProcessors[i] = new JpegComponentPostProcessor(allocator, frame, jpegData, postProcessorBufferSize, frame.Components[i]);
             }
 
             // single 'stride' rgba32 buffer for conversion between spectral and TPixel

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -804,7 +804,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             // 1 byte: Bits/sample precision
             byte precision = this.temp[0];
 
-            // Validity check: only 8-bit and 12-bit precisions are supported
+            // Validate: only 8-bit and 12-bit precisions are supported
             if (Array.IndexOf(this.supportedPrecisions, precision) == -1)
             {
                 JpegThrowHelper.ThrowInvalidImageContentException("Only 8-Bit and 12-Bit precision supported.");
@@ -816,7 +816,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             // 2 byte: Width
             int frameWidth = (this.temp[3] << 8) | this.temp[4];
 
-            // Validity check: width/height > 0 (they are upper-bounded by 2 byte max value so no need to check that)
+            // Validate: width/height > 0 (they are upper-bounded by 2 byte max value so no need to check that)
             if (frameHeight == 0 || frameWidth == 0)
             {
                 JpegThrowHelper.ThrowInvalidImageDimensions(frameWidth, frameHeight);
@@ -834,7 +834,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             {
                 remaining -= length;
 
-                // Validity check: remaining part must be equal to components * 3
+                // Validate: remaining part must be equal to components * 3
                 const int componentBytes = 3;
                 if (remaining != componentCount * componentBytes)
                 {
@@ -978,7 +978,15 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 JpegThrowHelper.ThrowInvalidImageContentException("No readable SOFn (Start Of Frame) marker found.");
             }
 
+            // 1 byte: Number of components in scan
             int selectorsCount = stream.ReadByte();
+
+            // Validate: 0 < count <= totalComponents
+            if (selectorsCount == 0 || selectorsCount > this.Frame.ComponentCount)
+            {
+                JpegThrowHelper.ThrowInvalidImageContentException($"Invalid number of components in scan: {selectorsCount}. Must be [0 < count <= {this.Frame.ComponentCount}]");
+            }
+
             this.Frame.MultiScan = this.Frame.ComponentCount != selectorsCount;
             for (int i = 0; i < selectorsCount; i++)
             {

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -110,22 +110,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         public Size ImageSizeInPixels { get; private set; }
 
         /// <inheritdoc/>
-        Size IImageDecoderInternals.Dimensions => this.ImageSizeInPixels;
+        Size IImageDecoderInternals.Dimensions => this.Frame.PixelSize;
 
         /// <summary>
         /// Gets the number of MCU blocks in the image as <see cref="Size"/>.
         /// </summary>
         public Size ImageSizeInMCU { get; private set; }
-
-        /// <summary>
-        /// Gets the image width
-        /// </summary>
-        public int ImageWidth => this.ImageSizeInPixels.Width;
-
-        /// <summary>
-        /// Gets the image height
-        /// </summary>
-        public int ImageHeight => this.ImageSizeInPixels.Height;
 
         /// <summary>
         /// Gets a value indicating whether the metadata should be ignored when the image is being decoded.
@@ -214,7 +204,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             this.InitIptcProfile();
             this.InitDerivedMetadataProperties();
 
-            return new ImageInfo(new PixelTypeInfo(this.Frame.BitsPerPixel), this.ImageWidth, this.ImageHeight, this.Metadata);
+            Size pixelSize = this.Frame.PixelSize;
+            return new ImageInfo(new PixelTypeInfo(this.Frame.BitsPerPixel), pixelSize.Width, pixelSize.Height, this.Metadata);
         }
 
         /// <summary>
@@ -852,8 +843,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 PixelWidth = frameWidth,
                 ComponentCount = componentCount
             };
-
-            this.ImageSizeInPixels = new Size(this.Frame.PixelWidth, this.Frame.PixelHeight);
 
             this.Metadata.GetJpegMetadata().ColorType = this.ColorSpace == JpegColorSpace.Grayscale ? JpegColorType.Luminance : JpegColorType.YCbCr;
 

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -828,15 +828,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
 
             this.Metadata.GetJpegMetadata().ColorType = this.ColorSpace == JpegColorSpace.Grayscale ? JpegColorType.Luminance : JpegColorType.YCbCr;
 
-            this.Frame = new JpegFrame
-            {
-                Extended = frameMarker.Marker == JpegConstants.Markers.SOF1,
-                Progressive = frameMarker.Marker == JpegConstants.Markers.SOF2,
-                Precision = precision,
-                PixelHeight = frameHeight,
-                PixelWidth = frameWidth,
-                ComponentCount = componentCount
-            };
+            this.Frame = new JpegFrame(frameMarker, precision, frameWidth, frameHeight, componentCount);
 
             if (!metadataOnly)
             {

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -107,9 +107,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         public JpegFrame Frame { get; private set; }
 
         /// <inheritdoc/>
-        public Size ImageSizeInPixels { get; private set; }
-
-        /// <inheritdoc/>
         Size IImageDecoderInternals.Dimensions => this.Frame.PixelSize;
 
         /// <summary>
@@ -845,12 +842,14 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             {
                 remaining -= length;
 
+                // Validity check: remaining part must be equal to components * 3
                 const int componentBytes = 3;
                 if (remaining != componentCount * componentBytes)
                 {
                     JpegThrowHelper.ThrowBadMarker("SOFn", remaining);
                 }
 
+                // components*3 bytes: component data
                 stream.Read(this.temp, 0, remaining);
 
                 // No need to pool this. They max out at 4
@@ -885,9 +884,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     index += componentBytes;
                 }
 
-                this.Frame.MaxHorizontalFactor = maxH;
-                this.Frame.MaxVerticalFactor = maxV;
-                this.Frame.InitComponents();
+                this.Frame.Init(maxH, maxV);
 
                 this.scanDecoder.InjectFrameData(this.Frame, this);
             }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -513,7 +513,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 JpegThrowHelper.ThrowInvalidImageContentException("Bad App1 Marker length.");
             }
 
-            var profile = new byte[remaining];
+            byte[] profile = new byte[remaining];
             stream.Read(profile, 0, remaining);
 
             if (ProfileResolver.IsProfile(profile, ProfileResolver.ExifMarker))
@@ -547,14 +547,14 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 return;
             }
 
-            var identifier = new byte[Icclength];
+            byte[] identifier = new byte[Icclength];
             stream.Read(identifier, 0, Icclength);
             remaining -= Icclength; // We have read it by this point
 
             if (ProfileResolver.IsProfile(identifier, ProfileResolver.IccMarker))
             {
                 this.isIcc = true;
-                var profile = new byte[remaining];
+                byte[] profile = new byte[remaining];
                 stream.Read(profile, 0, remaining);
 
                 if (this.iccData is null)
@@ -592,7 +592,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             remaining -= ProfileResolver.AdobePhotoshopApp13Marker.Length;
             if (ProfileResolver.IsProfile(this.temp, ProfileResolver.AdobePhotoshopApp13Marker))
             {
-                var resourceBlockData = new byte[remaining];
+                byte[] resourceBlockData = new byte[remaining];
                 stream.Read(resourceBlockData, 0, remaining);
                 Span<byte> blockDataSpan = resourceBlockData.AsSpan();
 
@@ -607,8 +607,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     Span<byte> imageResourceBlockId = blockDataSpan.Slice(0, 2);
                     if (ProfileResolver.IsProfile(imageResourceBlockId, ProfileResolver.AdobeIptcMarker))
                     {
-                        var resourceBlockNameLength = ReadImageResourceNameLength(blockDataSpan);
-                        var resourceDataSize = ReadResourceDataLength(blockDataSpan, resourceBlockNameLength);
+                        int resourceBlockNameLength = ReadImageResourceNameLength(blockDataSpan);
+                        int resourceDataSize = ReadResourceDataLength(blockDataSpan, resourceBlockNameLength);
                         int dataStartIdx = 2 + resourceBlockNameLength + 4;
                         if (resourceDataSize > 0 && blockDataSpan.Length >= dataStartIdx + resourceDataSize)
                         {
@@ -619,8 +619,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     }
                     else
                     {
-                        var resourceBlockNameLength = ReadImageResourceNameLength(blockDataSpan);
-                        var resourceDataSize = ReadResourceDataLength(blockDataSpan, resourceBlockNameLength);
+                        int resourceBlockNameLength = ReadImageResourceNameLength(blockDataSpan);
+                        int resourceDataSize = ReadResourceDataLength(blockDataSpan, resourceBlockNameLength);
                         int dataStartIdx = 2 + resourceBlockNameLength + 4;
                         if (blockDataSpan.Length < dataStartIdx + resourceDataSize)
                         {
@@ -643,7 +643,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         private static int ReadImageResourceNameLength(Span<byte> blockDataSpan)
         {
             byte nameLength = blockDataSpan[2];
-            var nameDataSize = nameLength == 0 ? 2 : nameLength;
+            int nameDataSize = nameLength == 0 ? 2 : nameLength;
             if (nameDataSize % 2 != 0)
             {
                 nameDataSize++;
@@ -660,9 +660,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <returns>The block length.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
         private static int ReadResourceDataLength(Span<byte> blockDataSpan, int resourceBlockNameLength)
-        {
-            return BinaryPrimitives.ReadInt32BigEndian(blockDataSpan.Slice(2 + resourceBlockNameLength, 4));
-        }
+            => BinaryPrimitives.ReadInt32BigEndian(blockDataSpan.Slice(2 + resourceBlockNameLength, 4));
 
         /// <summary>
         /// Processes the application header containing the Adobe identifier

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -835,20 +835,28 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 JpegThrowHelper.ThrowInvalidImageContentException("Only 8-Bit and 12-Bit precision supported.");
             }
 
+            // 2 byte: height
+            int frameHeight = (this.temp[1] << 8) | this.temp[2];
+
+            // 2 byte: width
+            int frameWidth = (this.temp[3] << 8) | this.temp[4];
+
+            // Validity check: width/height > 0 (they are upper-bounded by 2 byte max value so no need to check that)
+            if (frameHeight == 0 || frameWidth == 0)
+            {
+                JpegThrowHelper.ThrowInvalidImageDimensions(this.Frame.PixelWidth, this.Frame.PixelHeight);
+            }
+
+
             this.Frame = new JpegFrame
             {
                 Extended = frameMarker.Marker == JpegConstants.Markers.SOF1,
                 Progressive = frameMarker.Marker == JpegConstants.Markers.SOF2,
                 Precision = precision,
-                PixelHeight = (this.temp[1] << 8) | this.temp[2],
-                PixelWidth = (this.temp[3] << 8) | this.temp[4],
+                PixelHeight = frameHeight,
+                PixelWidth = frameWidth,
                 ComponentCount = this.temp[5]
             };
-
-            if (this.Frame.PixelWidth == 0 || this.Frame.PixelHeight == 0)
-            {
-                JpegThrowHelper.ThrowInvalidImageDimensions(this.Frame.PixelWidth, this.Frame.PixelHeight);
-            }
 
             this.ImageSizeInPixels = new Size(this.Frame.PixelWidth, this.Frame.PixelHeight);
             this.ComponentCount = this.Frame.ComponentCount;

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -1034,6 +1034,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 // Validate: both must be < 4
                 if (dcTableIndex >= 4 || acTableIndex >= 4)
                 {
+                    // TODO: extract as separate method?
                     JpegThrowHelper.ThrowInvalidImageContentException($"Invalid huffman table for component:{componentSelectorId}: dc={dcTableIndex}, ac={acTableIndex}");
                 }
 

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -984,28 +984,32 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             // Validate: 0 < count <= totalComponents
             if (selectorsCount == 0 || selectorsCount > this.Frame.ComponentCount)
             {
-                JpegThrowHelper.ThrowInvalidImageContentException($"Invalid number of components in scan: {selectorsCount}. Must be [1 <= count <= {this.Frame.ComponentCount}]");
+                // TODO: extract as separate method?
+                JpegThrowHelper.ThrowInvalidImageContentException($"Invalid number of components in scan: {selectorsCount}. Must be [1 <= count <= {this.Frame.ComponentCount}].");
             }
 
             this.Frame.MultiScan = this.Frame.ComponentCount != selectorsCount;
             for (int i = 0; i < selectorsCount; i++)
             {
-                int componentIndex = -1;
-                int selector = stream.ReadByte();
+                // 1 byte: Component id
+                int componentSelectorId = stream.ReadByte();
 
+                int componentIndex = -1;
                 for (int j = 0; j < this.Frame.ComponentIds.Length; j++)
                 {
                     byte id = this.Frame.ComponentIds[j];
-                    if (selector == id)
+                    if (componentSelectorId == id)
                     {
                         componentIndex = j;
                         break;
                     }
                 }
 
-                if (componentIndex < 0)
+                // Validate: must be found among registered components
+                if (componentIndex == -1)
                 {
-                    JpegThrowHelper.ThrowInvalidImageContentException($"Unknown component selector {componentIndex}.");
+                    // TODO: extract as separate method?
+                    JpegThrowHelper.ThrowInvalidImageContentException($"Invalid component id in scan: {componentSelectorId}. Must be [0 <= id <= {this.Frame.ComponentCount - 1}]");
                 }
 
                 this.Frame.ComponentOrder[i] = (byte)componentIndex;

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -43,11 +43,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         private readonly byte[] markerBuffer = new byte[2];
 
         /// <summary>
-        /// The reset interval determined by RST markers.
-        /// </summary>
-        private ushort resetInterval;
-
-        /// <summary>
         /// Whether the image has an EXIF marker.
         /// </summary>
         private bool isExif;
@@ -1001,7 +996,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 JpegThrowHelper.ThrowBadMarker(nameof(JpegConstants.Markers.DRI), remaining);
             }
 
-            this.resetInterval = this.ReadUint16(stream);
+            this.scanDecoder.ResetInterval = this.ReadUint16(stream);
         }
 
         /// <summary>
@@ -1051,9 +1046,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
 
             // All the comments below are for separate refactoring PR
             // Main reason it's not fixed here is to make this commit less intrusive
-
-            // This can be injectd in DRI marker callback
-            this.scanDecoder.ResetInterval = this.resetInterval;
 
             // This can be passed as ParseEntropyCodedData() parameter as it is used only there
             this.scanDecoder.ComponentsLength = selectorsCount;

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -1044,19 +1044,13 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             int spectralEnd = this.temp[1];
             int successiveApproximation = this.temp[2];
 
-            // All the comments below are for separate refactoring PR
-            // Main reason it's not fixed here is to make this commit less intrusive
-
-            // This can be passed as ParseEntropyCodedData() parameter as it is used only there
-            this.scanDecoder.ComponentsLength = selectorsCount;
-
             // This is okay to inject here, might be good to wrap it in a separate struct but not really necessary
             this.scanDecoder.SpectralStart = spectralStart;
             this.scanDecoder.SpectralEnd = spectralEnd;
             this.scanDecoder.SuccessiveHigh = successiveApproximation >> 4;
             this.scanDecoder.SuccessiveLow = successiveApproximation & 15;
 
-            this.scanDecoder.ParseEntropyCodedData();
+            this.scanDecoder.ParseEntropyCodedData(selectorsCount);
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
@@ -87,7 +87,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             TestImages.Jpeg.Issues.Fuzz.ArgumentException826B,
             TestImages.Jpeg.Issues.Fuzz.ArgumentException826C,
             TestImages.Jpeg.Issues.Fuzz.AccessViolationException827,
-            TestImages.Jpeg.Issues.Fuzz.ExecutionEngineException839
+            TestImages.Jpeg.Issues.Fuzz.ExecutionEngineException839,
+            TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException1693A,
+            TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException1693B
         };
 
         private static readonly Dictionary<string, float> CustomToleranceValues =

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -62,10 +62,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             return !TestEnvironment.Is64BitProcess && largeImagesToSkipOn32Bit.Contains(provider.SourceFileOrDescription);
         }
 
-        public JpegDecoderTests(ITestOutputHelper output)
-        {
-            this.Output = output;
-        }
+        public JpegDecoderTests(ITestOutputHelper output) => this.Output = output;
 
         private ITestOutputHelper Output { get; }
 
@@ -163,7 +160,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         {
             var cts = new CancellationTokenSource();
 
-            var file = Path.Combine(TestEnvironment.InputImagesDirectoryFullPath, TestImages.Jpeg.Baseline.Jpeg420Small);
+            string file = Path.Combine(TestEnvironment.InputImagesDirectoryFullPath, TestImages.Jpeg.Baseline.Jpeg420Small);
             using var pausedStream = new PausedStream(file);
             pausedStream.OnWaiting(s =>
             {

--- a/tests/ImageSharp.Tests/Formats/Jpg/ParseStreamTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ParseStreamTests.cs
@@ -48,7 +48,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
                 Size expectedSizeInBlocks = decoder.ImageSizeInPixels.DivideRoundUp(8);
 
-                Assert.Equal(expectedSizeInBlocks, decoder.ImageSizeInMCU);
+                Assert.Equal(expectedSizeInBlocks, decoder.Frame.McuSize);
 
                 var uniform1 = new Size(1, 1);
                 JpegComponent c0 = decoder.Components[0];
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             using (JpegDecoderCore decoder = JpegFixture.ParseJpegStream(imageFile))
             {
                 sb.AppendLine(imageFile);
-                sb.AppendLine($"Size:{decoder.ImageSizeInPixels} MCU:{decoder.ImageSizeInMCU}");
+                sb.AppendLine($"Size:{decoder.ImageSizeInPixels} MCU:{decoder.Frame.McuSize}");
                 JpegComponent c0 = decoder.Components[0];
                 JpegComponent c1 = decoder.Components[1];
 
@@ -115,7 +115,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
                 var uniform1 = new Size(1, 1);
 
-                Size expectedLumaSizeInBlocks = decoder.ImageSizeInMCU.MultiplyBy(fLuma);
+                Size expectedLumaSizeInBlocks = decoder.Frame.McuSize.MultiplyBy(fLuma);
 
                 Size divisor = fLuma.DivideBy(fChroma);
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/ParseStreamTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ParseStreamTests.cs
@@ -46,7 +46,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 Assert.Equal(1, decoder.Frame.ComponentCount);
                 Assert.Equal(1, decoder.Components.Length);
 
-                Size expectedSizeInBlocks = decoder.ImageSizeInPixels.DivideRoundUp(8);
+                Size expectedSizeInBlocks = decoder.Frame.PixelSize.DivideRoundUp(8);
 
                 Assert.Equal(expectedSizeInBlocks, decoder.Frame.McuSize);
 
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             using (JpegDecoderCore decoder = JpegFixture.ParseJpegStream(imageFile))
             {
                 sb.AppendLine(imageFile);
-                sb.AppendLine($"Size:{decoder.ImageSizeInPixels} MCU:{decoder.Frame.McuSize}");
+                sb.AppendLine($"Size:{decoder.Frame.PixelSize} MCU:{decoder.Frame.McuSize}");
                 JpegComponent c0 = decoder.Components[0];
                 JpegComponent c1 = decoder.Components[1];
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/ParseStreamTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ParseStreamTests.cs
@@ -43,7 +43,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         {
             using (JpegDecoderCore decoder = JpegFixture.ParseJpegStream(TestImages.Jpeg.Baseline.Jpeg400))
             {
-                Assert.Equal(1, decoder.ComponentCount);
+                Assert.Equal(1, decoder.Frame.ComponentCount);
                 Assert.Equal(1, decoder.Components.Length);
 
                 Size expectedSizeInBlocks = decoder.ImageSizeInPixels.DivideRoundUp(8);
@@ -106,7 +106,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
             using (JpegDecoderCore decoder = JpegFixture.ParseJpegStream(imageFile))
             {
-                Assert.Equal(componentCount, decoder.ComponentCount);
+                Assert.Equal(componentCount, decoder.Frame.ComponentCount);
                 Assert.Equal(componentCount, decoder.Components.Length);
 
                 JpegComponent c0 = decoder.Components[0];

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -261,6 +261,8 @@ namespace SixLabors.ImageSharp.Tests
                     public const string AccessViolationException827 = "Jpg/issues/fuzz/Issue827-AccessViolationException.jpg";
                     public const string ExecutionEngineException839 = "Jpg/issues/fuzz/Issue839-ExecutionEngineException.jpg";
                     public const string AccessViolationException922 = "Jpg/issues/fuzz/Issue922-AccessViolationException.jpg";
+                    public const string IndexOutOfRangeException1693A = "Jpg/issues/fuzz/Issue1693-IndexOutOfRangeException-A.jpg";
+                    public const string IndexOutOfRangeException1693B = "Jpg/issues/fuzz/Issue1693-IndexOutOfRangeException-B.jpg";
                 }
             }
 

--- a/tests/Images/Input/Jpg/issues/fuzz/Issue1693-IndexOutOfRangeException-A.jpg
+++ b/tests/Images/Input/Jpg/issues/fuzz/Issue1693-IndexOutOfRangeException-A.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb6acd612cdb09825493d04ec7c6aba8ef2a94cc9a86c6b16218720adfb8f5c
+size 58065

--- a/tests/Images/Input/Jpg/issues/fuzz/Issue1693-IndexOutOfRangeException-B.jpg
+++ b/tests/Images/Input/Jpg/issues/fuzz/Issue1693-IndexOutOfRangeException-B.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8720a9ccf118c3f55407aa250ee490d583286c7e40c8c62a6f8ca449ca3ddff3
+size 58067


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
- SOF/SOS marker parsing code refactoring, added comments
- Fixed #1693, added tests for them
- Huffman tables are now part of the `HuffmanScanDecoder`