### PR TITLE
Fix a few uses of DeflateStream.Read

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -506,11 +506,15 @@ namespace SixLabors.ImageSharp.Formats.Png
             while (this.currentRow < this.header.Height)
             {
                 Span<byte> scanlineSpan = this.scanline.GetSpan();
-                int bytesRead = compressedStream.Read(scanlineSpan, this.currentRowBytesRead, this.bytesPerScanline - this.currentRowBytesRead);
-                this.currentRowBytesRead += bytesRead;
-                if (this.currentRowBytesRead < this.bytesPerScanline)
+                while (this.currentRowBytesRead < this.bytesPerScanline)
                 {
-                    return;
+                    int bytesRead = compressedStream.Read(scanlineSpan, this.currentRowBytesRead, this.bytesPerScanline - this.currentRowBytesRead);
+                    if (bytesRead <= 0)
+                    {
+                        return;
+                    }
+
+                    this.currentRowBytesRead += bytesRead;
                 }
 
                 this.currentRowBytesRead = 0;
@@ -577,11 +581,15 @@ namespace SixLabors.ImageSharp.Formats.Png
 
                 while (this.currentRow < this.header.Height)
                 {
-                    int bytesRead = compressedStream.Read(this.scanline.GetSpan(), this.currentRowBytesRead, bytesPerInterlaceScanline - this.currentRowBytesRead);
-                    this.currentRowBytesRead += bytesRead;
-                    if (this.currentRowBytesRead < bytesPerInterlaceScanline)
+                    while (this.currentRowBytesRead < bytesPerInterlaceScanline)
                     {
-                        return;
+                        int bytesRead = compressedStream.Read(this.scanline.GetSpan(), this.currentRowBytesRead, bytesPerInterlaceScanline - this.currentRowBytesRead);
+                        if (bytesRead <= 0)
+                        {
+                            return;
+                        }
+
+                        this.currentRowBytesRead += bytesRead;
                     }
 
                     this.currentRowBytesRead = 0;

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/DeflateTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/DeflateTiffCompression.cs
@@ -46,7 +46,18 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
             {
                 deframeStream.AllocateNewBytes(byteCount, true);
                 DeflateStream dataStream = deframeStream.CompressedStream;
-                dataStream.Read(buffer, 0, buffer.Length);
+
+                int totalRead = 0;
+                while (totalRead < buffer.Length)
+                {
+                    int bytesRead = dataStream.Read(buffer, totalRead, buffer.Length - totalRead);
+                    if (bytesRead <= 0)
+                    {
+                        break;
+                    }
+
+                    totalRead += bytesRead;
+                }
             }
 
             if (this.Predictor == TiffPredictor.Horizontal)


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)
(68 of the 71 _existing_ PngDecoder tests already fail when run against `master`, before and after this change, and I'm not sure if that's expected... presumably not?  Maybe I'm just doing something wrong?  I'm running them in test explorer in VS2022.)

### Description

The code is assuming Stream.Read always returns the requested number of bytes unless it hits EOF, but that's not guaranteed; the Stream.Read contract only guarantees at least 1 byte will be returned until EOF even if more are requested.

Fixes https://github.com/SixLabors/ImageSharp/issues/1704
https://github.com/dotnet/runtime/issues/55866
