### PR TITLE
Use same byte order as IFD directory to decode pixels for 16 bit per channel images

### DIFF
--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgb161616TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgb161616TiffColor{TPixel}.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Buffers.Binary;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
+{
+    /// <summary>
+    /// Implements the 'RGB' photometric interpretation with 16 bits for each channel.
+    /// </summary>
+    internal class Rgb161616TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        private readonly bool isBigEndian;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Rgb161616TiffColor{TPixel}" /> class.
+        /// </summary>
+        /// <param name="isBigEndian">if set to <c>true</c> decodes the pixel data as big endian, otherwise as little endian.</param>
+        public Rgb161616TiffColor(bool isBigEndian) => this.isBigEndian = isBigEndian;
+
+        /// <inheritdoc/>
+        public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
+        {
+            var color = default(TPixel);
+
+            int offset = 0;
+
+            var rgba = default(Rgba64);
+            for (int y = top; y < top + height; y++)
+            {
+                Span<TPixel> pixelRow = pixels.GetRowSpan(y);
+
+                for (int x = left; x < left + width; x++)
+                {
+                    ulong r = this.ConvertToShort(data.Slice(offset, 2));
+                    offset += 2;
+                    ulong g = this.ConvertToShort(data.Slice(offset, 2));
+                    offset += 2;
+                    ulong b = this.ConvertToShort(data.Slice(offset, 2));
+                    offset += 2;
+
+                    rgba.PackedValue = r | (g << 16) | (b << 32) | (0xfffful << 48);
+                    color.FromRgba64(rgba);
+
+                    pixelRow[x] = color;
+                }
+            }
+        }
+
+        private ushort ConvertToShort(ReadOnlySpan<byte> buffer) => this.isBigEndian
+                ? BinaryPrimitives.ReadUInt16BigEndian(buffer)
+                : BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
     internal static class TiffColorDecoderFactory<TPixel>
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        public static TiffBaseColorDecoder<TPixel> Create(TiffColorType colorType, TiffBitsPerSample bitsPerSample, ushort[] colorMap)
+        public static TiffBaseColorDecoder<TPixel> Create(TiffColorType colorType, TiffBitsPerSample bitsPerSample, ushort[] colorMap, ByteOrder byteOrder)
         {
             switch (colorType)
             {
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                         && bitsPerSample.Channel0 == 16,
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
-                    return new RgbTiffColor<TPixel>(bitsPerSample);
+                    return new Rgb161616TiffColor<TPixel>(isBigEndian: byteOrder == ByteOrder.BigEndian);
 
                 case TiffColorType.PaletteColor:
                     DebugGuard.NotNull(colorMap, "colorMap");

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -37,6 +37,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         private BufferedReadStream inputStream;
 
         /// <summary>
+        /// Indicates the byte order of the stream.
+        /// </summary>
+        private ByteOrder byteOrder;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TiffDecoderCore" /> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
@@ -109,6 +114,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             var reader = new DirectoryReader(stream);
 
             IEnumerable<ExifProfile> directories = reader.Read();
+            this.byteOrder = reader.ByteOrder;
 
             var frames = new List<ImageFrame<TPixel>>();
             foreach (ExifProfile ifd in directories)
@@ -310,7 +316,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                 this.Predictor,
                 this.FaxCompressionOptions);
 
-            TiffBaseColorDecoder<TPixel> colorDecoder = TiffColorDecoderFactory<TPixel>.Create(this.ColorType, this.BitsPerSample, this.ColorMap);
+            TiffBaseColorDecoder<TPixel> colorDecoder = TiffColorDecoderFactory<TPixel>.Create(this.ColorType, this.BitsPerSample, this.ColorMap, this.byteOrder);
 
             for (int stripIndex = 0; stripIndex < stripOffsets.Length; stripIndex++)
             {

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -164,6 +164,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [Theory]
         [WithFile(FlowerRgb161616Contiguous, PixelTypes.Rgba32)]
         [WithFile(FlowerRgb161616Planar, PixelTypes.Rgba32)]
+        [WithFile(Issues1716Rgb161616BitLittleEndian, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_48Bit<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -582,6 +582,7 @@ namespace SixLabors.ImageSharp.Tests
             public const string Flower12BitGray = "Tiff/flower-minisblack-12.tiff";
             public const string Flower14BitGray = "Tiff/flower-minisblack-14.tiff";
             public const string Flower16BitGray = "Tiff/flower-minisblack-16.tiff";
+            public const string Issues1716Rgb161616BitLittleEndian = "Tiff/Issues/Issue1716.tiff";
 
             public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
             public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/Images/Input/Tiff/Issues/Issue1716.tiff
+++ b/tests/Images/Input/Tiff/Issues/Issue1716.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c734dd489c65fb77bd7a35cd663aa16ce986df2c2ab8c7ca43d8b65db9d47c03
+size 6666162


### PR DESCRIPTION
…channel data, fixes #1716

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Use same byte order as IFD directory to decode pixels for 16 bit per channel data, fixes #1716.