### PR TITLE
Do not use static options for default quantizer constructors.

### DIFF
--- a/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
@@ -27,6 +27,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         [MethodImpl(InliningOptions.ShortMethod)]
         public ErrorDither(in DenseMatrix<float> matrix, int offset)
         {
+            Guard.MustBeGreaterThan(offset, 0, nameof(offset));
+
             this.matrix = matrix;
             this.offset = offset;
         }

--- a/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
@@ -95,6 +95,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             where TFrameQuantizer : struct, IQuantizer<TPixel>
             where TPixel : unmanaged, IPixel<TPixel>
         {
+            if (this == default)
+            {
+                ThrowDefaultInstance();
+            }
+
             int offsetY = bounds.Top;
             int offsetX = bounds.Left;
             float scale = quantizer.Options.DitherScale;
@@ -210,5 +215,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         /// <inheritdoc/>
         public override int GetHashCode()
             => HashCode.Combine(this.offset, this.matrix);
+
+        [MethodImpl(InliningOptions.ColdPath)]
+        private static void ThrowDefaultInstance()
+            => throw new ImageProcessingException("Cannot use the default value type instance to dither.");
     }
 }

--- a/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
@@ -129,6 +129,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             where TPaletteDitherImageProcessor : struct, IPaletteDitherImageProcessor<TPixel>
             where TPixel : unmanaged, IPixel<TPixel>
         {
+            if (this == default)
+            {
+                ThrowDefaultInstance();
+            }
+
             float scale = processor.DitherScale;
             for (int y = bounds.Top; y < bounds.Bottom; y++)
             {

--- a/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
@@ -24,6 +24,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         [MethodImpl(InliningOptions.ShortMethod)]
         public OrderedDither(uint length)
         {
+            Guard.MustBeGreaterThan(length, 0, nameof(length));
+
             DenseMatrix<uint> ditherMatrix = OrderedDitherFactory.CreateDitherMatrix(length);
 
             // Create a new matrix to run against, that pre-thresholds the values.

--- a/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
@@ -109,6 +109,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             where TFrameQuantizer : struct, IQuantizer<TPixel>
             where TPixel : unmanaged, IPixel<TPixel>
         {
+            if (this == default)
+            {
+                ThrowDefaultInstance();
+            }
+
             int spread = CalculatePaletteSpread(destination.Palette.Length);
             float scale = quantizer.Options.DitherScale;
 
@@ -201,5 +206,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
         [MethodImpl(InliningOptions.ShortMethod)]
         public override int GetHashCode()
             => HashCode.Combine(this.thresholdMatrix, this.modulusX, this.modulusY);
+
+        [MethodImpl(InliningOptions.ColdPath)]
+        private static void ThrowDefaultInstance()
+            => throw new ImageProcessingException("Cannot use the default value type instance to dither.");
     }
 }

--- a/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
@@ -141,6 +141,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Dithering
             where TPaletteDitherImageProcessor : struct, IPaletteDitherImageProcessor<TPixel>
             where TPixel : unmanaged, IPixel<TPixel>
         {
+            if (this == default)
+            {
+                ThrowDefaultInstance();
+            }
+
             int spread = CalculatePaletteSpread(processor.Palette.Length);
             float scale = processor.DitherScale;
 

--- a/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer.cs
@@ -11,14 +11,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     public class OctreeQuantizer : IQuantizer
     {
-        private static readonly QuantizerOptions DefaultOptions = new QuantizerOptions();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="OctreeQuantizer"/> class
         /// using the default <see cref="QuantizerOptions"/>.
         /// </summary>
         public OctreeQuantizer()
-            : this(DefaultOptions)
+            : this(new QuantizerOptions())
         {
         }
 

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer.cs
@@ -11,7 +11,6 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     public class PaletteQuantizer : IQuantizer
     {
-        private static readonly QuantizerOptions DefaultOptions = new QuantizerOptions();
         private readonly ReadOnlyMemory<Color> colorPalette;
 
         /// <summary>
@@ -19,7 +18,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         /// </summary>
         /// <param name="palette">The color palette.</param>
         public PaletteQuantizer(ReadOnlyMemory<Color> palette)
-            : this(palette, DefaultOptions)
+            : this(palette, new QuantizerOptions())
         {
         }
 

--- a/src/ImageSharp/Processing/Processors/Quantization/WebSafePaletteQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/WebSafePaletteQuantizer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using SixLabors.ImageSharp.Processing.Processors.Dithering;
-
 namespace SixLabors.ImageSharp.Processing.Processors.Quantization
 {
     /// <summary>
@@ -10,13 +8,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     public class WebSafePaletteQuantizer : PaletteQuantizer
     {
-        private static readonly QuantizerOptions DefaultOptions = new QuantizerOptions();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="WebSafePaletteQuantizer" /> class.
         /// </summary>
         public WebSafePaletteQuantizer()
-            : this(DefaultOptions)
+            : this(new QuantizerOptions())
         {
         }
 

--- a/src/ImageSharp/Processing/Processors/Quantization/WernerPaletteQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/WernerPaletteQuantizer.cs
@@ -9,13 +9,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     public class WernerPaletteQuantizer : PaletteQuantizer
     {
-        private static readonly QuantizerOptions DefaultOptions = new QuantizerOptions();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="WernerPaletteQuantizer" /> class.
         /// </summary>
         public WernerPaletteQuantizer()
-            : this(DefaultOptions)
+            : this(new QuantizerOptions())
         {
         }
 

--- a/src/ImageSharp/Processing/Processors/Quantization/WuQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/WuQuantizer.cs
@@ -10,14 +10,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
     /// </summary>
     public class WuQuantizer : IQuantizer
     {
-        private static readonly QuantizerOptions DefaultOptions = new QuantizerOptions();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="WuQuantizer"/> class
         /// using the default <see cref="QuantizerOptions"/>.
         /// </summary>
         public WuQuantizer()
-            : this(DefaultOptions)
+            : this(new QuantizerOptions())
         {
         }
 

--- a/tests/ImageSharp.Tests/Processing/Processors/Dithering/DitherTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Dithering/DitherTests.cs
@@ -43,6 +43,13 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Dithering
                 { KnownDitherings.Ordered3x3, nameof(KnownDitherings.Ordered3x3) }
             };
 
+        public static readonly TheoryData<IDither> DefaultInstanceDitherers
+            = new TheoryData<IDither>
+            {
+                default(ErrorDither),
+                default(OrderedDither)
+            };
+
         private static readonly ImageComparer ValidatorComparer = ImageComparer.TolerantPercentage(0.05f);
 
         private static IDither DefaultDitherer => KnownDitherings.Bayer4x4;
@@ -174,6 +181,19 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Dithering
                 41,
                 c => c.Dither(dither),
                 name);
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultInstanceDitherers))]
+        public void ShouldThrowForDefaultDitherInstance(IDither dither)
+        {
+            void Command()
+            {
+                using var image = new Image<Rgba32>(10, 10);
+                image.Mutate(x => x.Dither(dither));
+            }
+
+            Assert.Throws<ImageProcessingException>(Command);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Quantization/QuantizerTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Quantization/QuantizerTests.cs
@@ -5,6 +5,7 @@ using System;
 
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Processors.Dithering;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 using Xunit;
@@ -152,6 +153,13 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Quantization
             new WuQuantizer(OrderedDitherOptions),
         };
 
+        public static readonly TheoryData<IDither> DefaultInstanceDitherers
+            = new TheoryData<IDither>
+        {
+            default(ErrorDither),
+            default(OrderedDither)
+        };
+
         private static readonly ImageComparer ValidatorComparer = ImageComparer.TolerantPercentage(0.05F);
 
         [Theory]
@@ -216,6 +224,21 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Quantization
                 comparer: ValidatorComparer,
                 testOutputDetails: testOutputDetails,
                 appendPixelTypeToFileName: false);
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultInstanceDitherers))]
+        public void ShouldThrowForDefaultDitherInstance(IDither dither)
+        {
+            void Command()
+            {
+                using var image = new Image<Rgba32>(10, 10);
+                var quantizer = new WebSafePaletteQuantizer();
+                quantizer.Options.Dither = dither;
+                image.Mutate(x => x.Quantize(quantizer));
+            }
+
+            Assert.Throws<ImageProcessingException>(Command);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Quantization/QuantizerTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Quantization/QuantizerTests.cs
@@ -155,10 +155,10 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Quantization
 
         public static readonly TheoryData<IDither> DefaultInstanceDitherers
             = new TheoryData<IDither>
-        {
-            default(ErrorDither),
-            default(OrderedDither)
-        };
+            {
+                default(ErrorDither),
+                default(OrderedDither)
+            };
 
         private static readonly ImageComparer ValidatorComparer = ImageComparer.TolerantPercentage(0.05F);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
While investigating #1583 I realized that the static default options in all the quantizer instances could be overwritten which we should not allow. 

I've also ensured we throw a better exception should someone use the default current struct instances to dither.
<!-- Thanks for contributing to ImageSharp! -->
