### PR TITLE
Add support for decoding tiff's encoded with LeastSignificantBitFirst

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanTiffCompression.cs
@@ -22,11 +22,12 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         /// Initializes a new instance of the <see cref="ModifiedHuffmanTiffCompression" /> class.
         /// </summary>
         /// <param name="allocator">The memory allocator.</param>
+        /// <param name="fillOrder">The logical order of bits within a byte.</param>
         /// <param name="width">The image width.</param>
         /// <param name="bitsPerPixel">The number of bits per pixel.</param>
         /// <param name="photometricInterpretation">The photometric interpretation.</param>
-        public ModifiedHuffmanTiffCompression(MemoryAllocator allocator, int width, int bitsPerPixel, TiffPhotometricInterpretation photometricInterpretation)
-            : base(allocator, width, bitsPerPixel, FaxCompressionOptions.None, photometricInterpretation)
+        public ModifiedHuffmanTiffCompression(MemoryAllocator allocator, TiffFillOrder fillOrder, int width, int bitsPerPixel, TiffPhotometricInterpretation photometricInterpretation)
+            : base(allocator, fillOrder, width, bitsPerPixel, FaxCompressionOptions.None, photometricInterpretation)
         {
             bool isWhiteZero = photometricInterpretation == TiffPhotometricInterpretation.WhiteIsZero;
             this.whiteValue = (byte)(isWhiteZero ? 0 : 1);
@@ -36,7 +37,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         /// <inheritdoc/>
         protected override void Decompress(BufferedReadStream stream, int byteCount, Span<byte> buffer)
         {
-            using var bitReader = new T4BitReader(stream, byteCount, this.Allocator, eolPadding: false, isModifiedHuffman: true);
+            using var bitReader = new T4BitReader(stream, this.FillOrder, byteCount, this.Allocator, eolPadding: false, isModifiedHuffman: true);
 
             buffer.Clear();
             uint bitsWritten = 0;

--- a/src/ImageSharp/Formats/Tiff/Compression/TiffDecompressorsFactory.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/TiffDecompressorsFactory.cs
@@ -16,7 +16,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression
             int width,
             int bitsPerPixel,
             TiffPredictor predictor,
-            FaxCompressionOptions faxOptions)
+            FaxCompressionOptions faxOptions,
+            TiffFillOrder fillOrder)
         {
             switch (method)
             {
@@ -40,11 +41,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression
 
                 case TiffDecoderCompressionType.T4:
                     DebugGuard.IsTrue(predictor == TiffPredictor.None, "Predictor should only be used with lzw or deflate compression");
-                    return new T4TiffCompression(allocator, width, bitsPerPixel, faxOptions, photometricInterpretation);
+                    return new T4TiffCompression(allocator, fillOrder, width, bitsPerPixel, faxOptions, photometricInterpretation);
 
                 case TiffDecoderCompressionType.HuffmanRle:
                     DebugGuard.IsTrue(predictor == TiffPredictor.None, "Predictor should only be used with lzw or deflate compression");
-                    return new ModifiedHuffmanTiffCompression(allocator, width, bitsPerPixel, photometricInterpretation);
+                    return new ModifiedHuffmanTiffCompression(allocator, fillOrder, width, bitsPerPixel, photometricInterpretation);
 
                 default:
                     throw TiffThrowHelper.NotSupportedDecompressor(nameof(method));

--- a/src/ImageSharp/Formats/Tiff/README.md
+++ b/src/ImageSharp/Formats/Tiff/README.md
@@ -25,7 +25,7 @@
 
 ## Implementation Status
 
-- The Decoder and Encoder currently only supports a single frame per image.
+- The Decoder currently only supports a single frame per image.
 - Some compression formats are not yet supported. See the list below.
 
 ### Deviations from the TIFF spec (to be fixed)
@@ -81,7 +81,7 @@
 |Thresholding               |       |       |                          |
 |CellWidth                  |       |       |                          |
 |CellLength                 |       |       |                          |
-|FillOrder                  |       |   -   | Ignore. In practice is very uncommon, and is not recommended. |
+|FillOrder                  |       |   Y   | 						   |
 |ImageDescription           |   Y   |   Y   |                          |
 |Make                       |   Y   |   Y   |                          |
 |Model                      |   Y   |   Y   |                          |

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -86,6 +86,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         public FaxCompressionOptions FaxCompressionOptions { get; set; }
 
         /// <summary>
+        /// Gets or sets the the logical order of bits within a byte.
+        /// </summary>
+        public TiffFillOrder FillOrder { get; set; }
+
+        /// <summary>
         /// Gets or sets the planar configuration type to use when decoding the image.
         /// </summary>
         public TiffPlanarConfiguration PlanarConfiguration { get; set; }
@@ -264,7 +269,15 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     stripBuffers[stripIndex] = this.memoryAllocator.Allocate<byte>(uncompressedStripSize);
                 }
 
-                using TiffBaseDecompressor decompressor = TiffDecompressorsFactory.Create(this.CompressionType, this.memoryAllocator, this.PhotometricInterpretation, frame.Width, bitsPerPixel, this.Predictor, this.FaxCompressionOptions);
+                using TiffBaseDecompressor decompressor = TiffDecompressorsFactory.Create(
+                    this.CompressionType,
+                    this.memoryAllocator,
+                    this.PhotometricInterpretation,
+                    frame.Width,
+                    bitsPerPixel,
+                    this.Predictor,
+                    this.FaxCompressionOptions,
+                    this.FillOrder);
 
                 TiffBasePlanarColorDecoder<TPixel> colorDecoder = TiffColorDecoderFactory<TPixel>.CreatePlanar(this.ColorType, this.BitsPerSample, this.ColorMap, this.byteOrder);
 
@@ -314,7 +327,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                 frame.Width,
                 bitsPerPixel,
                 this.Predictor,
-                this.FaxCompressionOptions);
+                this.FaxCompressionOptions,
+                this.FillOrder);
 
             TiffBaseColorDecoder<TPixel> colorDecoder = TiffColorDecoderFactory<TPixel>.Create(this.ColorType, this.BitsPerSample, this.ColorMap, this.byteOrder);
 

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
@@ -35,9 +35,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             }
 
             TiffFillOrder fillOrder = (TiffFillOrder?)exifProfile.GetValue(ExifTag.FillOrder)?.Value ?? TiffFillOrder.MostSignificantBitFirst;
-            if (fillOrder != TiffFillOrder.MostSignificantBitFirst)
+            if (fillOrder == TiffFillOrder.LeastSignificantBitFirst && frameMetadata.BitsPerPixel != TiffBitsPerPixel.Bit1)
             {
-                TiffThrowHelper.ThrowNotSupported("The lower-order bits of the byte FillOrder is not supported.");
+                TiffThrowHelper.ThrowNotSupported("The lower-order bits of the byte FillOrder is only supported in combination with 1bit per pixel bicolor tiff's.");
             }
 
             if (frameMetadata.Predictor == TiffPredictor.FloatingPoint)
@@ -69,6 +69,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             options.PhotometricInterpretation = frameMetadata.PhotometricInterpretation ?? TiffPhotometricInterpretation.Rgb;
             options.BitsPerPixel = frameMetadata.BitsPerPixel != null ? (int)frameMetadata.BitsPerPixel.Value : (int)TiffBitsPerPixel.Bit24;
             options.BitsPerSample = frameMetadata.BitsPerSample ?? new TiffBitsPerSample(0, 0, 0);
+            options.FillOrder = fillOrder;
 
             options.ParseColorType(exifProfile);
             options.ParseCompression(frameMetadata.Compression, exifProfile);

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -222,6 +222,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
+        [WithFile(CcittFax3LowerOrderBitsFirst01, PixelTypes.Rgba32)]
+        [WithFile(CcittFax3LowerOrderBitsFirst02, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_Compressed_LowerOrderBitsFirst<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
         [WithFile(Calliphora_RgbPackbits, PixelTypes.Rgba32)]
         [WithFile(RgbPackbits, PixelTypes.Rgba32)]
         [WithFile(RgbPackbitsMultistrip, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -222,8 +222,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
-        [WithFile(CcittFax3LowerOrderBitsFirst01, PixelTypes.Rgba32)]
-        [WithFile(CcittFax3LowerOrderBitsFirst02, PixelTypes.Rgba32)]
+        [WithFile(CcittFax3LowerOrderBitsFirst, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_Compressed_LowerOrderBitsFirst<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -117,7 +117,11 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [InlineData(TiffPhotometricInterpretation.Rgb, TiffCompression.Jpeg, TiffBitsPerPixel.Bit24, TiffCompression.None)]
         [InlineData(TiffPhotometricInterpretation.Rgb, TiffCompression.OldDeflate, TiffBitsPerPixel.Bit24, TiffCompression.None)]
         [InlineData(TiffPhotometricInterpretation.Rgb, TiffCompression.OldJpeg, TiffBitsPerPixel.Bit24, TiffCompression.None)]
-        public void EncoderOptions_SetPhotometricInterpretationAndCompression_Works(TiffPhotometricInterpretation? photometricInterpretation, TiffCompression compression, TiffBitsPerPixel expectedBitsPerPixel, TiffCompression expectedCompression)
+        public void EncoderOptions_SetPhotometricInterpretationAndCompression_Works(
+            TiffPhotometricInterpretation? photometricInterpretation,
+            TiffCompression compression,
+            TiffBitsPerPixel expectedBitsPerPixel,
+            TiffCompression expectedCompression)
         {
             // arrange
             var tiffEncoder = new TiffEncoder { PhotometricInterpretation = photometricInterpretation, Compression = compression };

--- a/tests/ImageSharp.Tests/Memory/Allocators/ArrayPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/ArrayPoolMemoryAllocatorTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Tests.Memory.Allocators
 {
+    [Collection("RunSerial")]
     public class ArrayPoolMemoryAllocatorTests
     {
         private const int MaxPooledBufferSizeInBytes = 2048;
@@ -56,19 +57,14 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
 
             [Fact]
             public void When_PoolSelectorThresholdInBytes_IsGreaterThan_MaxPooledBufferSizeInBytes_ExceptionIsThrown()
-            {
-                Assert.ThrowsAny<Exception>(() => new ArrayPoolMemoryAllocator(100, 200));
-            }
+                => Assert.ThrowsAny<Exception>(() => new ArrayPoolMemoryAllocator(100, 200));
         }
 
         [Theory]
         [InlineData(32)]
         [InlineData(512)]
         [InlineData(MaxPooledBufferSizeInBytes - 1)]
-        public void SmallBuffersArePooled_OfByte(int size)
-        {
-            Assert.True(this.LocalFixture.CheckIsRentingPooledBuffer<byte>(size));
-        }
+        public void SmallBuffersArePooled_OfByte(int size) => Assert.True(this.LocalFixture.CheckIsRentingPooledBuffer<byte>(size));
 
         [Theory]
         [InlineData(128 * 1024 * 1024)]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -539,8 +539,7 @@ namespace SixLabors.ImageSharp.Tests
             public const string CcittFax3AllMakeupCodes = "Tiff/ccitt_fax3_all_makeup_codes.tiff";
             public const string HuffmanRleAllTermCodes = "Tiff/huffman_rle_all_terminating_codes.tiff";
             public const string HuffmanRleAllMakeupCodes = "Tiff/huffman_rle_all_makeup_codes.tiff";
-            public const string CcittFax3LowerOrderBitsFirst01 = "Tiff/f8179f8f5e566349cf3583a1ff3ea95c.tiff";
-            public const string CcittFax3LowerOrderBitsFirst02 = "Tiff/g3test.tiff";
+            public const string CcittFax3LowerOrderBitsFirst = "Tiff/basi3p02_fax3_lowerOrderBitsFirst.tiff";
             public const string HuffmanRleLowerOrderBitsFirst = "Tiff/basi3p02_huffman_rle_lowerOrderBitsFirst.tiff";
 
             // Test case for an issue, that the last bits in a row got ignored.
@@ -607,7 +606,6 @@ namespace SixLabors.ImageSharp.Tests
             public const string MultiframeDifferentSize = "Tiff/multipage_differentSize.tiff";
             public const string MultiframeDifferentVariants = "Tiff/multipage_differentVariants.tiff";
 
-            public const string FillOrder2 = "Tiff/b0350_fillorder2.tiff";
             public const string LittleEndianByteOrder = "Tiff/little_endian.tiff";
 
             public const string Fax4_Motorola = "Tiff/moy.tiff";
@@ -622,7 +620,7 @@ namespace SixLabors.ImageSharp.Tests
 
             public static readonly string[] Metadata = { SampleMetadata };
 
-            public static readonly string[] NotSupported = { Calliphora_RgbJpeg, RgbJpeg, RgbUncompressedTiled, MultiframeDifferentSize, MultiframeDifferentVariants, FillOrder2, Calliphora_Fax4Compressed, Fax4_Motorola };
+            public static readonly string[] NotSupported = { Calliphora_RgbJpeg, RgbJpeg, RgbUncompressedTiled, MultiframeDifferentSize, MultiframeDifferentVariants, Calliphora_Fax4Compressed, Fax4_Motorola };
         }
     }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -539,6 +539,9 @@ namespace SixLabors.ImageSharp.Tests
             public const string CcittFax3AllMakeupCodes = "Tiff/ccitt_fax3_all_makeup_codes.tiff";
             public const string HuffmanRleAllTermCodes = "Tiff/huffman_rle_all_terminating_codes.tiff";
             public const string HuffmanRleAllMakeupCodes = "Tiff/huffman_rle_all_makeup_codes.tiff";
+            public const string CcittFax3LowerOrderBitsFirst01 = "Tiff/f8179f8f5e566349cf3583a1ff3ea95c.tiff";
+            public const string CcittFax3LowerOrderBitsFirst02 = "Tiff/g3test.tiff";
+            public const string HuffmanRleLowerOrderBitsFirst = "Tiff/basi3p02_huffman_rle_lowerOrderBitsFirst.tiff";
 
             // Test case for an issue, that the last bits in a row got ignored.
             public const string HuffmanRle_basi3p02 = "Tiff/basi3p02_huffman_rle.tiff";

--- a/tests/Images/Input/Tiff/7324fcaff3aad96f27899da51c1bb5d9.tiff
+++ b/tests/Images/Input/Tiff/7324fcaff3aad96f27899da51c1bb5d9.tiff
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:622d69dba0a8a67aa3b87e384a2b9ea8d29689eaa5cb5d0eee857f98ed660517
-size 15154924
+oid sha256:e4a6c925dd6d293c5d97aac01cdb0ab3f2fb4bbfa4bb1cbe6463545295f5c5fb
+size 207979

--- a/tests/Images/Input/Tiff/7324fcaff3aad96f27899da51c1bb5d9.tiff
+++ b/tests/Images/Input/Tiff/7324fcaff3aad96f27899da51c1bb5d9.tiff
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4a6c925dd6d293c5d97aac01cdb0ab3f2fb4bbfa4bb1cbe6463545295f5c5fb
-size 207979
+oid sha256:579db6b2bd34566846de992f255c6b341d0f88d957a0eb02b01caad3f20c5b44
+size 78794

--- a/tests/Images/Input/Tiff/Calliphora_ccitt_fax3.tiff
+++ b/tests/Images/Input/Tiff/Calliphora_ccitt_fax3.tiff
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b9b105857723bca5f478a9ab23c0aeca93abe863781019bbd2da47f18c46f24
-size 125778
+oid sha256:bba35f1e43c8425f3bcfab682efae4d2c00c62f0d8a4b411e646d32047469526
+size 125802

--- a/tests/Images/Input/Tiff/b0350_fillorder2.tiff
+++ b/tests/Images/Input/Tiff/b0350_fillorder2.tiff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37c6a28f460d8781fdc3bcf0cc9bd23f633b03899563546bfc6234a8478f67f0
-size 68637

--- a/tests/Images/Input/Tiff/basi3p02_fax3_lowerOrderBitsFirst.tiff
+++ b/tests/Images/Input/Tiff/basi3p02_fax3_lowerOrderBitsFirst.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb56b3582c5c7d91d712e68181110ab0bf74d21992030629f05803c420b7b483
+size 388

--- a/tests/Images/Input/Tiff/basi3p02_huffman_rle_lowerOrderBitsFirst.tiff
+++ b/tests/Images/Input/Tiff/basi3p02_huffman_rle_lowerOrderBitsFirst.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ac3e56a93996464a579ae19cf5f8d9531e2f08db36879aaba176731c24951a5
+size 352

--- a/tests/Images/Input/Tiff/f8179f8f5e566349cf3583a1ff3ea95c.tiff
+++ b/tests/Images/Input/Tiff/f8179f8f5e566349cf3583a1ff3ea95c.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf75c4b679d2449e239f228cdee6a25adc7d7b16dde3fb9061a07b2fb0699db1
+size 735412

--- a/tests/Images/Input/Tiff/g3test.tiff
+++ b/tests/Images/Input/Tiff/g3test.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5b2e1a17338133aa95cb8a16d82a171f5b50f7b9ae1a51ab06227dc3daa81d5
+size 50401


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This **PR** adds support for decoding 1bit tiff's encoded with LeastSignificantBitFirst: pixels are arranged within a byte such that pixels with lower column values are stored in the lower-order bits of the byte.

Also reduce test images size for some images to reduce memory usage and time it takes to execute the tiff tests.