### PR TITLE
Use bulk pixel conversion for some tiff color decoders

### DIFF
--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero16TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero16TiffColor{TPixel}.cs
@@ -16,11 +16,18 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
     {
         private readonly bool isBigEndian;
 
+        private readonly Configuration configuration;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BlackIsZero16TiffColor{TPixel}" /> class.
         /// </summary>
+        /// <param name="configuration">The configuration.</param>
         /// <param name="isBigEndian">if set to <c>true</c> decodes the pixel data as big endian, otherwise as little endian.</param>
-        public BlackIsZero16TiffColor(bool isBigEndian) => this.isBigEndian = isBigEndian;
+        public BlackIsZero16TiffColor(Configuration configuration, bool isBigEndian)
+        {
+            this.configuration = configuration;
+            this.isBigEndian = isBigEndian;
+        }
 
         /// <inheritdoc/>
         public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
@@ -47,13 +54,14 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                 }
                 else
                 {
-                    for (int x = 0; x < pixelRow.Length; x++)
-                    {
-                        ushort intensity = TiffUtils.ConvertToShortLittleEndian(data.Slice(offset, 2));
-                        offset += 2;
+                    int byteCount = pixelRow.Length * 2;
+                    PixelOperations<TPixel>.Instance.FromL16Bytes(
+                        this.configuration,
+                        data.Slice(offset, byteCount),
+                        pixelRow,
+                        pixelRow.Length);
 
-                        pixelRow[x] = TiffUtils.ColorFromL16(l16, intensity, color);
-                    }
+                    offset += byteCount;
                 }
             }
         }

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero8TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero8TiffColor{TPixel}.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp.Formats.Tiff.Utils;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -14,22 +13,26 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
     internal class BlackIsZero8TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
         where TPixel : unmanaged, IPixel<TPixel>
     {
+        private readonly Configuration configuration;
+
+        public BlackIsZero8TiffColor(Configuration configuration) => this.configuration = configuration;
+
         /// <inheritdoc/>
         public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
         {
-            var color = default(TPixel);
-
             int offset = 0;
 
-            var l8 = default(L8);
             for (int y = top; y < top + height; y++)
             {
                 Span<TPixel> pixelRow = pixels.GetRowSpan(y).Slice(left, width);
-                for (int x = 0; x < pixelRow.Length; x++)
-                {
-                    byte intensity = data[offset++];
-                    pixelRow[x] = TiffUtils.ColorFromL8(l8, intensity, color);
-                }
+                int byteCount = pixelRow.Length;
+                PixelOperations<TPixel>.Instance.FromL8Bytes(
+                    this.configuration,
+                    data.Slice(offset, byteCount),
+                    pixelRow,
+                    pixelRow.Length);
+
+                offset += byteCount;
             }
         }
     }

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
     internal static class TiffColorDecoderFactory<TPixel>
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        public static TiffBaseColorDecoder<TPixel> Create(TiffColorType colorType, TiffBitsPerSample bitsPerSample, ushort[] colorMap, ByteOrder byteOrder)
+        public static TiffBaseColorDecoder<TPixel> Create(Configuration configuration, TiffColorType colorType, TiffBitsPerSample bitsPerSample, ushort[] colorMap, ByteOrder byteOrder)
         {
             switch (colorType)
             {
@@ -55,12 +55,12 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                 case TiffColorType.BlackIsZero8:
                     DebugGuard.IsTrue(bitsPerSample.Channels == 1 && bitsPerSample.Channel0 == 8, "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
-                    return new BlackIsZero8TiffColor<TPixel>();
+                    return new BlackIsZero8TiffColor<TPixel>(configuration);
 
                 case TiffColorType.BlackIsZero16:
                     DebugGuard.IsTrue(bitsPerSample.Channels == 1 && bitsPerSample.Channel0 == 16, "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
-                    return new BlackIsZero16TiffColor<TPixel>(byteOrder == ByteOrder.BigEndian);
+                    return new BlackIsZero16TiffColor<TPixel>(configuration, byteOrder == ByteOrder.BigEndian);
 
                 case TiffColorType.Rgb:
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
@@ -94,7 +94,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                         && bitsPerSample.Channel0 == 8,
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
-                    return new Rgb888TiffColor<TPixel>();
+                    return new Rgb888TiffColor<TPixel>(configuration);
 
                 case TiffColorType.Rgb101010:
                     DebugGuard.IsTrue(
@@ -134,7 +134,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                         && bitsPerSample.Channel0 == 16,
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
-                    return new Rgb161616TiffColor<TPixel>(isBigEndian: byteOrder == ByteOrder.BigEndian);
+                    return new Rgb161616TiffColor<TPixel>(configuration, isBigEndian: byteOrder == ByteOrder.BigEndian);
 
                 case TiffColorType.PaletteColor:
                     DebugGuard.NotNull(colorMap, "colorMap");

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -316,7 +316,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                 this.Predictor,
                 this.FaxCompressionOptions);
 
-            TiffBaseColorDecoder<TPixel> colorDecoder = TiffColorDecoderFactory<TPixel>.Create(this.ColorType, this.BitsPerSample, this.ColorMap, this.byteOrder);
+            TiffBaseColorDecoder<TPixel> colorDecoder = TiffColorDecoderFactory<TPixel>.Create(this.Configuration, this.ColorType, this.BitsPerSample, this.ColorMap, this.byteOrder);
 
             for (int stripIndex = 0; stripIndex < stripOffsets.Length; stripIndex++)
             {

--- a/tests/ImageSharp.Tests/Formats/Tiff/PhotometricInterpretation/BlackIsZeroTiffColorTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/PhotometricInterpretation/BlackIsZeroTiffColorTests.cs
@@ -188,7 +188,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff.PhotometricInterpretation
         {
             AssertDecode(expectedResult, pixels =>
                 {
-                    new BlackIsZero8TiffColor<Rgba32>().Decode(inputData, pixels, left, top, width, height);
+                    new BlackIsZero8TiffColor<Rgba32>(Configuration.Default).Decode(inputData, pixels, left, top, width, height);
                 });
         }
     }

--- a/tests/ImageSharp.Tests/Formats/Tiff/PhotometricInterpretation/RgbTiffColorTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/PhotometricInterpretation/RgbTiffColorTests.cs
@@ -179,7 +179,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff.PhotometricInterpretation
         {
             AssertDecode(expectedResult, pixels =>
                 {
-                    new Rgb888TiffColor<Rgba32>().Decode(inputData, pixels, left, top, width, height);
+                    new Rgb888TiffColor<Rgba32>(Configuration.Default).Decode(inputData, pixels, left, top, width, height);
                 });
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

As the title says: Use bulk pixel conversion for some tiff color decoders
This should be a bit faster the converting pixel by pixel.