### PR TITLE
Enable .NET 6 Preview Builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,43 +34,30 @@ jobs:
                       codecov: false
                     - os: ubuntu-latest
                       framework: net5.0
-                      sdk: 5.0.x
-                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: macos-latest
                       framework: net5.0
-                      sdk: 5.0.x
-                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
                       framework: net5.0
-                      sdk: 5.0.x
-                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: ubuntu-latest
                       framework: netcoreapp3.1
-                      sdk: 3.1.x
-                      sdk-preview: false
                       runtime: -x64
                       codecov: true
                     - os: macos-latest
                       framework: netcoreapp3.1
-                      sdk: 3.1.x
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
                       framework: netcoreapp3.1
-                      sdk: 3.1.x
-                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
                       framework: netcoreapp2.1
-                      sdk: 2.1.x
-                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
@@ -123,11 +110,11 @@ jobs:
                   restore-keys: ${{ runner.os }}-nuget-
 
             - name: DotNet Setup
-              if: ${{ matrix.options.sdk != '' }}
+              if: ${{ matrix.options.sdk-preview == true }}
               uses: actions/setup-dotnet@v1
               with:
                 dotnet-version: ${{ matrix.options.sdk }}
-                include-prerelease: ${{ matrix.options.sdk-preview }}
+                include-prerelease: true
 
             - name: DotNet Build
               if: ${{ matrix.options.sdk-preview != true }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,7 +92,7 @@ jobs:
 
             - name: Build
               shell: pwsh
-              run: ./ci-build.ps1
+              run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING: True
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -122,28 +122,28 @@ jobs:
                   restore-keys: ${{ runner.os }}-nuget-
 
             - name: Setup dotnet
-              if: ${{ '${{matrix.options.sdk}}' != '' }}
+              if: ${{matrix.options.sdk}} != ""
               uses: actions/setup-dotnet@v1
               with:
                   dotnet-version: ${{ matrix.options.sdk }}
                   include-prerelease: ${{ matrix.options.sdk-preview }}
 
             - name: Build
-              if: ${{ '${{matrix.options.sdk-preview}}' != true }}
+              if: ${{ matrix.options.sdk-preview }} != true
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING: True
 
             - name: Build Preview
-              if: ${{ '${{matrix.options.sdk-preview}}' == true }}
+              if: ${{ matrix.options.sdk-preview }} == true
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING_PREVIEW: True
 
             - name: Test
-              if: ${{ '${{matrix.options.sdk-preview}}' != true }}
+              if: ${{ matrix.options.sdk-preview }} != true
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:
@@ -151,7 +151,7 @@ jobs:
                   XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
             - name: Test Preview
-              if: ${{ '${{matrix.options.sdk-preview}}' == true }}
+              if: ${{ matrix.options.sdk-preview }} == true
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,31 +15,62 @@ jobs:
             matrix:
                 options:
                     - os: ubuntu-latest
+                      framework: net6.0
+                      sdk: 6.0.x
+                      sdk-preview: true
+                      runtime: -x64
+                      codecov: false
+                    - os: macos-latest
+                      framework: net6.0
+                      sdk: 6.0.x
+                      sdk-preview: true
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: net6.0
+                      sdk: 6.0.x
+                      sdk-preview: true
+                      runtime: -x64
+                      codecov: false
+                    - os: ubuntu-latest
                       framework: net5.0
+                      sdk: 5.0.x
+                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: macos-latest
                       framework: net5.0
+                      sdk: 5.0.x
+                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
                       framework: net5.0
+                      sdk: 5.0.x
+                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: ubuntu-latest
                       framework: netcoreapp3.1
+                      sdk: 3.1.x
+                      sdk-preview: false
                       runtime: -x64
                       codecov: true
                     - os: macos-latest
                       framework: netcoreapp3.1
+                      sdk: 3.1.x
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
                       framework: netcoreapp3.1
+                      sdk: 3.1.x
+                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
                       framework: netcoreapp2.1
+                      sdk: 2.1.x
+                      sdk-preview: false
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
@@ -89,6 +120,13 @@ jobs:
                   path: ~/.nuget
                   key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
                   restore-keys: ${{ runner.os }}-nuget-
+
+            - name: Setup dotnet
+              if: ${{ "${{matrix.options.sdk}}" != "" }}
+              uses: actions/setup-dotnet@v1
+              with:
+                  dotnet-version: ${{ matrix.options.sdk }}
+                  include-prerelease: ${{ matrix.options.sdk-preview }}
 
             - name: Build
               shell: pwsh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,7 +87,7 @@ jobs:
 
         steps:
         - name: Conditional Check
-          if: ${{ ${{matrix.options.sdk-preview}} == true }} 
+          if: ${{ matrix.options.sdk-preview == true }} 
           shell: bash
           run: echo ${{matrix.options.sdk-preview}}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,185 +20,190 @@ jobs:
                       sdk-preview: true
                       runtime: -x64
                       codecov: false
-                    - os: macos-latest
-                      framework: net6.0
-                      sdk: 6.0.x
-                      sdk-preview: true
-                      runtime: -x64
-                      codecov: false
-                    - os: windows-latest
-                      framework: net6.0
-                      sdk: 6.0.x
-                      sdk-preview: true
-                      runtime: -x64
-                      codecov: false
-                    - os: ubuntu-latest
-                      framework: net5.0
-                      sdk: 5.0.x
-                      sdk-preview: false
-                      runtime: -x64
-                      codecov: false
-                    - os: macos-latest
-                      framework: net5.0
-                      sdk: 5.0.x
-                      sdk-preview: false
-                      runtime: -x64
-                      codecov: false
-                    - os: windows-latest
-                      framework: net5.0
-                      sdk: 5.0.x
-                      sdk-preview: false
-                      runtime: -x64
-                      codecov: false
-                    - os: ubuntu-latest
-                      framework: netcoreapp3.1
-                      sdk: 3.1.x
-                      sdk-preview: false
-                      runtime: -x64
-                      codecov: true
-                    - os: macos-latest
-                      framework: netcoreapp3.1
-                      sdk: 3.1.x
-                      runtime: -x64
-                      codecov: false
-                    - os: windows-latest
-                      framework: netcoreapp3.1
-                      sdk: 3.1.x
-                      sdk-preview: false
-                      runtime: -x64
-                      codecov: false
-                    - os: windows-latest
-                      framework: netcoreapp2.1
-                      sdk: 2.1.x
-                      sdk-preview: false
-                      runtime: -x64
-                      codecov: false
-                    - os: windows-latest
-                      framework: net472
-                      runtime: -x64
-                      codecov: false
-                    - os: windows-latest
-                      framework: net472
-                      runtime: -x86
-                      codecov: false
+                    #- os: macos-latest
+                    #  framework: net6.0
+                    #  sdk: 6.0.x
+                    #  sdk-preview: true
+                    #  runtime: -x64
+                    #  codecov: false
+                    #- os: windows-latest
+                    #  framework: net6.0
+                    #  sdk: 6.0.x
+                    #  sdk-preview: true
+                    #  runtime: -x64
+                    #  codecov: false
+                    #- os: ubuntu-latest
+                    #  framework: net5.0
+                    #  sdk: 5.0.x
+                    #  sdk-preview: false
+                    #  runtime: -x64
+                    #  codecov: false
+                    #- os: macos-latest
+                    #  framework: net5.0
+                    #  sdk: 5.0.x
+                    #  sdk-preview: false
+                    #  runtime: -x64
+                    #  codecov: false
+                    #- os: windows-latest
+                    #  framework: net5.0
+                    #  sdk: 5.0.x
+                    #  sdk-preview: false
+                    #  runtime: -x64
+                    #  codecov: false
+                    #- os: ubuntu-latest
+                    #  framework: netcoreapp3.1
+                    #  sdk: 3.1.x
+                    #  sdk-preview: false
+                    #  runtime: -x64
+                    #  codecov: true
+                    #- os: macos-latest
+                    #  framework: netcoreapp3.1
+                    #  sdk: 3.1.x
+                    #  runtime: -x64
+                    #  codecov: false
+                    #- os: windows-latest
+                    #  framework: netcoreapp3.1
+                    #  sdk: 3.1.x
+                    #  sdk-preview: false
+                    #  runtime: -x64
+                    #  codecov: false
+                    #- os: windows-latest
+                    #  framework: netcoreapp2.1
+                    #  sdk: 2.1.x
+                    #  sdk-preview: false
+                    #  runtime: -x64
+                    #  codecov: false
+                    #- os: windows-latest
+                    #  framework: net472
+                    #  runtime: -x64
+                    #  codecov: false
+                    #- os: windows-latest
+                    #  framework: net472
+                    #  runtime: -x86
+                    #  codecov: false
 
         runs-on: ${{matrix.options.os}}
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
         steps:
-            - uses: actions/checkout@v2
+        - name: Conditional Check
+          if: ${{ ${{matrix.options.sdk-preview}} == true }} 
+          shell: bash
+          run: echo ${{matrix.options.sdk-preview}}
+
+            #- uses: actions/checkout@v2
             
-            # See https://github.com/actions/checkout/issues/165#issuecomment-657673315
-            - name: Create LFS file list
-              run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+            ## See https://github.com/actions/checkout/issues/165#issuecomment-657673315
+            #- name: Create LFS file list
+            #  run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
-            - name: Restore LFS cache
-              uses: actions/cache@v2
-              id: lfs-cache
-              with:
-                path: .git/lfs
-                key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
+            #- name: Restore LFS cache
+            #  uses: actions/cache@v2
+            #  id: lfs-cache
+            #  with:
+            #    path: .git/lfs
+            #    key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
 
-            - name: Git LFS Pull
-              run: git lfs pull
+            #- name: Git LFS Pull
+            #  run: git lfs pull
 
-            - name: Install NuGet
-              uses: NuGet/setup-nuget@v1
+            #- name: Install NuGet
+            #  uses: NuGet/setup-nuget@v1
 
-            - name: Setup Git
-              shell: bash
-              run: |
-                  git config --global core.autocrlf false
-                  git config --global core.longpaths true
-                  git fetch --prune --unshallow
-                  git submodule -q update --init --recursive
+            #- name: Setup Git
+            #  shell: bash
+            #  run: |
+            #      git config --global core.autocrlf false
+            #      git config --global core.longpaths true
+            #      git fetch --prune --unshallow
+            #      git submodule -q update --init --recursive
 
-            - name: Setup NuGet Cache
-              uses: actions/cache@v2
-              id: nuget-cache
-              with:
-                  path: ~/.nuget
-                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
-                  restore-keys: ${{ runner.os }}-nuget-
+            #- name: Setup NuGet Cache
+            #  uses: actions/cache@v2
+            #  id: nuget-cache
+            #  with:
+            #      path: ~/.nuget
+            #      key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+            #      restore-keys: ${{ runner.os }}-nuget-
 
-            - name: Setup dotnet ${{ matrix.options.sdk }}
-              if: ${{matrix.options.sdk}} != ''
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: ${{ matrix.options.sdk }}
-                  include-prerelease: ${{ matrix.options.sdk-preview }}
+            #- name: Setup dotnet ${{ matrix.options.sdk }}
+            #  if: ${{ ${{matrix.options.sdk}} != '' }}
+            #  uses: actions/setup-dotnet@v1
+            #  with:
+            #      dotnet-version: ${{ matrix.options.sdk }}
+            #      include-prerelease: ${{ matrix.options.sdk-preview }}
 
-            - name: Build ${{matrix.options.sdk-preview}}
-              if: ${{matrix.options.sdk-preview}} == false
-              shell: pwsh
-              run: ./ci-build.ps1 "${{matrix.options.framework}}"
-              env:
-                SIXLABORS_TESTING: True
+            #- name: Build ${{matrix.options.sdk-preview}}
+            #  if: ${{ ${{matrix.options.sdk-preview}} == false }}
+            #  shell: pwsh
+            #  run: ./ci-build.ps1 "${{matrix.options.framework}}"
+            #  env:
+            #    SIXLABORS_TESTING: True
 
-            - name: Build Preview ${{matrix.options.sdk-preview}}
-              if: ${{matrix.options.sdk-preview}} == true
-              shell: pwsh
-              run: ./ci-build.ps1 "${{matrix.options.framework}}"
-              env:
-                SIXLABORS_TESTING_PREVIEW: True
+            #- name: Build Preview ${{matrix.options.sdk-preview}}
+            #  if: ${{ ${{matrix.options.sdk-preview}} == true }}
+            #  shell: pwsh
+            #  run: ./ci-build.ps1 "${{matrix.options.framework}}"
+            #  env:
+            #    SIXLABORS_TESTING_PREVIEW: True
 
-            - name: Test
-              if: ${{matrix.options.sdk-preview}} == false
-              shell: pwsh
-              run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
-              env:
-                  SIXLABORS_TESTING: True
-                  XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
+            #- name: Test
+            #  if: ${{matrix.options.sdk-preview}} == false
+            #  shell: pwsh
+            #  run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
+            #  env:
+            #      SIXLABORS_TESTING: True
+            #      XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
-            - name: Test Preview
-              if: ${{matrix.options.sdk-preview}} == true
-              shell: pwsh
-              run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
-              env:
-                  SIXLABORS_TESTING_PREVIEW: True
-                  XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
+            #- name: Test Preview
+            #  if: ${{matrix.options.sdk-preview}} == true
+            #  shell: pwsh
+            #  run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
+            #  env:
+            #      SIXLABORS_TESTING_PREVIEW: True
+            #      XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
-            - name: Export Failed Output
-              uses: actions/upload-artifact@v2
-              if: failure()
-              with:
-                  name: actual_output_${{ runner.os }}_${{ matrix.options.framework }}${{ matrix.options.runtime }}.zip
-                  path: tests/Images/ActualOutput/
+            #- name: Export Failed Output
+            #  uses: actions/upload-artifact@v2
+            #  if: failure()
+            #  with:
+            #      name: actual_output_${{ runner.os }}_${{ matrix.options.framework }}${{ matrix.options.runtime }}.zip
+            #      path: tests/Images/ActualOutput/
 
-            - name: Update Codecov
-              uses: codecov/codecov-action@v1
-              if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
-              with:
-                  flags: unittests
+            #- name: Update Codecov
+            #  uses: codecov/codecov-action@v1
+            #  if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
+            #  with:
+            #      flags: unittests
 
-    Publish:
-        needs: [Build]
+    #Publish:
+    #    needs: [Build]
 
-        runs-on: windows-latest
+    #    runs-on: windows-latest
 
-        if: (github.event_name == 'push')
+    #    if: (github.event_name == 'push')
 
-        steps:
-            - uses: actions/checkout@v2
+    #    steps:
+    #        - uses: actions/checkout@v2
 
-            - name: Install NuGet
-              uses: NuGet/setup-nuget@v1
+    #        - name: Install NuGet
+    #          uses: NuGet/setup-nuget@v1
 
-            - name: Setup Git
-              shell: bash
-              run: |
-                  git config --global core.autocrlf false
-                  git config --global core.longpaths true
-                  git fetch --prune --unshallow
-                  git submodule -q update --init --recursive
+    #        - name: Setup Git
+    #          shell: bash
+    #          run: |
+    #              git config --global core.autocrlf false
+    #              git config --global core.longpaths true
+    #              git fetch --prune --unshallow
+    #              git submodule -q update --init --recursive
 
-            - name: Pack
-              shell: pwsh
-              run: ./ci-pack.ps1
+    #        - name: Pack
+    #          shell: pwsh
+    #          run: ./ci-pack.ps1
 
-            - name: Publish to MyGet
-              shell: pwsh
-              run: |
-                  nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
-                  nuget.exe push .\artifacts\*.snupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v3/index.json
-              # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org
+    #        - name: Publish to MyGet
+    #          shell: pwsh
+    #          run: |
+    #              nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
+    #              nuget.exe push .\artifacts\*.snupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v3/index.json
+    #          # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,16 +129,33 @@ jobs:
                   include-prerelease: ${{ matrix.options.sdk-preview }}
 
             - name: Build
+              if: ${{ ${{matrix.options.sdk-preview}} != true }}
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING: True
 
+            - name: Build Preview
+              if: ${{ ${{matrix.options.sdk-preview}} == true }}
+              shell: pwsh
+              run: ./ci-build.ps1 "${{matrix.options.framework}}"
+              env:
+                SIXLABORS_TESTING_PREVIEW: True
+
             - name: Test
+              if: ${{ ${{matrix.options.sdk-preview}} != true }}
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:
                   SIXLABORS_TESTING: True
+                  XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
+
+            - name: Test Preview
+              if: ${{ ${{matrix.options.sdk-preview}} == true }}
+              shell: pwsh
+              run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
+              env:
+                  SIXLABORS_TESTING_PREVIEW: True
                   XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
             - name: Export Failed Output

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,21 +129,21 @@ jobs:
                   include-prerelease: ${{ matrix.options.sdk-preview }}
 
             - name: Build
-              if: ${{ ${{matrix.options.sdk-preview}} != true }}
+              if: ${{ '${{matrix.options.sdk-preview}}' != 'true' }}
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING: True
 
             - name: Build Preview
-              if: ${{ ${{matrix.options.sdk-preview}} == true }}
+              if: ${{ '${{matrix.options.sdk-preview}}' == 'true' }}
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING_PREVIEW: True
 
             - name: Test
-              if: ${{ ${{matrix.options.sdk-preview}} != true }}
+              if: ${{ '${{matrix.options.sdk-preview}}' != 'true' }}
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:
@@ -151,7 +151,7 @@ jobs:
                   XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
             - name: Test Preview
-              if: ${{ ${{matrix.options.sdk-preview}} == true }}
+              if: ${{ '${{matrix.options.sdk-preview}}' == 'true' }}
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,7 +92,7 @@ jobs:
 
             - name: Build
               shell: pwsh
-              run: ./ci-build.ps1 "${{matrix.options.framework}}"
+              run: ./ci-build.ps1
               env:
                 SIXLABORS_TESTING: True
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,29 +121,29 @@ jobs:
                   key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
                   restore-keys: ${{ runner.os }}-nuget-
 
-            - name: Setup dotnet
-              if: ${{matrix.options.sdk}} != ""
+            - name: Setup dotnet ${{ matrix.options.sdk }}
+              if: ${{ '${{matrix.options.sdk}}' != '' }}
               uses: actions/setup-dotnet@v1
               with:
                   dotnet-version: ${{ matrix.options.sdk }}
                   include-prerelease: ${{ matrix.options.sdk-preview }}
 
-            - name: Build
-              if: ${{ matrix.options.sdk-preview }} != true
+            - name: Build ${{matrix.options.sdk-preview}}
+              if: ${{ '${{matrix.options.sdk-preview}}' != 'true' }}
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING: True
 
-            - name: Build Preview
-              if: ${{ matrix.options.sdk-preview }} == true
+            - name: Build Preview ${{matrix.options.sdk-preview}}
+              if: ${{ '${{matrix.options.sdk-preview}}' == 'true' }}
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING_PREVIEW: True
 
             - name: Test
-              if: ${{ matrix.options.sdk-preview }} != true
+              if: ${{ '${{matrix.options.sdk-preview}}' != 'true' }}
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:
@@ -151,7 +151,7 @@ jobs:
                   XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
             - name: Test Preview
-              if: ${{ matrix.options.sdk-preview }} == true
+              if: ${{ '${{matrix.options.sdk-preview}}' == 'true' }}
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,7 +129,7 @@ jobs:
                 dotnet-version: ${{ matrix.options.sdk }}
                 include-prerelease: ${{ matrix.options.sdk-preview }}
 
-            - name: DotNet Build ${{matrix.options.sdk-preview}}
+            - name: DotNet Build
               if: ${{ matrix.options.sdk-preview != true }}
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,8 +86,13 @@ jobs:
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
         steps:
-        - name: Conditional Check
+        - name: Conditional True
           if: ${{ matrix.options.sdk-preview == true }} 
+          shell: bash
+          run: echo ${{matrix.options.sdk-preview}}
+
+        - name: Conditional False
+          if: ${{ matrix.options.sdk-preview != true }} 
           shell: bash
           run: echo ${{matrix.options.sdk-preview}}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,21 +129,21 @@ jobs:
                   include-prerelease: ${{ matrix.options.sdk-preview }}
 
             - name: Build
-              if: ${{ '${{matrix.options.sdk-preview}}' != 'true' }}
+              if: ${{ '${{matrix.options.sdk-preview}}' != true }}
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING: True
 
             - name: Build Preview
-              if: ${{ '${{matrix.options.sdk-preview}}' == 'true' }}
+              if: ${{ '${{matrix.options.sdk-preview}}' == true }}
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING_PREVIEW: True
 
             - name: Test
-              if: ${{ '${{matrix.options.sdk-preview}}' != 'true' }}
+              if: ${{ '${{matrix.options.sdk-preview}}' != true }}
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:
@@ -151,7 +151,7 @@ jobs:
                   XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
             - name: Test Preview
-              if: ${{ '${{matrix.options.sdk-preview}}' == 'true' }}
+              if: ${{ '${{matrix.options.sdk-preview}}' == true }}
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -122,7 +122,7 @@ jobs:
                   restore-keys: ${{ runner.os }}-nuget-
 
             - name: Setup dotnet
-              if: ${{ "${{matrix.options.sdk}}" != "" }}
+              if: ${{ '${{matrix.options.sdk}}' != '' }}
               uses: actions/setup-dotnet@v1
               with:
                   dotnet-version: ${{ matrix.options.sdk }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -122,28 +122,28 @@ jobs:
                   restore-keys: ${{ runner.os }}-nuget-
 
             - name: Setup dotnet ${{ matrix.options.sdk }}
-              if: ${{ '${{matrix.options.sdk}}' != '' }}
+              if: ${{matrix.options.sdk}} != ''
               uses: actions/setup-dotnet@v1
               with:
                   dotnet-version: ${{ matrix.options.sdk }}
                   include-prerelease: ${{ matrix.options.sdk-preview }}
 
             - name: Build ${{matrix.options.sdk-preview}}
-              if: ${{ '${{matrix.options.sdk-preview}}' != 'true' }}
+              if: ${{matrix.options.sdk-preview}} == false
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING: True
 
             - name: Build Preview ${{matrix.options.sdk-preview}}
-              if: ${{ '${{matrix.options.sdk-preview}}' == 'true' }}
+              if: ${{matrix.options.sdk-preview}} == true
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
               env:
                 SIXLABORS_TESTING_PREVIEW: True
 
             - name: Test
-              if: ${{ '${{matrix.options.sdk-preview}}' != 'true' }}
+              if: ${{matrix.options.sdk-preview}} == false
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:
@@ -151,7 +151,7 @@ jobs:
                   XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
             - name: Test Preview
-              if: ${{ '${{matrix.options.sdk-preview}}' == 'true' }}
+              if: ${{matrix.options.sdk-preview}} == true
               shell: pwsh
               run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
               env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -109,7 +109,7 @@ jobs:
                   key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
                   restore-keys: ${{ runner.os }}-nuget-
 
-            - name: DotNet Setup
+            - name: DotNet Setup Preview
               if: ${{ matrix.options.sdk-preview == true }}
               uses: actions/setup-dotnet@v1
               with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,14 +1,14 @@
 name: Build
 
 on:
-    push:
-        branches:
-            - master
-        tags:
-            - "v*"
-    pull_request:
-        branches:
-            - master
+   push:
+       branches:
+           - master
+       tags:
+           - "v*"
+   pull_request:
+       branches:
+          - master
 jobs:
     Build:
         strategy:
@@ -20,195 +20,196 @@ jobs:
                       sdk-preview: true
                       runtime: -x64
                       codecov: false
-                    #- os: macos-latest
-                    #  framework: net6.0
-                    #  sdk: 6.0.x
-                    #  sdk-preview: true
-                    #  runtime: -x64
-                    #  codecov: false
-                    #- os: windows-latest
-                    #  framework: net6.0
-                    #  sdk: 6.0.x
-                    #  sdk-preview: true
-                    #  runtime: -x64
-                    #  codecov: false
-                    #- os: ubuntu-latest
-                    #  framework: net5.0
-                    #  sdk: 5.0.x
-                    #  sdk-preview: false
-                    #  runtime: -x64
-                    #  codecov: false
-                    #- os: macos-latest
-                    #  framework: net5.0
-                    #  sdk: 5.0.x
-                    #  sdk-preview: false
-                    #  runtime: -x64
-                    #  codecov: false
-                    #- os: windows-latest
-                    #  framework: net5.0
-                    #  sdk: 5.0.x
-                    #  sdk-preview: false
-                    #  runtime: -x64
-                    #  codecov: false
-                    #- os: ubuntu-latest
-                    #  framework: netcoreapp3.1
-                    #  sdk: 3.1.x
-                    #  sdk-preview: false
-                    #  runtime: -x64
-                    #  codecov: true
-                    #- os: macos-latest
-                    #  framework: netcoreapp3.1
-                    #  sdk: 3.1.x
-                    #  runtime: -x64
-                    #  codecov: false
-                    #- os: windows-latest
-                    #  framework: netcoreapp3.1
-                    #  sdk: 3.1.x
-                    #  sdk-preview: false
-                    #  runtime: -x64
-                    #  codecov: false
-                    #- os: windows-latest
-                    #  framework: netcoreapp2.1
-                    #  sdk: 2.1.x
-                    #  sdk-preview: false
-                    #  runtime: -x64
-                    #  codecov: false
-                    #- os: windows-latest
-                    #  framework: net472
-                    #  runtime: -x64
-                    #  codecov: false
-                    #- os: windows-latest
-                    #  framework: net472
-                    #  runtime: -x86
-                    #  codecov: false
+                    - os: macos-latest
+                      framework: net6.0
+                      sdk: 6.0.x
+                      sdk-preview: true
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: net6.0
+                      sdk: 6.0.x
+                      sdk-preview: true
+                      runtime: -x64
+                      codecov: false
+                    - os: ubuntu-latest
+                      framework: net5.0
+                      sdk: 5.0.x
+                      sdk-preview: false
+                      runtime: -x64
+                      codecov: false
+                    - os: macos-latest
+                      framework: net5.0
+                      sdk: 5.0.x
+                      sdk-preview: false
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: net5.0
+                      sdk: 5.0.x
+                      sdk-preview: false
+                      runtime: -x64
+                      codecov: false
+                    - os: ubuntu-latest
+                      framework: netcoreapp3.1
+                      sdk: 3.1.x
+                      sdk-preview: false
+                      runtime: -x64
+                      codecov: true
+                    - os: macos-latest
+                      framework: netcoreapp3.1
+                      sdk: 3.1.x
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: netcoreapp3.1
+                      sdk: 3.1.x
+                      sdk-preview: false
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: netcoreapp2.1
+                      sdk: 2.1.x
+                      sdk-preview: false
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: net472
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: net472
+                      runtime: -x86
+                      codecov: false
 
         runs-on: ${{matrix.options.os}}
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
         steps:
-        - name: Conditional True
-          if: ${{ matrix.options.sdk-preview == true }} 
-          shell: bash
-          run: echo ${{matrix.options.sdk-preview}}
+            - name: Git Config
+              shell: bash
+              run: |
+                  git config --global core.autocrlf false
+                  git config --global core.longpaths true
 
-        - name: Conditional False
-          if: ${{ matrix.options.sdk-preview != true }} 
-          shell: bash
-          run: echo ${{matrix.options.sdk-preview}}
-
-            #- uses: actions/checkout@v2
+            - name: Git Checkout
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+                submodules: recursive
             
-            ## See https://github.com/actions/checkout/issues/165#issuecomment-657673315
-            #- name: Create LFS file list
-            #  run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+            # See https://github.com/actions/checkout/issues/165#issuecomment-657673315
+            - name: Git Create LFS FileList
+              run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
-            #- name: Restore LFS cache
-            #  uses: actions/cache@v2
-            #  id: lfs-cache
-            #  with:
-            #    path: .git/lfs
-            #    key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
+            - name: Git Setup LFS Cache
+              uses: actions/cache@v2
+              id: lfs-cache
+              with:
+                path: .git/lfs
+                key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
 
-            #- name: Git LFS Pull
-            #  run: git lfs pull
+            - name: Git Pull LFS
+              run: git lfs pull
 
-            #- name: Install NuGet
-            #  uses: NuGet/setup-nuget@v1
+            - name: NuGet Install
+              uses: NuGet/setup-nuget@v1
 
-            #- name: Setup Git
-            #  shell: bash
-            #  run: |
-            #      git config --global core.autocrlf false
-            #      git config --global core.longpaths true
-            #      git fetch --prune --unshallow
-            #      git submodule -q update --init --recursive
+            - name: NuGet Setup Cache
+              uses: actions/cache@v2
+              id: nuget-cache
+              with:
+                  path: ~/.nuget
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+                  restore-keys: ${{ runner.os }}-nuget-
 
-            #- name: Setup NuGet Cache
-            #  uses: actions/cache@v2
-            #  id: nuget-cache
-            #  with:
-            #      path: ~/.nuget
-            #      key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
-            #      restore-keys: ${{ runner.os }}-nuget-
+            - name: DotNet Setup
+              if: ${{ matrix.options.sdk != '' }}
+              uses: actions/setup-dotnet@v1
+              with:
+                dotnet-version: ${{ matrix.options.sdk }}
+                include-prerelease: ${{ matrix.options.sdk-preview }}
 
-            #- name: Setup dotnet ${{ matrix.options.sdk }}
-            #  if: ${{ ${{matrix.options.sdk}} != '' }}
-            #  uses: actions/setup-dotnet@v1
-            #  with:
-            #      dotnet-version: ${{ matrix.options.sdk }}
-            #      include-prerelease: ${{ matrix.options.sdk-preview }}
+            - name: DotNet Build ${{matrix.options.sdk-preview}}
+              if: ${{ matrix.options.sdk-preview != true }}
+              shell: pwsh
+              run: ./ci-build.ps1 "${{matrix.options.framework}}"
+              env:
+                SIXLABORS_TESTING: True
 
-            #- name: Build ${{matrix.options.sdk-preview}}
-            #  if: ${{ ${{matrix.options.sdk-preview}} == false }}
-            #  shell: pwsh
-            #  run: ./ci-build.ps1 "${{matrix.options.framework}}"
-            #  env:
-            #    SIXLABORS_TESTING: True
+            - name: DotNet Build Preview
+              if: ${{ matrix.options.sdk-preview == true }}
+              shell: pwsh
+              run: ./ci-build.ps1 "${{matrix.options.framework}}"
+              env:
+                SIXLABORS_TESTING_PREVIEW: True
 
-            #- name: Build Preview ${{matrix.options.sdk-preview}}
-            #  if: ${{ ${{matrix.options.sdk-preview}} == true }}
-            #  shell: pwsh
-            #  run: ./ci-build.ps1 "${{matrix.options.framework}}"
-            #  env:
-            #    SIXLABORS_TESTING_PREVIEW: True
+            - name: DotNet Test
+              if: ${{ matrix.options.sdk-preview != true }}
+              shell: pwsh
+              run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
+              env:
+                SIXLABORS_TESTING: True
+                XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
-            #- name: Test
-            #  if: ${{matrix.options.sdk-preview}} == false
-            #  shell: pwsh
-            #  run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
-            #  env:
-            #      SIXLABORS_TESTING: True
-            #      XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
+            - name: DotNet Test Preview
+              if: ${{ matrix.options.sdk-preview == true }}
+              shell: pwsh
+              run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
+              env:
+                SIXLABORS_TESTING_PREVIEW: True
+                XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
-            #- name: Test Preview
-            #  if: ${{matrix.options.sdk-preview}} == true
-            #  shell: pwsh
-            #  run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
-            #  env:
-            #      SIXLABORS_TESTING_PREVIEW: True
-            #      XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
+            - name: Export Failed Output
+              uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                name: actual_output_${{ runner.os }}_${{ matrix.options.framework }}${{ matrix.options.runtime }}.zip
+                path: tests/Images/ActualOutput/
 
-            #- name: Export Failed Output
-            #  uses: actions/upload-artifact@v2
-            #  if: failure()
-            #  with:
-            #      name: actual_output_${{ runner.os }}_${{ matrix.options.framework }}${{ matrix.options.runtime }}.zip
-            #      path: tests/Images/ActualOutput/
+            - name: Codecov Update
+              uses: codecov/codecov-action@v1
+              if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
+              with:
+                flags: unittests
 
-            #- name: Update Codecov
-            #  uses: codecov/codecov-action@v1
-            #  if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
-            #  with:
-            #      flags: unittests
+    Publish:
+        needs: [Build]
 
-    #Publish:
-    #    needs: [Build]
+        runs-on: ubuntu-latest
 
-    #    runs-on: windows-latest
+        if: (github.event_name == 'push')
 
-    #    if: (github.event_name == 'push')
+        steps:
+            - name: Git Config
+              shell: bash
+              run: |
+                  git config --global core.autocrlf false
+                  git config --global core.longpaths true
 
-    #    steps:
-    #        - uses: actions/checkout@v2
+            - name: Git Checkout
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+                submodules: recursive
 
-    #        - name: Install NuGet
-    #          uses: NuGet/setup-nuget@v1
+            - name: NuGet Install
+              uses: NuGet/setup-nuget@v1
 
-    #        - name: Setup Git
-    #          shell: bash
-    #          run: |
-    #              git config --global core.autocrlf false
-    #              git config --global core.longpaths true
-    #              git fetch --prune --unshallow
-    #              git submodule -q update --init --recursive
+            - name: NuGet Setup Cache
+              uses: actions/cache@v2
+              id: nuget-cache
+              with:
+                  path: ~/.nuget
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+                  restore-keys: ${{ runner.os }}-nuget-
 
-    #        - name: Pack
-    #          shell: pwsh
-    #          run: ./ci-pack.ps1
+            - name: DotNet Pack
+              shell: pwsh
+              run: ./ci-pack.ps1
 
-    #        - name: Publish to MyGet
-    #          shell: pwsh
-    #          run: |
-    #              nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
-    #              nuget.exe push .\artifacts\*.snupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v3/index.json
-    #          # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org
+            - name: MyGet Publish
+              shell: pwsh
+              run: |
+                  dotnet nuget push .\artifacts\*.nupkg -k ${{secrets.MYGET_TOKEN}} -s https://www.myget.org/F/sixlabors/api/v2/package
+                  dotnet nuget push .\artifacts\*.snupkg -k ${{secrets.MYGET_TOKEN}} -s https://www.myget.org/F/sixlabors/api/v3/index.json
+              # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,9 @@
   <!-- Import the shared global .props file -->
   <Import Project="$(MSBuildThisFileDirectory)shared-infrastructure\msbuild\props\SixLabors.Global.props" />
 
+  <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
+  <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+
   <!--
   Ensure all custom build configurations based upon "Release" are optimized.
   This is easier than setting each project individually.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,8 +19,7 @@
   <Import Project="$(MSBuildThisFileDirectory)shared-infrastructure\msbuild\props\SixLabors.Global.props" />
 
   <PropertyGroup Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
-    <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <!-- Workaround various issues bound to implicit language features. -->
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,9 +18,10 @@
   <!-- Import the shared global .props file -->
   <Import Project="$(MSBuildThisFileDirectory)shared-infrastructure\msbuild\props\SixLabors.Global.props" />
 
-  <PropertyGroup>
+  <PropertyGroup Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
     <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,8 +18,10 @@
   <!-- Import the shared global .props file -->
   <Import Project="$(MSBuildThisFileDirectory)shared-infrastructure\msbuild\props\SixLabors.Global.props" />
 
-  <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
-  <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+  <PropertyGroup>
+    <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+  </PropertyGroup>
 
   <!--
   Ensure all custom build configurations based upon "Release" are optimized.

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -1,11 +1,6 @@
-param(
-  [Parameter(Mandatory = $true, Position = 0)]
-  [string]$targetFramework
-)
-
 dotnet clean -c Release
 
 $repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
 
 # Building for a specific framework.
-dotnet build -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl
+dotnet build -c Release /p:RepositoryUrl=$repositoryUrl

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -1,6 +1,11 @@
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string]$targetFramework
+)
+
 dotnet clean -c Release
 
 $repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
 
 # Building for a specific framework.
-dotnet build -c Release /p:RepositoryUrl=$repositoryUrl
+dotnet build -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -18,7 +18,7 @@
   <Choose>
     <When Condition="$(SIXLABORS_TESTING) == true">
       <PropertyGroup>
-        <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;netstandard1.3;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;netstandard1.3;net472</TargetFrameworks>
       </PropertyGroup>
     </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -18,7 +18,7 @@
   <Choose>
     <When Condition="$(SIXLABORS_TESTING) == true">
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;netstandard1.3;net472</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;netstandard1.3;net472</TargetFrameworks>
       </PropertyGroup>
     </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -16,6 +16,11 @@
   </PropertyGroup>
 
   <Choose>
+    <When Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
+      <PropertyGroup>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;netstandard1.3;net472</TargetFrameworks>
+      </PropertyGroup>
+    </When>
     <When Condition="$(SIXLABORS_TESTING) == true">
       <PropertyGroup>
         <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;netstandard1.3;net472</TargetFrameworks>

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
@@ -257,7 +257,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
         [MethodImpl(InliningOptions.ShortMethod)]
         private void AddPixelsToHistogram(ref Vector4 greyValuesBase, ref int histogramBase, int luminanceLevels, int length)
         {
-            for (int idx = 0; idx < length; idx++)
+            for (nint idx = 0; idx < length; idx++)
             {
                 int luminance = ColorNumerics.GetBT709Luminance(ref Unsafe.Add(ref greyValuesBase, idx), luminanceLevels);
                 Unsafe.Add(ref histogramBase, luminance)++;

--- a/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
+++ b/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
@@ -14,11 +14,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(SIXLABORS_TESTING) == true">
-      <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
-      </PropertyGroup>
-    </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>

--- a/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
+++ b/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
@@ -14,6 +14,11 @@
   </PropertyGroup>
 
   <Choose>
+    <When Condition="$(SIXLABORS_TESTING) == true">
+      <PropertyGroup>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+      </PropertyGroup>
+    </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>

--- a/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
+++ b/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
@@ -14,6 +14,11 @@
   </PropertyGroup>
 
   <Choose>
+    <When Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
+      <PropertyGroup>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+      </PropertyGroup>
+    </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>

--- a/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
+++ b/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
@@ -9,7 +9,6 @@
     <!--Used to hide test project from dotnet test-->
     <IsTestProject>false</IsTestProject>
     <Configurations>Debug;Release;Debug-InnerLoop;Release-InnerLoop</Configurations>
-    <LangVersion>9</LangVersion>
     <!-- Uncomment this to run benchmarks depending on Colorful or Pfim (colorspaces and TGA): -->
     <!--<SignAssembly>false</SignAssembly>-->
   </PropertyGroup>

--- a/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
@@ -17,11 +17,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(SIXLABORS_TESTING) == true">
-      <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
-      </PropertyGroup>
-    </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>

--- a/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
@@ -17,6 +17,11 @@
   </PropertyGroup>
 
   <Choose>
+    <When Condition="$(SIXLABORS_TESTING) == true">
+      <PropertyGroup>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+      </PropertyGroup>
+    </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>

--- a/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
@@ -14,7 +14,6 @@
     <EnsureNETCoreAppRuntime>false</EnsureNETCoreAppRuntime>
     <Configurations>Debug;Release;Debug-InnerLoop;Release-InnerLoop</Configurations>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <Choose>

--- a/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
@@ -17,6 +17,11 @@
   </PropertyGroup>
 
   <Choose>
+    <When Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
+      <PropertyGroup>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+      </PropertyGroup>
+    </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>

--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -10,6 +10,11 @@
   </PropertyGroup>
 
   <Choose>
+    <When Condition="$(SIXLABORS_TESTING) == true">
+      <PropertyGroup>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+      </PropertyGroup>
+    </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
@@ -21,7 +26,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  
+
   <ItemGroup>
     <InternalsVisibleTo Include="ImageSharp.Tests.ProfilingSandbox" Key="$(SixLaborsPublicKey)" />
   </ItemGroup>

--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -10,6 +10,11 @@
   </PropertyGroup>
 
   <Choose>
+    <When Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
+      <PropertyGroup>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+      </PropertyGroup>
+    </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>

--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -10,11 +10,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(SIXLABORS_TESTING) == true">
-      <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
-      </PropertyGroup>
-    </When>
     <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
<strike>Just use the environment compiler to build things. When consumers build their applications they're already consuming a prebuilt binary. We only need to test with individual frameworks.</strike>

Added .NET 6 Preview builds to the matrix and fixed up the solution to handle that scenario. Also fixed the langversion to C#9

This allows us to use features like `nint` and also build/test against .NET 6 previews which we sorely need to do.

<!-- Thanks for contributing to ImageSharp! -->
