### PR TITLE
Add support for decoding tiff's with T.6 fax compression

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittReferenceScanline.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittReferenceScanline.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
+{
+    /// <summary>
+    /// Represents a reference scan line for CCITT 2D decoding.
+    /// </summary>
+    internal readonly ref struct CcittReferenceScanline
+    {
+        private readonly ReadOnlySpan<byte> scanLine;
+        private readonly int width;
+        private readonly byte whiteByte;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CcittReferenceScanline"/> struct.
+        /// </summary>
+        /// <param name="whiteIsZero">Indicates, if white is zero, otherwise black is zero.</param>
+        /// <param name="scanLine">The scan line.</param>
+        public CcittReferenceScanline(bool whiteIsZero, ReadOnlySpan<byte> scanLine)
+        {
+            this.scanLine = scanLine;
+            this.width = scanLine.Length;
+            this.whiteByte = whiteIsZero ? (byte)0 : (byte)255;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CcittReferenceScanline"/> struct.
+        /// </summary>
+        /// <param name="whiteIsZero">Indicates, if white is zero, otherwise black is zero.</param>
+        /// <param name="width">The width of the scanline.</param>
+        public CcittReferenceScanline(bool whiteIsZero, int width)
+        {
+            this.scanLine = default;
+            this.width = width;
+            this.whiteByte = whiteIsZero ? (byte)0 : (byte)255;
+        }
+
+        public bool IsEmpty => this.scanLine.IsEmpty;
+
+        /// <summary>
+        /// Finds b1: The first changing element on the reference line to the right of a0 and of opposite color to a0.
+        /// </summary>
+        /// <param name="a0">The reference or starting element om the coding line.</param>
+        /// <param name="a0Byte">Fill byte.</param>
+        /// <returns>Position of b1.</returns>
+        public int FindB1(int a0, byte a0Byte)
+        {
+            if (this.scanLine.IsEmpty)
+            {
+                return this.FindB1ForImaginaryWhiteLine(a0, a0Byte);
+            }
+
+            return this.FindB1ForNormalLine(a0, a0Byte);
+        }
+
+        /// <summary>
+        /// Finds b2: The next changing element to the right of b1 on the reference line.
+        /// </summary>
+        /// <param name="b1">The first changing element on the reference line to the right of a0 and opposite of color to a0.</param>
+        /// <returns>Position of b1.</returns>
+        public int FindB2(int b1)
+        {
+            if (this.scanLine.IsEmpty)
+            {
+                return this.FindB2ForImaginaryWhiteLine();
+            }
+
+            return this.FindB2ForNormalLine(b1);
+        }
+
+        private int FindB1ForImaginaryWhiteLine(int a0, byte a0Byte)
+        {
+            if (a0 < 0)
+            {
+                if (a0Byte != this.whiteByte)
+                {
+                    return 0;
+                }
+            }
+
+            return this.width;
+        }
+
+        private int FindB1ForNormalLine(int a0, byte a0Byte)
+        {
+            int offset = 0;
+            if (a0 < 0)
+            {
+                if (a0Byte != this.scanLine[0])
+                {
+                    return 0;
+                }
+            }
+            else
+            {
+                offset = a0;
+            }
+
+            ReadOnlySpan<byte> searchSpace = this.scanLine.Slice(offset);
+            byte searchByte = (byte)~a0Byte;
+            int index = searchSpace.IndexOf(searchByte);
+            if (index < 0)
+            {
+                return this.scanLine.Length;
+            }
+
+            if (index != 0)
+            {
+                return offset + index;
+            }
+
+            searchByte = (byte)~searchSpace[0];
+            index = searchSpace.IndexOf(searchByte);
+            if (index < 0)
+            {
+                return this.scanLine.Length;
+            }
+
+            searchSpace = searchSpace.Slice(index);
+            offset += index;
+            index = searchSpace.IndexOf((byte)~searchByte);
+            if (index < 0)
+            {
+                return this.scanLine.Length;
+            }
+
+            return index + offset;
+        }
+
+        private int FindB2ForImaginaryWhiteLine() => this.width;
+
+        private int FindB2ForNormalLine(int b1)
+        {
+            if (b1 >= this.scanLine.Length)
+            {
+                return this.scanLine.Length;
+            }
+
+            byte searchByte = (byte)~this.scanLine[b1];
+            int offset = b1 + 1;
+            ReadOnlySpan<byte> searchSpace = this.scanLine.Slice(offset);
+            int index = searchSpace.IndexOf(searchByte);
+            if (index == -1)
+            {
+                return this.scanLine.Length;
+            }
+
+            return offset + index;
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittReferenceScanline.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittReferenceScanline.cs
@@ -48,7 +48,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         /// <returns>Position of b1.</returns>
         public int FindB1(int a0, byte a0Byte)
         {
-            if (this.scanLine.IsEmpty)
+            if (this.IsEmpty)
             {
                 return this.FindB1ForImaginaryWhiteLine(a0, a0Byte);
             }
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         /// <returns>Position of b1.</returns>
         public int FindB2(int b1)
         {
-            if (this.scanLine.IsEmpty)
+            if (this.IsEmpty)
             {
                 return this.FindB2ForImaginaryWhiteLine();
             }

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittTwoDimensionalCode.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittTwoDimensionalCode.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
+{
+    [DebuggerDisplay("Type = {Type}")]
+    internal readonly struct CcittTwoDimensionalCode
+    {
+        private readonly ushort value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CcittTwoDimensionalCode"/> struct.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="bitsRequired">The bits required.</param>
+        /// <param name="extensionBits">The extension bits.</param>
+        public CcittTwoDimensionalCode(CcittTwoDimensionalCodeType type, int bitsRequired, int extensionBits = 0)
+            => this.value = (ushort)((byte)type | ((bitsRequired & 0b1111) << 8) | ((extensionBits & 0b111) << 11));
+
+        /// <summary>
+        /// Gets the code type.
+        /// </summary>
+        public CcittTwoDimensionalCodeType Type => (CcittTwoDimensionalCodeType)(this.value & 0b11111111);
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittTwoDimensionalCodeType.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittTwoDimensionalCodeType.cs
@@ -3,30 +3,71 @@
 
 namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
 {
+    /// <summary>
+    /// Enum for the different two dimensional code words for the ccitt fax compression.
+    /// </summary>
     internal enum CcittTwoDimensionalCodeType
     {
+        /// <summary>
+        /// No valid code word was read.
+        /// </summary>
         None = 0,
 
+        /// <summary>
+        /// Pass mode: This mode is identified when the position of b2 lies to the left of a1.
+        /// </summary>
         Pass = 1,
 
+        /// <summary>
+        /// Indicates horizontal mode.
+        /// </summary>
         Horizontal = 2,
 
+        /// <summary>
+        /// Vertical 0 code word: relative distance between a1 and b1 is 0.
+        /// </summary>
         Vertical0 = 3,
 
+        /// <summary>
+        /// Vertical r1 code word: relative distance between a1 and b1 is 1, a1 is to the right of b1.
+        /// </summary>
         VerticalR1 = 4,
 
+        /// <summary>
+        /// Vertical r2 code word: relative distance between a1 and b1 is 2, a1 is to the right of b1.
+        /// </summary>
         VerticalR2 = 5,
 
+        /// <summary>
+        /// Vertical r3 code word: relative distance between a1 and b1 is 3, a1 is to the right of b1.
+        /// </summary>
         VerticalR3 = 6,
 
+        /// <summary>
+        /// Vertical l1 code word: relative distance between a1 and b1 is 1, a1 is to the left of b1.
+        /// </summary>
         VerticalL1 = 7,
 
+        /// <summary>
+        /// Vertical l2 code word: relative distance between a1 and b1 is 2, a1 is to the left of b1.
+        /// </summary>
         VerticalL2 = 8,
 
+        /// <summary>
+        /// Vertical l3 code word: relative distance between a1 and b1 is 3, a1 is to the left of b1.
+        /// </summary>
         VerticalL3 = 9,
 
+        /// <summary>
+        /// 1d extensions code word, extension code is used to indicate the change from the current mode to another mode, e.g., another coding scheme.
+        /// Not supported.
+        /// </summary>
         Extensions1D = 10,
 
+        /// <summary>
+        /// 2d extensions code word, extension code is used to indicate the change from the current mode to another mode, e.g., another coding scheme.
+        /// Not supported.
+        /// </summary>
         Extensions2D = 11,
     }
 }

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittTwoDimensionalCodeType.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/CcittTwoDimensionalCodeType.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
+{
+    internal enum CcittTwoDimensionalCodeType
+    {
+        None = 0,
+
+        Pass = 1,
+
+        Horizontal = 2,
+
+        Vertical0 = 3,
+
+        VerticalR1 = 4,
+
+        VerticalR2 = 5,
+
+        VerticalR3 = 6,
+
+        VerticalL1 = 7,
+
+        VerticalL2 = 8,
+
+        VerticalL3 = 9,
+
+        Extensions1D = 10,
+
+        Extensions2D = 11,
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/DeflateTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/DeflateTiffCompression.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         }
 
         /// <inheritdoc/>
-        protected override void Decompress(BufferedReadStream stream, int byteCount, Span<byte> buffer)
+        protected override void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer)
         {
             long pos = stream.Position;
             using (var deframeStream = new ZlibInflateStream(

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/DeflateTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/DeflateTiffCompression.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
     /// <remarks>
     /// Note that the 'OldDeflate' compression type is identical to the 'Deflate' compression type.
     /// </remarks>
-    internal class DeflateTiffCompression : TiffBaseDecompressor
+    internal sealed class DeflateTiffCompression : TiffBaseDecompressor
     {
         private readonly bool isBigEndian;
 

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/LzwTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/LzwTiffCompression.cs
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         }
 
         /// <inheritdoc/>
-        protected override void Decompress(BufferedReadStream stream, int byteCount, Span<byte> buffer)
+        protected override void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer)
         {
             var decoder = new TiffLzwDecoder(stream);
             decoder.DecodePixels(buffer);

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/LzwTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/LzwTiffCompression.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
     /// <summary>
     /// Class to handle cases where TIFF image data is compressed using LZW compression.
     /// </summary>
-    internal class LzwTiffCompression : TiffBaseDecompressor
+    internal sealed class LzwTiffCompression : TiffBaseDecompressor
     {
         private readonly bool isBigEndian;
 

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanBitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanBitReader.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.IO;
+using SixLabors.ImageSharp.Formats.Tiff.Constants;
+using SixLabors.ImageSharp.Memory;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
+{
+    /// <summary>
+    /// Bit reader for data encoded with the modified huffman rle method.
+    /// See TIFF 6.0 specification, section 10.
+    /// </summary>
+    internal class ModifiedHuffmanBitReader : T4BitReader
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModifiedHuffmanBitReader"/> class.
+        /// </summary>
+        /// <param name="input">The compressed input stream.</param>
+        /// <param name="fillOrder">The logical order of bits within a byte.</param>
+        /// <param name="bytesToRead">The number of bytes to read from the stream.</param>
+        /// <param name="allocator">The memory allocator.</param>
+        public ModifiedHuffmanBitReader(Stream input, TiffFillOrder fillOrder, int bytesToRead, MemoryAllocator allocator)
+            : base(input, fillOrder, bytesToRead, allocator)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool HasMoreData => this.Position < (ulong)this.DataLength - 1 || (this.BitsRead > 0 && this.BitsRead < 7);
+
+        /// <inheritdoc/>
+        public override bool IsEndOfScanLine
+        {
+            get
+            {
+                if (this.IsWhiteRun && this.CurValueBitsRead == 12 && this.Value == 1)
+                {
+                    return true;
+                }
+
+                if (this.CurValueBitsRead == 11 && this.Value == 0)
+                {
+                    // black run.
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void StartNewRow()
+        {
+            base.StartNewRow();
+
+            int pad = 8 - (this.BitsRead % 8);
+            if (pad != 8)
+            {
+                // Skip padding bits, move to next byte.
+                this.Position++;
+                this.ResetBitsRead();
+            }
+        }
+
+        /// <summary>
+        /// No EOL is expected at the start of a run for the modified huffman encoding.
+        /// </summary>
+        protected override void ReadEolBeforeFirstData()
+        {
+            // Nothing to do here.
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanBitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanBitReader.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
     /// Bit reader for data encoded with the modified huffman rle method.
     /// See TIFF 6.0 specification, section 10.
     /// </summary>
-    internal class ModifiedHuffmanBitReader : T4BitReader
+    internal sealed class ModifiedHuffmanBitReader : T4BitReader
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModifiedHuffmanBitReader"/> class.

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanBitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanBitReader.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         }
 
         /// <inheritdoc/>
-        public override bool HasMoreData => this.Position < (ulong)this.DataLength - 1 || (this.BitsRead > 0 && this.BitsRead < 7);
+        public override bool HasMoreData => this.Position < (ulong)this.DataLength - 1 || ((uint)(this.BitsRead - 1) < (7 - 1));
 
         /// <inheritdoc/>
         public override bool IsEndOfScanLine
@@ -53,8 +53,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         {
             base.StartNewRow();
 
-            int pad = 8 - (this.BitsRead % 8);
-            if (pad != 8)
+            int remainder = this.BitsRead & 7;    // bit-hack for % 8
+            if (remainder != 0)
             {
                 // Skip padding bits, move to next byte.
                 this.Position++;

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanTiffCompression.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
     /// <summary>
     /// Class to handle cases where TIFF image data is compressed using Modified Huffman Compression.
     /// </summary>
-    internal class ModifiedHuffmanTiffCompression : T4TiffCompression
+    internal sealed class ModifiedHuffmanTiffCompression : TiffBaseDecompressor
     {
         private readonly byte whiteValue;
 
@@ -27,12 +27,18 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         /// <param name="bitsPerPixel">The number of bits per pixel.</param>
         /// <param name="photometricInterpretation">The photometric interpretation.</param>
         public ModifiedHuffmanTiffCompression(MemoryAllocator allocator, TiffFillOrder fillOrder, int width, int bitsPerPixel, TiffPhotometricInterpretation photometricInterpretation)
-            : base(allocator, fillOrder, width, bitsPerPixel, FaxCompressionOptions.None, photometricInterpretation)
+            : base(allocator, width, bitsPerPixel)
         {
+            this.FillOrder = fillOrder;
             bool isWhiteZero = photometricInterpretation == TiffPhotometricInterpretation.WhiteIsZero;
             this.whiteValue = (byte)(isWhiteZero ? 0 : 1);
             this.blackValue = (byte)(isWhiteZero ? 1 : 0);
         }
+
+        /// <summary>
+        /// Gets the logical order of bits within a byte.
+        /// </summary>
+        private TiffFillOrder FillOrder { get; }
 
         /// <inheritdoc/>
         protected override void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer)
@@ -80,6 +86,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
                     TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error, decoded more pixels then image width");
                 }
             }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
         }
     }
 }

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/NoneTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/NoneTiffCompression.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
     /// <summary>
     /// Class to handle cases where TIFF image data is not compressed.
     /// </summary>
-    internal class NoneTiffCompression : TiffBaseDecompressor
+    internal sealed class NoneTiffCompression : TiffBaseDecompressor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NoneTiffCompression" /> class.

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/NoneTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/NoneTiffCompression.cs
@@ -25,7 +25,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         }
 
         /// <inheritdoc/>
-        protected override void Decompress(BufferedReadStream stream, int byteCount, Span<byte> buffer) => _ = stream.Read(buffer, 0, Math.Min(buffer.Length, byteCount));
+        protected override void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer)
+            => _ = stream.Read(buffer, 0, Math.Min(buffer.Length, byteCount));
 
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/PackBitsTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/PackBitsTiffCompression.cs
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         }
 
         /// <inheritdoc/>
-        protected override void Decompress(BufferedReadStream stream, int byteCount, Span<byte> buffer)
+        protected override void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer)
         {
             if (this.compressedDataMemory == null)
             {

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/PackBitsTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/PackBitsTiffCompression.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
     /// <summary>
     /// Class to handle cases where TIFF image data is compressed using PackBits compression.
     /// </summary>
-    internal class PackBitsTiffCompression : TiffBaseDecompressor
+    internal sealed class PackBitsTiffCompression : TiffBaseDecompressor
     {
         private IMemoryOwner<byte> compressedDataMemory;
 

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4BitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4BitReader.cs
@@ -438,7 +438,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         /// <returns>The value read.</returns>
         protected uint ReadValue(int nBits)
         {
-            Guard.MustBeGreaterThan(nBits, 0, nameof(nBits));
+            DebugGuard.MustBeGreaterThan(nBits, 0, nameof(nBits));
 
             uint v = 0;
             int shift = nBits;

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4TiffCompression.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
     /// <summary>
     /// Class to handle cases where TIFF image data is compressed using CCITT T4 compression.
     /// </summary>
-    internal class T4TiffCompression : TiffBaseDecompressor
+    internal sealed class T4TiffCompression : TiffBaseDecompressor
     {
         private readonly FaxCompressionOptions faxCompressionOptions;
 
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         /// <summary>
         /// Gets the logical order of bits within a byte.
         /// </summary>
-        protected TiffFillOrder FillOrder { get; }
+        private TiffFillOrder FillOrder { get; }
 
         /// <inheritdoc/>
         protected override void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer)

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4TiffCompression.cs
@@ -31,7 +31,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         /// <param name="bitsPerPixel">The number of bits per pixel.</param>
         /// <param name="faxOptions">Fax compression options.</param>
         /// <param name="photometricInterpretation">The photometric interpretation.</param>
-        public T4TiffCompression(MemoryAllocator allocator, TiffFillOrder fillOrder, int width, int bitsPerPixel, FaxCompressionOptions faxOptions, TiffPhotometricInterpretation photometricInterpretation)
+        public T4TiffCompression(
+            MemoryAllocator allocator,
+            TiffFillOrder fillOrder,
+            int width,
+            int bitsPerPixel,
+            FaxCompressionOptions faxOptions,
+            TiffPhotometricInterpretation photometricInterpretation)
             : base(allocator, width, bitsPerPixel)
         {
             this.faxCompressionOptions = faxOptions;
@@ -48,7 +54,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         protected TiffFillOrder FillOrder { get; }
 
         /// <inheritdoc/>
-        protected override void Decompress(BufferedReadStream stream, int byteCount, Span<byte> buffer)
+        protected override void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer)
         {
             if (this.faxCompressionOptions.HasFlag(FaxCompressionOptions.TwoDimensionalCoding))
             {

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
@@ -63,7 +63,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         }
 
         /// <inheritdoc/>
-        public override bool HasMoreData => this.Position < (ulong)this.DataLength - 1 || (this.BitsRead > 0 && this.BitsRead < 7);
+        public override bool HasMoreData => this.Position < (ulong)this.DataLength - 1 || ((uint)(this.BitsRead - 1) < (7 - 1));
 
         /// <summary>
         /// Gets or sets the two dimensional code.

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
     /// Bit reader for reading CCITT T6 compressed fax data.
     /// See: Facsimile Coding Schemes and Coding Control Functions for Group 4 Facsimile Apparatus, itu-t recommendation t.6
     /// </summary>
-    internal class T6BitReader : T4BitReader
+    internal sealed class T6BitReader : T4BitReader
     {
         private readonly int maxCodeLength = 12;
 

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using System.IO;
+
+using SixLabors.ImageSharp.Formats.Tiff.Constants;
+using SixLabors.ImageSharp.Memory;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
+{
+    /// <summary>
+    /// Bit reader for reading CCITT T6 compressed fax data.
+    /// See: Facsimile Coding Schemes and Coding Control Functions for Group 4 Facsimile Apparatus, itu-t recommendation t.6
+    /// </summary>
+    internal class T6BitReader : T4BitReader
+    {
+        private readonly int maxCodeLength = 12;
+
+        private static readonly CcittTwoDimensionalCode None = new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.None, 0);
+
+        private static readonly Dictionary<uint, CcittTwoDimensionalCode> Len1Codes = new Dictionary<uint, CcittTwoDimensionalCode>()
+        {
+            { 0b1, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.Vertical0, 1) }
+        };
+
+        private static readonly Dictionary<uint, CcittTwoDimensionalCode> Len3Codes = new Dictionary<uint, CcittTwoDimensionalCode>()
+        {
+            { 0b001, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.Horizontal, 3) },
+            { 0b010, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.VerticalL1, 3) },
+            { 0b011, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.VerticalR1, 3) }
+        };
+
+        private static readonly Dictionary<uint, CcittTwoDimensionalCode> Len4Codes = new Dictionary<uint, CcittTwoDimensionalCode>()
+        {
+            { 0b0001, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.Pass, 4) }
+        };
+
+        private static readonly Dictionary<uint, CcittTwoDimensionalCode> Len6Codes = new Dictionary<uint, CcittTwoDimensionalCode>()
+        {
+            { 0b000011, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.VerticalR2, 6) },
+            { 0b000010, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.VerticalL2, 6) }
+        };
+
+        private static readonly Dictionary<uint, CcittTwoDimensionalCode> Len7Codes = new Dictionary<uint, CcittTwoDimensionalCode>()
+        {
+            { 0b0000011, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.VerticalR3, 7) },
+            { 0b0000010, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.VerticalL3, 7) },
+            { 0b0000001, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.Extensions2D, 7) },
+            { 0b0000000, new CcittTwoDimensionalCode(CcittTwoDimensionalCodeType.Extensions1D, 7) }
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T6BitReader"/> class.
+        /// </summary>
+        /// <param name="input">The compressed input stream.</param>
+        /// <param name="fillOrder">The logical order of bits within a byte.</param>
+        /// <param name="bytesToRead">The number of bytes to read from the stream.</param>
+        /// <param name="allocator">The memory allocator.</param>
+        public T6BitReader(Stream input, TiffFillOrder fillOrder, int bytesToRead, MemoryAllocator allocator)
+            : base(input, fillOrder, bytesToRead, allocator)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool HasMoreData => this.Position < (ulong)this.DataLength - 1 || (this.BitsRead > 0 && this.BitsRead < 7);
+
+        /// <summary>
+        /// Gets or sets the two dimensional code.
+        /// </summary>
+        public CcittTwoDimensionalCode Code { get; internal set; }
+
+        public bool ReadNextCodeWord()
+        {
+            this.Code = None;
+            this.Reset();
+            uint value = this.ReadValue(1);
+
+            do
+            {
+                if (this.CurValueBitsRead > this.maxCodeLength)
+                {
+                    TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error: invalid code length read");
+                }
+
+                switch (this.CurValueBitsRead)
+                {
+                    case 1:
+                        if (Len1Codes.ContainsKey(value))
+                        {
+                            this.Code = Len1Codes[value];
+                            return false;
+                        }
+
+                        break;
+
+                    case 3:
+                        if (Len3Codes.ContainsKey(value))
+                        {
+                            this.Code = Len3Codes[value];
+                            return false;
+                        }
+
+                        break;
+
+                    case 4:
+                        if (Len4Codes.ContainsKey(value))
+                        {
+                            this.Code = Len4Codes[value];
+                            return false;
+                        }
+
+                        break;
+
+                    case 6:
+                        if (Len6Codes.ContainsKey(value))
+                        {
+                            this.Code = Len6Codes[value];
+                            return false;
+                        }
+
+                        break;
+
+                    case 7:
+                        if (Len7Codes.ContainsKey(value))
+                        {
+                            this.Code = Len7Codes[value];
+                            return false;
+                        }
+
+                        break;
+                }
+
+                uint currBit = this.ReadValue(1);
+                value = (value << 1) | currBit;
+            }
+            while (!this.IsEndOfScanLine);
+
+            if (this.IsEndOfScanLine)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// No EOL is expected at the start of a run.
+        /// </summary>
+        protected override void ReadEolBeforeFirstData()
+        {
+            // Nothing to do here.
+        }
+
+        /// <summary>
+        /// Swaps the white run to black run an vise versa.
+        /// </summary>
+        public void SwapColor() => this.IsWhiteRun = !this.IsWhiteRun;
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -84,8 +84,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
             }
 
             // Write padding bytes, if necessary.
-            uint pad = 8 - (bitsWritten % 8);
-            if (pad != 8)
+            uint remainder = bitsWritten % 8;
+            if (remainder != 0)
             {
                 BitWriterUtils.WriteBits(buffer, (int)bitsWritten, pad, 0);
                 bitsWritten += pad;

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
     /// <summary>
     /// Class to handle cases where TIFF image data is compressed using CCITT T6 compression.
     /// </summary>
-    internal class T6TiffCompression : TiffBaseDecompressor
+    internal sealed class T6TiffCompression : TiffBaseDecompressor
     {
         private readonly bool isWhiteZero;
 

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -1,0 +1,253 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.ImageSharp.Formats.Tiff.Constants;
+using SixLabors.ImageSharp.IO;
+using SixLabors.ImageSharp.Memory;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
+{
+    /// <summary>
+    /// Class to handle cases where TIFF image data is compressed using CCITT T6 compression.
+    /// </summary>
+    internal class T6TiffCompression : TiffBaseDecompressor
+    {
+        private readonly bool isWhiteZero;
+
+        private readonly byte whiteValue;
+
+        private readonly byte blackValue;
+
+        private readonly int width;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T6TiffCompression" /> class.
+        /// </summary>
+        /// <param name="allocator">The memory allocator.</param>
+        /// <param name="fillOrder">The logical order of bits within a byte.</param>
+        /// <param name="width">The image width.</param>
+        /// <param name="bitsPerPixel">The number of bits per pixel.</param>
+        /// <param name="photometricInterpretation">The photometric interpretation.</param>
+        public T6TiffCompression(
+            MemoryAllocator allocator,
+            TiffFillOrder fillOrder,
+            int width,
+            int bitsPerPixel,
+            TiffPhotometricInterpretation photometricInterpretation)
+            : base(allocator, width, bitsPerPixel)
+        {
+            this.FillOrder = fillOrder;
+            this.width = width;
+            this.isWhiteZero = photometricInterpretation == TiffPhotometricInterpretation.WhiteIsZero;
+            this.whiteValue = (byte)(this.isWhiteZero ? 0 : 1);
+            this.blackValue = (byte)(this.isWhiteZero ? 1 : 0);
+        }
+
+        /// <summary>
+        /// Gets the logical order of bits within a byte.
+        /// </summary>
+        private TiffFillOrder FillOrder { get; }
+
+        /// <inheritdoc/>
+        protected override void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer)
+        {
+            int height = stripHeight;
+
+            using System.Buffers.IMemoryOwner<byte> scanLineBuffer = this.Allocator.Allocate<byte>(this.width * 2);
+            Span<byte> scanLine = scanLineBuffer.GetSpan().Slice(0, this.width);
+            Span<byte> referenceScanLineSpan = scanLineBuffer.GetSpan().Slice(this.width, this.width);
+
+            using var bitReader = new T6BitReader(stream, this.FillOrder, byteCount, this.Allocator);
+
+            var referenceScanLine = new CcittReferenceScanline(this.isWhiteZero, this.width);
+            uint bitsWritten = 0;
+            for (int y = 0; y < height; y++)
+            {
+                scanLine.Fill(0);
+                Decode2DScanline(bitReader, this.isWhiteZero, referenceScanLine, scanLine);
+
+                bitsWritten = this.WriteScanLine(buffer, scanLine, bitsWritten);
+
+                scanLine.CopyTo(referenceScanLineSpan);
+                referenceScanLine = new CcittReferenceScanline(this.isWhiteZero, referenceScanLineSpan);
+            }
+        }
+
+        private uint WriteScanLine(Span<byte> buffer, Span<byte> scanLine, uint bitsWritten)
+        {
+            byte white = (byte)(this.isWhiteZero ? 0 : 255);
+            for (int i = 0; i < scanLine.Length; i++)
+            {
+                BitWriterUtils.WriteBits(buffer, (int)bitsWritten, 1, scanLine[i] == white ? this.whiteValue : this.blackValue);
+                bitsWritten++;
+            }
+
+            // Write padding bytes, if necessary.
+            uint pad = 8 - (bitsWritten % 8);
+            if (pad != 8)
+            {
+                BitWriterUtils.WriteBits(buffer, (int)bitsWritten, pad, 0);
+                bitsWritten += pad;
+            }
+
+            return bitsWritten;
+        }
+
+        private static void Decode2DScanline(T6BitReader bitReader, bool whiteIsZero, CcittReferenceScanline referenceScanline, Span<byte> scanline)
+        {
+            int width = scanline.Length;
+            bitReader.StartNewRow();
+
+            // 2D Encoding variables.
+            int a0 = -1;
+            byte fillByte = whiteIsZero ? (byte)0 : (byte)255;
+
+            // Process every code word in this scanline.
+            int unpacked = 0;
+            while (true)
+            {
+                // Read next code word and advance pass it.
+                bool isEol = bitReader.ReadNextCodeWord();
+
+                // Special case handling for EOL.
+                if (isEol)
+                {
+                    // If a TIFF reader encounters EOFB before the expected number of lines has been extracted,
+                    // it is appropriate to assume that the missing rows consist entirely of white pixels.
+                    scanline.Fill(whiteIsZero ? (byte)0 : (byte)255);
+                    break;
+                }
+
+                // Update 2D Encoding variables.
+                int b1 = referenceScanline.FindB1(a0, fillByte);
+
+                // Switch on the code word.
+                int a1;
+                switch (bitReader.Code.Type)
+                {
+                    case CcittTwoDimensionalCodeType.None:
+                        TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error, could not read a valid code word.");
+                        break;
+
+                    case CcittTwoDimensionalCodeType.Pass:
+                        int b2 = referenceScanline.FindB2(b1);
+                        scanline.Slice(unpacked, b2 - unpacked).Fill(fillByte);
+                        unpacked = b2;
+                        a0 = b2;
+                        break;
+                    case CcittTwoDimensionalCodeType.Horizontal:
+                        // Decode M(a0a1)
+                        bitReader.ReadNextRun();
+                        int runLength = (int)bitReader.RunLength;
+                        if (runLength > (uint)(scanline.Length - unpacked))
+                        {
+                            TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error");
+                        }
+
+                        scanline.Slice(unpacked, runLength).Fill(fillByte);
+                        unpacked += runLength;
+                        fillByte = (byte)~fillByte;
+
+                        // Decode M(a1a2)
+                        bitReader.ReadNextRun();
+                        runLength = (int)bitReader.RunLength;
+                        if (runLength > (uint)(scanline.Length - unpacked))
+                        {
+                            TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error");
+                        }
+
+                        scanline.Slice(unpacked, runLength).Fill(fillByte);
+                        unpacked += runLength;
+                        fillByte = (byte)~fillByte;
+
+                        // Prepare next a0
+                        a0 = unpacked;
+                        break;
+
+                    case CcittTwoDimensionalCodeType.Vertical0:
+                        a1 = b1;
+                        scanline.Slice(unpacked, a1 - unpacked).Fill(fillByte);
+                        unpacked = a1;
+                        a0 = a1;
+                        fillByte = (byte)~fillByte;
+                        bitReader.SwapColor();
+                        break;
+
+                    case CcittTwoDimensionalCodeType.VerticalR1:
+                        a1 = b1 + 1;
+                        scanline.Slice(unpacked, a1 - unpacked).Fill(fillByte);
+                        unpacked = a1;
+                        a0 = a1;
+                        fillByte = (byte)~fillByte;
+                        bitReader.SwapColor();
+                        break;
+
+                    case CcittTwoDimensionalCodeType.VerticalR2:
+                        a1 = b1 + 2;
+                        scanline.Slice(unpacked, a1 - unpacked).Fill(fillByte);
+                        unpacked = a1;
+                        a0 = a1;
+                        fillByte = (byte)~fillByte;
+                        bitReader.SwapColor();
+                        break;
+
+                    case CcittTwoDimensionalCodeType.VerticalR3:
+                        a1 = b1 + 3;
+                        scanline.Slice(unpacked, a1 - unpacked).Fill(fillByte);
+                        unpacked = a1;
+                        a0 = a1;
+                        fillByte = (byte)~fillByte;
+                        bitReader.SwapColor();
+                        break;
+
+                    case CcittTwoDimensionalCodeType.VerticalL1:
+                        a1 = b1 - 1;
+                        scanline.Slice(unpacked, a1 - unpacked).Fill(fillByte);
+                        unpacked = a1;
+                        a0 = a1;
+                        fillByte = (byte)~fillByte;
+                        bitReader.SwapColor();
+                        break;
+
+                    case CcittTwoDimensionalCodeType.VerticalL2:
+                        a1 = b1 - 2;
+                        scanline.Slice(unpacked, a1 - unpacked).Fill(fillByte);
+                        unpacked = a1;
+                        a0 = a1;
+                        fillByte = (byte)~fillByte;
+                        bitReader.SwapColor();
+                        break;
+
+                    case CcittTwoDimensionalCodeType.VerticalL3:
+                        a1 = b1 - 3;
+                        scanline.Slice(unpacked, a1 - unpacked).Fill(fillByte);
+                        unpacked = a1;
+                        a0 = a1;
+                        fillByte = (byte)~fillByte;
+                        bitReader.SwapColor();
+                        break;
+
+                    default:
+                        throw new NotSupportedException("ccitt extensions are not supported.");
+                }
+
+                // This line is fully unpacked. Should exit and process next line.
+                if (unpacked == width)
+                {
+                    break;
+                }
+
+                if (unpacked > width)
+                {
+                    TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error, unpacked data > width");
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -87,8 +87,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
             uint remainder = bitsWritten % 8;
             if (remainder != 0)
             {
-                BitWriterUtils.WriteBits(buffer, (int)bitsWritten, pad, 0);
-                bitsWritten += pad;
+                uint padding = 8 - remainder;
+                BitWriterUtils.WriteBits(buffer, (int)bitsWritten, padding, 0);
+                bitsWritten += padding;
             }
 
             return bitsWritten;

--- a/src/ImageSharp/Formats/Tiff/Compression/TiffBaseDecompressor.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/TiffBaseDecompressor.cs
@@ -15,8 +15,15 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression
     /// </summary>
     internal abstract class TiffBaseDecompressor : TiffBaseCompression
     {
-        protected TiffBaseDecompressor(MemoryAllocator allocator, int width, int bitsPerPixel, TiffPredictor predictor = TiffPredictor.None)
-         : base(allocator, width, bitsPerPixel, predictor)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TiffBaseDecompressor"/> class.
+        /// </summary>
+        /// <param name="memoryAllocator">The memory allocator.</param>
+        /// <param name="width">The width of the image.</param>
+        /// <param name="bitsPerPixel">The bits per pixel.</param>
+        /// <param name="predictor">The predictor.</param>
+        protected TiffBaseDecompressor(MemoryAllocator memoryAllocator, int width, int bitsPerPixel, TiffPredictor predictor = TiffPredictor.None)
+         : base(memoryAllocator, width, bitsPerPixel, predictor)
         {
         }
 
@@ -26,8 +33,9 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression
         /// <param name="stream">The <see cref="Stream" /> to read image data from.</param>
         /// <param name="stripOffset">The strip offset of stream.</param>
         /// <param name="stripByteCount">The number of bytes to read from the input stream.</param>
+        /// <param name="stripHeight">The height of the strip.</param>
         /// <param name="buffer">The output buffer for uncompressed data.</param>
-        public void Decompress(BufferedReadStream stream, uint stripOffset, uint stripByteCount, Span<byte> buffer)
+        public void Decompress(BufferedReadStream stream, uint stripOffset, uint stripByteCount, int stripHeight, Span<byte> buffer)
         {
             if (stripByteCount > int.MaxValue)
             {
@@ -35,7 +43,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression
             }
 
             stream.Seek(stripOffset, SeekOrigin.Begin);
-            this.Decompress(stream, (int)stripByteCount, buffer);
+            this.Decompress(stream, (int)stripByteCount, stripHeight, buffer);
 
             if (stripOffset + stripByteCount < stream.Position)
             {
@@ -48,7 +56,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression
         /// </summary>
         /// <param name="stream">The <see cref="Stream" /> to read image data from.</param>
         /// <param name="byteCount">The number of bytes to read from the input stream.</param>
+        /// <param name="stripHeight">The height of the strip.</param>
         /// <param name="buffer">The output buffer for uncompressed data.</param>
-        protected abstract void Decompress(BufferedReadStream stream, int byteCount, Span<byte> buffer);
+        protected abstract void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer);
     }
 }

--- a/src/ImageSharp/Formats/Tiff/Compression/TiffDecoderCompressionType.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/TiffDecoderCompressionType.cs
@@ -29,9 +29,14 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression
         Lzw = 3,
 
         /// <summary>
-        /// Image data is compressed using T4-encoding: CCITT T.4.
+        /// Image data is compressed using CCITT T.4 fax compression.
         /// </summary>
         T4 = 4,
+
+        /// <summary>
+        /// Image data is compressed using CCITT T.6 fax compression.
+        /// </summary>
+        T6 = 6,
 
         /// <summary>
         /// Image data is compressed using modified huffman compression.

--- a/src/ImageSharp/Formats/Tiff/Compression/TiffDecompressorsFactory.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/TiffDecompressorsFactory.cs
@@ -46,6 +46,10 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression
                     DebugGuard.IsTrue(predictor == TiffPredictor.None, "Predictor should only be used with lzw or deflate compression");
                     return new T4TiffCompression(allocator, fillOrder, width, bitsPerPixel, faxOptions, photometricInterpretation);
 
+                case TiffDecoderCompressionType.T6:
+                    DebugGuard.IsTrue(predictor == TiffPredictor.None, "Predictor should only be used with lzw or deflate compression");
+                    return new T6TiffCompression(allocator, fillOrder, width, bitsPerPixel, photometricInterpretation);
+
                 case TiffDecoderCompressionType.HuffmanRle:
                     DebugGuard.IsTrue(predictor == TiffPredictor.None, "Predictor should only be used with lzw or deflate compression");
                     return new ModifiedHuffmanTiffCompression(allocator, fillOrder, width, bitsPerPixel, photometricInterpretation);

--- a/src/ImageSharp/Formats/Tiff/README.md
+++ b/src/ImageSharp/Formats/Tiff/README.md
@@ -45,7 +45,7 @@
 |Ccitt1D                    |   Y   |   Y   |                          |
 |PackBits                   |   Y   |   Y   |                          |
 |CcittGroup3Fax             |   Y   |   Y   |                          |
-|CcittGroup4Fax             |       |       |                          |
+|CcittGroup4Fax             |       |   Y   |                          |
 |Lzw                        |   Y   |   Y   | Based on ImageSharp GIF LZW implementation - this code could be modified to be (i) shared, or (ii) optimised for each case |
 |Old Jpeg                   |       |       | We should not even try to support this |
 |Jpeg (Technote 2)          |       |       |                          |

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -317,7 +317,12 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     int stripIndex = i;
                     for (int planeIndex = 0; planeIndex < stripsPerPixel; planeIndex++)
                     {
-                        decompressor.Decompress(this.inputStream, (uint)stripOffsets[stripIndex], (uint)stripByteCounts[stripIndex], stripBuffers[planeIndex].GetSpan());
+                        decompressor.Decompress(
+                            this.inputStream,
+                            (uint)stripOffsets[stripIndex],
+                            (uint)stripByteCounts[stripIndex],
+                            stripHeight,
+                            stripBuffers[planeIndex].GetSpan());
                         stripIndex += stripsPerPlane;
                     }
 
@@ -385,7 +390,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     break;
                 }
 
-                decompressor.Decompress(this.inputStream, (uint)stripOffsets[stripIndex], (uint)stripByteCounts[stripIndex], stripBufferSpan);
+                decompressor.Decompress(this.inputStream, (uint)stripOffsets[stripIndex], (uint)stripByteCounts[stripIndex], stripHeight, stripBufferSpan);
 
                 colorDecoder.Decode(stripBufferSpan, pixels, 0, top, frame.Width, stripHeight);
             }

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
@@ -418,6 +418,14 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     break;
                 }
 
+                case TiffCompression.CcittGroup4Fax:
+                {
+                    options.CompressionType = TiffDecoderCompressionType.T6;
+                    options.FaxCompressionOptions = exifProfile.GetValue(ExifTag.T4Options) != null ? (FaxCompressionOptions)exifProfile.GetValue(ExifTag.T4Options).Value : FaxCompressionOptions.None;
+
+                    break;
+                }
+
                 case TiffCompression.Ccitt1D:
                 {
                     options.CompressionType = TiffDecoderCompressionType.HuffmanRle;

--- a/tests/ImageSharp.Tests/Formats/Tiff/Compression/DeflateTiffCompressionTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/Compression/DeflateTiffCompressionTests.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff.Compression
 
                 using var decompressor = new DeflateTiffCompression(Configuration.Default.MemoryAllocator, 10, 8, TiffColorType.BlackIsZero8, TiffPredictor.None, false);
 
-                decompressor.Decompress(stream, 0, (uint)stream.Length, buffer);
+                decompressor.Decompress(stream, 0, (uint)stream.Length, 1, buffer);
 
                 Assert.Equal(data, buffer);
             }

--- a/tests/ImageSharp.Tests/Formats/Tiff/Compression/LzwTiffCompressionTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/Compression/LzwTiffCompressionTests.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff.Compression
             var buffer = new byte[data.Length];
 
             using var decompressor = new LzwTiffCompression(Configuration.Default.MemoryAllocator, 10, 8, TiffColorType.BlackIsZero8, TiffPredictor.None, false);
-            decompressor.Decompress(stream, 0, (uint)stream.Length, buffer);
+            decompressor.Decompress(stream, 0, (uint)stream.Length, 1, buffer);
 
             Assert.Equal(data, buffer);
         }

--- a/tests/ImageSharp.Tests/Formats/Tiff/Compression/NoneTiffCompressionTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/Compression/NoneTiffCompressionTests.cs
@@ -17,10 +17,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff.Compression
         [InlineData(new byte[] { 10, 15, 20, 25, 30, 35, 40, 45 }, 5, new byte[] { 10, 15, 20, 25, 30 })]
         public void Decompress_ReadsData(byte[] inputData, uint byteCount, byte[] expectedResult)
         {
-            var stream = new BufferedReadStream(Configuration.Default, new MemoryStream(inputData));
-            var buffer = new byte[expectedResult.Length];
+            using var memoryStream = new MemoryStream(inputData);
+            using var stream = new BufferedReadStream(Configuration.Default, memoryStream);
+            byte[] buffer = new byte[expectedResult.Length];
 
-            new NoneTiffCompression(default, default, default).Decompress(stream, 0, byteCount, buffer);
+            using var decompressor = new NoneTiffCompression(default, default, default);
+            decompressor.Decompress(stream, 0, byteCount, 1, buffer);
 
             Assert.Equal(expectedResult, buffer);
         }

--- a/tests/ImageSharp.Tests/Formats/Tiff/Compression/PackBitsTiffCompressionTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/Compression/PackBitsTiffCompressionTests.cs
@@ -26,11 +26,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff.Compression
         [InlineData(new byte[] { 0xFE, 0xAA, 0x02, 0x80, 0x00, 0x2A, 0xFD, 0xAA, 0x03, 0x80, 0x00, 0x2A, 0x22, 0xF7, 0xAA }, new byte[] { 0xAA, 0xAA, 0xAA, 0x80, 0x00, 0x2A, 0xAA, 0xAA, 0xAA, 0xAA, 0x80, 0x00, 0x2A, 0x22, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA })] // Apple PackBits sample
         public void Decompress_ReadsData(byte[] inputData, byte[] expectedResult)
         {
-            var stream = new BufferedReadStream(Configuration.Default, new MemoryStream(inputData));
-            var buffer = new byte[expectedResult.Length];
+            using var memoryStream = new MemoryStream(inputData);
+            using var stream = new BufferedReadStream(Configuration.Default, memoryStream);
+            byte[] buffer = new byte[expectedResult.Length];
 
             using var decompressor = new PackBitsTiffCompression(new ArrayPoolMemoryAllocator(), default, default);
-            decompressor.Decompress(stream, 0, (uint)inputData.Length, buffer);
+            decompressor.Decompress(stream, 0, (uint)inputData.Length, 1, buffer);
 
             Assert.Equal(expectedResult, buffer);
         }
@@ -41,7 +42,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff.Compression
         {
             // arrange
             Span<byte> input = inputData.AsSpan();
-            var compressed = new byte[expectedResult.Length];
+            byte[] compressed = new byte[expectedResult.Length];
 
             // act
             PackBitsWriter.PackBits(input, compressed);

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -23,14 +23,16 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
     {
         public static readonly string[] MultiframeTestImages = Multiframes;
 
-        public static readonly string[] NotSupportedImages = NotSupported;
-
         private static TiffDecoder TiffDecoder => new TiffDecoder();
 
         private static MagickReferenceDecoder ReferenceDecoder => new MagickReferenceDecoder();
 
         [Theory]
-        [WithFileCollection(nameof(NotSupportedImages), PixelTypes.Rgba32)]
+        [WithFile(Calliphora_RgbJpeg, PixelTypes.Rgba32)]
+        [WithFile(RgbJpeg, PixelTypes.Rgba32)]
+        [WithFile(RgbUncompressedTiled, PixelTypes.Rgba32)]
+        [WithFile(MultiframeDifferentSize, PixelTypes.Rgba32)]
+        [WithFile(MultiframeDifferentVariants, PixelTypes.Rgba32)]
         public void ThrowsNotSupported<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel> => Assert.Throws<NotSupportedException>(() => provider.GetImage(TiffDecoder));
 
@@ -354,6 +356,13 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [WithFile(Calliphora_Fax3Compressed_WithEolPadding, PixelTypes.Rgba32)]
         [WithFile(Fax3Uncompressed, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_Fax3Compressed<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(Fax4Compressed, PixelTypes.Rgba32)]
+        [WithFile(Fax4CompressedLowerOrderBitsFirst, PixelTypes.Rgba32)]
+        [WithFile(Calliphora_Fax4Compressed, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_Fax4Compressed<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -534,6 +534,8 @@ namespace SixLabors.ImageSharp.Tests
             public const string Calliphora_Fax4Compressed = "Tiff/Calliphora_ccitt_fax4.tiff";
             public const string Calliphora_HuffmanCompressed = "Tiff/Calliphora_huffman_rle.tiff";
             public const string Calliphora_BiColorUncompressed = "Tiff/Calliphora_bicolor_uncompressed.tiff";
+            public const string Fax4Compressed = "Tiff/basi3p02_fax4.tiff";
+            public const string Fax4CompressedLowerOrderBitsFirst = "Tiff/basi3p02_fax4_lowerOrderBitsFirst.tiff";
 
             public const string CcittFax3AllTermCodes = "Tiff/ccitt_fax3_all_terminating_codes.tiff";
             public const string CcittFax3AllMakeupCodes = "Tiff/ccitt_fax3_all_makeup_codes.tiff";
@@ -658,8 +660,6 @@ namespace SixLabors.ImageSharp.Tests
             public static readonly string[] Multiframes = { MultiframeDeflateWithPreview, MultiframeLzwPredictor /*, MultiFrameDifferentSize, MultiframeDifferentSizeTiled, MultiFrameDifferentVariants,*/ };
 
             public static readonly string[] Metadata = { SampleMetadata };
-
-            public static readonly string[] NotSupported = { Calliphora_RgbJpeg, RgbJpeg, RgbUncompressedTiled, MultiframeDifferentSize, MultiframeDifferentVariants, Calliphora_Fax4Compressed, Fax4_Motorola };
         }
     }
 }

--- a/tests/Images/Input/Tiff/Calliphora_ccitt_fax4.tiff
+++ b/tests/Images/Input/Tiff/Calliphora_ccitt_fax4.tiff
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a2c95aec08b96bca30af344f7d9952a603a951802ce534a5f2c5f563795cbd2
-size 117704
+oid sha256:b8c7f712f9e7d1feeeb55e7743f6ce7d66bc5292f4786ea8526d95057d73145e
+size 4534

--- a/tests/Images/Input/Tiff/basi3p02_fax4.tiff
+++ b/tests/Images/Input/Tiff/basi3p02_fax4.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:185ae3c4174b323adcf811d125cd77b71768406845923f50395c0baebff57b7c
+size 282

--- a/tests/Images/Input/Tiff/basi3p02_fax4_lowerOrderBitsFirst.tiff
+++ b/tests/Images/Input/Tiff/basi3p02_fax4_lowerOrderBitsFirst.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a19eb117f194718575681a81a4fbe7fe4a1b82b99113707295194090fb935784
+size 282

--- a/tests/Images/Input/Tiff/basi3p02_fax4_minisblack.tiff
+++ b/tests/Images/Input/Tiff/basi3p02_fax4_minisblack.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af0d8f3c18f96228aa369bc295201a1bfe1b044c23991ff168401adc5402ebb6
+size 308


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This **PR** adds support for decoding tiff image with ccitt T.6 fax compression (some call the compression fax4).

For the specification see pdf `T-REC-T.6-198811` in the Tiff folder.