### PR TITLE
Revert unoptimized edits to Jpeg Encoder.

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
@@ -104,7 +104,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
             {
                 GuardBlockIndex(idx);
                 ref float selfRef = ref Unsafe.As<Block8x8F, float>(ref this);
-                return Unsafe.Add(ref selfRef, idx);
+                return Unsafe.Add(ref selfRef, (nint)(uint)idx);
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -112,7 +112,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
             {
                 GuardBlockIndex(idx);
                 ref float selfRef = ref Unsafe.As<Block8x8F, float>(ref this);
-                Unsafe.Add(ref selfRef, idx) = value;
+                Unsafe.Add(ref selfRef, (nint)(uint)idx) = value;
             }
         }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbForwardConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbForwardConverter{TPixel}.cs
@@ -103,7 +103,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
 
             for (int i = 0; i < Block8x8F.Size; i++)
             {
-                Rgb24 c = Unsafe.Add(ref rgbStart, i);
+                Rgb24 c = Unsafe.Add(ref rgbStart, (nint)(uint)i);
 
                 redBlock[i] = c.R;
                 greenBlock[i] = c.G;

--- a/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
@@ -167,14 +167,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <param name="colorType">The color type.</param>
         /// <returns>true, if color type is supported.</returns>
         private static bool IsSupportedColorType(JpegColorType? colorType)
-        {
-            if (colorType == JpegColorType.YCbCrRatio444 || colorType == JpegColorType.YCbCrRatio420 || colorType == JpegColorType.Luminance || colorType == JpegColorType.Rgb)
-            {
-                return true;
-            }
-
-            return false;
-        }
+            => colorType == JpegColorType.YCbCrRatio444
+            || colorType == JpegColorType.YCbCrRatio420
+            || colorType == JpegColorType.Luminance
+            || colorType == JpegColorType.Rgb;
 
         /// <summary>
         /// Gets the component ids.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Reverts the bad changes to performance I made in #1734 and adds an `nint` codegen improvement. /cc @gfoidl

<!-- Thanks for contributing to ImageSharp! -->
