### PR TITLE
Fix ManagedBufferBase pinning behavior

### DIFF
--- a/src/ImageSharp/Memory/Allocators/Internals/ManagedBufferBase.cs
+++ b/src/ImageSharp/Memory/Allocators/Internals/ManagedBufferBase.cs
@@ -24,7 +24,9 @@ namespace SixLabors.ImageSharp.Memory.Internals
             }
 
             void* ptr = (void*)this.pinHandle.AddrOfPinnedObject();
-            return new MemoryHandle(ptr, this.pinHandle, this);
+
+            // We should only pass pinnable:this, when GCHandle lifetime is managed by the MemoryManager<T> instance.
+            return new MemoryHandle(ptr, pinnable: this);
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Memory/Allocators/Internals/ManagedBufferBase.cs
+++ b/src/ImageSharp/Memory/Allocators/Internals/ManagedBufferBase.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Memory.Internals
             }
 
             void* ptr = (void*)this.pinHandle.AddrOfPinnedObject();
-            return new MemoryHandle(ptr, this.pinHandle);
+            return new MemoryHandle(ptr, this.pinHandle, this);
         }
 
         /// <inheritdoc />

--- a/tests/ImageSharp.Tests/Memory/Allocators/ArrayPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/ArrayPoolMemoryAllocatorTests.cs
@@ -114,6 +114,23 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
             }
         }
 
+        [Fact]
+        public unsafe void Allocate_MemoryIsPinnableMultipleTimes()
+        {
+            ArrayPoolMemoryAllocator allocator = this.LocalFixture.MemoryAllocator;
+            using IMemoryOwner<byte> memoryOwner = allocator.Allocate<byte>(100);
+
+            using (MemoryHandle pin = memoryOwner.Memory.Pin())
+            {
+                Assert.NotEqual(IntPtr.Zero, (IntPtr)pin.Pointer);
+            }
+
+            using (MemoryHandle pin = memoryOwner.Memory.Pin())
+            {
+                Assert.NotEqual(IntPtr.Zero, (IntPtr)pin.Pointer);
+            }
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Buffers;
 using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.Memory;
 using Xunit;
@@ -34,6 +35,23 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
         {
             ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.AllocateManagedByteBuffer(length));
             Assert.Equal("length", ex.ParamName);
+        }
+
+        [Fact]
+        public unsafe void Allocate_MemoryIsPinnableMultipleTimes()
+        {
+            SimpleGcMemoryAllocator allocator = this.MemoryAllocator;
+            using IMemoryOwner<byte> memoryOwner = allocator.Allocate<byte>(100);
+
+            using (MemoryHandle pin = memoryOwner.Memory.Pin())
+            {
+                Assert.NotEqual(IntPtr.Zero, (IntPtr)pin.Pointer);
+            }
+
+            using (MemoryHandle pin = memoryOwner.Memory.Pin())
+            {
+                Assert.NotEqual(IntPtr.Zero, (IntPtr)pin.Pointer);
+            }
         }
 
         [StructLayout(LayoutKind.Explicit, Size = 512)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Fixes #1755.

Although `ArrayPoolMemoryAllocator` is about to be dumped with #1730 we'll keep `SimpleGcMemoryAllocator` so filing a separate fix.