### PR TITLE
Use shared ArrayPoolMemoryAllocator in tests to avoid OOM

### DIFF
--- a/tests/ImageSharp.Tests/Image/ImageFrameTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageFrameTests.cs
@@ -16,7 +16,8 @@ namespace SixLabors.ImageSharp.Tests
 
             private void LimitBufferCapacity(int bufferCapacityInBytes)
             {
-                var allocator = (ArrayPoolMemoryAllocator)this.configuration.MemoryAllocator;
+                var allocator = ArrayPoolMemoryAllocator.CreateDefault();
+                this.configuration.MemoryAllocator = allocator;
                 allocator.BufferCapacityInBytes = bufferCapacityInBytes;
             }
 

--- a/tests/ImageSharp.Tests/Image/ImageTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.cs
@@ -99,7 +99,8 @@ namespace SixLabors.ImageSharp.Tests
 
             private void LimitBufferCapacity(int bufferCapacityInBytes)
             {
-                var allocator = (ArrayPoolMemoryAllocator)this.configuration.MemoryAllocator;
+                var allocator = ArrayPoolMemoryAllocator.CreateDefault();
+                this.configuration.MemoryAllocator = allocator;
                 allocator.BufferCapacityInBytes = bufferCapacityInBytes;
             }
 

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
@@ -21,11 +21,20 @@ namespace SixLabors.ImageSharp.Tests
     public abstract partial class TestImageProvider<TPixel> : ITestImageProvider, IXunitSerializable
         where TPixel : unmanaged, IPixel<TPixel>
     {
+        // Create a Configuration with Configuration.CreateDefaultInstance(),
+        // but use the shared MemoryAllocator from Configuration.Default.MemoryAllocator
+        private static Configuration CreateDefaultConfiguration()
+        {
+            var configuration = Configuration.CreateDefaultInstance();
+            configuration.MemoryAllocator = ImageSharp.Configuration.Default.MemoryAllocator;
+            return configuration;
+        }
+
         public PixelTypes PixelType { get; private set; } = typeof(TPixel).GetPixelType();
 
         public virtual string SourceFileOrDescription => string.Empty;
 
-        public Configuration Configuration { get; set; } = Configuration.CreateDefaultInstance();
+        public Configuration Configuration { get; set; } = CreateDefaultConfiguration();
 
         /// <summary>
         /// Gets the utility instance to provide information about the test image & manage input/output.

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -663,7 +663,8 @@ namespace SixLabors.ImageSharp.Tests
             this TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            var allocator = (ArrayPoolMemoryAllocator)provider.Configuration.MemoryAllocator;
+            var allocator = ArrayPoolMemoryAllocator.CreateDefault();
+            provider.Configuration.MemoryAllocator = allocator;
             return new AllocatorBufferCapacityConfigurator(allocator, Unsafe.SizeOf<TPixel>());
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

I realized that the main reason behind the 32 bit test OOM-s is that every `TestImageProvider` creates a new `ArrayPoolMemoryAllocator` which practically disables pooling for the entire test run. Except for a few cases using `LimitBufferCapacity` which the PR addresses, we should be safe to use the shared allocator.

#1730 is also contains this fix, but it makes sense to get rid of the OOM pain on master now.