### PR TITLE
Fix a bug in MagickReferenceDecoder

### DIFF
--- a/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -32,15 +32,15 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs
         private static void FromRgba32Bytes<TPixel>(Configuration configuration, Span<byte> rgbaBytes, IMemoryGroup<TPixel> destinationGroup)
             where TPixel : unmanaged, ImageSharp.PixelFormats.IPixel<TPixel>
         {
+            Span<Rgba32> sourcePixels = MemoryMarshal.Cast<byte, Rgba32>(rgbaBytes);
             foreach (Memory<TPixel> m in destinationGroup)
             {
                 Span<TPixel> destBuffer = m.Span;
-                PixelOperations<TPixel>.Instance.FromRgba32Bytes(
+                PixelOperations<TPixel>.Instance.FromRgba32(
                     configuration,
-                    rgbaBytes,
-                    destBuffer,
-                    destBuffer.Length);
-                rgbaBytes = rgbaBytes.Slice(destBuffer.Length * 4);
+                    sourcePixels.Slice(0, destBuffer.Length),
+                    destBuffer);
+                sourcePixels = sourcePixels.Slice(destBuffer.Length);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This is causing intermittent failures on 32 bit. If `destinationGroup` contains of 2 `Memory<TPixel>` blocks, `rgbaBytes` is double of `destBuffer`, which is an invalid call to `PixelOperations.FromRgba32(Bytes)`, which wants to convert `source.Length` amount of pixels.