### PR TITLE
Use Span in GetHTreeGroupForPos to avoid allocations

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossless/WebpLosslessDecoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/WebpLosslessDecoder.cs
@@ -218,7 +218,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             ColorCache colorCache = decoder.Metadata.ColorCache;
             int colorCacheLimit = lenCodeLimit + colorCacheSize;
             int mask = decoder.Metadata.HuffmanMask;
-            HTreeGroup[] hTreeGroup = GetHTreeGroupForPos(decoder.Metadata, col, row);
+            Span<HTreeGroup> hTreeGroup = GetHTreeGroupForPos(decoder.Metadata, col, row);
 
             int totalPixels = width * height;
             int decodedPixels = 0;
@@ -731,7 +731,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             int lastRow = height;
             const int lenCodeLimit = WebpConstants.NumLiteralCodes + WebpConstants.NumLengthCodes;
             int mask = hdr.HuffmanMask;
-            HTreeGroup[] htreeGroup = pos < last ? GetHTreeGroupForPos(hdr, col, row) : null;
+            Span<HTreeGroup> htreeGroup = pos < last ? GetHTreeGroupForPos(hdr, col, row) : null;
             while (!this.bitReader.Eos && pos < last)
             {
                 // Only update when changing tile.
@@ -815,7 +815,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             decoder.Metadata.HuffmanMask = numBits == 0 ? ~0 : (1 << numBits) - 1;
         }
 
-        private uint ReadPackedSymbols(HTreeGroup[] group, Span<uint> pixelData, int decodedPixels)
+        private uint ReadPackedSymbols(Span<HTreeGroup> group, Span<uint> pixelData, int decodedPixels)
         {
             uint val = (uint)(this.bitReader.PrefetchBits() & (HuffmanUtils.HuffmanPackedTableSize - 1));
             HuffmanCode code = group[0].PackedTable[val];
@@ -895,10 +895,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]
-        private static HTreeGroup[] GetHTreeGroupForPos(Vp8LMetadata metadata, int x, int y)
+        private static Span<HTreeGroup> GetHTreeGroupForPos(Vp8LMetadata metadata, int x, int y)
         {
             uint metaIndex = GetMetaIndex(metadata.HuffmanImage, metadata.HuffmanXSize, metadata.HuffmanSubSampleBits, x, y);
-            return metadata.HTreeGroups.AsSpan((int)metaIndex).ToArray();
+            return metadata.HTreeGroups.AsSpan((int)metaIndex);
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR will remove an unnecessary call to ToArray() and use Span instead.

Before:
![Before](https://user-images.githubusercontent.com/38701097/138904685-cb87721c-73f3-4bd3-8e31-17729220d91b.png)

After:
![After](https://user-images.githubusercontent.com/38701097/138904739-ff0b6ce5-0db1-48ee-aa68-115b136027a5.png)

 Example is for `earth_lossless.webp`