### PR TITLE
Make sure magick.net and imagesharp use the same configuration for webp encoding

### DIFF
--- a/src/ImageSharp/Formats/Webp/IWebpEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Webp/IWebpEncoderOptions.cs
@@ -35,6 +35,7 @@ namespace SixLabors.ImageSharp.Formats.Webp
 
         /// <summary>
         /// Gets the number of entropy-analysis passes (in [1..10]).
+        /// Defaults to 1.
         /// </summary>
         int EntropyPasses { get; }
 

--- a/src/ImageSharp/Formats/Webp/WebpEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/WebpEncoder.cs
@@ -27,7 +27,7 @@ namespace SixLabors.ImageSharp.Formats.Webp
         public bool UseAlphaCompression { get; set; }
 
         /// <inheritdoc/>
-        public int EntropyPasses { get; set; }
+        public int EntropyPasses { get; set; } = 1;
 
         /// <inheritdoc/>
         public int SpatialNoiseShaping { get; set; } = 50;

--- a/tests/ImageSharp.Benchmarks/Codecs/DecodeWebp.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/DecodeWebp.cs
@@ -76,34 +76,29 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
             return image.Height;
         }
 
-        /* Results 17.06.2021
-         *  BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
+        /* Results 04.11.2021
+         *  BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1320 (21H1/May2021Update)
             Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
-            .NET Core SDK=3.1.202
-              [Host]     : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
-              Job-AQFZAV : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
-              Job-YCDAPQ : .NET Core 2.1.18 (CoreCLR 4.6.28801.04, CoreFX 4.6.28802.05), X64 RyuJIT
-              Job-WMTYOZ : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
+            .NET SDK=6.0.100-rc.2.21505.57
+              [Host]     : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT
+              Job-WQLXJO : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT
+              Job-OJJAMD : .NET Core 3.1.20 (CoreCLR 4.700.21.47003, CoreFX 4.700.21.47101), X64 RyuJIT
+              Job-OMFOAS : .NET Framework 4.8 (4.8.4420.0), X64 RyuJIT
 
-            IterationCount=3  LaunchCount=1  WarmupCount=3
-            |                     Method |        Job |       Runtime |        TestImageLossy |        TestImageLossless |       Mean |     Error |   StdDev |     Gen 0 |     Gen 1 | Gen 2 |   Allocated |
-            |--------------------------- |----------- |-------------- |---------------------- |------------------------- |-----------:|----------:|---------:|----------:|----------:|------:|------------:|
-            |        'Magick Lossy Webp' | Job-IERNAB |    .NET 4.7.2 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   105.8 ms |   6.28 ms |  0.34 ms |         - |         - |     - |    17.65 KB |
-            |    'ImageSharp Lossy Webp' | Job-IERNAB |    .NET 4.7.2 | Webp/earth_lossy.webp | Webp/earth_lossless.webp | 1,145.0 ms | 110.82 ms |  6.07 ms |         - |         - |     - |  2779.53 KB |
-            |     'Magick Lossless Webp' | Job-IERNAB |    .NET 4.7.2 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   145.9 ms |   8.55 ms |  0.47 ms |         - |         - |     - |    18.05 KB |
-            | 'ImageSharp Lossless Webp' | Job-IERNAB |    .NET 4.7.2 | Webp/earth_lossy.webp | Webp/earth_lossless.webp | 1,694.1 ms |  55.09 ms |  3.02 ms | 4000.0000 | 1000.0000 |     - | 30556.87 KB |
-            |        'Magick Lossy Webp' | Job-IMRAGJ | .NET Core 2.1 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   105.7 ms |   1.89 ms |  0.10 ms |         - |         - |     - |    15.75 KB |
-            |    'ImageSharp Lossy Webp' | Job-IMRAGJ | .NET Core 2.1 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   741.6 ms |  21.45 ms |  1.18 ms |         - |         - |     - |  2767.85 KB |
-            |     'Magick Lossless Webp' | Job-IMRAGJ | .NET Core 2.1 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   146.1 ms |   9.52 ms |  0.52 ms |         - |         - |     - |    16.54 KB |
-            | 'ImageSharp Lossless Webp' | Job-IMRAGJ | .NET Core 2.1 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   522.5 ms |  21.15 ms |  1.16 ms | 4000.0000 | 1000.0000 |     - | 22860.02 KB |
-            |        'Magick Lossy Webp' | Job-NAASQX | .NET Core 3.1 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   105.9 ms |   5.34 ms |  0.29 ms |         - |         - |     - |    15.45 KB |
-            |    'ImageSharp Lossy Webp' | Job-NAASQX | .NET Core 3.1 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   748.8 ms | 290.47 ms | 15.92 ms |         - |         - |     - |  2767.84 KB |
-            |     'Magick Lossless Webp' | Job-NAASQX | .NET Core 3.1 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   146.1 ms |   1.14 ms |  0.06 ms |         - |         - |     - |     15.9 KB |
-            | 'ImageSharp Lossless Webp' | Job-NAASQX | .NET Core 3.1 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   480.7 ms |  25.25 ms |  1.38 ms | 4000.0000 | 1000.0000 |     - |  22859.7 KB |
-            |        'Magick Lossy Webp' | Job-GLNACU | .NET Core 5.0 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   105.7 ms |   4.71 ms |  0.26 ms |         - |         - |     - |    15.48 KB |
-            |    'ImageSharp Lossy Webp' | Job-GLNACU | .NET Core 5.0 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   645.7 ms |  61.00 ms |  3.34 ms |         - |         - |     - |  2768.13 KB |
-            |     'Magick Lossless Webp' | Job-GLNACU | .NET Core 5.0 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   146.5 ms |  18.63 ms |  1.02 ms |         - |         - |     - |     15.8 KB |
-            | 'ImageSharp Lossless Webp' | Job-GLNACU | .NET Core 5.0 | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   306.7 ms |  32.31 ms |  1.77 ms | 4000.0000 | 1000.0000 |     - | 22860.02 KB |
+            |                     Method |        Job |              Runtime |             Arguments |        TestImageLossy |        TestImageLossless |       Mean |     Error |  StdDev |    Gen 0 | Gen 1 | Gen 2 | Allocated |
+            |--------------------------- |----------- |--------------------- |---------------------- |---------------------- |------------------------- |-----------:|----------:|--------:|---------:|------:|------:|----------:|
+            |        'Magick Lossy Webp' | Job-HLWZLL |             .NET 5.0 | /p:DebugType=portable | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   107.9 ms |  28.91 ms | 1.58 ms |        - |     - |     - |     25 KB |
+            |    'ImageSharp Lossy Webp' | Job-HLWZLL |             .NET 5.0 | /p:DebugType=portable | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   282.3 ms |  25.40 ms | 1.39 ms | 500.0000 |     - |     - |  2,428 KB |
+            |     'Magick Lossless Webp' | Job-HLWZLL |             .NET 5.0 | /p:DebugType=portable | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   106.3 ms |  11.99 ms | 0.66 ms |        - |     - |     - |     16 KB |
+            | 'ImageSharp Lossless Webp' | Job-HLWZLL |             .NET 5.0 | /p:DebugType=portable | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   280.2 ms |   6.21 ms | 0.34 ms |        - |     - |     - |  2,092 KB |
+            |        'Magick Lossy Webp' | Job-ALQPDS |        .NET Core 3.1 |               Default | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   106.2 ms |   9.32 ms | 0.51 ms |        - |     - |     - |     15 KB |
+            |    'ImageSharp Lossy Webp' | Job-ALQPDS |        .NET Core 3.1 |               Default | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   295.8 ms |  21.25 ms | 1.16 ms | 500.0000 |     - |     - |  2,427 KB |
+            |     'Magick Lossless Webp' | Job-ALQPDS |        .NET Core 3.1 |               Default | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   106.5 ms |   4.07 ms | 0.22 ms |        - |     - |     - |     15 KB |
+            | 'ImageSharp Lossless Webp' | Job-ALQPDS |        .NET Core 3.1 |               Default | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   464.0 ms |  55.70 ms | 3.05 ms |        - |     - |     - |  2,090 KB |
+            |        'Magick Lossy Webp' | Job-RYVVNN | .NET Framework 4.7.2 |               Default | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   108.0 ms |  29.60 ms | 1.62 ms |        - |     - |     - |     32 KB |
+            |    'ImageSharp Lossy Webp' | Job-RYVVNN | .NET Framework 4.7.2 |               Default | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   564.9 ms |  29.69 ms | 1.63 ms |        - |     - |     - |  2,436 KB |
+            |     'Magick Lossless Webp' | Job-RYVVNN | .NET Framework 4.7.2 |               Default | Webp/earth_lossy.webp | Webp/earth_lossless.webp |   106.2 ms |   4.74 ms | 0.26 ms |        - |     - |     - |     18 KB |
+            | 'ImageSharp Lossless Webp' | Job-RYVVNN | .NET Framework 4.7.2 |               Default | Webp/earth_lossy.webp | Webp/earth_lossless.webp | 1,767.5 ms | 106.33 ms | 5.83 ms |        - |     - |     - |  9,729 KB |
          */
     }
 }

--- a/tests/ImageSharp.Benchmarks/Codecs/EncodeWebp.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/EncodeWebp.cs
@@ -110,37 +110,34 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
             });
         }
 
-        /* Results 17.06.2021
+        /* Results 04.11.2021
          * Summary *
-        BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
+        BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1320 (21H1/May2021Update)
         Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
-        .NET Core SDK=5.0.100
-          [Host]     : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
-          Job-OUUGWL : .NET Framework 4.8 (4.8.4250.0), X64 RyuJIT
-          Job-GAIITM : .NET Core 2.1.23 (CoreCLR 4.6.29321.03, CoreFX 4.6.29321.01), X64 RyuJIT
-          Job-HWOBSO : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+        .NET SDK=6.0.100-rc.2.21505.57
+          [Host]     : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT
+          Job-WQLXJO : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT
+          Job-OJJAMD : .NET Core 3.1.20 (CoreCLR 4.700.21.47003, CoreFX 4.700.21.47101), X64 RyuJIT
+          Job-OMFOAS : .NET Framework 4.8 (4.8.4420.0), X64 RyuJIT
 
-        |                     Method |        Job |       Runtime |    TestImage |      Mean |      Error |    StdDev | Ratio | RatioSD |      Gen 0 |     Gen 1 |     Gen 2 |    Allocated |
-        |--------------------------- |----------- |-------------- |------------- |----------:|-----------:|----------:|------:|--------:|-----------:|----------:|----------:|-------------:|
-        |        'Magick Webp Lossy' | Job-RYVNHD |    .NET 4.7.2 | Png/Bike.png |  23.30 ms |   0.869 ms |  0.048 ms |  0.14 |    0.00 |          - |         - |         - |     68.19 KB |
-        |    'ImageSharp Webp Lossy' | Job-RYVNHD |    .NET 4.7.2 | Png/Bike.png |  68.22 ms |  16.454 ms |  0.902 ms |  0.42 |    0.01 |  6125.0000 |  125.0000 |         - |  26359.49 KB |
-        |     'Magick Webp Lossless' | Job-RYVNHD |    .NET 4.7.2 | Png/Bike.png | 161.96 ms |   9.879 ms |  0.541 ms |  1.00 |    0.00 |          - |         - |         - |    520.28 KB |
-        | 'ImageSharp Webp Lossless' | Job-RYVNHD |    .NET 4.7.2 | Png/Bike.png | 370.88 ms |  58.875 ms |  3.227 ms |  2.29 |    0.02 | 34000.0000 | 5000.0000 | 2000.0000 | 163177.15 KB |
-        |                            |            |               |              |           |            |           |       |         |            |           |           |              |
-        |        'Magick Webp Lossy' | Job-GOZXWU | .NET Core 2.1 | Png/Bike.png |  23.35 ms |   0.428 ms |  0.023 ms |  0.14 |    0.00 |          - |         - |         - |     67.76 KB |
-        |    'ImageSharp Webp Lossy' | Job-GOZXWU | .NET Core 2.1 | Png/Bike.png |  43.95 ms |   2.850 ms |  0.156 ms |  0.27 |    0.00 |  6250.0000 |  250.0000 |   83.3333 |  26284.72 KB |
-        |     'Magick Webp Lossless' | Job-GOZXWU | .NET Core 2.1 | Png/Bike.png | 161.44 ms |   3.749 ms |  0.206 ms |  1.00 |    0.00 |          - |         - |         - |    519.26 KB |
-        | 'ImageSharp Webp Lossless' | Job-GOZXWU | .NET Core 2.1 | Png/Bike.png | 335.78 ms |  78.666 ms |  4.312 ms |  2.08 |    0.03 | 34000.0000 | 5000.0000 | 2000.0000 | 162727.56 KB |
-        |                            |            |               |              |           |            |           |       |         |            |           |           |              |
-        |        'Magick Webp Lossy' | Job-VRDVKW | .NET Core 3.1 | Png/Bike.png |  23.48 ms |   4.325 ms |  0.237 ms |  0.15 |    0.00 |          - |         - |         - |     67.66 KB |
-        |    'ImageSharp Webp Lossy' | Job-VRDVKW | .NET Core 3.1 | Png/Bike.png |  43.29 ms |  16.503 ms |  0.905 ms |  0.27 |    0.01 |  6272.7273 |  272.7273 |   90.9091 |  26284.86 KB |
-        |     'Magick Webp Lossless' | Job-VRDVKW | .NET Core 3.1 | Png/Bike.png | 161.81 ms |  10.693 ms |  0.586 ms |  1.00 |    0.00 |          - |         - |         - |    523.25 KB |
-        | 'ImageSharp Webp Lossless' | Job-VRDVKW | .NET Core 3.1 | Png/Bike.png | 323.97 ms | 235.468 ms | 12.907 ms |  2.00 |    0.08 | 34000.0000 | 5000.0000 | 2000.0000 | 162724.84 KB |
-        |                            |            |               |              |           |            |           |       |         |            |           |           |              |
-        |        'Magick Webp Lossy' | Job-ZJRLRB | .NET Core 5.0 | Png/Bike.png |  23.36 ms |   0.448 ms |  0.025 ms |  0.14 |    0.00 |          - |         - |         - |     67.66 KB |
-        |    'ImageSharp Webp Lossy' | Job-ZJRLRB | .NET Core 5.0 | Png/Bike.png |  40.11 ms |   2.465 ms |  0.135 ms |  0.25 |    0.00 |  6307.6923 |  230.7692 |   76.9231 |  26284.71 KB |
-        |     'Magick Webp Lossless' | Job-ZJRLRB | .NET Core 5.0 | Png/Bike.png | 161.55 ms |   6.662 ms |  0.365 ms |  1.00 |    0.00 |          - |         - |         - |    518.84 KB |
-        | 'ImageSharp Webp Lossless' | Job-ZJRLRB | .NET Core 5.0 | Png/Bike.png | 298.73 ms |  17.953 ms |  0.984 ms |  1.85 |    0.01 | 34000.0000 | 5000.0000 | 2000.0000 | 162725.13 KB |
+        IterationCount=3  LaunchCount=1  WarmupCount=3
+
+        |                     Method |        Job |              Runtime |             Arguments |    TestImage |      Mean |     Error |   StdDev | Ratio | RatioSD |       Gen 0 |     Gen 1 |     Gen 2 |  Allocated |
+        |--------------------------- |----------- |--------------------- |---------------------- |------------- |----------:|----------:|---------:|------:|--------:|------------:|----------:|----------:|-----------:|
+        |        'Magick Webp Lossy' | Job-WQLXJO |             .NET 5.0 | /p:DebugType=portable | Png/Bike.png |  23.33 ms |  1.491 ms | 0.082 ms |  0.15 |    0.00 |           - |         - |         - |      67 KB |
+        |    'ImageSharp Webp Lossy' | Job-WQLXJO |             .NET 5.0 | /p:DebugType=portable | Png/Bike.png | 245.80 ms | 24.288 ms | 1.331 ms |  1.53 |    0.01 | 135000.0000 |         - |         - | 552,713 KB |
+        |     'Magick Webp Lossless' | Job-WQLXJO |             .NET 5.0 | /p:DebugType=portable | Png/Bike.png | 160.36 ms | 11.131 ms | 0.610 ms |  1.00 |    0.00 |           - |         - |         - |     518 KB |
+        | 'ImageSharp Webp Lossless' | Job-WQLXJO |             .NET 5.0 | /p:DebugType=portable | Png/Bike.png | 313.93 ms | 45.605 ms | 2.500 ms |  1.96 |    0.01 |  34000.0000 | 5000.0000 | 2000.0000 | 161,670 KB |
+        |                            |            |                      |                       |              |           |           |          |       |         |             |           |           |            |
+        |        'Magick Webp Lossy' | Job-OJJAMD |        .NET Core 3.1 |               Default | Png/Bike.png |  23.36 ms |  2.289 ms | 0.125 ms |  0.15 |    0.00 |           - |         - |         - |      67 KB |
+        |    'ImageSharp Webp Lossy' | Job-OJJAMD |        .NET Core 3.1 |               Default | Png/Bike.png | 254.64 ms | 19.620 ms | 1.075 ms |  1.59 |    0.00 | 135000.0000 |         - |         - | 552,713 KB |
+        |     'Magick Webp Lossless' | Job-OJJAMD |        .NET Core 3.1 |               Default | Png/Bike.png | 160.30 ms |  9.549 ms | 0.523 ms |  1.00 |    0.00 |           - |         - |         - |     518 KB |
+        | 'ImageSharp Webp Lossless' | Job-OJJAMD |        .NET Core 3.1 |               Default | Png/Bike.png | 320.35 ms | 22.924 ms | 1.257 ms |  2.00 |    0.01 |  34000.0000 | 5000.0000 | 2000.0000 | 161,669 KB |
+        |                            |            |                      |                       |              |           |           |          |       |         |             |           |           |            |
+        |        'Magick Webp Lossy' | Job-OMFOAS | .NET Framework 4.7.2 |               Default | Png/Bike.png |  23.37 ms |  0.908 ms | 0.050 ms |  0.15 |    0.00 |           - |         - |         - |      68 KB |
+        |    'ImageSharp Webp Lossy' | Job-OMFOAS | .NET Framework 4.7.2 |               Default | Png/Bike.png | 378.67 ms | 25.540 ms | 1.400 ms |  2.36 |    0.01 | 135000.0000 |         - |         - | 554,351 KB |
+        |     'Magick Webp Lossless' | Job-OMFOAS | .NET Framework 4.7.2 |               Default | Png/Bike.png | 160.13 ms |  5.115 ms | 0.280 ms |  1.00 |    0.00 |           - |         - |         - |     520 KB |
+        | 'ImageSharp Webp Lossless' | Job-OMFOAS | .NET Framework 4.7.2 |               Default | Png/Bike.png | 379.01 ms | 71.192 ms | 3.902 ms |  2.37 |    0.02 |  34000.0000 | 5000.0000 | 2000.0000 | 162,119 KB |
         */
     }
 }

--- a/tests/ImageSharp.Benchmarks/Codecs/EncodeWebp.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/EncodeWebp.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using BenchmarkDotNet.Attributes;
 using ImageMagick;
+using ImageMagick.Formats;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests;
@@ -44,8 +45,22 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
         public void MagickWebpLossy()
         {
             using var memoryStream = new MemoryStream();
-            this.webpMagick.Settings.SetDefine(MagickFormat.WebP, "lossless", false);
-            this.webpMagick.Write(memoryStream, MagickFormat.WebP);
+
+            var defines = new WebPWriteDefines
+            {
+                Lossless = false,
+                Method = 4,
+                AlphaCompression = WebPAlphaCompression.None,
+                FilterStrength = 60,
+                SnsStrength = 50,
+                Pass = 1,
+
+                // 100 means off.
+                NearLossless = 100
+            };
+
+            this.webpMagick.Settings.SetDefine(MagickFormat.WebP, "quality", 75);
+            this.webpMagick.Write(memoryStream, defines);
         }
 
         [Benchmark(Description = "ImageSharp Webp Lossy")]
@@ -54,7 +69,12 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
             using var memoryStream = new MemoryStream();
             this.webp.Save(memoryStream, new WebpEncoder()
             {
-                FileFormat = WebpFileFormatType.Lossy
+                FileFormat = WebpFileFormatType.Lossy,
+                Method = WebpEncodingMethod.Level4,
+                UseAlphaCompression = false,
+                FilterStrength = 60,
+                SpatialNoiseShaping = 50,
+                EntropyPasses = 1
             });
         }
 
@@ -62,8 +82,18 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
         public void MagickWebpLossless()
         {
             using var memoryStream = new MemoryStream();
-            this.webpMagick.Settings.SetDefine(MagickFormat.WebP, "lossless", true);
-            this.webpMagick.Write(memoryStream, MagickFormat.WebP);
+            var defines = new WebPWriteDefines
+            {
+                Lossless = true,
+                Method = 4,
+
+                // 100 means off.
+                NearLossless = 100
+            };
+
+            this.webpMagick.Settings.SetDefine(MagickFormat.WebP, "exact", false);
+            this.webpMagick.Settings.SetDefine(MagickFormat.WebP, "quality", 75);
+            this.webpMagick.Write(memoryStream, defines);
         }
 
         [Benchmark(Description = "ImageSharp Webp Lossless")]
@@ -72,7 +102,10 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
             using var memoryStream = new MemoryStream();
             this.webp.Save(memoryStream, new WebpEncoder()
             {
-                FileFormat = WebpFileFormatType.Lossless
+                FileFormat = WebpFileFormatType.Lossless,
+                Method = WebpEncodingMethod.Level4,
+                NearLossless = false,
+                TransparentColorMode = WebpTransparentColorMode.Clear
             });
         }
 

--- a/tests/ImageSharp.Benchmarks/Codecs/EncodeWebp.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/EncodeWebp.cs
@@ -59,7 +59,7 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
                 NearLossless = 100
             };
 
-            this.webpMagick.Settings.SetDefine(MagickFormat.WebP, "quality", 75);
+            this.webpMagick.Quality = 75;
             this.webpMagick.Write(memoryStream, defines);
         }
 
@@ -91,8 +91,7 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
                 NearLossless = 100
             };
 
-            this.webpMagick.Settings.SetDefine(MagickFormat.WebP, "exact", false);
-            this.webpMagick.Settings.SetDefine(MagickFormat.WebP, "quality", 75);
+            this.webpMagick.Quality = 75;
             this.webpMagick.Write(memoryStream, defines);
         }
 
@@ -105,6 +104,8 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
                 FileFormat = WebpFileFormatType.Lossless,
                 Method = WebpEncodingMethod.Level4,
                 NearLossless = false,
+
+                // This is equal to exact = false in libwebp, which is the default.
                 TransparentColorMode = WebpTransparentColorMode.Clear
             });
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR makes sure magick.net and imagesharp use the same configuration for encoding benchmarks, so we comparing the same thing.
Related to #1786