### PR TITLE
Add SSE41 version of Quantize block

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -541,18 +541,18 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 // Load all inputs.
                 Vector128<short> input0 = Unsafe.As<short, Vector128<short>>(ref MemoryMarshal.GetReference(input));
                 Vector128<short> input8 = Unsafe.As<short, Vector128<short>>(ref MemoryMarshal.GetReference(input.Slice(8, 8)));
-                Vector128<ushort> iq0 = Unsafe.As<ushort, Vector128<ushort>>(ref MemoryMarshal.GetReference(mtx.IQ.AsSpan(0, 8)));
-                Vector128<ushort> iq8 = Unsafe.As<ushort, Vector128<ushort>>(ref MemoryMarshal.GetReference(mtx.IQ.AsSpan(8, 8)));
-                Vector128<ushort> q0 = Unsafe.As<ushort, Vector128<ushort>>(ref MemoryMarshal.GetReference(mtx.Q.AsSpan(0, 8)));
-                Vector128<ushort> q8 = Unsafe.As<ushort, Vector128<ushort>>(ref MemoryMarshal.GetReference(mtx.Q.AsSpan(8, 8)));
+                Vector128<ushort> iq0 = Unsafe.As<ushort, Vector128<ushort>>(ref mtx.IQ[0]);
+                Vector128<ushort> iq8 = Unsafe.As<ushort, Vector128<ushort>>(ref mtx.IQ[8]);
+                Vector128<ushort> q0 = Unsafe.As<ushort, Vector128<ushort>>(ref mtx.Q[0]);
+                Vector128<ushort> q8 = Unsafe.As<ushort, Vector128<ushort>>(ref mtx.Q[8]);
 
                 // coeff = abs(in)
                 Vector128<ushort> coeff0 = Ssse3.Abs(input0);
                 Vector128<ushort> coeff8 = Ssse3.Abs(input8);
 
                 // coeff = abs(in) + sharpen
-                Vector128<short> sharpen0 = Unsafe.As<short, Vector128<short>>(ref MemoryMarshal.GetReference(mtx.Sharpen.AsSpan(0, 8)));
-                Vector128<short> sharpen8 = Unsafe.As<short, Vector128<short>>(ref MemoryMarshal.GetReference(mtx.Sharpen.AsSpan(8, 8)));
+                Vector128<short> sharpen0 = Unsafe.As<short, Vector128<short>>(ref mtx.Sharpen[0]);
+                Vector128<short> sharpen8 = Unsafe.As<short, Vector128<short>>(ref mtx.Sharpen[8]);
                 Sse2.Add(coeff0.AsInt16(), sharpen0);
                 Sse2.Add(coeff8.AsInt16(), sharpen8);
 
@@ -569,10 +569,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 Vector128<ushort> out12 = Sse2.UnpackHigh(coeffiQ8L, coeffiQ8H);
 
                 // out = (coeff * iQ + B)
-                Vector128<uint> bias00 = Unsafe.As<uint, Vector128<uint>>(ref MemoryMarshal.GetReference(mtx.Bias.AsSpan(0, 4)));
-                Vector128<uint> bias04 = Unsafe.As<uint, Vector128<uint>>(ref MemoryMarshal.GetReference(mtx.Bias.AsSpan(4, 4)));
-                Vector128<uint> bias08 = Unsafe.As<uint, Vector128<uint>>(ref MemoryMarshal.GetReference(mtx.Bias.AsSpan(8, 4)));
-                Vector128<uint> bias12 = Unsafe.As<uint, Vector128<uint>>(ref MemoryMarshal.GetReference(mtx.Bias.AsSpan(12, 4)));
+                Vector128<uint> bias00 = Unsafe.As<uint, Vector128<uint>>(ref mtx.Bias[0]);
+                Vector128<uint> bias04 = Unsafe.As<uint, Vector128<uint>>(ref mtx.Bias[4]);
+                Vector128<uint> bias08 = Unsafe.As<uint, Vector128<uint>>(ref mtx.Bias[8]);
+                Vector128<uint> bias12 = Unsafe.As<uint, Vector128<uint>>(ref mtx.Bias[12]);
                 out00 = Sse2.Add(out00.AsInt32(), bias00.AsInt32()).AsUInt16();
                 out04 = Sse2.Add(out04.AsInt32(), bias04.AsInt32()).AsUInt16();
                 out08 = Sse2.Add(out08.AsInt32(), bias08.AsInt32()).AsUInt16();

--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -600,12 +600,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 input0 = Sse2.MultiplyLow(out0, q0.AsInt16());
                 input8 = Sse2.MultiplyLow(out8, q8.AsInt16());
 
-                fixed (short* inputPtr = input)
-                {
-                    // in = out * Q
-                    Sse2.Store(inputPtr, input0);
-                    Sse2.Store(inputPtr + 8, input8);
-                }
+                // in = out * Q
+                ref short inputRef = ref MemoryMarshal.GetReference(input);
+                Unsafe.As<short, Vector128<short>>(ref inputRef) = input0;
+                Unsafe.As<short, Vector128<short>>(ref Unsafe.Add(ref inputRef, 8)) = input8;
 
                 // zigzag the output before storing it. The re-ordering is:
                 //    0 1 2 3 4 5 6 7 | 8  9 10 11 12 13 14 15
@@ -620,11 +618,9 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 Vector128<byte> outZ0 = Sse2.Or(tmpLo, tmp8);
                 Vector128<byte> outZ8 = Sse2.Or(tmpHi, tmp7);
 
-                fixed (short* outputPtr = output)
-                {
-                    Sse2.Store(outputPtr, outZ0.AsInt16());
-                    Sse2.Store(outputPtr + 8, outZ8.AsInt16());
-                }
+                ref short outputRef = ref MemoryMarshal.GetReference(output);
+                Unsafe.As<short, Vector128<short>>(ref outputRef) = outZ0.AsInt16();
+                Unsafe.As<short, Vector128<short>>(ref Unsafe.Add(ref outputRef, 8)) = outZ8.AsInt16();
 
                 Vector128<sbyte> packedOutput = Sse2.PackSignedSaturate(outZ0.AsInt16(), outZ8.AsInt16());
 

--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -516,6 +516,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 fixed (ushort* mtxIqPtr = mtx.IQ)
                 fixed (ushort* mtxQPtr = mtx.Q)
                 fixed (uint* biasQPtr = mtx.Bias)
+                fixed (short* sharpenPtr = mtx.Sharpen)
                 fixed (short* inputPtr = input)
                 fixed (short* outputPtr = output)
                 {
@@ -530,6 +531,12 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                     // coeff = abs(in)
                     Vector128<ushort> coeff0 = Ssse3.Abs(input0);
                     Vector128<ushort> coeff8 = Ssse3.Abs(input8);
+
+                    // coeff = abs(in) + sharpen
+                    Vector128<short> sharpen0 = Sse2.LoadVector128(sharpenPtr);
+                    Vector128<short> sharpen8 = Sse2.LoadVector128(sharpenPtr + 8);
+                    Sse2.Add(coeff0.AsInt16(), sharpen0);
+                    Sse2.Add(coeff8.AsInt16(), sharpen8);
 
                     // out = (coeff * iQ + B) >> QFIX
                     // doing calculations with 32b precision (QFIX=17)

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
@@ -502,7 +502,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             this.ResetStats();
         }
 
-        private void AdjustFilterStrength()
+        private unsafe void AdjustFilterStrength()
         {
             if (this.filterStrength > 0)
             {
@@ -806,17 +806,13 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             proba.NbSkip = 0;
         }
 
-        private void SetupMatrices(Vp8SegmentInfo[] dqm)
+        private unsafe void SetupMatrices(Vp8SegmentInfo[] dqm)
         {
             int tlambdaScale = this.method >= WebpEncodingMethod.Default ? this.spatialNoiseShaping : 0;
             for (int i = 0; i < dqm.Length; i++)
             {
                 Vp8SegmentInfo m = dqm[i];
                 int q = m.Quant;
-
-                m.Y1 = new Vp8Matrix();
-                m.Y2 = new Vp8Matrix();
-                m.Uv = new Vp8Matrix();
 
                 m.Y1.Q[0] = WebpLookupTables.DcTable[Numerics.Clamp(q + this.DqY1Dc, 0, 127)];
                 m.Y1.Q[1] = WebpLookupTables.AcTable[Numerics.Clamp(q, 0, 127)];

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Matrix.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Matrix.cs
@@ -3,7 +3,7 @@
 
 namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 {
-    internal class Vp8Matrix
+    internal unsafe struct Vp8Matrix
     {
         private static readonly int[][] BiasMatrices =
         {
@@ -23,50 +23,29 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         private const int SharpenBits = 11;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Vp8Matrix"/> class.
+        /// The quantizer steps.
         /// </summary>
-        public Vp8Matrix()
-        {
-            this.Q = new ushort[16];
-            this.IQ = new ushort[16];
-            this.Bias = new uint[16];
-            this.ZThresh = new uint[16];
-            this.Sharpen = new short[16];
-        }
-
-        public Vp8Matrix(ushort[] q, ushort[] iq, uint[] bias, uint[] zThresh, short[] sharpen)
-        {
-            this.Q = q;
-            this.IQ = iq;
-            this.Bias = bias;
-            this.ZThresh = zThresh;
-            this.Sharpen = sharpen;
-        }
+        public fixed ushort Q[16];
 
         /// <summary>
-        /// Gets the quantizer steps.
+        /// The reciprocals, fixed point.
         /// </summary>
-        public ushort[] Q { get; }
+        public fixed ushort IQ[16];
 
         /// <summary>
-        /// Gets the reciprocals, fixed point.
+        /// The rounding bias.
         /// </summary>
-        public ushort[] IQ { get; }
+        public fixed uint Bias[16];
 
         /// <summary>
-        /// Gets the rounding bias.
+        /// The value below which a coefficient is zeroed.
         /// </summary>
-        public uint[] Bias { get; }
+        public fixed uint ZThresh[16];
 
         /// <summary>
-        /// Gets the value below which a coefficient is zeroed.
+        /// The frequency boosters for slight sharpening.
         /// </summary>
-        public uint[] ZThresh { get; }
-
-        /// <summary>
-        /// Gets the frequency boosters for slight sharpening.
-        /// </summary>
-        public short[] Sharpen { get; }
+        public fixed short Sharpen[16];
 
         /// <summary>
         /// Returns the average quantizer.
@@ -81,7 +60,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 int isAcCoeff = i > 0 ? 1 : 0;
                 int bias = BiasMatrices[type][isAcCoeff];
                 this.IQ[i] = (ushort)((1 << WebpConstants.QFix) / this.Q[i]);
-                this.Bias[i] = (uint)this.BIAS(bias);
+                this.Bias[i] = (uint)BIAS(bias);
 
                 // zthresh is the exact value such that QUANTDIV(coeff, iQ, B) is:
                 //   * zero if coeff <= zthresh
@@ -115,6 +94,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             return (sum + 8) >> 4;
         }
 
-        private int BIAS(int b) => b << (WebpConstants.QFix - 8);
+        private static int BIAS(int b) => b << (WebpConstants.QFix - 8);
     }
 }

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Matrix.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Matrix.cs
@@ -34,6 +34,15 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             this.Sharpen = new short[16];
         }
 
+        public Vp8Matrix(ushort[] q, ushort[] iq, uint[] bias, uint[] zThresh, short[] sharpen)
+        {
+            this.Q = q;
+            this.IQ = iq;
+            this.Bias = bias;
+            this.ZThresh = zThresh;
+            this.Sharpen = sharpen;
+        }
+
         /// <summary>
         /// Gets the quantizer steps.
         /// </summary>

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8SegmentInfo.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8SegmentInfo.cs
@@ -10,6 +10,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         /// <summary>
         /// Gets the quantization matrix y1.
         /// </summary>
+#pragma warning disable SA1401 // Fields should be private
         public Vp8Matrix Y1;
 
         /// <summary>
@@ -21,6 +22,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         /// Gets the quantization matrix uv.
         /// </summary>
         public Vp8Matrix Uv;
+#pragma warning restore SA1401 // Fields should be private
 
         /// <summary>
         /// Gets or sets the quant-susceptibility, range [-127,127]. Zero is neutral. Lower values indicate a lower risk of blurriness.

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8SegmentInfo.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8SegmentInfo.cs
@@ -8,19 +8,19 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
     internal class Vp8SegmentInfo
     {
         /// <summary>
-        /// Gets or sets the quantization matrix y1.
+        /// Gets the quantization matrix y1.
         /// </summary>
-        public Vp8Matrix Y1 { get; set; }
+        public Vp8Matrix Y1;
 
         /// <summary>
-        /// Gets or sets the quantization matrix y2.
+        /// Gets the quantization matrix y2.
         /// </summary>
-        public Vp8Matrix Y2 { get; set; }
+        public Vp8Matrix Y2;
 
         /// <summary>
-        /// Gets or sets the quantization matrix uv.
+        /// Gets the quantization matrix uv.
         /// </summary>
-        public Vp8Matrix Uv { get; set; }
+        public Vp8Matrix Uv;
 
         /// <summary>
         /// Gets or sets the quant-susceptibility, range [-127,127]. Zero is neutral. Lower values indicate a lower risk of blurriness.

--- a/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.WebP
             }
 
             // act
-            int actualResult = QuantEnc.QuantizeBlock(input, output, vp8Matrix);
+            int actualResult = QuantEnc.QuantizeBlock(input, output, ref vp8Matrix);
 
             // assert
             Assert.True(output.SequenceEqual(expectedOutput));

--- a/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
@@ -11,22 +11,25 @@ namespace SixLabors.ImageSharp.Tests.Formats.WebP
     [Trait("Format", "Webp")]
     public class QuantEncTests
     {
-        private static void RunQuantizeBlockTest()
+        private static unsafe void RunQuantizeBlockTest()
         {
             // arrange
             short[] input = { 378, 777, -851, 888, 259, 148, 0, -111, -185, -185, -74, -37, 148, 74, 111, 74 };
             short[] output = new short[16];
             ushort[] q = { 42, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37 };
             ushort[] iq = { 3120, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542 };
-            uint[] bias =
-            {
-                49152, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296,
-                55296, 55296
-            };
+            uint[] bias = { 49152, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296 };
             uint[] zthresh = { 26, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21 };
             short[] expectedOutput = { 9, 21, 7, -5, 4, -23, 24, 0, -5, 4, 2, -2, -3, -1, 3, 2 };
             int expectedResult = 1;
-            var vp8Matrix = new Vp8Matrix(q, iq, bias, zthresh, new short[16]);
+            Vp8Matrix vp8Matrix = default;
+            for (int i = 0; i < 16; i++)
+            {
+                vp8Matrix.Q[i] = q[i];
+                vp8Matrix.IQ[i] = iq[i];
+                vp8Matrix.Bias[i] = bias[i];
+                vp8Matrix.ZThresh[i] = zthresh[i];
+            }
 
             // act
             int actualResult = QuantEnc.QuantizeBlock(input, output, vp8Matrix);

--- a/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Linq;
+using SixLabors.ImageSharp.Formats.Webp.Lossy;
+using SixLabors.ImageSharp.Tests.TestUtilities;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.WebP
+{
+    [Trait("Format", "Webp")]
+    public class QuantEncTests
+    {
+        private static void RunQuantizeBlockTest()
+        {
+            // arrange
+            short[] input = { 378, 777, -851, 888, 259, 148, 0, -111, -185, -185, -74, -37, 148, 74, 111, 74 };
+            short[] output = new short[16];
+            ushort[] q = { 42, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37 };
+            ushort[] iq = { 3120, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542, 3542 };
+            uint[] bias =
+            {
+                49152, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296, 55296,
+                55296, 55296
+            };
+            uint[] zthresh = { 26, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21 };
+            short[] expectedOutput = { 9, 21, 7, -5, 4, -23, 24, 0, -5, 4, 2, -2, -3, -1, 3, 2 };
+            int expectedResult = 1;
+            var vp8Matrix = new Vp8Matrix(q, iq, bias, zthresh, new short[16]);
+
+            // act
+            int actualResult = QuantEnc.QuantizeBlock(input, output, vp8Matrix);
+
+            // assert
+            Assert.True(output.SequenceEqual(expectedOutput));
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void QuantizeBlock_Works() => RunQuantizeBlockTest();
+
+#if SUPPORTS_RUNTIME_INTRINSICS
+        [Fact]
+        public void QuantizeBlock_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunQuantizeBlockTest, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void QuantizeBlock_WithoutSSE2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunQuantizeBlockTest, HwIntrinsics.DisableSSE2);
+
+        [Fact]
+        public void QuantizeBlock_WithoutSSSE3_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunQuantizeBlockTest, HwIntrinsics.DisableSSSE3);
+
+        [Fact]
+        public void QuantizeBlock_WithoutSSE2AndSSSE3_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunQuantizeBlockTest, HwIntrinsics.DisableSSE2 | HwIntrinsics.DisableSSSE3);
+#endif
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
@@ -44,13 +44,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.WebP
         public void QuantizeBlock_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunQuantizeBlockTest, HwIntrinsics.AllowAll);
 
         [Fact]
-        public void QuantizeBlock_WithoutSSE2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunQuantizeBlockTest, HwIntrinsics.DisableSSE2);
-
-        [Fact]
-        public void QuantizeBlock_WithoutSSSE3_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunQuantizeBlockTest, HwIntrinsics.DisableSSSE3);
-
-        [Fact]
-        public void QuantizeBlock_WithoutSSE2AndSSSE3_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunQuantizeBlockTest, HwIntrinsics.DisableSSE2 | HwIntrinsics.DisableSSSE3);
+        public void QuantizeBlock_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunQuantizeBlockTest, HwIntrinsics.DisableHWIntrinsic);
 #endif
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR add SSE41 version of Quantize block, which is used during lossy encoding.
Related to #1786

### Profiling results

Before:
![quantize_block](https://user-images.githubusercontent.com/38701097/140648558-4919343b-1396-424d-94de-c5bbbd38541e.png)

After:
![quantize_block_sse](https://user-images.githubusercontent.com/38701097/140648569-0a1007be-f8e6-406a-8415-e690f539b260.png)


