### PR TITLE
Collapse AsSpan().Slice(..) calls into AsSpan(..)

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1071,7 +1071,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                 int bytesRead = inflateStream.CompressedStream.Read(this.buffer, 0, this.buffer.Length);
                 while (bytesRead != 0)
                 {
-                    uncompressedBytes.AddRange(this.buffer.AsSpan().Slice(0, bytesRead).ToArray());
+                    uncompressedBytes.AddRange(this.buffer.AsSpan(0, bytesRead).ToArray());
                     bytesRead = inflateStream.CompressedStream.Read(this.buffer, 0, this.buffer.Length);
                 }
 

--- a/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
@@ -306,7 +306,7 @@ namespace SixLabors.ImageSharp.Formats.Webp
 
             // Check for VP8 magic bytes.
             this.currentStream.Read(this.buffer, 0, 3);
-            if (!this.buffer.AsSpan().Slice(0, 3).SequenceEqual(WebpConstants.Vp8HeaderMagicBytes))
+            if (!this.buffer.AsSpan(0, 3).SequenceEqual(WebpConstants.Vp8HeaderMagicBytes))
             {
                 WebpThrowHelper.ThrowImageFormatException("VP8 magic bytes not found");
             }

--- a/src/ImageSharp/IO/ChunkedMemoryStream.cs
+++ b/src/ImageSharp/IO/ChunkedMemoryStream.cs
@@ -243,7 +243,7 @@ namespace SixLabors.ImageSharp.IO
             const string bufferMessage = "Offset subtracted from the buffer length is less than count.";
             Guard.IsFalse(buffer.Length - offset < count, nameof(buffer), bufferMessage);
 
-            return this.ReadImpl(buffer.AsSpan().Slice(offset, count));
+            return this.ReadImpl(buffer.AsSpan(offset, count));
         }
 
 #if SUPPORTS_SPAN_STREAM
@@ -359,7 +359,7 @@ namespace SixLabors.ImageSharp.IO
             const string bufferMessage = "Offset subtracted from the buffer length is less than count.";
             Guard.IsFalse(buffer.Length - offset < count, nameof(buffer), bufferMessage);
 
-            this.WriteImpl(buffer.AsSpan().Slice(offset, count));
+            this.WriteImpl(buffer.AsSpan(offset, count));
         }
 
 #if SUPPORTS_SPAN_STREAM

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
@@ -216,7 +216,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             ResizeKernel kernel = this.CreateKernel(dataRowIndex, left, right);
 
-            Span<double> kernelValues = this.tempValues.AsSpan().Slice(0, kernel.Length);
+            Span<double> kernelValues = this.tempValues.AsSpan(0, kernel.Length);
             double sum = 0;
 
             for (int j = left; j <= right; j++)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable) _(N/A)_

### Description
This PR collapses all AsSpan().Slice(..) calls into AsSpan(..) (excluding test code), as it is less code and potentially a bit faster.

