### PR TITLE
Add SSE2 version of Vp8Sse4X4

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
@@ -19,14 +19,17 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         private static readonly Vector128<byte> Mean16x4Mask = Vector128.Create((short)0x00ff).AsByte();
 #endif
 
+        // Note: method name in libwebp reference implementation is called VP8SSE16x16.
         [MethodImpl(InliningOptions.ShortMethod)]
-        public static int Vp8Sse16X16(Span<byte> a, Span<byte> b) => GetSse(a, b, 16, 16);
+        public static int Vp8_Sse16X16(Span<byte> a, Span<byte> b) => Vp8_SseNxN(a, b, 16, 16);
 
+        // Note: method name in libwebp reference implementation is called VP8SSE16x8.
         [MethodImpl(InliningOptions.ShortMethod)]
-        public static int Vp8Sse16X8(Span<byte> a, Span<byte> b) => GetSse(a, b, 16, 8);
+        public static int Vp8_Sse16X8(Span<byte> a, Span<byte> b) => Vp8_SseNxN(a, b, 16, 8);
 
+        // Note: method name in libwebp reference implementation is called VP8SSE4x4.
         [MethodImpl(InliningOptions.ShortMethod)]
-        public static int Vp8Sse4X4(Span<byte> a, Span<byte> b)
+        public static int Vp8_Sse4X4(Span<byte> a, Span<byte> b)
         {
 #if SUPPORTS_RUNTIME_INTRINSICS
             if (Sse2.IsSupported)
@@ -67,12 +70,12 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             else
 #endif
             {
-                return GetSse(a, b, 4, 4);
+                return Vp8_SseNxN(a, b, 4, 4);
             }
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]
-        public static int GetSse(Span<byte> a, Span<byte> b, int w, int h)
+        public static int Vp8_SseNxN(Span<byte> a, Span<byte> b, int w, int h)
         {
             int count = 0;
             int aOffset = 0;

--- a/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
@@ -28,14 +28,16 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             if (Sse2.IsSupported)
             {
                 // Load values.
-                Vector128<byte> a0 = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(a));
-                Vector128<byte> a1 = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(a.Slice(WebpConstants.Bps, 8)));
-                Vector128<byte> a2 = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(a.Slice(WebpConstants.Bps * 2, 8)));
-                Vector128<byte> a3 = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(a.Slice(WebpConstants.Bps * 3, 8)));
-                Vector128<byte> b0 = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(b));
-                Vector128<byte> b1 = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(b.Slice(WebpConstants.Bps, 8)));
-                Vector128<byte> b2 = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(b.Slice(WebpConstants.Bps * 2, 8)));
-                Vector128<byte> b3 = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(b.Slice(WebpConstants.Bps * 3, 8)));
+                ref byte aRef = ref MemoryMarshal.GetReference(a);
+                Vector128<byte> a0 = Unsafe.As<byte, Vector128<byte>>(ref aRef);
+                Vector128<byte> a1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref aRef, WebpConstants.Bps));
+                Vector128<byte> a2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref aRef, WebpConstants.Bps * 2));
+                Vector128<byte> a3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref aRef, WebpConstants.Bps * 3));
+                ref byte bRef = ref MemoryMarshal.GetReference(b);
+                Vector128<byte> b0 = Unsafe.As<byte, Vector128<byte>>(ref bRef);
+                Vector128<byte> b1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bRef, WebpConstants.Bps));
+                Vector128<byte> b2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bRef, WebpConstants.Bps * 2));
+                Vector128<byte> b3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bRef, WebpConstants.Bps * 3));
 
                 // Combine pair of lines.
                 Vector128<int> a01 = Sse2.UnpackLow(a0.AsInt32(), a1.AsInt32());

--- a/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
@@ -13,7 +13,7 @@ using System.Runtime.Intrinsics.X86;
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 {
-    internal static unsafe class LossyUtils
+    internal static class LossyUtils
     {
         [MethodImpl(InliningOptions.ShortMethod)]
         public static int Vp8Sse16X16(Span<byte> a, Span<byte> b) => GetSse(a, b, 16, 16);
@@ -771,7 +771,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         public static void TransformOne(Span<short> src, Span<byte> dst, Span<int> scratch)
         {
             Span<int> tmp = scratch.Slice(0, 16);
-            tmp.Clear();
             int tmpOffset = 0;
             for (int srcOffset = 0; srcOffset < 4; srcOffset++)
             {

--- a/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
@@ -127,7 +127,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 #if SUPPORTS_RUNTIME_INTRINSICS
             if (Sse41.IsSupported)
             {
-                int diffSum = TTransformSse41(a, b, w, scratch);
+                int diffSum = TTransformSse41(a, b, w);
                 return Math.Abs(diffSum) >> 5;
             }
             else
@@ -654,7 +654,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         /// Returns the weighted sum of the absolute value of transformed coefficients.
         /// w[] contains a row-major 4 by 4 symmetric matrix.
         /// </summary>
-        public static int TTransformSse41(Span<byte> inputA, Span<byte> inputB, Span<ushort> w, Span<int> scratch)
+        public static int TTransformSse41(Span<byte> inputA, Span<byte> inputB, Span<ushort> w)
         {
             // Load and combine inputs.
             Vector128<byte> ina0 = Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(inputA));

--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -340,8 +340,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             Span<byte> reference = it.YuvP.AsSpan(Vp8Encoding.Vp8I4ModeOffsets[mode]);
             Span<short> tmp = it.Scratch2.AsSpan(0, 16);
             Span<int> scratch = it.Scratch3.AsSpan(0, 16);
-            tmp.Clear();
-            scratch.Clear();
             Vp8Encoding.FTransform(src, reference, tmp, scratch);
             int nz = QuantizeBlock(tmp, levels, ref dqm.Y1);
             Vp8Encoding.ITransform(reference, tmp, yuvOut, false, scratch);
@@ -357,8 +355,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             int n;
             Span<short> tmp = it.Scratch2.AsSpan(0, 8 * 16);
             Span<int> scratch = it.Scratch3.AsSpan(0, 16);
-            tmp.Clear();
-            scratch.Clear();
 
             for (n = 0; n < 8; n += 2)
             {

--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -66,7 +66,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 rdCur.Nz = (uint)ReconstructIntra16(it, dqm, rdCur, tmpDst, mode);
 
                 // Measure RD-score.
-                rdCur.D = LossyUtils.Vp8Sse16X16(src, tmpDst);
+                rdCur.D = LossyUtils.Vp8_Sse16X16(src, tmpDst);
                 rdCur.SD = tlambda != 0 ? Mult8B(tlambda, LossyUtils.Vp8Disto16X16(src, tmpDst, WeightY, scratch)) : 0;
                 rdCur.H = WebpConstants.Vp8FixedCostsI16[mode];
                 rdCur.R = it.GetCostLuma16(rdCur, proba, res);
@@ -160,7 +160,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                     rdTmp.Nz = (uint)ReconstructIntra4(it, dqm, tmpLevels, src, tmpDst, mode);
 
                     // Compute RD-score.
-                    rdTmp.D = LossyUtils.Vp8Sse4X4(src, tmpDst);
+                    rdTmp.D = LossyUtils.Vp8_Sse4X4(src, tmpDst);
                     rdTmp.SD = tlambda != 0 ? Mult8B(tlambda, LossyUtils.Vp8Disto4X4(src, tmpDst, WeightY, scratch)) : 0;
                     rdTmp.H = modeCosts[mode];
 
@@ -251,7 +251,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 rdUv.Nz = (uint)ReconstructUv(it, dqm, rdUv, tmpDst, mode);
 
                 // Compute RD-score
-                rdUv.D = LossyUtils.Vp8Sse16X8(src, tmpDst);
+                rdUv.D = LossyUtils.Vp8_Sse16X8(src, tmpDst);
                 rdUv.SD = 0;    // not calling TDisto here: it tends to flatten areas.
                 rdUv.H = WebpConstants.Vp8FixedCostsUv[mode];
                 rdUv.R = it.GetCostUv(rdUv, proba, res);
@@ -407,7 +407,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 for (mode = 0; mode < WebpConstants.NumPredModes; ++mode)
                 {
                     Span<byte> reference = it.YuvP.AsSpan(Vp8Encoding.Vp8I16ModeOffsets[mode]);
-                    long score = (LossyUtils.Vp8Sse16X16(src, reference) * WebpConstants.RdDistoMult) + (WebpConstants.Vp8FixedCostsI16[mode] * lambdaDi16);
+                    long score = (LossyUtils.Vp8_Sse16X16(src, reference) * WebpConstants.RdDistoMult) + (WebpConstants.Vp8FixedCostsI16[mode] * lambdaDi16);
 
                     if (mode > 0 && WebpConstants.Vp8FixedCostsI16[mode] > bitLimit)
                     {
@@ -454,7 +454,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                     for (mode = 0; mode < WebpConstants.NumBModes; ++mode)
                     {
                         Span<byte> reference = it.YuvP.AsSpan(Vp8Encoding.Vp8I4ModeOffsets[mode]);
-                        long score = (LossyUtils.Vp8Sse4X4(src, reference) * WebpConstants.RdDistoMult) + (modeCosts[mode] * lambdaDi4);
+                        long score = (LossyUtils.Vp8_Sse4X4(src, reference) * WebpConstants.RdDistoMult) + (modeCosts[mode] * lambdaDi4);
                         if (score < bestI4Score)
                         {
                             bestI4Mode = mode;
@@ -503,7 +503,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 for (mode = 0; mode < WebpConstants.NumPredModes; ++mode)
                 {
                     Span<byte> reference = it.YuvP.AsSpan(Vp8Encoding.Vp8UvModeOffsets[mode]);
-                    long score = (LossyUtils.Vp8Sse16X8(src, reference) * WebpConstants.RdDistoMult) + (WebpConstants.Vp8FixedCostsUv[mode] * lambdaDuv);
+                    long score = (LossyUtils.Vp8_Sse16X8(src, reference) * WebpConstants.RdDistoMult) + (WebpConstants.Vp8FixedCostsUv[mode] * lambdaDuv);
                     if (score < bestUvScore)
                     {
                         bestMode = mode;

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
@@ -81,7 +81,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         {
             int i;
             Span<int> tmp = scratch.Slice(0, 16);
-            tmp.Clear();
             for (i = 0; i < 4; i++)
             {
                 // vertical pass.
@@ -124,7 +123,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         {
             int i;
             Span<int> tmp = scratch.Slice(0, 16);
-            tmp.Clear();
 
             int srcIdx = 0;
             int refIdx = 0;
@@ -163,7 +161,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         public static void FTransformWht(Span<short> input, Span<short> output, Span<int> scratch)
         {
             Span<int> tmp = scratch.Slice(0, 16);
-            tmp.Clear();
 
             int i;
             int inputIdx = 0;

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Histogram.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Histogram.cs
@@ -49,7 +49,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             this.distribution.AsSpan().Clear();
             for (j = startBlock; j < endBlock; j++)
             {
-                this.output.AsSpan().Clear();
                 this.Vp8FTransform(reference.Slice(WebpLookupTables.Vp8DspScan[j]), pred.Slice(WebpLookupTables.Vp8DspScan[j]), this.output);
 
                 // Convert coefficients to bin.

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8ModeScore.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8ModeScore.cs
@@ -97,18 +97,11 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 
         public void Clear()
         {
-            this.YDcLevels.AsSpan().Clear();
-            this.YAcLevels.AsSpan().Clear();
-            this.UvLevels.AsSpan().Clear();
-            this.ModesI4.AsSpan().Clear();
-
-            for (int i = 0; i < 2; i++)
-            {
-                for (int j = 0; j < 3; j++)
-                {
-                    this.Derr[i, j] = 0;
-                }
-            }
+            Array.Clear(this.YDcLevels, 0, this.YDcLevels.Length);
+            Array.Clear(this.YAcLevels, 0, this.YAcLevels.Length);
+            Array.Clear(this.UvLevels, 0, this.UvLevels.Length);
+            Array.Clear(this.ModesI4, 0, this.ModesI4.Length);
+            Array.Clear(this.Derr, 0, this.Derr.Length);
         }
 
         public void InitScore()

--- a/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
@@ -10,6 +10,35 @@ namespace SixLabors.ImageSharp.Tests.Formats.WebP
     [Trait("Format", "Webp")]
     public class LossyUtilsTests
     {
+        private static void RunVp8Sse4X4Test()
+        {
+            byte[] a =
+            {
+                27, 27, 28, 29, 29, 28, 27, 27, 27, 28, 28, 29, 29, 28, 28, 27, 129, 129, 129, 129, 129, 129, 129,
+                129, 128, 128, 128, 128, 128, 128, 128, 128, 27, 27, 27, 27, 27, 27, 27, 27, 27, 28, 28, 29, 29, 28,
+                28, 27, 129, 129, 129, 129, 129, 129, 129, 129, 128, 128, 128, 128, 128, 128, 128, 128, 27, 27, 26,
+                26, 26, 26, 27, 27, 27, 28, 28, 29, 29, 28, 28, 27, 129, 129, 129, 129, 129, 129, 129, 129, 128,
+                128, 128, 128, 128, 128, 128, 128, 28, 27, 27, 26, 26, 27, 27, 28, 27, 28, 28, 29, 29, 28, 28, 27,
+                129, 129, 129, 129, 129, 129, 129, 129, 128, 128, 128, 128, 128, 128, 128, 128
+            };
+
+            byte[] b =
+            {
+                26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 204, 204, 204, 204, 204, 204, 204,
+                204, 204, 204, 204, 204, 204, 204, 204, 204, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28,
+                28, 28, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 26, 26, 26,
+                26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 204, 204, 204, 204, 204, 204, 204, 204, 204,
+                204, 204, 204, 204, 204, 204, 204, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28,
+                204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204, 204
+            };
+
+            int expected = 27;
+
+            int actual = LossyUtils.Vp8Sse4X4(a, b);
+
+            Assert.Equal(expected, actual);
+        }
+
         private static void RunHadamardTransformTest()
         {
             byte[] a =
@@ -38,9 +67,18 @@ namespace SixLabors.ImageSharp.Tests.Formats.WebP
         }
 
         [Fact]
+        public void Vp8Sse4X4_Works() => RunVp8Sse4X4Test();
+
+        [Fact]
         public void HadamardTransform_Works() => RunHadamardTransformTest();
 
 #if SUPPORTS_RUNTIME_INTRINSICS
+        [Fact]
+        public void Vp8Sse4X4_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunVp8Sse4X4Test, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void Vp8Sse4X4_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunVp8Sse4X4Test, HwIntrinsics.DisableHWIntrinsic);
+
         [Fact]
         public void HadamardTransform_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunHadamardTransformTest, HwIntrinsics.AllowAll);
 

--- a/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.WebP
 
             int expected = 27;
 
-            int actual = LossyUtils.Vp8Sse4X4(a, b);
+            int actual = LossyUtils.Vp8_Sse4X4(a, b);
 
             Assert.Equal(expected, actual);
 		}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This adds a SSE2 version of the method `Vp8Sse4X4`, which is used during lossy encoding of webp images.
Related to #1786

### Profiling results:

#### Master Branch:
![Vp8Sse4X4_master](https://user-images.githubusercontent.com/38701097/140972701-5036630e-ca69-4d6e-9dd6-833ae6eec16a.png)

#### PR:
![Vp8Sse4X4_sse](https://user-images.githubusercontent.com/38701097/140972728-62293054-fc9a-4eb5-b65f-02e266ca8694.png)

P.S. im not sure again why the call count is different, it was the same image

