### PR TITLE
Some minor optimizations

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
@@ -288,8 +288,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         /// <param name="componentCount">The number of components to write.</param>
         private void WriteDefineHuffmanTables(int componentCount)
         {
+            // This uses a C#'s compiler optimization that refers to the static data segment of the assembly,
+            // and doesn't incur any allocation at all.
             // Table identifiers.
-            ReadOnlySpan<byte> headers = stackalloc byte[]
+            ReadOnlySpan<byte> headers = new byte[]
             {
                 0x00,
                 0x10,

--- a/src/ImageSharp/Formats/Tiff/Compression/Compressors/TiffLzwEncoder.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Compressors/TiffLzwEncoder.cs
@@ -256,8 +256,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Compressors
 
         private void ResetTables()
         {
-            this.children.GetSpan().Fill(0);
-            this.siblings.GetSpan().Fill(0);
+            this.children.GetSpan().Clear();
+            this.siblings.GetSpan().Clear();
             this.bitsPerCode = MinBits;
             this.maxCode = MaxValue(this.bitsPerCode);
             this.nextValidCode = EoiCode + 1;

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -64,7 +64,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
             uint bitsWritten = 0;
             for (int y = 0; y < height; y++)
             {
-                scanLine.Fill(0);
+                scanLine.Clear();
                 Decode2DScanline(bitReader, this.isWhiteZero, referenceScanLine, scanLine);
 
                 bitsWritten = this.WriteScanLine(buffer, scanLine, bitsWritten);
@@ -116,7 +116,15 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
                 {
                     // If a TIFF reader encounters EOFB before the expected number of lines has been extracted,
                     // it is appropriate to assume that the missing rows consist entirely of white pixels.
-                    scanline.Fill(whiteIsZero ? (byte)0 : (byte)255);
+                    if (whiteIsZero)
+                    {
+                        scanline.Clear();
+                    }
+                    else
+                    {
+                        scanline.Fill((byte)255);
+                    }
+
                     break;
                 }
 

--- a/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
@@ -87,7 +87,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
             if (nonzeros <= 1)
             {
-                output.AsSpan(0, numSymbols).Fill(0);
+                output.AsSpan(0, numSymbols).Clear();
             }
             else
             {

--- a/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
@@ -287,7 +287,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
             // Create a mapping from a cluster id to its minimal version.
             int clusterMax = 0;
-            clusterMappingsTmp.AsSpan().Fill(0);
+            clusterMappingsTmp.AsSpan().Clear();
 
             // Re-map the ids.
             for (int i = 0; i < symbols.Length; i++)

--- a/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         public static void CreateHuffmanTree(uint[] histogram, int treeDepthLimit, bool[] bufRle, HuffmanTree[] huffTree, HuffmanTreeCode huffCode)
         {
             int numSymbols = huffCode.NumSymbols;
-            bufRle.AsSpan().Fill(false);
+            bufRle.AsSpan().Clear();
             OptimizeHuffmanForRle(numSymbols, bufRle, histogram);
             GenerateOptimalTree(huffTree, histogram, numSymbols, treeDepthLimit, huffCode.CodeLengths);
 

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
@@ -320,7 +320,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
             else
             {
-                output.Literal.AsSpan(0, literalSize).Fill(0);
+                output.Literal.AsSpan(0, literalSize).Clear();
             }
         }
 
@@ -343,7 +343,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
             else
             {
-                output.Red.AsSpan(0, size).Fill(0);
+                output.Red.AsSpan(0, size).Clear();
             }
         }
 
@@ -366,7 +366,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
             else
             {
-                output.Blue.AsSpan(0, size).Fill(0);
+                output.Blue.AsSpan(0, size).Clear();
             }
         }
 
@@ -389,7 +389,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
             else
             {
-                output.Alpha.AsSpan(0, size).Fill(0);
+                output.Alpha.AsSpan(0, size).Clear();
             }
         }
 
@@ -412,7 +412,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
             else
             {
-                output.Distance.AsSpan(0, size).Fill(0);
+                output.Distance.AsSpan(0, size).Clear();
             }
         }
 

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8EncIterator.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8EncIterator.cs
@@ -911,7 +911,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 
             this.LeftNz[8] = 0;
 
-            this.LeftDerr.AsSpan().Fill(0);
+            this.LeftDerr.AsSpan().Clear();
         }
 
         private void InitTop()
@@ -919,14 +919,14 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             int topSize = this.mbw * 16;
             this.YTop.AsSpan(0, topSize).Fill(127);
             this.UvTop.AsSpan().Fill(127);
-            this.Nz.AsSpan().Fill(0);
+            this.Nz.AsSpan().Clear();
 
             int predsW = (4 * this.mbw) + 1;
             int predsH = (4 * this.mbh) + 1;
             int predsSize = predsW * predsH;
-            this.Preds.AsSpan(predsSize + this.predsWidth, this.mbw).Fill(0);
+            this.Preds.AsSpan(predsSize + this.predsWidth, this.mbw).Clear();
 
-            this.TopDerr.AsSpan().Fill(0);
+            this.TopDerr.AsSpan().Clear();
         }
 
         private int Bit(uint nz, int n) => (nz & (1 << n)) != 0 ? 1 : 0;

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
@@ -546,7 +546,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             int predsW = (4 * this.Mbw) + 1;
             int predsH = (4 * this.Mbh) + 1;
             int predsSize = predsW * predsH;
-            this.Preds.AsSpan(predsSize + this.PredsWidth - 4, 4).Fill(0);
+            this.Preds.AsSpan(predsSize + this.PredsWidth - 4, 4).Clear();
 
             this.Nz[0] = 0;   // constant
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable) _N/A_

### Description
1st commit:
Revert a `stackalloc` de-optimization from #1734 (it was probably forgotten in #1750) and add a comment 

2nd commit:
Replace all `Span<T>.Fill(default)` calls with `Span<T>.Clear()` , as `Span<T>.Clear()` is more optimized than `Span<T>.Fill(default)`
