### PR TITLE
WIP: Add SSE2 versions of Average2/3/4

### DIFF
--- a/tests/ImageSharp.Tests/Formats/WebP/LosslessUtilsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/LosslessUtilsTests.cs
@@ -132,6 +132,126 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
             Assert.Equal(expectedOutput, pixelData);
         }
 
+        private static void RunPredictor5Test()
+        {
+            // arrange
+            uint[] topData = { 4284254193, 4284318702 };
+            uint left = 4284384236;
+            uint expectedResult = 4284253679;
+
+            // act
+            unsafe
+            {
+                fixed (uint* top = &topData[0])
+                {
+                    uint actual = LosslessUtils.Predictor5(left, top);
+
+                    // assert
+                    Assert.Equal(expectedResult, actual);
+                }
+            }
+        }
+
+        private static void RunPredictor6Test()
+        {
+            // arrange
+            uint[] topData = { 4284188659, 4284254193 };
+            uint left = 4284384236;
+            uint expectedResult = 4284253679;
+
+            // act
+            unsafe
+            {
+                fixed (uint* top = &topData[1])
+                {
+                    uint actual = LosslessUtils.Predictor6(left, top);
+
+                    // assert
+                    Assert.Equal(expectedResult, actual);
+                }
+            }
+        }
+
+        private static void RunPredictor7Test()
+        {
+            // arrange
+            uint[] topData = { 4284254193, 4284318702 };
+            uint left = 4284384236;
+            uint expectedResult = 4284319214;
+
+            // act
+            unsafe
+            {
+                fixed (uint* top = &topData[0])
+                {
+                    uint actual = LosslessUtils.Predictor7(left, top);
+
+                    // assert
+                    Assert.Equal(expectedResult, actual);
+                }
+            }
+        }
+
+        private static void RunPredictor8Test()
+        {
+            // arrange
+            uint[] topData = { 4284254193, 4284318702 };
+            uint left = 4284384236;
+            uint expectedResult = 4284253679;
+
+            // act
+            unsafe
+            {
+                fixed (uint* top = &topData[1])
+                {
+                    uint actual = LosslessUtils.Predictor8(left, top);
+
+                    // assert
+                    Assert.Equal(expectedResult, actual);
+                }
+            }
+        }
+
+        private static void RunPredictor9Test()
+        {
+            // arrange
+            uint[] topData = { 4284254193, 4284318702 };
+            uint left = 4284384236;
+            uint expectedResult = 4284253679;
+
+            // act
+            unsafe
+            {
+                fixed (uint* top = &topData[0])
+                {
+                    uint actual = LosslessUtils.Predictor9(left, top);
+
+                    // assert
+                    Assert.Equal(expectedResult, actual);
+                }
+            }
+        }
+
+        private static void RunPredictor10Test()
+        {
+            // arrange
+            uint[] topData = { 4278193664, 4278193664, 4278193664 };
+            uint left = 4278193664;
+            uint expectedResult = 4278193664;
+
+            // act
+            unsafe
+            {
+                fixed (uint* top = &topData[1])
+                {
+                    uint actual = LosslessUtils.Predictor10(left, top);
+
+                    // assert
+                    Assert.Equal(expectedResult, actual);
+                }
+            }
+        }
+
         private static void RunPredictor11Test()
         {
             // arrange
@@ -194,6 +314,24 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
         }
 
         [Fact]
+        public void Predictor5_Works() => RunPredictor5Test();
+
+        [Fact]
+        public void Predictor6_Works() => RunPredictor6Test();
+
+        [Fact]
+        public void Predictor7_Works() => RunPredictor7Test();
+
+        [Fact]
+        public void Predictor8_Works() => RunPredictor8Test();
+
+        [Fact]
+        public void Predictor9_Works() => RunPredictor9Test();
+
+        [Fact]
+        public void Predictor10_Works() => RunPredictor10Test();
+
+        [Fact]
         public void Predictor11_Works() => RunPredictor11Test();
 
         [Fact]
@@ -215,6 +353,42 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
         public void TransformColorInverse_Works() => RunTransformColorInverseTest();
 
 #if SUPPORTS_RUNTIME_INTRINSICS
+        [Fact]
+        public void Predictor5_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor5Test, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void Predictor5_WithoutSSE2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor5Test, HwIntrinsics.DisableSSE2);
+
+        [Fact]
+        public void Predictor6_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor6Test, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void Predictor6_WithoutSSE2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor6Test, HwIntrinsics.DisableSSE2);
+
+        [Fact]
+        public void Predictor7_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor7Test, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void Predictor7_WithoutSSE2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor7Test, HwIntrinsics.DisableSSE2);
+
+        [Fact]
+        public void Predictor8_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor8Test, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void Predictor8_WithoutSSE2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor8Test, HwIntrinsics.DisableSSE2);
+
+        [Fact]
+        public void Predictor9_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor9Test, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void Predictor9_WithoutSSE2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor9Test, HwIntrinsics.DisableSSE2);
+
+        [Fact]
+        public void Predictor10_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor10Test, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void Predictor10_WithoutSSE2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor10Test, HwIntrinsics.DisableSSE2);
+
         [Fact]
         public void Predictor11_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPredictor11Test, HwIntrinsics.AllowAll);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

I though it would be a good idea to use SSE2 in `Average2`, `Average2` and `Average3`, which is used `Predictor5` to `Predictor10`.  Those Predictor methods are used during lossless webp encoding and decoding.

Unfortunately the profiling results do not look good. Its actually slower then the none vectorized versions.
I think it could be due to `_mm_cvtsi32_si128` having a latency of 2 for skylake, according to the [intel docs](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtsi32_si128&ig_expand=5074,2283,7353,92,349,2283), which is used often here.

Maybe this will look better on newer CPU's. Mine is rather old now. Its a `i7 6700K`
Also maybe its possible to avoid using `_mm_cvtsi32_si128` here and replace it with other commands.

Related to #1786

Profile results:

### Master:

![Average3](https://user-images.githubusercontent.com/38701097/142009856-9fdd2c81-06b2-4f05-a1bf-4e09c1ff340c.png)

![Average4](https://user-images.githubusercontent.com/38701097/142009877-66f01f0f-b3a1-4881-81d9-f143e97689e1.png)

### PR:

![Average3_sse](https://user-images.githubusercontent.com/38701097/142009908-33909f38-ab42-4dda-85f4-a7b3f49e87d9.png)

![Average4_sse](https://user-images.githubusercontent.com/38701097/142009925-a7d8cbd2-f169-40b0-b083-027c667bf06a.png)

The profiling was done by decoding a lossless webp and then encode it again.
```
using var image = Image.Load(@"Calliphora_lossless_originalsize.webp");
image.Save("output.webp", new WebpEncoder() { FileFormat = WebpFileFormatType.Lossless });
```

The following image was used:
[Calliphora_lossless_originalsize.zip](https://github.com/SixLabors/ImageSharp/files/7547527/Calliphora_lossless_originalsize.zip)

