### PR TITLE
Remove HistogramEqualizationOptions.Default

### DIFF
--- a/src/ImageSharp/Processing/Extensions/Normalization/HistogramEqualizationExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/Normalization/HistogramEqualizationExtensions.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="source">The image this method extends.</param>
         /// <returns>The <see cref="IImageProcessingContext"/> to allow chaining of operations.</returns>
         public static IImageProcessingContext HistogramEqualization(this IImageProcessingContext source) =>
-            HistogramEqualization(source, HistogramEqualizationOptions.Default);
+            HistogramEqualization(source, new HistogramEqualizationOptions());
 
         /// <summary>
         /// Equalizes the histogram of an image to increases the contrast.

--- a/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationOptions.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationOptions.cs
@@ -9,11 +9,6 @@ namespace SixLabors.ImageSharp.Processing.Processors.Normalization
     public class HistogramEqualizationOptions
     {
         /// <summary>
-        /// Gets the default <see cref="HistogramEqualizationOptions"/> instance.
-        /// </summary>
-        public static HistogramEqualizationOptions Default { get; } = new HistogramEqualizationOptions();
-
-        /// <summary>
         /// Gets or sets the histogram equalization method to use. Defaults to global histogram equalization.
         /// </summary>
         public HistogramEqualizationMethod Method { get; set; } = HistogramEqualizationMethod.Global;

--- a/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
@@ -38,7 +38,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.WebP
             int actual = LossyUtils.Vp8_Sse4X4(a, b);
 
             Assert.Equal(expected, actual);
-		}
+        }
 
         private static void RunMean16x4Test()
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
We should not expose an arbitrary mutable variable like this. The common practice in the library is to use constructor to new-up instances of similar `XyzOptions` objects.
