### PR TITLE
Make ColorDistanceCache non-readonly

### DIFF
--- a/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
@@ -22,6 +22,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         where TPixel : unmanaged, IPixel<TPixel>
     {
         private Rgba32[] rgbaPalette;
+
+        // Do not make this readonly! Struct value would be always copied on non-readonly method calls.
         private ColorDistanceCache cache;
         private readonly Configuration configuration;
 

--- a/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization
         where TPixel : unmanaged, IPixel<TPixel>
     {
         private Rgba32[] rgbaPalette;
-        private readonly ColorDistanceCache cache;
+        private ColorDistanceCache cache;
         private readonly Configuration configuration;
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
![image](https://user-images.githubusercontent.com/6835152/142604203-d7fdad20-f424-4827-a1e6-c4a5f3e45fdc.png)

I wonder if it was result of IDE0044 suggestion? It [may report false recommendations](https://stackoverflow.com/questions/58452638/ide0044-make-field-readonly-depending-on-target-framework) for us.