### PR TITLE
Webp improvements

### DIFF
--- a/src/ImageSharp/Formats/Webp/EntropyIx.cs
+++ b/src/ImageSharp/Formats/Webp/EntropyIx.cs
@@ -6,7 +6,7 @@ namespace SixLabors.ImageSharp.Formats.Webp
     /// <summary>
     /// These five modes are evaluated and their respective entropy is computed.
     /// </summary>
-    internal enum EntropyIx
+    internal enum EntropyIx : byte
     {
         Direct = 0,
 

--- a/src/ImageSharp/Formats/Webp/HistoIx.cs
+++ b/src/ImageSharp/Formats/Webp/HistoIx.cs
@@ -3,7 +3,7 @@
 
 namespace SixLabors.ImageSharp.Formats.Webp
 {
-    internal enum HistoIx
+    internal enum HistoIx : byte
     {
         HistoAlpha = 0,
 

--- a/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
@@ -114,6 +114,8 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
             BackwardReferences2DLocality(width, best);
 
+            hashChainBox?.Dispose();
+
             return best;
         }
 
@@ -281,7 +283,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
 
             costModel.Build(xSize, cacheBits, refs);
-            var costManager = new CostManager(memoryAllocator, distArrayBuffer, pixCount, costModel);
+            using var costManager = new CostManager(memoryAllocator, distArrayBuffer, pixCount, costModel);
             Span<float> costManagerCosts = costManager.Costs.GetSpan();
             Span<ushort> distArray = distArrayBuffer.GetSpan();
 

--- a/src/ImageSharp/Formats/Webp/Lossless/CostManager.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/CostManager.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
+using System.Buffers;
 using System.Collections.Generic;
+using SixLabors.ImageSharp.Memory;
 
 namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 {
@@ -10,21 +13,23 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
     /// It caches the different CostCacheInterval, caches the different
     /// GetLengthCost(costModel, k) in costCache and the CostInterval's.
     /// </summary>
-    internal class CostManager
+    internal class CostManager : IDisposable
     {
+        private bool disposed;
+
         private CostInterval head;
 
         private const int FreeIntervalsStartCount = 25;
 
         private readonly Stack<CostInterval> freeIntervals = new(FreeIntervalsStartCount);
 
-        public CostManager(ushort[] distArray, int pixCount, CostModel costModel)
+        public CostManager(MemoryAllocator memoryAllocator, IMemoryOwner<ushort> distArray, int pixCount, CostModel costModel)
         {
             int costCacheSize = pixCount > BackwardReferenceEncoder.MaxLength ? BackwardReferenceEncoder.MaxLength : pixCount;
 
             this.CacheIntervals = new List<CostCacheInterval>();
             this.CostCache = new List<double>();
-            this.Costs = new float[pixCount];
+            this.Costs = memoryAllocator.Allocate<float>(pixCount);
             this.DistArray = distArray;
             this.Count = 0;
 
@@ -73,10 +78,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
 
             // Set the initial costs high for every pixel as we will keep the minimum.
-            for (int i = 0; i < pixCount; i++)
-            {
-                this.Costs[i] = 1e38f;
-            }
+            this.Costs.GetSpan().Fill(1e38f);
         }
 
         /// <summary>
@@ -91,9 +93,9 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
         public int CacheIntervalsSize { get; }
 
-        public float[] Costs { get; }
+        public IMemoryOwner<float> Costs { get; }
 
-        public ushort[] DistArray { get; }
+        public IMemoryOwner<ushort> DistArray { get; }
 
         public List<CostCacheInterval> CacheIntervals { get; }
 
@@ -137,6 +139,8 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             // interval logic, just serialize it right away. This constant is empirical.
             int skipDistance = 10;
 
+            Span<float> costs = this.Costs.GetSpan();
+            Span<ushort> distArray = this.DistArray.GetSpan();
             if (len < skipDistance)
             {
                 for (int j = position; j < position + len; j++)
@@ -144,10 +148,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                     int k = j - position;
                     float costTmp = (float)(distanceCost + this.CostCache[k]);
 
-                    if (this.Costs[j] > costTmp)
+                    if (costs[j] > costTmp)
                     {
-                        this.Costs[j] = costTmp;
-                        this.DistArray[j] = (ushort)(k + 1);
+                        costs[j] = costTmp;
+                        distArray[j] = (ushort)(k + 1);
                     }
                 }
 
@@ -314,12 +318,35 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         /// </summary>
         private void UpdateCost(int i, int position, float cost)
         {
+            Span<float> costs = this.Costs.GetSpan();
+            Span<ushort> distArray = this.DistArray.GetSpan();
             int k = i - position;
-            if (this.Costs[i] > cost)
+            if (costs[i] > cost)
             {
-                this.Costs[i] = cost;
-                this.DistArray[i] = (ushort)(k + 1);
+                costs[i] = cost;
+                distArray[i] = (ushort)(k + 1);
             }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposed)
+            {
+                if (disposing)
+                {
+                    this.Costs.Dispose();
+                }
+
+                this.disposed = true;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            this.Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/ImageSharp/Formats/Webp/Lossless/HTreeGroup.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HTreeGroup.cs
@@ -19,10 +19,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         {
             this.HTrees = new List<HuffmanCode[]>(WebpConstants.HuffmanCodesPerMetaCode);
             this.PackedTable = new HuffmanCode[packedTableSize];
-            for (int i = 0; i < packedTableSize; i++)
-            {
-                this.PackedTable[i] = new HuffmanCode();
-            }
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Webp/Lossless/HTreeGroup.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HTreeGroup.cs
@@ -13,12 +13,16 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
     ///  - UsePackedTable: few enough literal symbols, so all the bit codes can fit into a small look-up table PackedTable[]
     /// The common literal base, if applicable, is stored in 'LiteralArb'.
     /// </summary>
-    internal class HTreeGroup
+    internal struct HTreeGroup
     {
         public HTreeGroup(uint packedTableSize)
         {
             this.HTrees = new List<HuffmanCode[]>(WebpConstants.HuffmanCodesPerMetaCode);
             this.PackedTable = new HuffmanCode[packedTableSize];
+            this.IsTrivialCode = false;
+            this.IsTrivialLiteral = false;
+            this.LiteralArb = 0;
+            this.UsePackedTable = false;
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Webp/Lossless/HuffmanCode.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HuffmanCode.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
     /// A classic way to do entropy coding where a smaller number of bits are used for more frequent codes.
     /// </summary>
     [DebuggerDisplay("BitsUsed: {BitsUsed}, Value: {Value}")]
-    internal class HuffmanCode
+    internal struct HuffmanCode
     {
         /// <summary>
         /// Gets or sets the number of bits used for this symbol.

--- a/src/ImageSharp/Formats/Webp/Lossless/HuffmanTree.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HuffmanTree.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
     /// Represents the Huffman tree.
     /// </summary>
     [DebuggerDisplay("TotalCount = {TotalCount}, Value = {Value}, Left = {PoolIndexLeft}, Right = {PoolIndexRight}")]
-    internal struct HuffmanTree : IDeepCloneable
+    internal struct HuffmanTree
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HuffmanTree"/> struct.
@@ -57,7 +57,5 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
             return t1.Value < t2.Value ? -1 : 1;
         }
-
-        public IDeepCloneable DeepClone() => new HuffmanTree(this);
     }
 }

--- a/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 {
@@ -307,9 +308,9 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
         public static int BuildHuffmanTable(Span<HuffmanCode> table, int rootBits, int[] codeLengths, int codeLengthsSize)
         {
-            Guard.MustBeGreaterThan(rootBits, 0, nameof(rootBits));
-            Guard.NotNull(codeLengths, nameof(codeLengths));
-            Guard.MustBeGreaterThan(codeLengthsSize, 0, nameof(codeLengthsSize));
+            DebugGuard.MustBeGreaterThan(rootBits, 0, nameof(rootBits));
+            DebugGuard.NotNull(codeLengths, nameof(codeLengths));
+            DebugGuard.MustBeGreaterThan(codeLengthsSize, 0, nameof(codeLengthsSize));
 
             // sorted[codeLengthsSize] is a pre-allocated array for sorting symbols by code length.
             int[] sorted = new int[codeLengthsSize];
@@ -467,27 +468,27 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
                     break;
                 }
-                else if (repetitions < 11)
+
+                if (repetitions < 11)
                 {
                     tokens[pos].Code = 17;
                     tokens[pos].ExtraBits = (byte)(repetitions - 3);
                     pos++;
                     break;
                 }
-                else if (repetitions < 139)
+
+                if (repetitions < 139)
                 {
                     tokens[pos].Code = 18;
                     tokens[pos].ExtraBits = (byte)(repetitions - 11);
                     pos++;
                     break;
                 }
-                else
-                {
-                    tokens[pos].Code = 18;
-                    tokens[pos].ExtraBits = 0x7f;  // 138 repeated 0s
-                    pos++;
-                    repetitions -= 138;
-                }
+
+                tokens[pos].Code = 18;
+                tokens[pos].ExtraBits = 0x7f;  // 138 repeated 0s
+                pos++;
+                repetitions -= 138;
             }
 
             return pos;
@@ -519,20 +520,19 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
                     break;
                 }
-                else if (repetitions < 7)
+
+                if (repetitions < 7)
                 {
                     tokens[pos].Code = 16;
                     tokens[pos].ExtraBits = (byte)(repetitions - 3);
                     pos++;
                     break;
                 }
-                else
-                {
-                    tokens[pos].Code = 16;
-                    tokens[pos].ExtraBits = 3;
-                    pos++;
-                    repetitions -= 6;
-                }
+
+                tokens[pos].Code = 16;
+                tokens[pos].ExtraBits = 3;
+                pos++;
+                repetitions -= 6;
             }
 
             return pos;
@@ -541,7 +541,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         /// <summary>
         /// Get the actual bit values for a tree of bit depths.
         /// </summary>
-        /// <param name="tree">The hiffman tree.</param>
+        /// <param name="tree">The huffman tree.</param>
         private static void ConvertBitDepthsToSymbols(HuffmanTreeCode tree)
         {
             // 0 bit-depth means that the symbol does not exist.
@@ -628,7 +628,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         /// </summary>
         private static void ReplicateValue(Span<HuffmanCode> table, int step, int end, HuffmanCode code)
         {
-            Guard.IsTrue(end % step == 0, nameof(end), "end must be a multiple of step");
+            DebugGuard.IsTrue(end % step == 0, nameof(end), "end must be a multiple of step");
 
             do
             {
@@ -656,6 +656,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         /// <summary>
         /// Heuristics for selecting the stride ranges to collapse.
         /// </summary>
+        [MethodImpl(InliningOptions.ShortMethod)]
         private static bool ValuesShouldBeCollapsedToStrideAverage(int a, int b) => Math.Abs(a - b) < 4;
     }
 }

--- a/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
@@ -219,8 +219,8 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                     while (treeSize > 1)
                     {
                         // Finish when we have only one root.
-                        treePool[treePoolSize++] = (HuffmanTree)tree[treeSize - 1].DeepClone();
-                        treePool[treePoolSize++] = (HuffmanTree)tree[treeSize - 2].DeepClone();
+                        treePool[treePoolSize++] = tree[treeSize - 1];
+                        treePool[treePoolSize++] = tree[treeSize - 2];
                         int count = treePool[treePoolSize - 1].TotalCount + treePool[treePoolSize - 2].TotalCount;
                         treeSize -= 2;
 
@@ -239,7 +239,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                         int startIdx = endIdx + num - 1;
                         for (int i = startIdx; i >= endIdx; i--)
                         {
-                            tree[i] = (HuffmanTree)tree[i - 1].DeepClone();
+                            tree[i] = tree[i - 1];
                         }
 
                         tree[k].TotalCount = count;

--- a/src/ImageSharp/Formats/Webp/Lossless/PixOrCopyMode.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/PixOrCopyMode.cs
@@ -3,7 +3,7 @@
 
 namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 {
-    internal enum PixOrCopyMode
+    internal enum PixOrCopyMode : byte
     {
         Literal,
 

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LBackwardRefs.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LBackwardRefs.cs
@@ -7,7 +7,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 {
     internal class Vp8LBackwardRefs
     {
-        public Vp8LBackwardRefs() => this.Refs = new List<PixOrCopy>();
+        public Vp8LBackwardRefs(int pixels) => this.Refs = new List<PixOrCopy>(pixels);
 
         /// <summary>
         /// Gets or sets the common block-size.

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             this.EncodedData = memoryAllocator.Allocate<uint>(pixelCount);
             this.Palette = memoryAllocator.Allocate<uint>(WebpConstants.MaxPaletteSize);
             this.Refs = new Vp8LBackwardRefs[3];
-            this.HashChain = new Vp8LHashChain(pixelCount);
+            this.HashChain = new Vp8LHashChain(memoryAllocator, pixelCount);
 
             // We round the block size up, so we're guaranteed to have at most MaxRefsBlockPerImage blocks used:
             int refsBlockSize = ((pixelCount - 1) / MaxRefsBlockPerImage) + 1;
@@ -515,7 +515,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
 
             // Calculate backward references from BGRA image.
-            this.HashChain.Fill(this.memoryAllocator, bgra, this.quality, width, height, lowEffort);
+            this.HashChain.Fill(bgra, this.quality, width, height, lowEffort);
 
             Vp8LBitWriter bitWriterBest = config.SubConfigs.Count > 1 ? this.bitWriter.Clone() : this.bitWriter;
             Vp8LBitWriter bwInit = this.bitWriter;
@@ -529,6 +529,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                     this.quality,
                     subConfig.Lz77,
                     ref cacheBits,
+                    this.memoryAllocator,
                     this.HashChain,
                     this.Refs[0],
                     this.Refs[1]);
@@ -735,7 +736,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
 
             // Calculate backward references from the image pixels.
-            hashChain.Fill(this.memoryAllocator, bgra, quality, width, height, lowEffort);
+            hashChain.Fill(bgra, quality, width, height, lowEffort);
 
             Vp8LBackwardRefs refs = BackwardReferenceEncoder.GetBackwardReferences(
                 width,
@@ -744,6 +745,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                 quality,
                 (int)Vp8LLz77Type.Lz77Standard | (int)Vp8LLz77Type.Lz77Rle,
                 ref cacheBits,
+                this.memoryAllocator,
                 hashChain,
                 refsTmp1,
                 refsTmp2);
@@ -1802,6 +1804,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             this.BgraScratch.Dispose();
             this.Palette.Dispose();
             this.TransformData.Dispose();
+            this.HashChain.Dispose();
         }
     }
 }

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -130,7 +130,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             int refsBlockSize = ((pixelCount - 1) / MaxRefsBlockPerImage) + 1;
             for (int i = 0; i < this.Refs.Length; i++)
             {
-                this.Refs[i] = new Vp8LBackwardRefs
+                this.Refs[i] = new Vp8LBackwardRefs(pixelCount)
                 {
                     BlockSize = refsBlockSize < MinBlockSize ? MinBlockSize : refsBlockSize
                 };

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -137,6 +137,12 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             }
         }
 
+        // RFC 1951 will calm you down if you are worried about this funny sequence.
+        // This sequence is tuned from that, but more weighted for lower symbol count,
+        // and more spiking histograms.
+        // This uses C#'s compiler optimization to refer to assembly's static data directly.
+        private static ReadOnlySpan<byte> StorageOrder => new byte[] { 17, 18, 0, 1, 2, 3, 4, 5, 16, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+
         // This uses C#'s compiler optimization to refer to assembly's static data directly.
         private static ReadOnlySpan<byte> Order => new byte[] { 1, 2, 0, 3 };
 
@@ -942,16 +948,11 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
         private void StoreHuffmanTreeOfHuffmanTreeToBitMask(byte[] codeLengthBitDepth)
         {
-            // RFC 1951 will calm you down if you are worried about this funny sequence.
-            // This sequence is tuned from that, but more weighted for lower symbol count,
-            // and more spiking histograms.
-            byte[] storageOrder = { 17, 18, 0, 1, 2, 3, 4, 5, 16, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-
             // Throw away trailing zeros:
             int codesToStore = WebpConstants.CodeLengthCodes;
             for (; codesToStore > 4; codesToStore--)
             {
-                if (codeLengthBitDepth[storageOrder[codesToStore - 1]] != 0)
+                if (codeLengthBitDepth[StorageOrder[codesToStore - 1]] != 0)
                 {
                     break;
                 }
@@ -960,7 +961,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             this.bitWriter.PutBits((uint)codesToStore - 4, 4);
             for (int i = 0; i < codesToStore; i++)
             {
-                this.bitWriter.PutBits(codeLengthBitDepth[storageOrder[i]], 3);
+                this.bitWriter.PutBits(codeLengthBitDepth[StorageOrder[i]], 3);
             }
         }
 

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHashChain.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHashChain.cs
@@ -8,7 +8,7 @@ using SixLabors.ImageSharp.Memory;
 
 namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 {
-    internal class Vp8LHashChain
+    internal class Vp8LHashChain : IDisposable
     {
         private const uint HashMultiplierHi = 0xc6a4a793u;
 
@@ -28,14 +28,19 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         /// </summary>
         private const int WindowSize = (1 << WindowSizeBits) - 120;
 
+        private readonly MemoryAllocator memoryAllocator;
+
+        private bool disposed;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Vp8LHashChain"/> class.
         /// </summary>
+        /// <param name="memoryAllocator">The memory allocator.</param>
         /// <param name="size">The size off the chain.</param>
-        public Vp8LHashChain(int size)
+        public Vp8LHashChain(MemoryAllocator memoryAllocator, int size)
         {
-            this.OffsetLength = new uint[size];
-            this.OffsetLength.AsSpan().Fill(0xcdcdcdcd);
+            this.memoryAllocator = memoryAllocator;
+            this.OffsetLength = this.memoryAllocator.Allocate<uint>(size, AllocationOptions.Clean);
             this.Size = size;
         }
 
@@ -45,16 +50,16 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         /// These 20 bits are the limit defined by GetWindowSizeForHashChain (through WindowSize = 1 &lt;&lt; 20).
         /// The lower 12 bits contain the length of the match.
         /// </summary>
-        public uint[] OffsetLength { get; }
+        public IMemoryOwner<uint> OffsetLength { get; }
 
         /// <summary>
         /// Gets the size of the hash chain.
-        /// This is the maximum size of the hash_chain that can be constructed.
+        /// This is the maximum size of the hashchain that can be constructed.
         /// Typically this is the pixel count (width x height) for a given image.
         /// </summary>
         public int Size { get; }
 
-        public void Fill(MemoryAllocator memoryAllocator, ReadOnlySpan<uint> bgra, int quality, int xSize, int ySize, bool lowEffort)
+        public void Fill(ReadOnlySpan<uint> bgra, int quality, int xSize, int ySize, bool lowEffort)
         {
             int size = xSize * ySize;
             int iterMax = GetMaxItersForQuality(quality);
@@ -63,20 +68,21 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
             if (size <= 2)
             {
-                this.OffsetLength[0] = 0;
+                this.OffsetLength.GetSpan()[0] = 0;
                 return;
             }
 
-            using IMemoryOwner<int> hashToFirstIndexBuffer = memoryAllocator.Allocate<int>(HashSize);
+            using IMemoryOwner<int> hashToFirstIndexBuffer = this.memoryAllocator.Allocate<int>(HashSize);
+            using IMemoryOwner<int> chainBuffer = this.memoryAllocator.Allocate<int>(size, AllocationOptions.Clean);
             Span<int> hashToFirstIndex = hashToFirstIndexBuffer.GetSpan();
+            Span<int> chain = chainBuffer.GetSpan();
 
             // Initialize hashToFirstIndex array to -1.
             hashToFirstIndex.Fill(-1);
 
-            int[] chain = new int[size];
-
             // Fill the chain linking pixels with the same hash.
             bool bgraComp = bgra.Length > 1 && bgra[0] == bgra[1];
+            Span<uint> tmp = stackalloc uint[2];
             for (pos = 0; pos < size - 2;)
             {
                 uint hashCode;
@@ -85,7 +91,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                 {
                     // Consecutive pixels with the same color will share the same hash.
                     // We therefore use a different hash: the color and its repetition length.
-                    uint[] tmp = new uint[2];
+                    tmp.Clear();
                     uint len = 1;
                     tmp[0] = bgra[pos];
 
@@ -134,7 +140,8 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             // Find the best match interval at each pixel, defined by an offset to the
             // pixel and a length. The right-most pixel cannot match anything to the right
             // (hence a best length of 0) and the left-most pixel nothing to the left (hence an offset of 0).
-            this.OffsetLength[0] = this.OffsetLength[size - 1] = 0;
+            Span<uint> offsetLength = this.OffsetLength.GetSpan();
+            offsetLength[0] = offsetLength[size - 1] = 0;
             for (int basePosition = size - 2; basePosition > 0;)
             {
                 int maxLen = LosslessUtils.MaxFindCopyLength(size - 1 - basePosition);
@@ -208,7 +215,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                 uint maxBasePosition = (uint)basePosition;
                 while (true)
                 {
-                    this.OffsetLength[basePosition] = (bestDistance << BackwardReferenceEncoder.MaxLengthBits) | (uint)bestLength;
+                    offsetLength[basePosition] = (bestDistance << BackwardReferenceEncoder.MaxLengthBits) | (uint)bestLength;
                     --basePosition;
 
                     // Stop if we don't have a match or if we are out of bounds.
@@ -242,10 +249,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]
-        public int FindLength(int basePosition) => (int)(this.OffsetLength[basePosition] & ((1U << BackwardReferenceEncoder.MaxLengthBits) - 1));
+        public int FindLength(int basePosition) => (int)(this.OffsetLength.GetSpan()[basePosition] & ((1U << BackwardReferenceEncoder.MaxLengthBits) - 1));
 
         [MethodImpl(InliningOptions.ShortMethod)]
-        public int FindOffset(int basePosition) => (int)(this.OffsetLength[basePosition] >> BackwardReferenceEncoder.MaxLengthBits);
+        public int FindOffset(int basePosition) => (int)(this.OffsetLength.GetSpan()[basePosition] >> BackwardReferenceEncoder.MaxLengthBits);
 
         /// <summary>
         /// Calculates the hash for a pixel pair.
@@ -279,6 +286,26 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                 : xSize << 4;
 
             return maxWindowSize > WindowSize ? WindowSize : maxWindowSize;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposed)
+            {
+                if (disposing)
+                {
+                    this.OffsetLength.Dispose();
+                }
+
+                this.disposed = true;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/ImageSharp/Formats/Webp/Lossless/WebpLosslessDecoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/WebpLosslessDecoder.cs
@@ -65,14 +65,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             FixedTableSize + 2704
         };
 
-        private static readonly byte[] CodeLengthCodeOrder = { 17, 18, 0, 1, 2, 3, 4, 5, 16, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-
         private static readonly int NumCodeLengthCodes = CodeLengthCodeOrder.Length;
-
-        private static readonly byte[] LiteralMap =
-        {
-            0, 1, 1, 1, 0
-        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebpLosslessDecoder"/> class.
@@ -86,6 +79,12 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             this.memoryAllocator = memoryAllocator;
             this.configuration = configuration;
         }
+
+        // This uses C#'s compiler optimization to refer to assembly's static data directly.
+        private static ReadOnlySpan<byte> CodeLengthCodeOrder => new byte[] { 17, 18, 0, 1, 2, 3, 4, 5, 16, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+
+        // This uses C#'s compiler optimization to refer to assembly's static data directly.
+        private static ReadOnlySpan<byte> LiteralMap => new byte[] { 0, 1, 1, 1, 0 };
 
         /// <summary>
         /// Decodes the image from the stream using the bitreader.

--- a/src/ImageSharp/Formats/Webp/Lossless/WebpLosslessDecoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/WebpLosslessDecoder.cs
@@ -834,10 +834,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
 
         private void BuildPackedTable(HTreeGroup hTreeGroup)
         {
-            for (uint code = 0; code < HuffmanUtils.HuffmanPackedTableSize; ++code)
+            for (uint code = 0; code < HuffmanUtils.HuffmanPackedTableSize; code++)
             {
                 uint bits = code;
-                HuffmanCode huff = hTreeGroup.PackedTable[bits];
+                ref HuffmanCode huff = ref hTreeGroup.PackedTable[bits];
                 HuffmanCode hCode = hTreeGroup.HTrees[HuffIndex.Green][bits];
                 if (hCode.Value >= WebpConstants.NumLiteralCodes)
                 {
@@ -848,10 +848,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                 {
                     huff.BitsUsed = 0;
                     huff.Value = 0;
-                    bits >>= AccumulateHCode(hCode, 8, huff);
-                    bits >>= AccumulateHCode(hTreeGroup.HTrees[HuffIndex.Red][bits], 16, huff);
-                    bits >>= AccumulateHCode(hTreeGroup.HTrees[HuffIndex.Blue][bits], 0, huff);
-                    bits >>= AccumulateHCode(hTreeGroup.HTrees[HuffIndex.Alpha][bits], 24, huff);
+                    bits >>= AccumulateHCode(hCode, 8, ref huff);
+                    bits >>= AccumulateHCode(hTreeGroup.HTrees[HuffIndex.Red][bits], 16, ref huff);
+                    bits >>= AccumulateHCode(hTreeGroup.HTrees[HuffIndex.Blue][bits], 0, ref huff);
+                    bits >>= AccumulateHCode(hTreeGroup.HTrees[HuffIndex.Alpha][bits], 24, ref huff);
                 }
             }
         }
@@ -992,7 +992,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]
-        private static int AccumulateHCode(HuffmanCode hCode, int shift, HuffmanCode huff)
+        private static int AccumulateHCode(HuffmanCode hCode, int shift, ref HuffmanCode huff)
         {
             huff.BitsUsed += hCode.BitsUsed;
             huff.Value |= hCode.Value << shift;

--- a/src/ImageSharp/Formats/Webp/WebpLookupTables.cs
+++ b/src/ImageSharp/Formats/Webp/WebpLookupTables.cs
@@ -239,7 +239,8 @@ namespace SixLabors.ImageSharp.Formats.Webp
             }
         };
 
-        public static readonly byte[] Norm =
+        // This uses C#'s compiler optimization to refer to assembly's static data directly.
+        public static ReadOnlySpan<byte> Norm => new byte[]
         {
             // renorm_sizes[i] = 8 - log2(i)
             7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4,

--- a/tests/ImageSharp.Tests/Formats/WebP/ColorSpaceTransformUtilsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/ColorSpaceTransformUtilsTests.cs
@@ -5,7 +5,7 @@ using SixLabors.ImageSharp.Formats.Webp.Lossless;
 using SixLabors.ImageSharp.Tests.TestUtilities;
 using Xunit;
 
-namespace SixLabors.ImageSharp.Tests.Formats.WebP
+namespace SixLabors.ImageSharp.Tests.Formats.Webp
 {
     [Trait("Format", "Webp")]
     public class ColorSpaceTransformUtilsTests

--- a/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
@@ -6,7 +6,7 @@ using SixLabors.ImageSharp.Formats.Webp.Lossy;
 using SixLabors.ImageSharp.Tests.TestUtilities;
 using Xunit;
 
-namespace SixLabors.ImageSharp.Tests.Formats.WebP
+namespace SixLabors.ImageSharp.Tests.Formats.Webp
 {
     [Trait("Format", "Webp")]
     public class LossyUtilsTests

--- a/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/QuantEncTests.cs
@@ -6,7 +6,7 @@ using SixLabors.ImageSharp.Formats.Webp.Lossy;
 using SixLabors.ImageSharp.Tests.TestUtilities;
 using Xunit;
 
-namespace SixLabors.ImageSharp.Tests.Formats.WebP
+namespace SixLabors.ImageSharp.Tests.Formats.Webp
 {
     [Trait("Format", "Webp")]
     public class QuantEncTests

--- a/tests/ImageSharp.Tests/Formats/WebP/Vp8EncodingTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/Vp8EncodingTests.cs
@@ -6,7 +6,7 @@ using SixLabors.ImageSharp.Formats.Webp.Lossy;
 using SixLabors.ImageSharp.Tests.TestUtilities;
 using Xunit;
 
-namespace SixLabors.ImageSharp.Tests.Formats.WebP
+namespace SixLabors.ImageSharp.Tests.Formats.Webp
 {
     [Trait("Format", "Webp")]
     public class Vp8EncodingTests


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR changes the following:

- Change hashchain to use the memoryAllocator (OffsetLength array is as big as the pixel count)
- Change huffman code and HTreeGroup to a struct
- Avoid allocating too many `CostInterval` objects by pooling a small amount of them. The number of `CostInterval` objects can easily get into 100k+ for an 1 megapixel image.
- CostsManager now uses MemoryAllocator
- Remove not needed DeepClone of HuffmanTree (while it was changed to a struct, the DeepClone was not removed and is responible for alot of allocations)
- Change PixOrCopyMode, HistoIx and EntropyIx enums to be of byte type

Related to #1786

### Allocations master:

![Allocations_master](https://user-images.githubusercontent.com/38701097/142771598-62221374-42f2-4412-a89b-12e6e301e9ef.png)

### Allocations PR:

![Allocations_pr](https://user-images.githubusercontent.com/38701097/142771601-bd8517e2-6e27-4ff6-b1aa-706160782217.png)

Test was done with lossless encoding of Calliphora image.

