### PR TITLE
Add SSE2 version of FTransform

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -744,19 +744,21 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         private static bool IsFlat(Span<short> levels, int numBlocks, int thresh)
         {
             int score = 0;
+            ref short levelsRef = ref MemoryMarshal.GetReference(levels);
+            int offset = 0;
             while (numBlocks-- > 0)
             {
                 for (int i = 1; i < 16; i++)
                 {
                     // omit DC, we're only interested in AC
-                    score += levels[i] != 0 ? 1 : 0;
+                    score += Unsafe.Add(ref levelsRef, offset) != 0 ? 1 : 0;
                     if (score > thresh)
                     {
                         return false;
                     }
                 }
 
-                levels = levels.Slice(16);
+                offset += 16;
             }
 
             return true;

--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -726,7 +726,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         {
             uint v = src[0] * 0x01010101u;
             Span<byte> vSpan = BitConverter.GetBytes(v).AsSpan();
-            for (int i = 0; i < 16; i++)
+            for (nint i = 0; i < 16; i++)
             {
                 if (!src.Slice(0, 4).SequenceEqual(vSpan) || !src.Slice(4, 4).SequenceEqual(vSpan) ||
                     !src.Slice(8, 4).SequenceEqual(vSpan) || !src.Slice(12, 4).SequenceEqual(vSpan))
@@ -748,7 +748,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             int offset = 0;
             while (numBlocks-- > 0)
             {
-                for (int i = 1; i < 16; i++)
+                for (nint i = 1; i < 16; i++)
                 {
                     // omit DC, we're only interested in AC
                     score += Unsafe.Add(ref levelsRef, offset) != 0 ? 1 : 0;

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
@@ -459,6 +459,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 }
             }
             else
+#pragma warning restore SA1503 // Braces should not be omitted
 #endif
             {
                 FTransform(src, reference, output, scratch);

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
@@ -542,14 +542,18 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 
                 for (i = 0; i < 4; i++)
                 {
-                    int a0 = tmp[0 + i] + tmp[12 + i]; // 15b
-                    int a1 = tmp[4 + i] + tmp[8 + i];
-                    int a2 = tmp[4 + i] - tmp[8 + i];
-                    int a3 = tmp[0 + i] - tmp[12 + i];
-                    output[0 + i] = (short)((a0 + a1 + 7) >> 4); // 12b
-                    output[4 + i] = (short)((((a2 * 2217) + (a3 * 5352) + 12000) >> 16) + (a3 != 0 ? 1 : 0));
-                    output[8 + i] = (short)((a0 - a1 + 7) >> 4);
+                    int t12 = tmp[12 + i]; // 15b
+                    int t8 = tmp[8 + i];
+
+                    int a1 = tmp[4 + i] + t8;
+                    int a2 = tmp[4 + i] - t8;
+                    int a0 = tmp[0 + i] + t12; // 15b
+                    int a3 = tmp[0 + i] - t12;
+
                     output[12 + i] = (short)(((a3 * 2217) - (a2 * 5352) + 51000) >> 16);
+                    output[8 + i] = (short)((a0 - a1 + 7) >> 4);
+                    output[4 + i] = (short)((((a2 * 2217) + (a3 * 5352) + 12000) >> 16) + (a3 != 0 ? 1 : 0));
+                    output[0 + i] = (short)((a0 + a1 + 7) >> 4); // 12b
                 }
             }
         }
@@ -648,9 +652,9 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             int inputIdx = 0;
             for (i = 0; i < 4; i++)
             {
-                int a0 = input[inputIdx + (0 * 16)] + input[inputIdx + (2 * 16)];  // 13b
                 int a1 = input[inputIdx + (1 * 16)] + input[inputIdx + (3 * 16)];
                 int a2 = input[inputIdx + (1 * 16)] - input[inputIdx + (3 * 16)];
+                int a0 = input[inputIdx + (0 * 16)] + input[inputIdx + (2 * 16)];  // 13b
                 int a3 = input[inputIdx + (0 * 16)] - input[inputIdx + (2 * 16)];
                 tmp[3 + (i * 4)] = a0 - a1;
                 tmp[2 + (i * 4)] = a3 - a2;
@@ -662,18 +666,23 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 
             for (i = 0; i < 4; i++)
             {
-                int a0 = tmp[0 + i] + tmp[8 + i];  // 15b
-                int a1 = tmp[4 + i] + tmp[12 + i];
-                int a2 = tmp[4 + i] - tmp[12 + i];
-                int a3 = tmp[0 + i] - tmp[8 + i];
+                int t12 = tmp[12 + i];
+                int t8 = tmp[8 + i];
+
+                int a1 = tmp[4 + i] + t12;
+                int a2 = tmp[4 + i] - t12;
+                int a0 = tmp[0 + i] + t8;  // 15b
+                int a3 = tmp[0 + i] - t8;
+
                 int b0 = a0 + a1;    // 16b
                 int b1 = a3 + a2;
                 int b2 = a3 - a2;
                 int b3 = a0 - a1;
-                output[0 + i] = (short)(b0 >> 1);     // 15b
-                output[4 + i] = (short)(b1 >> 1);
-                output[8 + i] = (short)(b2 >> 1);
+
                 output[12 + i] = (short)(b3 >> 1);
+                output[8 + i] = (short)(b2 >> 1);
+                output[4 + i] = (short)(b1 >> 1);
+                output[0 + i] = (short)(b0 >> 1);     // 15b
             }
         }
 

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
@@ -66,11 +66,39 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         public static readonly int[] Vp8I4ModeOffsets = { I4DC4, I4TM4, I4VE4, I4HE4, I4RD4, I4VR4, I4LD4, I4VL4, I4HD4, I4HU4 };
 
 #if SUPPORTS_RUNTIME_INTRINSICS
-        public static readonly Vector128<short> K1 = Vector128.Create((short)20091).AsInt16();
+#pragma warning disable SA1310 // Field names should not contain underscore
+        private static readonly Vector128<short> K1 = Vector128.Create((short)20091).AsInt16();
 
-        public static readonly Vector128<short> K2 = Vector128.Create((short)-30068).AsInt16();
+        private static readonly Vector128<short> K2 = Vector128.Create((short)-30068).AsInt16();
 
-        public static readonly Vector128<short> Four = Vector128.Create((short)4);
+        private static readonly Vector128<short> Four = Vector128.Create((short)4);
+
+        private static readonly Vector128<short> Seven = Vector128.Create((short)7);
+
+        private static readonly Vector128<short> K88p = Vector128.Create(8, 0, 8, 0, 8, 0, 8, 0, 8, 0, 8, 0, 8, 0, 8, 0).AsInt16();
+
+        private static readonly Vector128<short> K88m = Vector128.Create(8, 0, 248, 255, 8, 0, 248, 255, 8, 0, 248, 255, 8, 0, 248, 255).AsInt16();
+
+        private static readonly Vector128<short> K5352_2217p = Vector128.Create(232, 20, 169, 8, 232, 20, 169, 8, 232, 20, 169, 8, 232, 20, 169, 8).AsInt16();
+
+        private static readonly Vector128<short> K5352_2217m = Vector128.Create(169, 8, 24, 235, 169, 8, 24, 235, 169, 8, 24, 235, 169, 8, 24, 235).AsInt16();
+
+        private static readonly Vector128<int> K937 = Vector128.Create(937);
+
+        private static readonly Vector128<int> K1812 = Vector128.Create(1812);
+
+        private static readonly Vector128<short> K5352_2217 = Vector128.Create(169, 8, 232, 20, 169, 8, 232, 20, 169, 8, 232, 20, 169, 8, 232, 20).AsInt16();
+
+        private static readonly Vector128<short> K2217_5352 = Vector128.Create(24, 235, 169, 8, 24, 235, 169, 8, 24, 235, 169, 8, 24, 235, 169, 8).AsInt16();
+
+        private static readonly Vector128<int> K12000PlusOne = Vector128.Create(12000 + (1 << 16));
+
+        private static readonly Vector128<int> K51000 = Vector128.Create(51000);
+
+        private static readonly byte MmShuffle2301 = SimdUtils.Shuffle.MmShuffle(2, 3, 0, 1);
+
+        private static readonly byte MmShuffle1032 = SimdUtils.Shuffle.MmShuffle(1, 0, 3, 2);
+#pragma warning restore SA1310 // Field names should not contain underscore
 #endif
 
         static Vp8Encoding()
@@ -476,17 +504,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 #if SUPPORTS_RUNTIME_INTRINSICS
         public static void FTransformPass1SSE2(Vector128<short> row01, Vector128<short> row23, out Vector128<int> out01, out Vector128<int> out32)
         {
-            var k937 = Vector128.Create(937);
-            var k1812 = Vector128.Create(1812);
-            Vector128<short> k88p = Vector128.Create(8, 0, 8, 0, 8, 0, 8, 0, 8, 0, 8, 0, 8, 0, 8, 0).AsInt16();
-            Vector128<short> k88m = Vector128.Create(8, 0, 248, 255, 8, 0, 248, 255, 8, 0, 248, 255, 8, 0, 248, 255).AsInt16();
-            Vector128<short> k5352_2217p = Vector128.Create(232, 20, 169, 8, 232, 20, 169, 8, 232, 20, 169, 8, 232, 20, 169, 8).AsInt16();
-            Vector128<short> k5352_2217m = Vector128.Create(169, 8, 24, 235, 169, 8, 24, 235, 169, 8, 24, 235, 169, 8, 24, 235).AsInt16();
-
             // *in01 = 00 01 10 11 02 03 12 13
             // *in23 = 20 21 30 31 22 23 32 33
-            Vector128<short> shuf01_p = Sse2.ShuffleHigh(row01.AsInt16(), SimdUtils.Shuffle.MmShuffle(2, 3, 0, 1));
-            Vector128<short> shuf32_p = Sse2.ShuffleHigh(row23.AsInt16(), SimdUtils.Shuffle.MmShuffle(2, 3, 0, 1));
+            Vector128<short> shuf01_p = Sse2.ShuffleHigh(row01, MmShuffle2301);
+            Vector128<short> shuf32_p = Sse2.ShuffleHigh(row23, MmShuffle2301);
 
             // 00 01 10 11 03 02 13 12
             // 20 21 30 31 23 22 33 32
@@ -500,12 +521,12 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 
             // [d0 + d3 | d1 + d2 | ...] = [a0 a1 | a0' a1' | ... ]
             // [d0 - d3 | d1 - d2 | ...] = [a3 a2 | a3' a2' | ... ]
-            Vector128<int> tmp0 = Sse2.MultiplyAddAdjacent(a01, k88p); // [ (a0 + a1) << 3, ... ]
-            Vector128<int> tmp2 = Sse2.MultiplyAddAdjacent(a01, k88m); // [ (a0 - a1) << 3, ... ]
-            Vector128<int> tmp11 = Sse2.MultiplyAddAdjacent(a32, k5352_2217p);
-            Vector128<int> tmp31 = Sse2.MultiplyAddAdjacent(a32, k5352_2217m);
-            Vector128<int> tmp12 = Sse2.Add(tmp11, k1812);
-            Vector128<int> tmp32 = Sse2.Add(tmp31, k937);
+            Vector128<int> tmp0 = Sse2.MultiplyAddAdjacent(a01, K88p); // [ (a0 + a1) << 3, ... ]
+            Vector128<int> tmp2 = Sse2.MultiplyAddAdjacent(a01, K88m); // [ (a0 - a1) << 3, ... ]
+            Vector128<int> tmp11 = Sse2.MultiplyAddAdjacent(a32, K5352_2217p);
+            Vector128<int> tmp31 = Sse2.MultiplyAddAdjacent(a32, K5352_2217m);
+            Vector128<int> tmp12 = Sse2.Add(tmp11, K1812);
+            Vector128<int> tmp32 = Sse2.Add(tmp31, K937);
             Vector128<int> tmp1 = Sse2.ShiftRightArithmetic(tmp12, 9);
             Vector128<int> tmp3 = Sse2.ShiftRightArithmetic(tmp32, 9);
             Vector128<short> s03 = Sse2.PackSignedSaturate(tmp0, tmp2);
@@ -514,17 +535,11 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             Vector128<short> shi = Sse2.UnpackHigh(s03, s12); // 2 3 2 3 2 3
             Vector128<int> v23 = Sse2.UnpackHigh(slo.AsInt32(), shi.AsInt32());
             out01 = Sse2.UnpackLow(slo.AsInt32(), shi.AsInt32());
-            out32 = Sse2.Shuffle(v23, SimdUtils.Shuffle.MmShuffle(1, 0, 3, 2));
+            out32 = Sse2.Shuffle(v23, MmShuffle1032);
         }
 
         public static void FTransformPass2SSE2(Vector128<int> v01, Vector128<int> v32, Span<short> output)
         {
-            var seven = Vector128.Create((short)7);
-            Vector128<short> k5352_2217 = Vector128.Create(169, 8, 232, 20, 169, 8, 232, 20, 169, 8, 232, 20, 169, 8, 232, 20).AsInt16();
-            Vector128<short> k2217_5352 = Vector128.Create(24, 235, 169, 8, 24, 235, 169, 8, 24, 235, 169, 8, 24, 235, 169, 8).AsInt16();
-            var k12000PlusOne = Vector128.Create(12000 + (1 << 16));
-            var k51000 = Vector128.Create(51000);
-
             // Same operations are done on the (0,3) and (1,2) pairs.
             // a3 = v0 - v3
             // a2 = v1 - v2
@@ -532,10 +547,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             Vector128<long> a22 = Sse2.UnpackHigh(a32.AsInt64(), a32.AsInt64());
 
             Vector128<short> b23 = Sse2.UnpackLow(a22.AsInt16(), a32.AsInt16());
-            Vector128<int> c1 = Sse2.MultiplyAddAdjacent(b23, k5352_2217);
-            Vector128<int> c3 = Sse2.MultiplyAddAdjacent(b23, k2217_5352);
-            Vector128<int> d1 = Sse2.Add(c1, k12000PlusOne);
-            Vector128<int> d3 = Sse2.Add(c3, k51000);
+            Vector128<int> c1 = Sse2.MultiplyAddAdjacent(b23, K5352_2217);
+            Vector128<int> c3 = Sse2.MultiplyAddAdjacent(b23, K2217_5352);
+            Vector128<int> d1 = Sse2.Add(c1, K12000PlusOne);
+            Vector128<int> d3 = Sse2.Add(c3, K51000);
             Vector128<int> e1 = Sse2.ShiftRightArithmetic(d1, 16);
             Vector128<int> e3 = Sse2.ShiftRightArithmetic(d3, 16);
 
@@ -553,7 +568,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             // a0 = v0 + v3
             // a1 = v1 + v2
             Vector128<int> a01 = Sse2.Add(v01, v32);
-            Vector128<short> a01Plus7 = Sse2.Add(a01.AsInt16(), seven);
+            Vector128<short> a01Plus7 = Sse2.Add(a01.AsInt16(), Seven);
             Vector128<short> a11 = Sse2.UnpackHigh(a01.AsInt64(), a01.AsInt64()).AsInt16();
             Vector128<short> c0 = Sse2.Add(a01Plus7, a11);
             Vector128<short> c2 = Sse2.Subtract(a01Plus7, a11);

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoding.cs
@@ -523,18 +523,18 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 int refIdx = 0;
                 for (i = 0; i < 4; i++)
                 {
-                    int d0 = src[srcIdx] - reference[refIdx]; // 9bit dynamic range ([-255,255])
-                    int d1 = src[srcIdx + 1] - reference[refIdx + 1];
-                    int d2 = src[srcIdx + 2] - reference[refIdx + 2];
                     int d3 = src[srcIdx + 3] - reference[refIdx + 3];
+                    int d2 = src[srcIdx + 2] - reference[refIdx + 2];
+                    int d1 = src[srcIdx + 1] - reference[refIdx + 1];
+                    int d0 = src[srcIdx] - reference[refIdx]; // 9bit dynamic range ([-255,255])
                     int a0 = d0 + d3; // 10b                      [-510,510]
                     int a1 = d1 + d2;
                     int a2 = d1 - d2;
                     int a3 = d0 - d3;
-                    tmp[0 + (i * 4)] = (a0 + a1) * 8; // 14b                      [-8160,8160]
-                    tmp[1 + (i * 4)] = ((a2 * 2217) + (a3 * 5352) + 1812) >> 9; // [-7536,7542]
-                    tmp[2 + (i * 4)] = (a0 - a1) * 8;
                     tmp[3 + (i * 4)] = ((a3 * 2217) - (a2 * 5352) + 937) >> 9;
+                    tmp[2 + (i * 4)] = (a0 - a1) * 8;
+                    tmp[1 + (i * 4)] = ((a2 * 2217) + (a3 * 5352) + 1812) >> 9; // [-7536,7542]
+                    tmp[0 + (i * 4)] = (a0 + a1) * 8; // 14b                      [-8160,8160]
 
                     srcIdx += WebpConstants.Bps;
                     refIdx += WebpConstants.Bps;
@@ -652,10 +652,10 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 int a1 = input[inputIdx + (1 * 16)] + input[inputIdx + (3 * 16)];
                 int a2 = input[inputIdx + (1 * 16)] - input[inputIdx + (3 * 16)];
                 int a3 = input[inputIdx + (0 * 16)] - input[inputIdx + (2 * 16)];
-                tmp[0 + (i * 4)] = a0 + a1;   // 14b
-                tmp[1 + (i * 4)] = a3 + a2;
-                tmp[2 + (i * 4)] = a3 - a2;
                 tmp[3 + (i * 4)] = a0 - a1;
+                tmp[2 + (i * 4)] = a3 - a2;
+                tmp[1 + (i * 4)] = a3 + a2;
+                tmp[0 + (i * 4)] = a0 + a1;   // 14b
 
                 inputIdx += 64;
             }

--- a/tests/ImageSharp.Tests/Formats/WebP/Vp8EncodingTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/Vp8EncodingTests.cs
@@ -11,6 +11,57 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
     [Trait("Format", "Webp")]
     public class Vp8EncodingTests
     {
+        private static void RunFTransform2Test()
+        {
+            // arrange
+            byte[] src = { 154, 154, 151, 151, 149, 148, 151, 157, 163, 163, 154, 132, 102, 98, 104, 108, 107, 104, 104, 103, 101, 106, 123, 119, 170, 171, 172, 171, 168, 175, 171, 173, 151, 151, 149, 150, 147, 147, 146, 159, 164, 165, 154, 129, 92, 90, 101, 105, 104, 103, 104, 101, 100, 105, 123, 117, 172, 172, 172, 168, 170, 177, 170, 175, 151, 149, 150, 150, 147, 147, 156, 161, 161, 161, 151, 126, 93, 90, 102, 107, 104, 103, 104, 101, 104, 104, 122, 117, 172, 172, 170, 168, 170, 177, 172, 175, 150, 149, 152, 151, 148, 151, 160, 159, 157, 157, 148, 133, 96, 90, 103, 107, 104, 104, 101, 100, 102, 102, 121, 117, 170, 170, 169, 171, 171, 179, 173, 175 };
+            byte[] reference = { 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129 };
+            short[] actualOutput1 = new short[16];
+            short[] actualOutput2 = new short[16];
+            short[] expectedOutput1 = { 182, 4, 1, 1, 6, 7, -1, -4, 5, 0, -2, 1, 2, 1, 1, 1 };
+            short[] expectedOutput2 = { 192, -34, 10, 1, -11, 8, 10, -7, 6, 3, -8, 4, 5, -3, -2, 6 };
+
+            // act
+            Vp8Encoding.FTransform2(src, reference, actualOutput1, actualOutput2, new int[16]);
+
+            // assert
+            Assert.True(expectedOutput1.SequenceEqual(actualOutput1));
+            Assert.True(expectedOutput2.SequenceEqual(actualOutput2));
+        }
+
+        private static void RunFTransformTest()
+        {
+            // arrange
+            byte[] src =
+            {
+                154, 154, 151, 151, 149, 148, 151, 157, 163, 163, 154, 132, 102, 98, 104, 108, 107, 104, 104, 103,
+                101, 106, 123, 119, 170, 171, 172, 171, 168, 175, 171, 173, 151, 151, 149, 150, 147, 147, 146, 159,
+                164, 165, 154, 129, 92, 90, 101, 105, 104, 103, 104, 101, 100, 105, 123, 117, 172, 172, 172, 168,
+                170, 177, 170, 175, 151, 149, 150, 150, 147, 147, 156, 161, 161, 161, 151, 126, 93, 90, 102, 107,
+                104, 103, 104, 101, 104, 104, 122, 117, 172, 172, 170, 168, 170, 177, 172, 175, 150, 149, 152, 151,
+                148, 151, 160, 159, 157, 157, 148, 133, 96, 90, 103, 107, 104, 104, 101, 100, 102, 102, 121, 117,
+                170, 170, 169, 171, 171, 179, 173, 175
+            };
+            byte[] reference =
+            {
+                128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 129, 129, 129, 129,
+                129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 128, 128, 128, 128, 128, 128, 128, 128,
+                128, 128, 128, 128, 128, 128, 128, 128, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129,
+                129, 129, 129, 129, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+                129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 129, 128, 128, 128, 128,
+                128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 129, 129, 129, 129, 129, 129, 129, 129,
+                129, 129, 129, 129, 129, 129, 129, 129
+            };
+            short[] actualOutput = new short[16];
+            short[] expectedOutput = { 182, 4, 1, 1, 6, 7, -1, -4, 5, 0, -2, 1, 2, 1, 1, 1 };
+
+            // act
+            Vp8Encoding.FTransform(src, reference, actualOutput, new int[16]);
+
+            // assert
+            Assert.True(expectedOutput.SequenceEqual(actualOutput));
+        }
+
         private static void RunOneInverseTransformTest()
         {
             // arrange
@@ -76,12 +127,30 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
         }
 
         [Fact]
+        public void FTransform2_Works() => RunFTransform2Test();
+
+        [Fact]
+        public void FTransform_Works() => RunFTransformTest();
+
+        [Fact]
         public void OneInverseTransform_Works() => RunOneInverseTransformTest();
 
         [Fact]
         public void TwoInverseTransform_Works() => RunTwoInverseTransformTest();
 
 #if SUPPORTS_RUNTIME_INTRINSICS
+        [Fact]
+        public void FTransform2_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunFTransform2Test, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void FTransform2_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunFTransform2Test, HwIntrinsics.DisableHWIntrinsic);
+
+        [Fact]
+        public void FTransform_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunFTransformTest, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void FTransform_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunFTransformTest, HwIntrinsics.DisableHWIntrinsic);
+
         [Fact]
         public void OneInverseTransform_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunOneInverseTransformTest, HwIntrinsics.AllowAll);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR adds a SSE2 version of `FTransform` and `FTransform2` (two transforms at once), which are used for webp lossy encoding.
Related to #1786

Profiling results:

### master
![FTransform](https://user-images.githubusercontent.com/38701097/143595576-17312281-c3f2-4343-b141-830912d6a06c.png)

### PR
![FTransformSSE2](https://user-images.githubusercontent.com/38701097/143595590-73aec090-6748-447b-a92f-e524a6aed535.png)

Test image was Calliphora.png

