### PR TITLE
Add AVX2 version of Vp8_Sse4X4

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
@@ -32,15 +32,48 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         public static int Vp8_Sse4X4(Span<byte> a, Span<byte> b)
         {
 #if SUPPORTS_RUNTIME_INTRINSICS
+            if (Avx2.IsSupported)
+            {
+                // Load values.
+                ref byte aRef = ref MemoryMarshal.GetReference(a);
+                ref byte bRef = ref MemoryMarshal.GetReference(b);
+                var a0 = Vector256.Create(
+                    Unsafe.As<byte, Vector128<byte>>(ref aRef),
+                    Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref aRef, WebpConstants.Bps)));
+                var a1 = Vector256.Create(
+                    Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref aRef, WebpConstants.Bps * 2)),
+                    Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref aRef, WebpConstants.Bps * 3)));
+                var b0 = Vector256.Create(
+                    Unsafe.As<byte, Vector128<byte>>(ref bRef),
+                    Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bRef, WebpConstants.Bps)));
+                var b1 = Vector256.Create(
+                    Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bRef, WebpConstants.Bps * 2)),
+                    Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bRef, WebpConstants.Bps * 3)));
+
+                // Combine pair of lines.
+                Vector256<int> a01 = Avx2.UnpackLow(a0.AsInt32(), a1.AsInt32());
+                Vector256<int> b01 = Avx2.UnpackLow(b0.AsInt32(), b1.AsInt32());
+
+                // Convert to 16b.
+                Vector256<byte> a01s = Avx2.UnpackLow(a01.AsByte(), Vector256<byte>.Zero);
+                Vector256<byte> b01s = Avx2.UnpackLow(b01.AsByte(), Vector256<byte>.Zero);
+
+                // subtract, square and accumulate.
+                Vector256<byte> d0 = Avx2.SubtractSaturate(a01s, b01s);
+                Vector256<int> e0 = Avx2.MultiplyAddAdjacent(d0.AsInt16(), d0.AsInt16());
+
+                return Numerics.ReduceSum(e0);
+            }
+
             if (Sse2.IsSupported)
             {
                 // Load values.
                 ref byte aRef = ref MemoryMarshal.GetReference(a);
+                ref byte bRef = ref MemoryMarshal.GetReference(b);
                 Vector128<byte> a0 = Unsafe.As<byte, Vector128<byte>>(ref aRef);
                 Vector128<byte> a1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref aRef, WebpConstants.Bps));
                 Vector128<byte> a2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref aRef, WebpConstants.Bps * 2));
                 Vector128<byte> a3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref aRef, WebpConstants.Bps * 3));
-                ref byte bRef = ref MemoryMarshal.GetReference(b);
                 Vector128<byte> b0 = Unsafe.As<byte, Vector128<byte>>(ref bRef);
                 Vector128<byte> b1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bRef, WebpConstants.Bps));
                 Vector128<byte> b2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bRef, WebpConstants.Bps * 2));
@@ -67,7 +100,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 
                 return Numerics.ReduceSum(sum);
             }
-            else
 #endif
             {
                 return Vp8_SseNxN(a, b, 4, 4);

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8EncIterator.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8EncIterator.cs
@@ -358,7 +358,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             int kThreshold = 8 + ((17 - 8) * q / 100);
             int k;
             Span<uint> dc = stackalloc uint[16];
-            Span<ushort> tmp = stackalloc ushort[16];
             uint m;
             uint m2;
             for (k = 0; k < 16; k += 4)

--- a/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/LossyUtilsTests.cs
@@ -104,7 +104,10 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
         public void Vp8Sse4X4_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunVp8Sse4X4Test, HwIntrinsics.AllowAll);
 
         [Fact]
-        public void Vp8Sse4X4_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunVp8Sse4X4Test, HwIntrinsics.DisableHWIntrinsic);
+        public void Vp8Sse4X4_WithoutSSE2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunVp8Sse4X4Test, HwIntrinsics.DisableSSE2);
+
+        [Fact]
+        public void Vp8Sse4X4_WithoutAVX2_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunVp8Sse4X4Test, HwIntrinsics.DisableAVX2);
 
         [Fact]
         public void Mean16x4_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunMean16x4Test, HwIntrinsics.AllowAll);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR adds a AVX2 version of Vp8_Sse4X4, which is used during lossy webp encoding.

Related to #1786

Profiler results:

### master:

![Sse4x4Master](https://user-images.githubusercontent.com/38701097/143993768-f8820a2f-b109-41ce-9386-0e8ed722f085.png)

### PR
![Sse4x4Avx](https://user-images.githubusercontent.com/38701097/143993788-ddfd99cc-5f9d-4fd7-bc8f-3cb886487bbe.png)

Test image was Calliphora.png

