### PR TITLE
Do not remove EXIF orientation in RotateProcessor

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/RotateProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/RotateProcessor{TPixel}.cs
@@ -41,26 +41,6 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             base.OnFrameApply(source, destination);
         }
 
-        /// <inheritdoc/>
-        protected override void AfterImageApply(Image<TPixel> destination)
-        {
-            ExifProfile profile = destination.Metadata.ExifProfile;
-            if (profile is null)
-            {
-                return;
-            }
-
-            if (MathF.Abs(WrapDegrees(this.degrees)) < Constants.Epsilon)
-            {
-                // No need to do anything so return.
-                return;
-            }
-
-            profile.RemoveValue(ExifTag.Orientation);
-
-            base.AfterImageApply(destination);
-        }
-
         /// <summary>
         /// Wraps a given angle in degrees so that it falls withing the 0-360 degree range
         /// </summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I noticed the RotateProcessor also removed the EXIF orientation, which should be an explicit operation (as mentioned here https://github.com/SixLabors/ImageSharp/issues/400#issuecomment-944202410).