### PR TITLE
Add AutoOrientMode to configure handling of EXIF orientation flag

### DIFF
--- a/src/ImageSharp/Processing/AutoOrientMode.cs
+++ b/src/ImageSharp/Processing/AutoOrientMode.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Processing
+{
+    /// <summary>
+    /// Provides an enumeration over how an image should be auto oriented.
+    /// </summary>
+    public enum AutoOrientMode
+    {
+        /// <summary>
+        /// Reset the EXIF orientation flag to horizontal (normal).
+        /// </summary>
+        ResetExifValue,
+
+        /// <summary>
+        /// Keep the existing EXIF orientation flag.
+        /// </summary>
+        KeepExifValue,
+
+        /// <summary>
+        /// Remove the EXIF orientation flag.
+        /// </summary>
+        RemoveExifValue
+    }
+}

--- a/src/ImageSharp/Processing/MetadataExtensions.cs
+++ b/src/ImageSharp/Processing/MetadataExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Metadata;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Processing;
+
+namespace SixLabors.ImageSharp
+{
+    /// <summary>
+    /// Extension methods for the <see cref="ImageMetadata"/> type.
+    /// </summary>
+    public static partial class MetadataExtensions
+    {
+        /// <summary>
+        /// Gets the orientation of the image.
+        /// </summary>
+        /// <param name="metadata">The metadata.</param>
+        /// <returns>The <see cref="OrientationMode"/></returns>
+        public static OrientationMode GetOrientation(this ImageMetadata metadata) => (OrientationMode)(metadata.ExifProfile?.GetValue(ExifTag.Orientation)?.Value ?? 0);
+    }
+}

--- a/src/ImageSharp/Processing/OrientationMode.cs
+++ b/src/ImageSharp/Processing/OrientationMode.cs
@@ -14,42 +14,42 @@ namespace SixLabors.ImageSharp.Processing
         Unknown = 0,
 
         /// <summary>
-        /// The 0th row at the top, the 0th column on the left.
+        /// Horizontal (normal) - the 0th row at the top, the 0th column on the left.
         /// </summary>
         TopLeft = 1,
 
         /// <summary>
-        /// The 0th row at the top, the 0th column on the right.
+        /// Mirror horizontal - the 0th row at the top, the 0th column on the right.
         /// </summary>
         TopRight = 2,
 
         /// <summary>
-        /// The 0th row at the bottom, the 0th column on the right.
+        /// Rotate 180 - the 0th row at the bottom, the 0th column on the right.
         /// </summary>
         BottomRight = 3,
 
         /// <summary>
-        /// The 0th row at the bottom, the 0th column on the left.
+        /// Mirror vertical - the 0th row at the bottom, the 0th column on the left.
         /// </summary>
         BottomLeft = 4,
 
         /// <summary>
-        /// The 0th row on the left, the 0th column at the top.
+        /// Mirror horizontal and rotate 270 CW - the 0th row on the left, the 0th column at the top.
         /// </summary>
         LeftTop = 5,
 
         /// <summary>
-        /// The 0th row at the right, the 0th column at the top.
+        /// Rotate 90 CW - the 0th row at the right, the 0th column at the top.
         /// </summary>
         RightTop = 6,
 
         /// <summary>
-        /// The 0th row on the right, the 0th column at the bottom.
+        /// Mirror horizontal and rotate 90 CW - the 0th row on the right, the 0th column at the bottom.
         /// </summary>
         RightBottom = 7,
 
         /// <summary>
-        /// The 0th row on the left, the 0th column at the bottom.
+        /// Rotate 270 CW - the 0th row on the left, the 0th column at the bottom.
         /// </summary>
         LeftBottom = 8
     }

--- a/src/ImageSharp/Processing/OrientationMode.cs
+++ b/src/ImageSharp/Processing/OrientationMode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.ImageSharp.Processing
@@ -6,7 +6,7 @@ namespace SixLabors.ImageSharp.Processing
     /// <summary>
     /// Enumerates the available orientation values supplied by EXIF metadata.
     /// </summary>
-    internal enum OrientationMode : ushort
+    public enum OrientationMode : ushort
     {
         /// <summary>
         /// Unknown rotation.

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AutoOrientProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AutoOrientProcessor.cs
@@ -10,9 +10,26 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     /// </summary>
     public sealed class AutoOrientProcessor : IImageProcessor
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoOrientProcessor"/> class.
+        /// </summary>
+        public AutoOrientProcessor()
+            : this(AutoOrientMode.ResetExifValue);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoOrientProcessor"/> class.
+        /// </summary>
+        /// <param name="autoOrientMode">The <see cref="AutoOrientMode"/> used to perform the auto orientation.</param>
+        public AutoOrientProcessor(AutoOrientMode autoOrientMode) => this.AutoOrientMode = autoOrientMode;
+
+        /// <summary>
+        /// Gets the <see cref="AutoOrientMode"/> used to perform the auto orientation.
+        /// </summary>
+        public AutoOrientMode AutoOrientMode { get; }
+
         /// <inheritdoc />
         public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
             where TPixel : unmanaged, IPixel<TPixel>
-            => new AutoOrientProcessor<TPixel>(configuration, source, sourceRectangle);
+            => new AutoOrientProcessor<TPixel>(configuration, this, source, sourceRectangle);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
This PR makes the `OrientationMode` enumeration public and introduces a `GetOrientation()` extension method on the image metadata, so you can easily get this value using e.g. `image.Metadata.GetOrientation()`.

The `AutoOrientProcessor` uses this extension method (instead of its own private `GetExifOrientation()` that also resets the value) and now also allows you to configure how to deal with the EXIF orientation flag after applying the rotating/flipping. The default is to reset the flag to 0/horizontal (normal)/top-left to keep the existing behavior.

Because this processor uses the `RotateProcessor`, PR https://github.com/SixLabors/ImageSharp/pull/1866 needs to be merged to be able to use `AutoOrientMode.KeepExifValue` on images that are rotated (otherwise the flag would still be removed).

_I've created this as draft, as it still needs test coverage to validate the new `AutoOrientMode` and also requires the above PR to be merged first._