### PR TITLE
Do not keep a reference to the FlipProcessor instance

### DIFF
--- a/src/ImageSharp/Processing/FlipMode.cs
+++ b/src/ImageSharp/Processing/FlipMode.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.ImageSharp.Processing
 {
     /// <summary>
-    /// Provides enumeration over how a image should be flipped.
+    /// Provides an enumeration over how an image should be flipped.
     /// </summary>
     public enum FlipMode
     {
@@ -21,6 +21,6 @@ namespace SixLabors.ImageSharp.Processing
         /// <summary>
         /// Flip the image vertically.
         /// </summary>
-        Vertical,
+        Vertical
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/FlipProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/FlipProcessor{TPixel}.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     internal class FlipProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        private readonly FlipProcessor definition;
+        private readonly FlipMode flipMode;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FlipProcessor{TPixel}"/> class.
@@ -27,14 +27,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         public FlipProcessor(Configuration configuration, FlipProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
             : base(configuration, source, sourceRectangle)
-        {
-            this.definition = definition;
-        }
+            => this.flipMode = definition.FlipMode;
 
         /// <inheritdoc/>
         protected override void OnFrameApply(ImageFrame<TPixel> source)
         {
-            switch (this.definition.FlipMode)
+            switch (this.flipMode)
             {
                 // No default needed as we have already set the pixels.
                 case FlipMode.Vertical:


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
`FlipProcessor<TPixel>` kept a reference to the `FlipProcessor`, which is inconsistent with all the other processors, so this is a simple change to only store the `FlipMode`.