### PR TITLE
Do not keep a reference to the EntropyCropProcessor instance

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/EntropyCropProcessor{TPixel}.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
     internal class EntropyCropProcessor<TPixel> : ImageProcessor<TPixel>
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        private readonly EntropyCropProcessor definition;
+        private readonly float threshold;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntropyCropProcessor{TPixel}"/> class.
@@ -28,9 +28,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
         public EntropyCropProcessor(Configuration configuration, EntropyCropProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
             : base(configuration, source, sourceRectangle)
-        {
-            this.definition = definition;
-        }
+            => this.threshold = definition.Threshold;
 
         /// <inheritdoc/>
         protected override void BeforeImageApply()
@@ -47,7 +45,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 new EdgeDetector2DProcessor(KnownEdgeDetectorKernels.Sobel, false).Execute(this.Configuration, temp, this.SourceRectangle);
 
                 // Apply threshold binarization filter.
-                new BinaryThresholdProcessor(this.definition.Threshold).Execute(this.Configuration, temp, this.SourceRectangle);
+                new BinaryThresholdProcessor(this.threshold).Execute(this.Configuration, temp, this.SourceRectangle);
 
                 // Search for the first white pixels
                 rectangle = GetFilteredBoundingRectangle(temp.Frames.RootFrame, 0);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Similar to https://github.com/SixLabors/ImageSharp/pull/1869, this only stores the threshold value of the `EntropyCropProcessor`.