### PR TITLE
Allocate clean buffer in AnalyzeEntropy

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -192,7 +192,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
         public bool UseCrossColorTransform { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to use the substract green transform.
+        /// Gets or sets a value indicating whether to use the subtract green transform.
         /// </summary>
         public bool UseSubtractGreenTransform { get; set; }
 
@@ -1049,7 +1049,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
                 return EntropyIx.Palette;
             }
 
-            using IMemoryOwner<uint> histoBuffer = this.memoryAllocator.Allocate<uint>((int)HistoIx.HistoTotal * 256);
+            using IMemoryOwner<uint> histoBuffer = this.memoryAllocator.Allocate<uint>((int)HistoIx.HistoTotal * 256, AllocationOptions.Clean);
             Span<uint> histo = histoBuffer.Memory.Span;
             uint pixPrev = bgra[0]; // Skip the first pixel.
             ReadOnlySpan<uint> prevRow = null;

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
@@ -102,6 +102,24 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
         }
 
         [Theory]
+        [WithFile(Lossy.NoFilter06, PixelTypes.Rgba32, 15114)]
+        public void Encode_Lossless_WithBestQuality_HasExpectedSize<TPixel>(TestImageProvider<TPixel> provider, int expectedBytes)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            var encoder = new WebpEncoder()
+            {
+                FileFormat = WebpFileFormatType.Lossless,
+                Method = WebpEncodingMethod.BestQuality
+            };
+
+            using Image<TPixel> image = provider.GetImage();
+            using var memoryStream = new MemoryStream();
+            image.Save(memoryStream, encoder);
+
+            Assert.Equal(memoryStream.Length, expectedBytes);
+        }
+
+        [Theory]
         [WithFile(RgbTestPattern100x100, PixelTypes.Rgba32, 85)]
         [WithFile(RgbTestPattern100x100, PixelTypes.Rgba32, 60)]
         [WithFile(RgbTestPattern80x80, PixelTypes.Rgba32, 40)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR fixes a bug in `AnalyzeEntropy` which did not allocate a clean buffer from the memory allocator, resulting in possible unpredictable results.

Closes #1872 
