### PR TITLE
Fixed jpeg encoder last bytes flushing bug

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/HuffmanScanEncoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/HuffmanScanEncoder.cs
@@ -650,6 +650,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             }
 
             this.target.Write(this.streamWriteBuffer, 0, writeIdx);
+            this.emitWriteIndex = this.emitBuffer.Length;
         }
 
         /// <summary>
@@ -660,11 +661,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
         /// This must be called only if <see cref="IsStreamFlushNeeded"/> is true
         /// only during the macroblocks encoding routine.
         /// </remarks>
-        private void FlushToStream()
-        {
+        private void FlushToStream() =>
             this.FlushToStream(this.emitWriteIndex * 4);
-            this.emitWriteIndex = this.emitBuffer.Length;
-        }
 
         /// <summary>
         /// Flushes final cached bits to the stream padding 1's to
@@ -681,10 +679,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             // And writing only valuable count of bytes count we want to write to the output stream
             int valuableBytesCount = (int)Numerics.DivideCeil((uint)this.bitCount, 8);
             uint packedBytes = this.accumulatedBits | (uint.MaxValue >> this.bitCount);
-            this.emitBuffer[--this.emitWriteIndex] = packedBytes;
+            this.emitBuffer[this.emitWriteIndex - 1] = packedBytes;
 
             // Flush cached bytes to the output stream with padding bits
-            this.FlushToStream((this.emitWriteIndex * 4) - 4 + valuableBytesCount);
+            int lastByteIndex = (this.emitWriteIndex * 4) - valuableBytesCount;
+            this.FlushToStream(lastByteIndex);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I've made quite a mistake during jpeg encoder optimization for last bytes flushing to the stream:

```csharp
int valuableBytesCount = (int)Numerics.DivideCeil((uint)this.bitCount, 8);
uint packedBytes = this.accumulatedBits | (uint.MaxValue >> this.bitCount);
this.emitBuffer[--this.emitWriteIndex] = packedBytes;

int endIndex = (this.emitWriteIndex * 4) - 4 + valuableBytesCount;
this.FlushToStream(endIndex);
```

`uint` buffer size is 4 for simplicity. Let's say we have 3 bits to pad with 1's for full byte and write to the stream:

```
bufferSize = 4
emitWriteIndex = 4
bitCount = 3
accumulatedBits = 101|0_0000_...

int valuableBytesCount = 1
uint packedBytes = 101|1_1111_...
--emitWriteIndex = 3
int endIndex = 3 * 4 - 4 + 1 = 12 - 4 + 1 = 9

// bytes indices written to the stream:
15 14 13 12 11 10 9
```

So extra 6 bytes written on top of 1 byte with actual information. Same setup with fix from this PR:

```
bufferSize = 4
emitWriteIndex = 4
bitCount = 3
accumulatedBits = 101|0_0000_...

int valuableBytesCount = 1
uint packedBytes = 101|1_1111_...
int endIndex = 4 * 4 - 1 = 16 - 1 = 15

// bytes indices written to the stream:
15
```

This bug wasn't critical and actually isn't spottable by photoshop or JpegSnoop as extra written bytes do not corrupt resulting jpeg but it's still a problem introduced in one of my PRs (I'm really sorry).

I've tested a couple of images from test folder and got following binary size difference:

[Calliphora.jpg](https://github.com/SixLabors/ImageSharp/blob/master/tests/Images/Input/Jpg/baseline/Calliphora.jpg): 
master: 257.540b
PR: 257.537b

[winter420_noninterleaved.jpg](https://github.com/SixLabors/ImageSharp/blob/master/tests/Images/Input/Jpg/progressive/winter420_noninterleaved.jpg): - 
master: 248.048b
PR: 248.042b