### PR TITLE
Tiff: Add maximum IFD threshold

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Ifd/EntryReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Ifd/EntryReader.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             this.lazyLoaders = lazyLoaders;
         }
 
-        public List<IExifValue> Values { get; } = new List<IExifValue>();
+        public List<IExifValue> Values { get; } = new();
 
         public uint NextIfdOffset { get; private set; }
 

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -380,6 +380,18 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         public void TiffDecoder_CanDecode_JpegCompressed<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, useExactComparer: false);
 
+        // https://github.com/SixLabors/ImageSharp/issues/1891
+        [Theory]
+        [WithFile(Issues1891, PixelTypes.Rgba32)]
+        public void TiffDecoder_ThrowsException_WithTooManyDirectories<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => Assert.Throws<ImageFormatException>(
+                () =>
+                {
+                    using (provider.GetImage(TiffDecoder))
+                    {
+                    }
+                });
+
         [Theory]
         [WithFileCollection(nameof(MultiframeTestImages), PixelTypes.Rgba32)]
         public void DecodeMultiframe<TPixel>(TestImageProvider<TPixel> provider)

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -840,6 +840,7 @@ namespace SixLabors.ImageSharp.Tests
             public const string Flower32BitGrayPredictorLittleEndian = "Tiff/flower-minisblack-32_lsb_deflate_predictor.tiff";
 
             public const string Issues1716Rgb161616BitLittleEndian = "Tiff/Issues/Issue1716.tiff";
+            public const string Issues1891 = "Tiff/Issues/Issue1891.tiff";
 
             public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
             public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/Images/Input/Tiff/Issues/Issue1891.tiff
+++ b/tests/Images/Input/Tiff/Issues/Issue1891.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2779c7fb2c2ad858e0d7efcfffd594cc6fb2846e0475a2998a3cda50f289b9b
+size 307


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR adds a maximum of 65534 IFD directories. Images with more then that will throw a `ImageFormatException`.
Fixes #1891