### PR TITLE
PNG: Verify CRC of IDAT chunk is correct

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -255,7 +255,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void Decode_MissingDataChunk_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            System.Exception ex = Record.Exception(
+            Exception ex = Record.Exception(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
@@ -271,7 +271,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void Decode_InvalidBitDepth_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            System.Exception ex = Record.Exception(
+            Exception ex = Record.Exception(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
@@ -287,7 +287,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void Decode_InvalidColorType_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            System.Exception ex = Record.Exception(
+            Exception ex = Record.Exception(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
@@ -297,13 +297,28 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             Assert.Contains("Invalid or unsupported color type", ex.Message);
         }
 
+        [Theory]
+        [WithFile(TestImages.Png.Bad.WrongCrcDataChunk, PixelTypes.Rgba32)]
+        public void Decode_InvalidDataChunkCrc_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Exception ex = Record.Exception(
+                () =>
+                {
+                    using Image<TPixel> image = provider.GetImage(PngDecoder);
+                    image.DebugSave(provider);
+                });
+            Assert.NotNull(ex);
+            Assert.Contains("CRC Error. PNG IDAT chunk is corrupt!", ex.Message);
+        }
+
         // https://github.com/SixLabors/ImageSharp/issues/1014
         [Theory]
         [WithFileCollection(nameof(TestImagesIssue1014), PixelTypes.Rgba32)]
         public void Issue1014_DataSplitOverMultipleIDatChunks<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            System.Exception ex = Record.Exception(
+            Exception ex = Record.Exception(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
@@ -319,7 +334,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void Issue1177_CRC_Omitted<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            System.Exception ex = Record.Exception(
+            Exception ex = Record.Exception(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
@@ -335,7 +350,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void Issue1127<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            System.Exception ex = Record.Exception(
+            Exception ex = Record.Exception(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
@@ -351,7 +366,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void Issue1047<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            System.Exception ex = Record.Exception(
+            Exception ex = Record.Exception(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
@@ -372,7 +387,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void Issue1765<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            System.Exception ex = Record.Exception(
+            Exception ex = Record.Exception(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
@@ -388,7 +403,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void Issue410_MalformedApplePng<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            System.Exception ex = Record.Exception(
+            Exception ex = Record.Exception(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -302,11 +302,10 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         public void Decode_InvalidDataChunkCrc_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            Exception ex = Record.Exception(
+            InvalidImageContentException ex = Assert.Throws<InvalidImageContentException>(
                 () =>
                 {
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
-                    image.DebugSave(provider);
                 });
             Assert.NotNull(ex);
             Assert.Contains("CRC Error. PNG IDAT chunk is corrupt!", ex.Message);

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -120,6 +120,7 @@ namespace SixLabors.ImageSharp.Tests
             public static class Bad
             {
                 public const string MissingDataChunk = "Png/xdtn0g01.png";
+                public const string WrongCrcDataChunk = "Png/xcsn0g01.png";
                 public const string CorruptedChunk = "Png/big-corrupted-chunk.png";
 
                 // Zlib errors.

--- a/tests/Images/Input/Png/xcsn0g01.png
+++ b/tests/Images/Input/Png/xcsn0g01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71e4b2826f61556eda39f3a93c8769b14d3ac90f135177b9373061199dbef39a
+size 164


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR changes the PNG decoder to verify that the CRC of IDAT chunk is correct.