### PR TITLE
Jpeg sampling factor validation #1894

### DIFF
--- a/src/ImageSharp/Common/Helpers/Numerics.cs
+++ b/src/ImageSharp/Common/Helpers/Numerics.cs
@@ -963,5 +963,14 @@ namespace SixLabors.ImageSharp
         public static uint RotateRightSoftwareFallback(uint value, int offset)
             => (value >> offset) | (value << (32 - offset));
 #endif
+
+        /// <summary>
+        /// Tells whether input value is outside of the given range.
+        /// </summary>
+        /// <param name="value">Value.</param>
+        /// <param name="min">Mininum value, inclusive.</param>
+        /// <param name="max">Maximum value, inclusive.</param>
+        public static bool IsOutOfRange(int value, int min, int max)
+            => (uint)(value - min) > (uint)(max - min);
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponent.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegComponent.cs
@@ -19,20 +19,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             this.Frame = frame;
             this.Id = id;
 
-            // Validate sampling factors.
-            if (horizontalFactor == 0 || verticalFactor == 0)
-            {
-                JpegThrowHelper.ThrowBadSampling();
-            }
-
             this.HorizontalSamplingFactor = horizontalFactor;
             this.VerticalSamplingFactor = verticalFactor;
             this.SamplingFactors = new Size(this.HorizontalSamplingFactor, this.VerticalSamplingFactor);
-
-            if (quantizationTableIndex > 3)
-            {
-                JpegThrowHelper.ThrowBadQuantizationTableIndex(quantizationTableIndex);
-            }
 
             this.QuantizationTableIndex = quantizationTableIndex;
             this.Index = index;

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -1033,13 +1033,13 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 // Validate: 1-4 range
                 if (h is < 1 or > 4)
                 {
-                    JpegThrowHelper.ThrowInvalidImageContentException($"Bad horizontal sampling factor: {h}");
+                    JpegThrowHelper.ThrowBadSampling(h);
                 }
 
                 // Validate: 1-4 range
                 if (v is < 1 or > 4)
                 {
-                    JpegThrowHelper.ThrowInvalidImageContentException($"Bad vertical sampling factor: {v}");
+                    JpegThrowHelper.ThrowBadSampling(v);
                 }
 
                 if (maxH < h)

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -1031,13 +1031,13 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 int v = hv & 15;
 
                 // Validate: 1-4 range
-                if (h is < 1 or > 4)
+                if (Numerics.IsOutOfRange(h, 1, 4))
                 {
                     JpegThrowHelper.ThrowBadSampling(h);
                 }
 
                 // Validate: 1-4 range
-                if (v is < 1 or > 4)
+                if (Numerics.IsOutOfRange(v, 1, 4))
                 {
                     JpegThrowHelper.ThrowBadSampling(v);
                 }

--- a/src/ImageSharp/Formats/Jpeg/JpegThrowHelper.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegThrowHelper.cs
@@ -22,23 +22,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowInvalidImageContentException(string errorMessage) => throw new InvalidImageContentException(errorMessage);
 
-        /// <summary>
-        /// Cold path optimization for throwing <see cref="InvalidImageContentException"/>'s.
-        /// </summary>
-        /// <param name="errorMessage">The error message for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference
-        /// if no inner exception is specified.</param>
-        [MethodImpl(InliningOptions.ColdPath)]
-        public static void ThrowInvalidImageContentException(string errorMessage, Exception innerException) => throw new InvalidImageContentException(errorMessage, innerException);
-
-        /// <summary>
-        /// Cold path optimization for throwing <see cref="NotImplementedException"/>'s
-        /// </summary>
-        /// <param name="errorMessage">The error message for the exception.</param>
-        [MethodImpl(InliningOptions.ColdPath)]
-        public static void ThrowNotImplementedException(string errorMessage)
-            => throw new NotImplementedException(errorMessage);
-
         [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowBadMarker(string marker, int length) => throw new InvalidImageContentException($"Marker {marker} has bad length {length}.");
 
@@ -50,6 +33,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
 
         [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowBadSampling() => throw new InvalidImageContentException("Bad sampling factor.");
+
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowBadSampling(int factor) => throw new InvalidImageContentException($"Bad sampling factor: {factor}");
 
         [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowBadProgressiveScan(int ss, int se, int ah, int al) => throw new InvalidImageContentException($"Invalid progressive parameters Ss={ss} Se={se} Ah={ah} Al={al}.");

--- a/tests/ImageSharp.Tests/Common/NumericsTests.cs
+++ b/tests/ImageSharp.Tests/Common/NumericsTests.cs
@@ -16,6 +16,8 @@ namespace SixLabors.ImageSharp.Tests.Common
             this.Output = output;
         }
 
+        public static TheoryData<int> IsOutOfRangeTestData = new() { int.MinValue, -1, 0, 1, 6, 7, 8, 91, 92, 93, int.MaxValue };
+
         private static int Log2_ReferenceImplementation(uint value)
         {
             int n = 0;
@@ -101,21 +103,16 @@ namespace SixLabors.ImageSharp.Tests.Common
         private static bool IsOutOfRange_ReferenceImplementation(int value, int min, int max) => value < min || value > max;
 
         [Theory]
-        [InlineData(1, 100)]
-        public void IsOutOfRange(int seed, int count)
+        [MemberData(nameof(IsOutOfRangeTestData))]
+        public void IsOutOfRange(int value)
         {
-            var rng = new Random(seed);
-            for (int i = 0; i < count; i++)
-            {
-                int value = rng.Next();
-                int min = rng.Next();
-                int max = rng.Next(min, int.MaxValue);
+            const int min = 7;
+            const int max = 92;
 
-                bool expected = IsOutOfRange_ReferenceImplementation(value, min, max);
-                bool actual = Numerics.IsOutOfRange(value, min, max);
+            bool expected = IsOutOfRange_ReferenceImplementation(value, min, max);
+            bool actual = Numerics.IsOutOfRange(value, min, max);
 
-                Assert.True(expected == actual, $"IsOutOfRange({value}, {min}, {max})");
-            }
+            Assert.True(expected == actual, $"IsOutOfRange({value}, {min}, {max})");
         }
     }
 }

--- a/tests/ImageSharp.Tests/Common/NumericsTests.cs
+++ b/tests/ImageSharp.Tests/Common/NumericsTests.cs
@@ -97,5 +97,25 @@ namespace SixLabors.ImageSharp.Tests.Common
                 Assert.True(expected == actual, $"Expected: {expected}\nActual: {actual}\n{value} / {divisor} = {expected}");
             }
         }
+
+        private static bool IsOutOfRange_ReferenceImplementation(int value, int min, int max) => value < min || value > max;
+
+        [Theory]
+        [InlineData(1, 100)]
+        public void IsOutOfRange(int seed, int count)
+        {
+            var rng = new Random(seed);
+            for (int i = 0; i < count; i++)
+            {
+                int value = rng.Next();
+                int min = rng.Next();
+                int max = rng.Next(min, int.MaxValue);
+
+                bool expected = IsOutOfRange_ReferenceImplementation(value, min, max);
+                bool actual = Numerics.IsOutOfRange(value, min, max);
+
+                Assert.True(expected == actual, $"IsOutOfRange({value}, {min}, {max})");
+            }
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
@@ -40,9 +40,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 // LibJpeg can open this despite incorrect colorspace metadata.
                 TestImages.Jpeg.Issues.IncorrectColorspace855,
 
-                // LibJpeg can open this despite the invalid subsampling units.
-                TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException824C,
-
                 // High depth images
                 TestImages.Jpeg.Baseline.Testorig12bit,
             };
@@ -90,7 +87,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             TestImages.Jpeg.Issues.Fuzz.AccessViolationException827,
             TestImages.Jpeg.Issues.Fuzz.ExecutionEngineException839,
             TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException1693A,
-            TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException1693B
+            TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException1693B,
+            TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException824C,
         };
 
         private static readonly Dictionary<string, float> CustomToleranceValues =


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #1894. Moved mentioned image from decoder tests to 'throws exception' tests.