### PR TITLE
Add AVX2 version of GetResidualCost and SSE2 version of SetCoeffs

### DIFF
--- a/tests/ImageSharp.Tests/Formats/WebP/Vp8ResidualTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/Vp8ResidualTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Formats.Webp.Lossy;
+using SixLabors.ImageSharp.Tests.TestUtilities;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.WebP
+{
+    [Trait("Format", "Webp")]
+    public class Vp8ResidualTests
+    {
+        private static void RunSetCoeffsTest()
+        {
+            // arrange
+            var residual = new Vp8Residual();
+            short[] coeffs = { 110, 0, -2, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0 };
+
+            // act
+            residual.SetCoeffs(coeffs);
+
+            // assert
+            Assert.Equal(9, residual.Last);
+        }
+
+        [Fact]
+        public void RunSetCoeffsTest_Works() => RunSetCoeffsTest();
+
+#if SUPPORTS_RUNTIME_INTRINSICS
+        [Fact]
+        public void RunSetCoeffsTest_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunSetCoeffsTest, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void RunSetCoeffsTest_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunSetCoeffsTest, HwIntrinsics.DisableHWIntrinsic);
+#endif
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 using Xunit;
 using static SixLabors.ImageSharp.Tests.TestImages.Webp;
@@ -14,6 +15,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
     [Trait("Format", "Webp")]
     public class WebpEncoderTests
     {
+        private static string TestImageLossyFullPath => Path.Combine(TestEnvironment.InputImagesDirectoryFullPath, Lossy.NoFilter06);
+
         [Theory]
         [WithFile(Flag, PixelTypes.Rgba32, WebpFileFormatType.Lossless)] // if its not a webp input image, it should default to lossless.
         [WithFile(Lossless.NoTransform1, PixelTypes.Rgba32, WebpFileFormatType.Lossless)]
@@ -287,6 +290,23 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
             var encoder = new WebpEncoder() { FileFormat = WebpFileFormatType.Lossy };
             image.VerifyEncoder(provider, "webp", string.Empty, encoder, ImageComparer.Tolerant(0.04f));
         }
+
+        public static void RunEncodeLossy_WithPeakImage()
+        {
+            var provider = TestImageProvider<Rgba32>.File(TestImageLossyFullPath);
+            using Image<Rgba32> image = provider.GetImage();
+
+            var encoder = new WebpEncoder() { FileFormat = WebpFileFormatType.Lossy };
+            image.VerifyEncoder(provider, "webp", string.Empty, encoder, ImageComparer.Tolerant(0.04f));
+        }
+
+#if SUPPORTS_RUNTIME_INTRINSICS
+        [Fact]
+        public void RunEncodeLossy_WithPeakImage_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunEncodeLossy_WithPeakImage, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void RunEncodeLossy_WithPeakImage_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunEncodeLossy_WithPeakImage, HwIntrinsics.DisableHWIntrinsic);
+#endif
 
         private static ImageComparer GetComparer(int quality)
         {


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

This PR adds a AVX2 version of  `GetResidualCost` and SSE2 version of `SetCoeffs`, which is used during webp lossy encoding.

Related to #1786

Profiling results:

### master

![GetResidualCosts](https://user-images.githubusercontent.com/38701097/146780418-37a84ee2-d1c5-4b3d-b758-3aad0cdac967.png)

![SetCoeffs](https://user-images.githubusercontent.com/38701097/146780458-ae941300-fe02-4a77-8bcd-13c762790aab.png)


### PR

![GetResidualCostsAvx](https://user-images.githubusercontent.com/38701097/146780477-b356b219-6c50-4f69-bf38-42404a44ef23.png)

![SetCoeffsSse2](https://user-images.githubusercontent.com/38701097/146780490-73c44565-0a59-4ad3-a713-e95605d4f8b2.png)

The performance gain from `GetResidualCost` is a bit underwhelming, but its not nothing either.

