### PR TITLE
Expose ImageFrame<TPixel>.PixelBuffer

### DIFF
--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -145,13 +145,8 @@ namespace SixLabors.ImageSharp
             source.PixelBuffer.FastMemoryGroup.CopyTo(this.PixelBuffer.FastMemoryGroup);
         }
 
-        /// <summary>
-        /// Gets the image pixels. Not private as Buffer2D requires an array in its constructor.
-        /// </summary>
-        internal Buffer2D<TPixel> PixelBuffer { get; private set; }
-
         /// <inheritdoc/>
-        Buffer2D<TPixel> IPixelSource<TPixel>.PixelBuffer => this.PixelBuffer;
+        public Buffer2D<TPixel> PixelBuffer { get; private set; }
 
         /// <summary>
         /// Gets or sets the pixel at the specified position.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
We need to expose this property to allow migrating the ImageSharp.Drawing brush API to the latest ImageSharp v2 versions without runtime error.

<!-- Thanks for contributing to ImageSharp! -->
