### PR TITLE
Fixed Jpeg IDCT missing scalar implementation

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/FastFloatingPointDCT.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/FastFloatingPointDCT.cs
@@ -146,11 +146,13 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
         /// <summary>
         /// Apply floating point IDCT inplace using <see cref="Vector4"/> API.
         /// </summary>
+        /// <remarks>
+        /// This method can be used even if there's no SIMD intrinsics available
+        /// as <see cref="Vector4"/> can be compiled to scalar instructions.
+        /// </remarks>
         /// <param name="transposedBlock">Input block.</param>
         private static void IDCT_Vector4(ref Block8x8F transposedBlock)
         {
-            DebugGuard.IsTrue(Vector.IsHardwareAccelerated, "Scalar implementation should be called for non-accelerated hardware.");
-
             // First pass - process columns
             IDCT8x4_Vector4(ref transposedBlock.V0L);
             IDCT8x4_Vector4(ref transposedBlock.V0R);

--- a/tests/ImageSharp.Tests/Formats/Jpg/DCTTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/DCTTests.cs
@@ -197,8 +197,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 // 4 paths:
                 // 1. AllowAll - call avx/fma implementation
                 // 2. DisableFMA - call avx without fma implementation
-                // 3. DisableAvx - call sse implementation
-                // 4. DisableSIMD - call Vector4 fallback implementation
+                // 3. DisableAvx - call Vector4 implementation
+                // 4. DisableSIMD - call scalar fallback implementation
                 FeatureTestRunner.RunWithHwIntrinsicsFeature(
                     RunTest,
                     seed,

--- a/tests/ImageSharp.Tests/Formats/Jpg/DCTTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/DCTTests.cs
@@ -149,12 +149,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 // 4 paths:
                 // 1. AllowAll - call avx/fma implementation
                 // 2. DisableFMA - call avx without fma implementation
-                // 3. DisableAvx - call sse Vector4 implementation
-                // 4. DisableHWIntrinsic - call scalar fallback implementation
+                // 3. DisableAvx - call sse implementation
+                // 4. DisableSIMD - call Vector4 fallback implementation
                 FeatureTestRunner.RunWithHwIntrinsicsFeature(
                     RunTest,
                     seed,
-                    HwIntrinsics.AllowAll | HwIntrinsics.DisableFMA | HwIntrinsics.DisableAVX | HwIntrinsics.DisableHWIntrinsic);
+                    HwIntrinsics.AllowAll | HwIntrinsics.DisableFMA | HwIntrinsics.DisableAVX | HwIntrinsics.DisableSIMD);
             }
 
             // Forward transform
@@ -197,12 +197,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 // 4 paths:
                 // 1. AllowAll - call avx/fma implementation
                 // 2. DisableFMA - call avx without fma implementation
-                // 3. DisableAvx - call sse Vector4 implementation
-                // 4. DisableHWIntrinsic - call scalar fallback implementation
+                // 3. DisableAvx - call sse implementation
+                // 4. DisableSIMD - call Vector4 fallback implementation
                 FeatureTestRunner.RunWithHwIntrinsicsFeature(
                     RunTest,
                     seed,
-                    HwIntrinsics.AllowAll | HwIntrinsics.DisableFMA | HwIntrinsics.DisableAVX | HwIntrinsics.DisableHWIntrinsic);
+                    HwIntrinsics.AllowAll | HwIntrinsics.DisableFMA | HwIntrinsics.DisableAVX | HwIntrinsics.DisableSIMD);
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #1917.

Fix is simple: I've removed `Debug` check for `Vector4.IsHardwareAccelerated` as `Vector4` code can be compiled to a scalar implementation. That check was deprecated long ago - when I've merged de-zigzag and single transpose call so now every IDCT implementation must do a single transpose call.

FDCT method does have a scalar implementation right now because current encoding pipeline does not have a merged zig-zag/transpose code. I'm yet to implement it in #1778 (coding those sse/avx zigzag tables is a horror). Because of two transpose calls scalar code can do DCT stuff a little trickier than simd without transpose calls at all but with a tranposed block input we must transpose it second time durint IDCT call.