### PR TITLE
Jpeg ArgumentException fix

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -472,7 +472,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     : JpegColorSpace.Cmyk;
             }
 
-            JpegThrowHelper.ThrowInvalidImageContentException($"Unsupported color mode. Supported component counts 1, 3, and 4; found {componentCount}");
+            JpegThrowHelper.ThrowNotSupportedComponentCount(componentCount);
             return default;
         }
 
@@ -997,6 +997,14 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
 
             // 1 byte: Number of components
             byte componentCount = this.temp[5];
+
+            // Validate: componentCount more than 4 can lead to a buffer overflow during stream
+            // reading so we must limit it to 4
+            // We do not support jpeg images with more than 4 components anyway
+            if (componentCount > 4)
+            {
+                JpegThrowHelper.ThrowNotSupportedComponentCount(componentCount);
+            }
 
             this.Frame = new JpegFrame(frameMarker, precision, frameWidth, frameHeight, componentCount);
 

--- a/src/ImageSharp/Formats/Jpeg/JpegThrowHelper.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegThrowHelper.cs
@@ -45,5 +45,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
 
         [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowDimensionsTooLarge(int width, int height) => throw new ImageFormatException($"Image is too large to encode at {width}x{height} for JPEG format.");
+
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowNotSupportedComponentCount(int componentCount) => throw new NotSupportedException($"Images with {componentCount} components are not supported.");
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
@@ -10,58 +10,72 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
     public partial class JpegDecoderTests
     {
         public static string[] BaselineTestJpegs =
-            {
-                TestImages.Jpeg.Baseline.Calliphora,
-                TestImages.Jpeg.Baseline.Cmyk,
-                TestImages.Jpeg.Baseline.Ycck,
-                TestImages.Jpeg.Baseline.Jpeg400,
-                TestImages.Jpeg.Baseline.Turtle420,
-                TestImages.Jpeg.Baseline.Testorig420,
-                TestImages.Jpeg.Baseline.Jpeg420Small,
-                TestImages.Jpeg.Issues.Fuzz.AccessViolationException922,
-                TestImages.Jpeg.Baseline.Jpeg444,
-                TestImages.Jpeg.Baseline.Jpeg422,
-                TestImages.Jpeg.Baseline.Bad.BadEOF,
-                TestImages.Jpeg.Baseline.MultiScanBaselineCMYK,
-                TestImages.Jpeg.Baseline.YcckSubsample1222,
-                TestImages.Jpeg.Baseline.Bad.BadRST,
-                TestImages.Jpeg.Issues.MultiHuffmanBaseline394,
-                TestImages.Jpeg.Issues.ExifDecodeOutOfRange694,
-                TestImages.Jpeg.Issues.InvalidEOI695,
-                TestImages.Jpeg.Issues.ExifResizeOutOfRange696,
-                TestImages.Jpeg.Issues.InvalidAPP0721,
-                TestImages.Jpeg.Issues.ExifGetString750Load,
-                TestImages.Jpeg.Issues.ExifGetString750Transform,
-                TestImages.Jpeg.Issues.BadSubSampling1076,
+        {
+            TestImages.Jpeg.Baseline.Calliphora,
+            TestImages.Jpeg.Baseline.Cmyk,
+            TestImages.Jpeg.Baseline.Ycck,
+            TestImages.Jpeg.Baseline.Jpeg400,
+            TestImages.Jpeg.Baseline.Turtle420,
+            TestImages.Jpeg.Baseline.Testorig420,
+            TestImages.Jpeg.Baseline.Jpeg420Small,
+            TestImages.Jpeg.Issues.Fuzz.AccessViolationException922,
+            TestImages.Jpeg.Baseline.Jpeg444,
+            TestImages.Jpeg.Baseline.Jpeg422,
+            TestImages.Jpeg.Baseline.Bad.BadEOF,
+            TestImages.Jpeg.Baseline.MultiScanBaselineCMYK,
+            TestImages.Jpeg.Baseline.YcckSubsample1222,
+            TestImages.Jpeg.Baseline.Bad.BadRST,
+            TestImages.Jpeg.Issues.MultiHuffmanBaseline394,
+            TestImages.Jpeg.Issues.ExifDecodeOutOfRange694,
+            TestImages.Jpeg.Issues.InvalidEOI695,
+            TestImages.Jpeg.Issues.ExifResizeOutOfRange696,
+            TestImages.Jpeg.Issues.InvalidAPP0721,
+            TestImages.Jpeg.Issues.ExifGetString750Load,
+            TestImages.Jpeg.Issues.ExifGetString750Transform,
+            TestImages.Jpeg.Issues.BadSubSampling1076,
 
-                // LibJpeg can open this despite the invalid density units.
-                TestImages.Jpeg.Issues.Fuzz.ArgumentOutOfRangeException825B,
+            // LibJpeg can open this despite the invalid density units.
+            TestImages.Jpeg.Issues.Fuzz.ArgumentOutOfRangeException825B,
 
-                // LibJpeg can open this despite incorrect colorspace metadata.
-                TestImages.Jpeg.Issues.IncorrectColorspace855,
+            // LibJpeg can open this despite incorrect colorspace metadata.
+            TestImages.Jpeg.Issues.IncorrectColorspace855,
 
-                // High depth images
-                TestImages.Jpeg.Baseline.Testorig12bit,
-            };
+            // High depth images
+            TestImages.Jpeg.Baseline.Testorig12bit,
+        };
 
         public static string[] ProgressiveTestJpegs =
-            {
-                TestImages.Jpeg.Progressive.Fb,
-                TestImages.Jpeg.Progressive.Progress,
-                TestImages.Jpeg.Progressive.Festzug,
-                TestImages.Jpeg.Progressive.Bad.BadEOF,
-                TestImages.Jpeg.Issues.BadCoeffsProgressive178,
-                TestImages.Jpeg.Issues.MissingFF00ProgressiveGirl159,
-                TestImages.Jpeg.Issues.MissingFF00ProgressiveBedroom159,
-                TestImages.Jpeg.Issues.BadZigZagProgressive385,
-                TestImages.Jpeg.Progressive.Bad.ExifUndefType,
-                TestImages.Jpeg.Issues.NoEoiProgressive517,
-                TestImages.Jpeg.Issues.BadRstProgressive518,
-                TestImages.Jpeg.Issues.DhtHasWrongLength624,
-                TestImages.Jpeg.Issues.OrderedInterleavedProgressive723A,
-                TestImages.Jpeg.Issues.OrderedInterleavedProgressive723B,
-                TestImages.Jpeg.Issues.OrderedInterleavedProgressive723C
-            };
+        {
+            TestImages.Jpeg.Progressive.Fb,
+            TestImages.Jpeg.Progressive.Progress,
+            TestImages.Jpeg.Progressive.Festzug,
+            TestImages.Jpeg.Progressive.Bad.BadEOF,
+            TestImages.Jpeg.Issues.BadCoeffsProgressive178,
+            TestImages.Jpeg.Issues.MissingFF00ProgressiveGirl159,
+            TestImages.Jpeg.Issues.MissingFF00ProgressiveBedroom159,
+            TestImages.Jpeg.Issues.BadZigZagProgressive385,
+            TestImages.Jpeg.Progressive.Bad.ExifUndefType,
+            TestImages.Jpeg.Issues.NoEoiProgressive517,
+            TestImages.Jpeg.Issues.BadRstProgressive518,
+            TestImages.Jpeg.Issues.DhtHasWrongLength624,
+            TestImages.Jpeg.Issues.OrderedInterleavedProgressive723A,
+            TestImages.Jpeg.Issues.OrderedInterleavedProgressive723B,
+            TestImages.Jpeg.Issues.OrderedInterleavedProgressive723C
+        };
+
+        public static string[] UnsupportedTestJpegs =
+        {
+            // Invalid componentCount value (2 or > 4)
+            TestImages.Jpeg.Issues.Fuzz.NullReferenceException823,
+            TestImages.Jpeg.Issues.MalformedUnsupportedComponentCount,
+
+            // Arithmetic coding
+            TestImages.Jpeg.Baseline.ArithmeticCoding,
+            TestImages.Jpeg.Baseline.ArithmeticCodingProgressive,
+
+            // Lossless jpeg
+            TestImages.Jpeg.Baseline.Lossless
+        };
 
         public static string[] UnrecoverableTestJpegs =
         {
@@ -70,7 +84,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             TestImages.Jpeg.Issues.Fuzz.AccessViolationException798,
             TestImages.Jpeg.Issues.Fuzz.DivideByZeroException821,
             TestImages.Jpeg.Issues.Fuzz.DivideByZeroException822,
-            TestImages.Jpeg.Issues.Fuzz.NullReferenceException823,
             TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException824A,
             TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException824B,
             TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException824D,
@@ -91,28 +104,27 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException824C,
         };
 
-        private static readonly Dictionary<string, float> CustomToleranceValues =
-            new Dictionary<string, float>
-            {
-                // Baseline:
-                [TestImages.Jpeg.Baseline.Calliphora] = 0.00002f / 100,
-                [TestImages.Jpeg.Baseline.Bad.BadEOF] = 0.38f / 100,
-                [TestImages.Jpeg.Baseline.Bad.BadRST] = 0.0589f / 100,
+        private static readonly Dictionary<string, float> CustomToleranceValues = new()
+        {
+            // Baseline:
+            [TestImages.Jpeg.Baseline.Calliphora] = 0.00002f / 100,
+            [TestImages.Jpeg.Baseline.Bad.BadEOF] = 0.38f / 100,
+            [TestImages.Jpeg.Baseline.Bad.BadRST] = 0.0589f / 100,
 
-                [TestImages.Jpeg.Baseline.Jpeg422] = 0.0013f / 100,
-                [TestImages.Jpeg.Baseline.Testorig420] = 0.38f / 100,
-                [TestImages.Jpeg.Baseline.Jpeg420Small] = 0.287f / 100,
-                [TestImages.Jpeg.Baseline.Turtle420] = 1.0f / 100,
+            [TestImages.Jpeg.Baseline.Jpeg422] = 0.0013f / 100,
+            [TestImages.Jpeg.Baseline.Testorig420] = 0.38f / 100,
+            [TestImages.Jpeg.Baseline.Jpeg420Small] = 0.287f / 100,
+            [TestImages.Jpeg.Baseline.Turtle420] = 1.0f / 100,
 
-                // Progressive:
-                [TestImages.Jpeg.Issues.MissingFF00ProgressiveGirl159] = 0.34f / 100,
-                [TestImages.Jpeg.Issues.BadCoeffsProgressive178] = 0.38f / 100,
-                [TestImages.Jpeg.Progressive.Bad.BadEOF] = 0.3f / 100,
-                [TestImages.Jpeg.Progressive.Festzug] = 0.02f / 100,
-                [TestImages.Jpeg.Progressive.Fb] = 0.16f / 100,
-                [TestImages.Jpeg.Progressive.Progress] = 0.31f / 100,
-                [TestImages.Jpeg.Issues.BadZigZagProgressive385] = 0.23f / 100,
-                [TestImages.Jpeg.Progressive.Bad.ExifUndefType] = 0.011f / 100,
-            };
+            // Progressive:
+            [TestImages.Jpeg.Issues.MissingFF00ProgressiveGirl159] = 0.34f / 100,
+            [TestImages.Jpeg.Issues.BadCoeffsProgressive178] = 0.38f / 100,
+            [TestImages.Jpeg.Progressive.Bad.BadEOF] = 0.3f / 100,
+            [TestImages.Jpeg.Progressive.Festzug] = 0.02f / 100,
+            [TestImages.Jpeg.Progressive.Fb] = 0.16f / 100,
+            [TestImages.Jpeg.Progressive.Progress] = 0.31f / 100,
+            [TestImages.Jpeg.Issues.BadZigZagProgressive385] = 0.23f / 100,
+            [TestImages.Jpeg.Progressive.Bad.ExifUndefType] = 0.011f / 100,
+        };
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -193,6 +193,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [WithFile(TestImages.Jpeg.Baseline.ArithmeticCoding, PixelTypes.Rgba32)]
         [WithFile(TestImages.Jpeg.Baseline.ArithmeticCodingProgressive, PixelTypes.Rgba32)]
         [WithFile(TestImages.Jpeg.Baseline.Lossless, PixelTypes.Rgba32)]
+        [WithFile(TestImages.Jpeg.Issues.MalformedUnsupportedComponentCount, PixelTypes.Rgba32)]
         public void ThrowsNotSupported_WithUnsupportedJpegs<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -190,10 +190,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         }
 
         [Theory]
-        [WithFile(TestImages.Jpeg.Baseline.ArithmeticCoding, PixelTypes.Rgba32)]
-        [WithFile(TestImages.Jpeg.Baseline.ArithmeticCodingProgressive, PixelTypes.Rgba32)]
-        [WithFile(TestImages.Jpeg.Baseline.Lossless, PixelTypes.Rgba32)]
-        [WithFile(TestImages.Jpeg.Issues.MalformedUnsupportedComponentCount, PixelTypes.Rgba32)]
+        [WithFileCollection(nameof(UnsupportedTestJpegs), PixelTypes.Rgba32)]
         public void ThrowsNotSupported_WithUnsupportedJpegs<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -256,6 +256,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string BadSubSampling1076 = "Jpg/issues/issue-1076-invalid-subsampling.jpg";
                 public const string IdentifyMultiFrame1211 = "Jpg/issues/issue-1221-identify-multi-frame.jpg";
                 public const string WrongColorSpace = "Jpg/issues/Issue1732-WrongColorSpace.jpg";
+                public const string MalformedUnsupportedComponentCount = "Jpg/issues/issue-1900-malformed-unsupported-255-components.jpg";
 
                 public static class Fuzz
                 {

--- a/tests/Images/Input/Jpg/issues/issue-1900-malformed-unsupported-255-components.jpg
+++ b/tests/Images/Input/Jpg/issues/issue-1900-malformed-unsupported-255-components.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3553f76b72b98986df13a7508cd073a30b7c846dc441d1d68a518bf7b93bc66
+size 3951


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #1900.

I've actually found another image from fuzz issue which has 131 components and was throwing `InvalidImageContentException`. Moved it to the `NotSupportedException` test suite.
