### PR TITLE
HuffmanTable related code improvements

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
@@ -110,7 +110,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 
             this.remainingBits -= size;
 
-            return h.Values[(h.ValOffset[size] + (int)(x >> (JpegConstants.Huffman.RegisterSize - size))) & 0xFF];
+            // No need to mask this value with 0xFF after shifting because we
+            // are fetching MSB bits, everything else is zeroed out by unsigned
+            // shift operation itself
+            int code = (int)(x >> (JpegConstants.Huffman.RegisterSize - size));
+            return h.Decode(size, code);
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
@@ -110,9 +110,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 
             this.remainingBits -= size;
 
-            // No need to mask this value with 0xFF after shifting because we
-            // are fetching MSB bits, everything else is zeroed out by unsigned
-            // shift operation itself
             int code = (int)(x >> (JpegConstants.Huffman.RegisterSize - size));
             return h.Decode(size, code);
         }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
@@ -167,18 +167,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             int mcusPerLine = this.frame.McusPerLine;
             ref HuffmanScanBuffer buffer = ref this.scanBuffer;
 
-            // Pre-derive the huffman table to avoid in-loop checks.
-            for (int i = 0; i < this.componentsCount; i++)
-            {
-                int order = this.frame.ComponentOrder[i];
-                JpegComponent component = this.components[order];
-
-                ref HuffmanTable dcHuffmanTable = ref this.dcHuffmanTables[component.DCHuffmanTableId];
-                ref HuffmanTable acHuffmanTable = ref this.acHuffmanTables[component.ACHuffmanTableId];
-                dcHuffmanTable.Configure();
-                acHuffmanTable.Configure();
-            }
-
             for (int j = 0; j < mcusPerColumn; j++)
             {
                 this.cancellationToken.ThrowIfCancellationRequested();
@@ -248,8 +236,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 
             ref HuffmanTable dcHuffmanTable = ref this.dcHuffmanTables[component.DCHuffmanTableId];
             ref HuffmanTable acHuffmanTable = ref this.acHuffmanTables[component.ACHuffmanTableId];
-            dcHuffmanTable.Configure();
-            acHuffmanTable.Configure();
 
             for (int j = 0; j < h; j++)
             {
@@ -347,15 +333,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             int mcusPerLine = this.frame.McusPerLine;
             ref HuffmanScanBuffer buffer = ref this.scanBuffer;
 
-            // Pre-derive the huffman table to avoid in-loop checks.
-            for (int k = 0; k < this.componentsCount; k++)
-            {
-                int order = this.frame.ComponentOrder[k];
-                JpegComponent component = this.components[order];
-                ref HuffmanTable dcHuffmanTable = ref this.dcHuffmanTables[component.DCHuffmanTableId];
-                dcHuffmanTable.Configure();
-            }
-
             for (int j = 0; j < mcusPerColumn; j++)
             {
                 for (int i = 0; i < mcusPerLine; i++)
@@ -416,7 +393,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             if (this.SpectralStart == 0)
             {
                 ref HuffmanTable dcHuffmanTable = ref this.dcHuffmanTables[component.DCHuffmanTableId];
-                dcHuffmanTable.Configure();
 
                 for (int j = 0; j < h; j++)
                 {
@@ -444,7 +420,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             else
             {
                 ref HuffmanTable acHuffmanTable = ref this.acHuffmanTables[component.ACHuffmanTableId];
-                acHuffmanTable.Configure();
 
                 for (int j = 0; j < h; j++)
                 {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -13,13 +13,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct HuffmanTable
     {
-        private bool isConfigured;
-
-        /// <summary>
-        /// Derived from the DHT marker. Sizes[k] = # of symbols with codes of length k bits; Sizes[0] is unused.
-        /// </summary>
-        public fixed byte Sizes[17];
-
         /// <summary>
         /// Derived from the DHT marker. Contains the symbols, in order of incremental code length.
         /// </summary>
@@ -62,20 +55,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <param name="values">The huffman values</param>
         public HuffmanTable(ReadOnlySpan<byte> codeLengths, ReadOnlySpan<byte> values)
         {
-            this.isConfigured = false;
-            Unsafe.CopyBlockUnaligned(ref this.Sizes[0], ref MemoryMarshal.GetReference(codeLengths), (uint)codeLengths.Length);
             Unsafe.CopyBlockUnaligned(ref this.Values[0], ref MemoryMarshal.GetReference(values), (uint)values.Length);
-        }
-
-        /// <summary>
-        /// Expands the HuffmanTable into its readable form.
-        /// </summary>
-        public void Configure()
-        {
-            if (this.isConfigured)
-            {
-                return;
-            }
 
             Span<char> huffSize = stackalloc char[257];
             Span<uint> huffCode = stackalloc uint[257];
@@ -84,7 +64,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             int p = 0;
             for (int j = 1; j <= 16; j++)
             {
-                int i = this.Sizes[j];
+                int i = codeLengths[j];
                 while (i-- != 0)
                 {
                     huffSize[p++] = (char)j;
@@ -113,10 +93,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             p = 0;
             for (int j = 1; j <= 16; j++)
             {
-                if (this.Sizes[j] != 0)
+                if (codeLengths[j] != 0)
                 {
                     this.ValOffset[j] = p - (int)huffCode[p];
-                    p += this.Sizes[j];
+                    p += codeLengths[j];
                     this.MaxCode[j] = huffCode[p - 1]; // Maximum code of length l
                     this.MaxCode[j] <<= JpegConstants.Huffman.RegisterSize - j; // Left justify
                     this.MaxCode[j] |= (1ul << (JpegConstants.Huffman.RegisterSize - j)) - 1;
@@ -142,7 +122,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             for (int length = 1; length <= JpegConstants.Huffman.LookupBits; length++)
             {
                 int jShift = JpegConstants.Huffman.LookupBits - length;
-                for (int i = 1; i <= this.Sizes[length]; i++, p++)
+                for (int i = 1; i <= codeLengths[length]; i++, p++)
                 {
                     // length = current code's length, p = its index in huffCode[] & Values[].
                     // Generate left-justified code followed by all possible bit sequences
@@ -155,8 +135,14 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
                     }
                 }
             }
+        }
 
-            this.isConfigured = true;
+        /// <summary>
+        /// Expands the HuffmanTable into its readable form.
+        /// </summary>
+        public void Configure()
+        {
+
         }
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -136,13 +136,5 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
                 }
             }
         }
-
-        /// <summary>
-        /// Expands the HuffmanTable into its readable form.
-        /// </summary>
-        public void Configure()
-        {
-
-        }
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -14,20 +14,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
     internal unsafe struct HuffmanTable
     {
         /// <summary>
-        /// Derived from the DHT marker. Sizes[k] = # of symbols with codes of length k bits; Sizes[0] is unused.
-        /// </summary>
-        public fixed byte Sizes[17];
-
-        /// <summary>
         /// Derived from the DHT marker. Contains the symbols, in order of incremental code length.
         /// </summary>
         private fixed byte values[256];
-
-        /// <summary>
-        /// Contains the largest code of length k (0 if none). MaxCode[17] is a sentinel to
-        /// ensure <see cref="HuffmanScanBuffer.DecodeHuffman"/> terminates.
-        /// </summary>
-        public fixed ulong MaxCode[18];
 
         /// <summary>
         /// Values[] offset for codes of length k  ValOffset[k] = Values[] index of 1st symbol of code length
@@ -35,6 +24,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// Values[code + ValOffset[k]].
         /// </summary>
         private fixed int valOffset[19];
+
+        /// <summary>
+        /// Contains the largest code of length k (0 if none). MaxCode[17] is a sentinel to
+        /// ensure <see cref="HuffmanScanBuffer.DecodeHuffman"/> terminates.
+        /// </summary>
+        public fixed ulong MaxCode[18];
 
         /// <summary>
         /// Contains the length of bits for the given k value.
@@ -60,7 +55,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <param name="values">The huffman values</param>
         public HuffmanTable(ReadOnlySpan<byte> codeLengths, ReadOnlySpan<byte> values)
         {
-            Unsafe.CopyBlockUnaligned(ref this.Sizes[0], ref MemoryMarshal.GetReference(codeLengths), (uint)codeLengths.Length);
             Unsafe.CopyBlockUnaligned(ref this.values[0], ref MemoryMarshal.GetReference(values), (uint)values.Length);
 
             Span<char> huffSize = stackalloc char[257];
@@ -70,7 +64,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             int p = 0;
             for (int j = 1; j <= 16; j++)
             {
-                int i = this.Sizes[j];
+                int i = codeLengths[j];
                 while (i-- != 0)
                 {
                     huffSize[p++] = (char)j;
@@ -99,10 +93,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             p = 0;
             for (int j = 1; j <= 16; j++)
             {
-                if (this.Sizes[j] != 0)
+                if (codeLengths[j] != 0)
                 {
                     this.valOffset[j] = p - (int)huffCode[p];
-                    p += this.Sizes[j];
+                    p += codeLengths[j];
                     this.MaxCode[j] = huffCode[p - 1]; // Maximum code of length l
                     this.MaxCode[j] <<= JpegConstants.Huffman.RegisterSize - j; // Left justify
                     this.MaxCode[j] |= (1ul << (JpegConstants.Huffman.RegisterSize - j)) - 1;
@@ -128,7 +122,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             for (int length = 1; length <= JpegConstants.Huffman.LookupBits; length++)
             {
                 int jShift = JpegConstants.Huffman.LookupBits - length;
-                for (int i = 1; i <= this.Sizes[length]; i++, p++)
+                for (int i = 1; i <= codeLengths[length]; i++, p++)
                 {
                     // length = current code's length, p = its index in huffCode[] & Values[].
                     // Generate left-justified code followed by all possible bit sequences

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -144,6 +144,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         }
 
         [MethodImpl(InliningOptions.AlwaysInline)]
-        public byte Decode(int size, int code) => this.values[this.valOffset[size] + code];
+        public byte Decode(int size, int code) => this.values[(this.valOffset[size] + code) & 0xFF];
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Main purpose of this PR is to reduce huffman-table-related code: previously huffman tables were built only on request from each component which led some redundant checks and extra code in the binary decoder. Now tables are build in the ctor.

I've also marked some `HuffmanTable` field private, it doesn't really add anything except code readability (imo) but it felt like a right thing to do considering those fields are unsafe raw pointers.

Updated code does contain a little bit of optimizations. There's less empty calls on each scan parsing routine but you know, there's not so many scans per image :P