### PR TITLE
Jpeg HuffmanTable improvements

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
@@ -728,10 +728,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <param name="codeLengths">Code lengths.</param>
         /// <param name="values">Code values.</param>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public void BuildHuffmanTable(int type, int index, ReadOnlySpan<byte> codeLengths, ReadOnlySpan<byte> values)
+        public void BuildHuffmanTable(int type, int index, ReadOnlySpan<byte> codeLengths, ReadOnlySpan<byte> values, Span<uint> workspace)
         {
             HuffmanTable[] tables = type == 0 ? this.dcHuffmanTables : this.acHuffmanTables;
-            tables[index] = new HuffmanTable(codeLengths, values);
+            tables[index] = new HuffmanTable(codeLengths, values, workspace);
         }
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
@@ -167,18 +167,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             int mcusPerLine = this.frame.McusPerLine;
             ref HuffmanScanBuffer buffer = ref this.scanBuffer;
 
-            // Pre-derive the huffman table to avoid in-loop checks.
-            for (int i = 0; i < this.componentsCount; i++)
-            {
-                int order = this.frame.ComponentOrder[i];
-                JpegComponent component = this.components[order];
-
-                ref HuffmanTable dcHuffmanTable = ref this.dcHuffmanTables[component.DCHuffmanTableId];
-                ref HuffmanTable acHuffmanTable = ref this.acHuffmanTables[component.ACHuffmanTableId];
-                dcHuffmanTable.Configure();
-                acHuffmanTable.Configure();
-            }
-
             for (int j = 0; j < mcusPerColumn; j++)
             {
                 this.cancellationToken.ThrowIfCancellationRequested();
@@ -248,8 +236,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 
             ref HuffmanTable dcHuffmanTable = ref this.dcHuffmanTables[component.DCHuffmanTableId];
             ref HuffmanTable acHuffmanTable = ref this.acHuffmanTables[component.ACHuffmanTableId];
-            dcHuffmanTable.Configure();
-            acHuffmanTable.Configure();
 
             for (int j = 0; j < h; j++)
             {
@@ -347,15 +333,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             int mcusPerLine = this.frame.McusPerLine;
             ref HuffmanScanBuffer buffer = ref this.scanBuffer;
 
-            // Pre-derive the huffman table to avoid in-loop checks.
-            for (int k = 0; k < this.componentsCount; k++)
-            {
-                int order = this.frame.ComponentOrder[k];
-                JpegComponent component = this.components[order];
-                ref HuffmanTable dcHuffmanTable = ref this.dcHuffmanTables[component.DCHuffmanTableId];
-                dcHuffmanTable.Configure();
-            }
-
             for (int j = 0; j < mcusPerColumn; j++)
             {
                 for (int i = 0; i < mcusPerLine; i++)
@@ -416,7 +393,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             if (this.SpectralStart == 0)
             {
                 ref HuffmanTable dcHuffmanTable = ref this.dcHuffmanTables[component.DCHuffmanTableId];
-                dcHuffmanTable.Configure();
 
                 for (int j = 0; j < h; j++)
                 {
@@ -444,7 +420,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             else
             {
                 ref HuffmanTable acHuffmanTable = ref this.acHuffmanTables[component.ACHuffmanTableId];
-                acHuffmanTable.Configure();
 
                 for (int j = 0; j < h; j++)
                 {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
@@ -727,6 +727,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <param name="index">Table index.</param>
         /// <param name="codeLengths">Code lengths.</param>
         /// <param name="values">Code values.</param>
+        /// <param name="workspace">The provided spare workspace memory, can be dirty.</param>
         [MethodImpl(InliningOptions.ShortMethod)]
         public void BuildHuffmanTable(int type, int index, ReadOnlySpan<byte> codeLengths, ReadOnlySpan<byte> values, Span<uint> workspace)
         {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -57,27 +57,16 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         {
             Unsafe.CopyBlockUnaligned(ref this.Values[0], ref MemoryMarshal.GetReference(values), (uint)values.Length);
 
-            Span<byte> huffSize = stackalloc byte[257];
             Span<uint> huffCode = stackalloc uint[257];
 
-            // Figure C.1: make table of Huffman code length for each symbol
-            int p = 0;
-            for (int j = 1; j <= 16; j++)
-            {
-                int count = codeLengths[j];
-                huffSize.Slice(p, count).Fill((byte)j);
-                p += count;
-            }
-
-            huffSize[p] = 0;
-
-            // Figure C.2: generate the codes themselves
+            // Generate codes
             uint code = 0;
-            int si = huffSize[0];
-            p = 0;
-            while (huffSize[p] != 0)
+            int si = 1;
+            int p = 0;
+            for (int i = 1; i <= 16; i++)
             {
-                while (huffSize[p] == si)
+                int count = codeLengths[i];
+                for (int j = 0; j < count; j++)
                 {
                     huffCode[p++] = code;
                     code++;

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -94,6 +94,17 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
                         code++;
                     }
 
+                    // 'code' is now 1 more than the last code used for codelength 'si'
+                    // in the valid worst possible case 'code' would have the least
+                    // significant bit set to 1, e.g. 1111(0) +1 => 1111(1)
+                    // but it must still fit in 'si' bits since no huffman code can be equal to all 1s
+                    // if last code is all ones, e.g. 1111(1), then incrementing it by 1 would yield
+                    // a new code which occupies one extra bit, e.g. 1111(1) +1 => (1)1111(0)
+                    if (code >= (1 << si))
+                    {
+                        JpegThrowHelper.ThrowInvalidImageContentException("Bad huffman table.");
+                    }
+
                     code <<= 1;
                     si++;
                 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -14,6 +14,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
     internal unsafe struct HuffmanTable
     {
         /// <summary>
+        /// Memory workspace buffer size used in <see cref="HuffmanTable"/> ctor.
+        /// </summary>
+        public const int WorkspaceByteSize = 256 * sizeof(uint);
+
+        /// <summary>
         /// Derived from the DHT marker. Contains the symbols, in order of incremental code length.
         /// </summary>
         public fixed byte Values[256];

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -58,7 +58,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             Unsafe.CopyBlockUnaligned(ref this.Values[0], ref MemoryMarshal.GetReference(values), (uint)values.Length);
 
             // TODO: testing code
-            Span<char> huffSize = stackalloc char[257];
+            Span<byte> huffSize = stackalloc byte[257];
             Span<uint> huffCode = stackalloc uint[257];
 
             // Figure C.1: make table of Huffman code length for each symbol
@@ -68,11 +68,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
                 int i = codeLengths[j];
                 while (i-- != 0)
                 {
-                    huffSize[p++] = (char)j;
+                    huffSize[p++] = (byte)j;
                 }
             }
 
-            huffSize[p] = (char)0;
+            huffSize[p] = 0;
 
             // Figure C.2: generate the codes themselves
             uint code = 0;

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -51,13 +51,14 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         /// <summary>
         /// Initializes a new instance of the <see cref="HuffmanTable"/> struct.
         /// </summary>
-        /// <param name="codeLengths">The code lengths</param>
-        /// <param name="values">The huffman values</param>
-        public HuffmanTable(ReadOnlySpan<byte> codeLengths, ReadOnlySpan<byte> values)
+        /// <param name="codeLengths">The code lengths.</param>
+        /// <param name="values">The huffman values.</param>
+        /// <param name="workspace">The spare workspace memory, must be provided by the caller.</param>
+        public HuffmanTable(ReadOnlySpan<byte> codeLengths, ReadOnlySpan<byte> values, Span<uint> workspace)
         {
             Unsafe.CopyBlockUnaligned(ref this.Values[0], ref MemoryMarshal.GetReference(values), (uint)values.Length);
 
-            Span<uint> huffCode = stackalloc uint[257];
+            Span<uint> huffCode = workspace;
 
             // Generate codes
             uint code = 0;

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -57,7 +57,6 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         {
             Unsafe.CopyBlockUnaligned(ref this.Values[0], ref MemoryMarshal.GetReference(values), (uint)values.Length);
 
-            // TODO: testing code
             Span<byte> huffSize = stackalloc byte[257];
             Span<uint> huffCode = stackalloc uint[257];
 
@@ -65,11 +64,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             int p = 0;
             for (int j = 1; j <= 16; j++)
             {
-                int i = codeLengths[j];
-                while (i-- != 0)
-                {
-                    huffSize[p++] = (byte)j;
-                }
+                int count = codeLengths[j];
+                huffSize.Slice(p, count).Fill((byte)j);
+                p += count;
             }
 
             huffSize[p] = 0;

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanTable.cs
@@ -57,81 +57,91 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         {
             Unsafe.CopyBlockUnaligned(ref this.Values[0], ref MemoryMarshal.GetReference(values), (uint)values.Length);
 
-            Span<char> huffSize = stackalloc char[257];
-            Span<uint> huffCode = stackalloc uint[257];
+            // TODO: testing code
+            Span<char> huffSize = new char[257];
+            Span<uint> huffCode = new uint[257];
 
-            // Figure C.1: make table of Huffman code length for each symbol
-            int p = 0;
-            for (int j = 1; j <= 16; j++)
+            fixed (void* maxCodePtr = this.MaxCode, valOffsetPtr = this.ValOffset, lookaheadSizePtr = this.LookaheadSize, lookaheadValuePtr = this.LookaheadValue)
             {
-                int i = codeLengths[j];
-                while (i-- != 0)
+                // TODO: testing spans
+                var maxCodeSpan = new Span<ulong>(maxCodePtr, 18);
+                var valOffsetSpan = new Span<int>(valOffsetPtr, 19);
+                var lookaheadSizeSpan = new Span<byte>(lookaheadSizePtr, JpegConstants.Huffman.LookupSize);
+                var lookaheadValueSpan = new Span<byte>(lookaheadValuePtr, JpegConstants.Huffman.LookupSize);
+
+                // Figure C.1: make table of Huffman code length for each symbol
+                int p = 0;
+                for (int j = 1; j <= 16; j++)
                 {
-                    huffSize[p++] = (char)j;
-                }
-            }
-
-            huffSize[p] = (char)0;
-
-            // Figure C.2: generate the codes themselves
-            uint code = 0;
-            int si = huffSize[0];
-            p = 0;
-            while (huffSize[p] != 0)
-            {
-                while (huffSize[p] == si)
-                {
-                    huffCode[p++] = code;
-                    code++;
-                }
-
-                code <<= 1;
-                si++;
-            }
-
-            // Figure F.15: generate decoding tables for bit-sequential decoding
-            p = 0;
-            for (int j = 1; j <= 16; j++)
-            {
-                if (codeLengths[j] != 0)
-                {
-                    this.ValOffset[j] = p - (int)huffCode[p];
-                    p += codeLengths[j];
-                    this.MaxCode[j] = huffCode[p - 1]; // Maximum code of length l
-                    this.MaxCode[j] <<= JpegConstants.Huffman.RegisterSize - j; // Left justify
-                    this.MaxCode[j] |= (1ul << (JpegConstants.Huffman.RegisterSize - j)) - 1;
-                }
-                else
-                {
-                    this.MaxCode[j] = 0;
-                }
-            }
-
-            this.ValOffset[18] = 0;
-            this.MaxCode[17] = ulong.MaxValue; // Ensures huff decode terminates
-
-            // Compute lookahead tables to speed up decoding.
-            // First we set all the table entries to JpegConstants.Huffman.SlowBits, indicating "too long";
-            // then we iterate through the Huffman codes that are short enough and
-            // fill in all the entries that correspond to bit sequences starting
-            // with that code.
-            ref byte lookupSizeRef = ref this.LookaheadSize[0];
-            Unsafe.InitBlockUnaligned(ref lookupSizeRef, JpegConstants.Huffman.SlowBits, JpegConstants.Huffman.LookupSize);
-
-            p = 0;
-            for (int length = 1; length <= JpegConstants.Huffman.LookupBits; length++)
-            {
-                int jShift = JpegConstants.Huffman.LookupBits - length;
-                for (int i = 1; i <= codeLengths[length]; i++, p++)
-                {
-                    // length = current code's length, p = its index in huffCode[] & Values[].
-                    // Generate left-justified code followed by all possible bit sequences
-                    int lookBits = (int)(huffCode[p] << jShift);
-                    for (int ctr = 1 << (JpegConstants.Huffman.LookupBits - length); ctr > 0; ctr--)
+                    int i = codeLengths[j];
+                    while (i-- != 0)
                     {
-                        this.LookaheadSize[lookBits] = (byte)length;
-                        this.LookaheadValue[lookBits] = this.Values[p];
-                        lookBits++;
+                        huffSize[p++] = (char)j;
+                    }
+                }
+
+                huffSize[p] = (char)0;
+
+                // Figure C.2: generate the codes themselves
+                uint code = 0;
+                int si = huffSize[0];
+                p = 0;
+                while (huffSize[p] != 0)
+                {
+                    while (huffSize[p] == si)
+                    {
+                        huffCode[p++] = code;
+                        code++;
+                    }
+
+                    code <<= 1;
+                    si++;
+                }
+
+                // Figure F.15: generate decoding tables for bit-sequential decoding
+                p = 0;
+                for (int j = 1; j <= 16; j++)
+                {
+                    if (codeLengths[j] != 0)
+                    {
+                        valOffsetSpan[j] = p - (int)huffCode[p];
+                        p += codeLengths[j];
+                        maxCodeSpan[j] = huffCode[p - 1]; // Maximum code of length l
+                        maxCodeSpan[j] <<= JpegConstants.Huffman.RegisterSize - j; // Left justify
+                        maxCodeSpan[j] |= (1ul << (JpegConstants.Huffman.RegisterSize - j)) - 1;
+                    }
+                    else
+                    {
+                        maxCodeSpan[j] = 0;
+                    }
+                }
+
+                valOffsetSpan[18] = 0;
+                maxCodeSpan[17] = ulong.MaxValue; // Ensures huff decode terminates
+
+                // Compute lookahead tables to speed up decoding.
+                // First we set all the table entries to JpegConstants.Huffman.SlowBits, indicating "too long";
+                // then we iterate through the Huffman codes that are short enough and
+                // fill in all the entries that correspond to bit sequences starting
+                // with that code.
+                ref byte lookupSizeRef = ref lookaheadSizeSpan[0];
+                Unsafe.InitBlockUnaligned(ref lookupSizeRef, JpegConstants.Huffman.SlowBits, JpegConstants.Huffman.LookupSize);
+
+                p = 0;
+                for (int length = 1; length <= JpegConstants.Huffman.LookupBits; length++)
+                {
+                    int jShift = JpegConstants.Huffman.LookupBits - length;
+                    for (int i = 1; i <= codeLengths[length]; i++, p++)
+                    {
+                        // length = current code's length, p = its index in huffCode[] & Values[].
+                        // Generate left-justified code followed by all possible bit sequences
+                        int lookBits = (int)(huffCode[p] << jShift);
+                        for (int ctr = 1 << (JpegConstants.Huffman.LookupBits - length); ctr > 0; ctr--)
+                        {
+                            lookaheadSizeSpan[lookBits] = (byte)length;
+                            lookaheadValueSpan[lookBits] = this.Values[p];
+                            lookBits++;
+                        }
                     }
                 }
             }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -1110,13 +1110,13 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     // Types 0..1 DC..AC
                     if (tableType > 1)
                     {
-                        JpegThrowHelper.ThrowInvalidImageContentException($"Bad huffman table type: {tableType}");
+                        JpegThrowHelper.ThrowInvalidImageContentException($"Bad huffman table type: {tableType}.");
                     }
 
                     // Max tables of each type
                     if (tableIndex > 3)
                     {
-                        JpegThrowHelper.ThrowInvalidImageContentException($"Bad huffman table index: {tableIndex}");
+                        JpegThrowHelper.ThrowInvalidImageContentException($"Bad huffman table index: {tableIndex}.");
                     }
 
                     stream.Read(huffmanDataSpan, 0, 16);

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -1150,7 +1150,8 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                                 tableType,
                                 tableIndex,
                                 codeLengthsSpan,
-                                huffmanValuesSpan);
+                                huffmanValuesSpan,
+                                stackalloc uint[257]);
                         }
                     }
                 }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -1097,16 +1097,15 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         {
             const int codeLengthsByteSize = 17;
             const int codeValuesMaxByteSize = 256;
-            const int tableWorkspaceByteSize = 256 * sizeof(uint);
-            const int totalBufferSize = codeLengthsByteSize + codeValuesMaxByteSize + tableWorkspaceByteSize;
+            const int totalBufferSize = codeLengthsByteSize + codeValuesMaxByteSize + HuffmanTable.WorkspaceByteSize;
 
             int length = remaining;
             using (IMemoryOwner<byte> buffer = this.Configuration.MemoryAllocator.Allocate<byte>(totalBufferSize))
             {
                 Span<byte> bufferSpan = buffer.GetSpan();
-                Span<byte> huffmanLegthsSpan = buffer.Slice(0, codeLengthsByteSize);
-                Span<byte> huffmanValuesSpan = buffer.Slice(codeLengthsByteSize, codeValuesMaxByteSize);
-                Span<uint> tableWorkspace = MemoryMarshal.Cast<byte, uint>(buffer.Slice(codeLengthsByteSize + codeValuesMaxByteSize));
+                Span<byte> huffmanLegthsSpan = bufferSpan.Slice(0, codeLengthsByteSize);
+                Span<byte> huffmanValuesSpan = bufferSpan.Slice(codeLengthsByteSize, codeValuesMaxByteSize);
+                Span<uint> tableWorkspace = MemoryMarshal.Cast<byte, uint>(bufferSpan.Slice(codeLengthsByteSize + codeValuesMaxByteSize));
 
                 for (int i = 2; i < remaining;)
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR removes redundant `Configure()` calls for `HuffmanTable` and removes stack pressure from `stackalloc` calls.

### TODO
- [x] Remove `Configure()` method 
- [x] Remove `stackalloc` calls
- [x] Create out-of-bounds huffman table test image