### PR TITLE
Change the constructor of PixelTypeInfo and ImageMetadata from internal to public so that a user can implement IImageInfo

### DIFF
--- a/src/ImageSharp/Formats/PixelTypeInfo.cs
+++ b/src/ImageSharp/Formats/PixelTypeInfo.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Formats
         /// </summary>
         /// <param name="bitsPerPixel">Color depth, in number of bits per pixel.</param>
         /// <param name="alpha">Tthe pixel alpha transparency behavior.</param>
-        internal PixelTypeInfo(int bitsPerPixel, PixelAlphaRepresentation? alpha = null)
+        public PixelTypeInfo(int bitsPerPixel, PixelAlphaRepresentation? alpha = null)
         {
             this.BitsPerPixel = bitsPerPixel;
             this.AlphaRepresentation = alpha;

--- a/src/ImageSharp/Formats/PixelTypeInfo.cs
+++ b/src/ImageSharp/Formats/PixelTypeInfo.cs
@@ -15,8 +15,17 @@ namespace SixLabors.ImageSharp.Formats
         /// Initializes a new instance of the <see cref="PixelTypeInfo"/> class.
         /// </summary>
         /// <param name="bitsPerPixel">Color depth, in number of bits per pixel.</param>
-        /// <param name="alpha">Tthe pixel alpha transparency behavior.</param>
-        public PixelTypeInfo(int bitsPerPixel, PixelAlphaRepresentation? alpha = null)
+        public PixelTypeInfo(int bitsPerPixel)
+        {
+            this.BitsPerPixel = bitsPerPixel;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PixelTypeInfo"/> class.
+        /// </summary>
+        /// <param name="bitsPerPixel">Color depth, in number of bits per pixel.</param>
+        /// <param name="alpha">The pixel alpha transparency behavior.</param>
+        public PixelTypeInfo(int bitsPerPixel, PixelAlphaRepresentation alpha)
         {
             this.BitsPerPixel = bitsPerPixel;
             this.AlphaRepresentation = alpha;

--- a/src/ImageSharp/Metadata/ImageMetadata.cs
+++ b/src/ImageSharp/Metadata/ImageMetadata.cs
@@ -39,7 +39,7 @@ namespace SixLabors.ImageSharp.Metadata
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageMetadata"/> class.
         /// </summary>
-        internal ImageMetadata()
+        public ImageMetadata()
         {
             this.horizontalResolution = DefaultHorizontalResolution;
             this.verticalResolution = DefaultVerticalResolution;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Case a user implements `IImageInfo` and supports user-specific image formats:
`IImageInfo` has `PixelTypeInfo` and `ImageMetadata` properties. But
* `ImageMetadata` cannot be instanced because it has an internal constructor.
* `PixelTypeInfo` cannot be instanced because it has an internal constructor.

So change the constructor of `PixelTypeInfo` and `ImageMetadata` from internal to public

Related discussion: https://github.com/SixLabors/ImageSharp/discussions/1914

<!-- Thanks for contributing to ImageSharp! -->
