### PR TITLE
Fix for Jpeg Metadata Decoding with unknown APP13 profile

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -788,6 +788,11 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     }
                 }
             }
+            else
+            {
+                // If the profile is unknown skip over the rest of it.
+                stream.Skip(remaining);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

Fix for Jpeg Decoding Metadata for unknown APP13 profiles. Without this fix the parser will continue parsing any non-Photoshop profile looking for markers and under the right circumstances cause the SOS marker to get missed. Sorry not able to provide the image where this issue was originally encountered for a test case.

