### PR TITLE
Only attempt to decode the first JFIF marker instance

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -103,26 +103,22 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 
         /// <inheritdoc/>
         public bool Equals(JFifMarker other)
-        {
-            return this.MajorVersion == other.MajorVersion
+            => this.MajorVersion == other.MajorVersion
                 && this.MinorVersion == other.MinorVersion
                 && this.DensityUnits == other.DensityUnits
                 && this.XDensity == other.XDensity
                 && this.YDensity == other.YDensity;
-        }
 
         /// <inheritdoc/>
         public override bool Equals(object obj) => obj is JFifMarker other && this.Equals(other);
 
         /// <inheritdoc/>
         public override int GetHashCode()
-        {
-            return HashCode.Combine(
+            => HashCode.Combine(
                 this.MajorVersion,
                 this.MinorVersion,
                 this.DensityUnits,
                 this.XDensity,
                 this.YDensity);
-        }
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -625,7 +625,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         private void ProcessApplicationHeaderMarker(BufferedReadStream stream, int remaining)
         {
             // We can only decode JFif identifiers.
-            if (remaining < JFifMarker.Length)
+            // Some bad images contain multiple App0 markers (Issue 1932) so we check to see
+            // if it's already been read.
+            if (remaining < JFifMarker.Length || (!this.jFif.Equals(default)))
             {
                 // Skip the application header length
                 stream.Skip(remaining);

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -625,7 +625,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         private void ProcessApplicationHeaderMarker(BufferedReadStream stream, int remaining)
         {
             // We can only decode JFif identifiers.
-            // Some bad images contain multiple App0 markers (Issue 1932) so we check to see
+            // Some images contain multiple JFIF markers (Issue 1932) so we check to see
             // if it's already been read.
             if (remaining < JFifMarker.Length || (!this.jFif.Equals(default)))
             {

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         // TODO: A JPEGsnoop & metadata expert should review if the Exif/Icc expectations are correct.
         // I'm seeing several entries with Exif-related names in images where we do not decode an exif profile. (- Anton)
         public static readonly TheoryData<bool, string, int, bool, bool> MetadataTestData =
-        new TheoryData<bool, string, int, bool, bool>
+        new()
         {
             { false, TestImages.Jpeg.Progressive.Progress, 24, false, false },
             { false, TestImages.Jpeg.Progressive.Fb, 24, false, true },
@@ -42,15 +42,16 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         };
 
         public static readonly TheoryData<string, int, int, PixelResolutionUnit> RatioFiles =
-        new TheoryData<string, int, int, PixelResolutionUnit>
+        new()
         {
             { TestImages.Jpeg.Baseline.Ratio1x1, 1, 1, PixelResolutionUnit.AspectRatio },
             { TestImages.Jpeg.Baseline.Snake, 300, 300, PixelResolutionUnit.PixelsPerInch },
-            { TestImages.Jpeg.Baseline.GammaDalaiLamaGray, 72, 72, PixelResolutionUnit.PixelsPerInch }
+            { TestImages.Jpeg.Baseline.GammaDalaiLamaGray, 72, 72, PixelResolutionUnit.PixelsPerInch },
+            { TestImages.Jpeg.Issues.MultipleApp01932, 400, 400, PixelResolutionUnit.PixelsPerInch }
         };
 
         public static readonly TheoryData<string, int> QualityFiles =
-        new TheoryData<string, int>
+        new()
         {
             { TestImages.Jpeg.Baseline.Calliphora, 80 },
             { TestImages.Jpeg.Progressive.Fb, 75 },

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -257,6 +257,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string IdentifyMultiFrame1211 = "Jpg/issues/issue-1221-identify-multi-frame.jpg";
                 public const string WrongColorSpace = "Jpg/issues/Issue1732-WrongColorSpace.jpg";
                 public const string MalformedUnsupportedComponentCount = "Jpg/issues/issue-1900-malformed-unsupported-255-components.jpg";
+                public const string MultipleApp01932 = "Jpg/issues/issue-1932-app0-resolution.jpg";
 
                 public static class Fuzz
                 {

--- a/tests/Images/Input/Jpg/issues/issue-1932-app0-resolution.jpg
+++ b/tests/Images/Input/Jpg/issues/issue-1932-app0-resolution.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9d1a583e5c8c0a1a7362d06befd82883e1dc4231129ddb11d11d8c428691ff5
+size 1126332

--- a/tests/Images/Input/Jpg/issues/issue-1932-app0-resolution.jpg
+++ b/tests/Images/Input/Jpg/issues/issue-1932-app0-resolution.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9d1a583e5c8c0a1a7362d06befd82883e1dc4231129ddb11d11d8c428691ff5
-size 1126332
+oid sha256:3654c48003b85c1110bad8c31d2f94eaf4dcfe488698246b3ead4b54715d8d18
+size 1325


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Immediately following the JFIF APP0 marker segment may be a JFIF extension APP0 marker segment. This segment may only be present for JFIF versions 1.02 and above. This PR ensures that we do not attempt to decode secondary JFIF markers in an image. Fix #1932

<!-- Thanks for contributing to ImageSharp! -->
