### PR TITLE
ImageFormatDetector Configuration Cleanup

### DIFF
--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -122,25 +122,25 @@ namespace SixLabors.ImageSharp
         public ReadOrigin ReadOrigin { get; set; } = ReadOrigin.Current;
 
         /// <summary>
-        /// Gets or sets the <see cref="ImageFormatManager"/> that is currently in use.
+        /// Gets or the <see cref="ImageFormatManager"/> that is currently in use.
         /// </summary>
-        public ImageFormatManager ImageFormatsManager { get; set; } = new ImageFormatManager();
+        public ImageFormatManager ImageFormatsManager { get; } = new ImageFormatManager();
 
         /// <summary>
-        /// Gets or sets the <see cref="ImageSharp.Memory.MemoryAllocator"/> that is currently in use.
-        /// Defaults to <see cref="ImageSharp.Memory.MemoryAllocator.Default"/>.
+        /// Gets or sets the <see cref="Memory.MemoryAllocator"/> that is currently in use.
+        /// Defaults to <see cref="MemoryAllocator.Default"/>.
         /// <para />
         /// Allocators are expensive, so it is strongly recommended to use only one busy instance per process.
         /// In case you need to customize it, you can ensure this by changing
         /// </summary>
         /// <remarks>
         /// It's possible to reduce allocator footprint by assigning a custom instance created with
-        /// <see cref="Memory.MemoryAllocator.Create(MemoryAllocatorOptions)"/>, but note that since the default pooling
+        /// <see cref="MemoryAllocator.Create(MemoryAllocatorOptions)"/>, but note that since the default pooling
         /// allocators are expensive, it is strictly recommended to use a single process-wide allocator.
         /// You can ensure this by altering the allocator of <see cref="Default"/>, or by implementing custom application logic that
         /// manages allocator lifetime.
         /// <para />
-        /// If an allocator has to be dropped for some reason, <see cref="Memory.MemoryAllocator.ReleaseRetainedResources"/>
+        /// If an allocator has to be dropped for some reason, <see cref="MemoryAllocator.ReleaseRetainedResources"/>
         /// shall be invoked after disposing all associated <see cref="Image"/> instances.
         /// </remarks>
         public MemoryAllocator MemoryAllocator
@@ -192,7 +192,7 @@ namespace SixLabors.ImageSharp
         /// Creates a shallow copy of the <see cref="Configuration"/>.
         /// </summary>
         /// <returns>A new configuration instance.</returns>
-        public Configuration Clone() => new Configuration
+        public Configuration Clone() => new()
         {
             MaxDegreeOfParallelism = this.MaxDegreeOfParallelism,
             StreamProcessingBufferSize = this.StreamProcessingBufferSize,
@@ -216,7 +216,7 @@ namespace SixLabors.ImageSharp
         /// <see cref="WebpConfigurationModule"/>.
         /// </summary>
         /// <returns>The default configuration of <see cref="Configuration"/>.</returns>
-        internal static Configuration CreateDefaultInstance() => new Configuration(
+        internal static Configuration CreateDefaultInstance() => new(
                 new PngConfigurationModule(),
                 new JpegConfigurationModule(),
                 new GifConfigurationModule(),

--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Gets or the <see cref="ImageFormatManager"/> that is currently in use.
         /// </summary>
-        public ImageFormatManager ImageFormatsManager { get; } = new ImageFormatManager();
+        public ImageFormatManager ImageFormatsManager { get; private set; } = new ImageFormatManager();
 
         /// <summary>
         /// Gets or sets the <see cref="Memory.MemoryAllocator"/> that is currently in use.

--- a/src/ImageSharp/Formats/ImageFormatManager.cs
+++ b/src/ImageSharp/Formats/ImageFormatManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -17,27 +17,27 @@ namespace SixLabors.ImageSharp.Formats
         /// Used for locking against as there is no ConcurrentSet type.
         /// <see href="https://github.com/dotnet/corefx/issues/6318"/>
         /// </summary>
-        private static readonly object HashLock = new object();
+        private static readonly object HashLock = new();
 
         /// <summary>
         /// The list of supported <see cref="IImageEncoder"/> keyed to mime types.
         /// </summary>
-        private readonly ConcurrentDictionary<IImageFormat, IImageEncoder> mimeTypeEncoders = new ConcurrentDictionary<IImageFormat, IImageEncoder>();
+        private readonly ConcurrentDictionary<IImageFormat, IImageEncoder> mimeTypeEncoders = new();
 
         /// <summary>
         /// The list of supported <see cref="IImageEncoder"/> keyed to mime types.
         /// </summary>
-        private readonly ConcurrentDictionary<IImageFormat, IImageDecoder> mimeTypeDecoders = new ConcurrentDictionary<IImageFormat, IImageDecoder>();
+        private readonly ConcurrentDictionary<IImageFormat, IImageDecoder> mimeTypeDecoders = new();
 
         /// <summary>
         /// The list of supported <see cref="IImageFormat"/>s.
         /// </summary>
-        private readonly HashSet<IImageFormat> imageFormats = new HashSet<IImageFormat>();
+        private readonly HashSet<IImageFormat> imageFormats = new();
 
         /// <summary>
         /// The list of supported <see cref="IImageFormatDetector"/>s.
         /// </summary>
-        private ConcurrentBag<IImageFormatDetector> imageFormatDetectors = new ConcurrentBag<IImageFormatDetector>();
+        private readonly ConcurrentBag<IImageFormatDetector> imageFormatDetectors = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageFormatManager" /> class.
@@ -113,9 +113,7 @@ namespace SixLabors.ImageSharp.Formats
         /// <param name="mimeType">The mime-type to discover</param>
         /// <returns>The <see cref="IImageFormat"/> if found; otherwise null</returns>
         public IImageFormat FindFormatByMimeType(string mimeType)
-        {
-            return this.imageFormats.FirstOrDefault(x => x.MimeTypes.Contains(mimeType, StringComparer.OrdinalIgnoreCase));
-        }
+            => this.imageFormats.FirstOrDefault(x => x.MimeTypes.Contains(mimeType, StringComparer.OrdinalIgnoreCase));
 
         /// <summary>
         /// Sets a specific image encoder as the encoder for a specific image format.
@@ -146,10 +144,7 @@ namespace SixLabors.ImageSharp.Formats
         /// <summary>
         /// Removes all the registered image format detectors.
         /// </summary>
-        public void ClearImageFormatDetectors()
-        {
-            this.imageFormatDetectors = new ConcurrentBag<IImageFormatDetector>();
-        }
+        public void ClearImageFormatDetectors() => this.imageFormatDetectors.Clear();
 
         /// <summary>
         /// Adds a new detector for detecting mime types.
@@ -193,9 +188,6 @@ namespace SixLabors.ImageSharp.Formats
         /// <summary>
         /// Sets the max header size.
         /// </summary>
-        private void SetMaxHeaderSize()
-        {
-            this.MaxHeaderSize = this.imageFormatDetectors.Max(x => x.HeaderSize);
-        }
+        private void SetMaxHeaderSize() => this.MaxHeaderSize = this.imageFormatDetectors.Max(x => x.HeaderSize);
     }
 }

--- a/src/ImageSharp/Formats/ImageFormatManager.cs
+++ b/src/ImageSharp/Formats/ImageFormatManager.cs
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Formats
         /// <summary>
         /// The list of supported <see cref="IImageFormatDetector"/>s.
         /// </summary>
-        private readonly ConcurrentBag<IImageFormatDetector> imageFormatDetectors = new();
+        private ConcurrentBag<IImageFormatDetector> imageFormatDetectors = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageFormatManager" /> class.
@@ -144,7 +144,7 @@ namespace SixLabors.ImageSharp.Formats
         /// <summary>
         /// Removes all the registered image format detectors.
         /// </summary>
-        public void ClearImageFormatDetectors() => this.imageFormatDetectors.Clear();
+        public void ClearImageFormatDetectors() => this.imageFormatDetectors = new();
 
         /// <summary>
         /// Adds a new detector for detecting mime types.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Updates around `ImageFormatDetector`. Fixes #1850 

Minimum changes. 
- Removes the public setter from the `Configuration` type
- Minor style cleanup.

This still leaves it possible to clear the collection of detectors, therefore limiting the collection of available image formats.

<!-- Thanks for contributing to ImageSharp! -->
