### PR TITLE
Correctly handle identity transforms with varying dimensions

### DIFF
--- a/src/ImageSharp/Memory/Buffer2DRegion{T}.cs
+++ b/src/ImageSharp/Memory/Buffer2DRegion{T}.cs
@@ -88,7 +88,7 @@ namespace SixLabors.ImageSharp.Memory
         /// <param name="y">The row index</param>
         /// <returns>The span</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> GetRowSpan(int y)
+        public Span<T> DangerousGetRowSpan(int y)
         {
             int yy = this.Rectangle.Y + y;
             int xx = this.Rectangle.X;
@@ -152,7 +152,7 @@ namespace SixLabors.ImageSharp.Memory
 
             for (int y = 0; y < this.Rectangle.Height; y++)
             {
-                Span<T> row = this.GetRowSpan(y);
+                Span<T> row = this.DangerousGetRowSpan(y);
                 row.Clear();
             }
         }

--- a/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/CloningImageProcessor{TPixel}.cs
@@ -46,38 +46,25 @@ namespace SixLabors.ImageSharp.Processing.Processors
         /// <inheritdoc/>
         Image<TPixel> ICloningImageProcessor<TPixel>.CloneAndExecute()
         {
-            try
+            Image<TPixel> clone = this.CreateTarget();
+            this.CheckFrameCount(this.Source, clone);
+
+            Configuration configuration = this.Configuration;
+            this.BeforeImageApply(clone);
+
+            for (int i = 0; i < this.Source.Frames.Count; i++)
             {
-                Image<TPixel> clone = this.CreateTarget();
-                this.CheckFrameCount(this.Source, clone);
+                ImageFrame<TPixel> sourceFrame = this.Source.Frames[i];
+                ImageFrame<TPixel> clonedFrame = clone.Frames[i];
 
-                Configuration configuration = this.Configuration;
-                this.BeforeImageApply(clone);
-
-                for (int i = 0; i < this.Source.Frames.Count; i++)
-                {
-                    ImageFrame<TPixel> sourceFrame = this.Source.Frames[i];
-                    ImageFrame<TPixel> clonedFrame = clone.Frames[i];
-
-                    this.BeforeFrameApply(sourceFrame, clonedFrame);
-                    this.OnFrameApply(sourceFrame, clonedFrame);
-                    this.AfterFrameApply(sourceFrame, clonedFrame);
-                }
-
-                this.AfterImageApply(clone);
-
-                return clone;
+                this.BeforeFrameApply(sourceFrame, clonedFrame);
+                this.OnFrameApply(sourceFrame, clonedFrame);
+                this.AfterFrameApply(sourceFrame, clonedFrame);
             }
-#if DEBUG
-            catch (Exception)
-            {
-                throw;
-#else
-            catch (Exception ex)
-            {
-                throw new ImageProcessingException($"An error occurred when processing the image using {this.GetType().Name}. See the inner exception for more detail.", ex);
-#endif
-            }
+
+            this.AfterImageApply(clone);
+
+            return clone;
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor.cs
@@ -21,6 +21,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             Guard.NotNull(sampler, nameof(sampler));
             Guard.MustBeValueType(sampler, nameof(sampler));
 
+            if (TransformUtils.IsDegenerate(matrix))
+            {
+                throw new DegenerateTransformException("Matrix is degenerate. Check input values.");
+            }
+
             this.Sampler = sampler;
             this.TransformMatrix = matrix;
             this.DestinationSize = targetDimensions;

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
@@ -64,7 +64,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             if (matrix.Equals(default) || matrix.Equals(Matrix3x2.Identity))
             {
                 // The clone will be blank here copy all the pixel data over
-                source.GetPixelMemoryGroup().CopyTo(destination.GetPixelMemoryGroup());
+                var interest = Rectangle.Intersect(this.SourceRectangle, destination.Bounds());
+                Buffer2DRegion<TPixel> sourceBuffer = source.PixelBuffer.GetRegion(interest);
+                Buffer2DRegion<TPixel> destbuffer = destination.PixelBuffer.GetRegion(interest);
+                for (int y = 0; y < sourceBuffer.Height; y++)
+                {
+                    sourceBuffer.DangerousGetRowSpan(y).CopyTo(destbuffer.DangerousGetRowSpan(y));
+                }
+
                 return;
             }
 

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
@@ -201,9 +201,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 float yRadius = this.yRadius;
                 float xRadius = this.xRadius;
                 int minY = this.bounds.Y;
-                int maxY = this.bounds.Right - 1;
+                int maxY = this.bounds.Bottom - 1;
                 int minX = this.bounds.X;
-                int maxX = this.bounds.Bottom - 1;
+                int maxX = this.bounds.Right - 1;
 
                 for (int y = rows.Min; y < rows.Max; y++)
                 {

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
@@ -61,7 +61,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             Matrix3x2 matrix = this.transformMatrix;
 
             // Handle transforms that result in output identical to the original.
-            if (matrix.Equals(default) || matrix.Equals(Matrix3x2.Identity))
+            // Degenerate matrices are already handled in the upstream definition.
+            if (matrix.Equals(Matrix3x2.Identity))
             {
                 // The clone will be blank here copy all the pixel data over
                 var interest = Rectangle.Intersect(this.SourceRectangle, destination.Bounds());

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
@@ -266,9 +266,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 float yRadius = this.yRadius;
                 float xRadius = this.xRadius;
                 int minY = this.bounds.Y;
-                int maxY = this.bounds.Right - 1;
+                int maxY = this.bounds.Bottom - 1;
                 int minX = this.bounds.X;
-                int maxX = this.bounds.Bottom - 1;
+                int maxX = this.bounds.Right - 1;
 
                 for (int y = rows.Min; y < rows.Max; y++)
                 {

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
@@ -81,7 +81,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             if (sampler is NearestNeighborResampler)
             {
-                var nnOperation = new NNAffineOperation(source.PixelBuffer, destination.PixelBuffer, matrix);
+                var nnOperation = new NNAffineOperation(
+                    source.PixelBuffer,
+                    Rectangle.Intersect(this.SourceRectangle, source.Bounds()),
+                    destination.PixelBuffer,
+                    matrix);
+
                 ParallelRowIterator.IterateRows(
                     configuration,
                     destination.Bounds(),
@@ -93,6 +98,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             var operation = new AffineOperation<TResampler>(
                 configuration,
                 source.PixelBuffer,
+                Rectangle.Intersect(this.SourceRectangle, source.Bounds()),
                 destination.PixelBuffer,
                 in sampler,
                 matrix);
@@ -113,12 +119,13 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             [MethodImpl(InliningOptions.ShortMethod)]
             public NNAffineOperation(
                 Buffer2D<TPixel> source,
+                Rectangle bounds,
                 Buffer2D<TPixel> destination,
                 Matrix3x2 matrix)
             {
                 this.source = source;
+                this.bounds = bounds;
                 this.destination = destination;
-                this.bounds = source.Bounds();
                 this.matrix = matrix;
             }
 
@@ -146,6 +153,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         {
             private readonly Configuration configuration;
             private readonly Buffer2D<TPixel> source;
+            private readonly Rectangle bounds;
             private readonly Buffer2D<TPixel> destination;
             private readonly TResampler sampler;
             private readonly Matrix3x2 matrix;
@@ -156,12 +164,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             public AffineOperation(
                 Configuration configuration,
                 Buffer2D<TPixel> source,
+                Rectangle bounds,
                 Buffer2D<TPixel> destination,
                 in TResampler sampler,
                 Matrix3x2 matrix)
             {
                 this.configuration = configuration;
                 this.source = source;
+                this.bounds = bounds;
                 this.destination = destination;
                 this.sampler = sampler;
                 this.matrix = matrix;
@@ -190,8 +200,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 TResampler sampler = this.sampler;
                 float yRadius = this.yRadius;
                 float xRadius = this.xRadius;
-                int maxY = this.source.Height - 1;
-                int maxX = this.source.Width - 1;
+                int minY = this.bounds.Y;
+                int maxY = this.bounds.Right - 1;
+                int minX = this.bounds.X;
+                int maxX = this.bounds.Bottom - 1;
 
                 for (int y = rows.Min; y < rows.Max; y++)
                 {
@@ -208,10 +220,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                         float pY = point.Y;
                         float pX = point.X;
 
-                        int top = LinearTransformUtility.GetRangeStart(yRadius, pY, maxY);
-                        int bottom = LinearTransformUtility.GetRangeEnd(yRadius, pY, maxY);
-                        int left = LinearTransformUtility.GetRangeStart(xRadius, pX, maxX);
-                        int right = LinearTransformUtility.GetRangeEnd(xRadius, pX, maxX);
+                        int top = LinearTransformUtility.GetRangeStart(yRadius, pY, minY, maxY);
+                        int bottom = LinearTransformUtility.GetRangeEnd(yRadius, pY, minY, maxY);
+                        int left = LinearTransformUtility.GetRangeStart(xRadius, pX, minX, maxX);
+                        int right = LinearTransformUtility.GetRangeEnd(xRadius, pX, minX, maxX);
 
                         if (bottom == top || right == left)
                         {
@@ -253,8 +265,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 TResampler sampler = this.sampler;
                 float yRadius = this.yRadius;
                 float xRadius = this.xRadius;
-                int maxY = this.source.Height - 1;
-                int maxX = this.source.Width - 1;
+                int minY = this.bounds.Y;
+                int maxY = this.bounds.Right - 1;
+                int minX = this.bounds.X;
+                int maxX = this.bounds.Bottom - 1;
 
                 for (int y = rows.Min; y < rows.Max; y++)
                 {
@@ -271,10 +285,10 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                         float pY = point.Y;
                         float pX = point.X;
 
-                        int top = LinearTransformUtility.GetRangeStart(yRadius, pY, maxY);
-                        int bottom = LinearTransformUtility.GetRangeEnd(yRadius, pY, maxY);
-                        int left = LinearTransformUtility.GetRangeStart(xRadius, pX, maxX);
-                        int right = LinearTransformUtility.GetRangeEnd(xRadius, pX, maxX);
+                        int top = LinearTransformUtility.GetRangeStart(yRadius, pY, minY, maxY);
+                        int bottom = LinearTransformUtility.GetRangeEnd(yRadius, pY, minY, maxY);
+                        int left = LinearTransformUtility.GetRangeStart(xRadius, pX, minX, maxX);
+                        int right = LinearTransformUtility.GetRangeEnd(xRadius, pX, minX, maxX);
 
                         if (bottom == top || right == left)
                         {

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/LinearTransformUtility.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/LinearTransformUtility.cs
@@ -39,11 +39,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// </summary>
         /// <param name="radius">The radius.</param>
         /// <param name="center">The center position.</param>
+        /// <param name="min">The min allowed amouunt.</param>
         /// <param name="max">The max allowed amouunt.</param>
         /// <returns>The <see cref="int"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public static int GetRangeStart(float radius, float center, int max)
-            => Numerics.Clamp((int)MathF.Ceiling(center - radius), 0, max);
+        public static int GetRangeStart(float radius, float center, int min, int max)
+            => Numerics.Clamp((int)MathF.Ceiling(center - radius), min, max);
 
         /// <summary>
         /// Gets the end position (inclusive) for a sampling range given
@@ -51,10 +52,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         /// </summary>
         /// <param name="radius">The radius.</param>
         /// <param name="center">The center position.</param>
+        /// <param name="min">The min allowed amouunt.</param>
         /// <param name="max">The max allowed amouunt.</param>
         /// <returns>The <see cref="int"/>.</returns>
         [MethodImpl(InliningOptions.ShortMethod)]
-        public static int GetRangeEnd(float radius, float center, int max)
-            => Numerics.Clamp((int)MathF.Floor(center + radius), 0, max);
+        public static int GetRangeEnd(float radius, float center, int min, int max)
+            => Numerics.Clamp((int)MathF.Floor(center + radius), min, max);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor.cs
@@ -21,6 +21,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             Guard.NotNull(sampler, nameof(sampler));
             Guard.MustBeValueType(sampler, nameof(sampler));
 
+            if (TransformUtils.IsDegenerate(matrix))
+            {
+                throw new DegenerateTransformException("Matrix is degenerate. Check input values.");
+            }
+
             this.Sampler = sampler;
             this.TransformMatrix = matrix;
             this.DestinationSize = targetDimensions;

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
@@ -200,9 +200,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 float yRadius = this.yRadius;
                 float xRadius = this.xRadius;
                 int minY = this.bounds.Y;
-                int maxY = this.bounds.Right - 1;
+                int maxY = this.bounds.Bottom - 1;
                 int minX = this.bounds.X;
-                int maxX = this.bounds.Bottom - 1;
+                int maxX = this.bounds.Right - 1;
 
                 for (int y = rows.Min; y < rows.Max; y++)
                 {

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
@@ -60,7 +60,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             Matrix4x4 matrix = this.transformMatrix;
 
             // Handle transforms that result in output identical to the original.
-            if (matrix.Equals(default) || matrix.Equals(Matrix4x4.Identity))
+            // Degenerate matrices are already handled in the upstream definition.
+            if (matrix.Equals(Matrix4x4.Identity))
             {
                 // The clone will be blank here copy all the pixel data over
                 var interest = Rectangle.Intersect(this.SourceRectangle, destination.Bounds());

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
@@ -63,7 +63,14 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             if (matrix.Equals(default) || matrix.Equals(Matrix4x4.Identity))
             {
                 // The clone will be blank here copy all the pixel data over
-                source.GetPixelMemoryGroup().CopyTo(destination.GetPixelMemoryGroup());
+                var interest = Rectangle.Intersect(this.SourceRectangle, destination.Bounds());
+                Buffer2DRegion<TPixel> sourceBuffer = source.PixelBuffer.GetRegion(interest);
+                Buffer2DRegion<TPixel> destbuffer = destination.PixelBuffer.GetRegion(interest);
+                for (int y = 0; y < sourceBuffer.Height; y++)
+                {
+                    sourceBuffer.DangerousGetRowSpan(y).CopyTo(destbuffer.DangerousGetRowSpan(y));
+                }
+
                 return;
             }
 

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
@@ -265,9 +265,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
                 float yRadius = this.yRadius;
                 float xRadius = this.xRadius;
                 int minY = this.bounds.Y;
-                int maxY = this.bounds.Right - 1;
+                int maxY = this.bounds.Bottom - 1;
                 int minX = this.bounds.X;
-                int maxX = this.bounds.Bottom - 1;
+                int maxX = this.bounds.Right - 1;
 
                 for (int y = rows.Min; y < rows.Max; y++)
                 {

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
@@ -171,7 +171,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             for (int y = calculationInterval.Min; y < calculationInterval.Max; y++)
             {
-                Span<TPixel> sourceRow = this.source.GetRowSpan(y);
+                Span<TPixel> sourceRow = this.source.DangerousGetRowSpan(y);
 
                 PixelOperations<TPixel>.Instance.ToVector4(
                     this.configuration,

--- a/tests/ImageSharp.Tests/Memory/BufferAreaTests.cs
+++ b/tests/ImageSharp.Tests/Memory/BufferAreaTests.cs
@@ -68,7 +68,7 @@ namespace SixLabors.ImageSharp.Tests.Memory
 
             Buffer2DRegion<int> region = buffer.GetRegion(r);
 
-            Span<int> span = region.GetRowSpan(y);
+            Span<int> span = region.DangerousGetRowSpan(y);
 
             Assert.Equal(w, span.Length);
 

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/AffineTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/AffineTransformTests.cs
@@ -235,6 +235,36 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
             Assert.Equal(100, image.Height);
         }
 
+        [Theory]
+        [WithTestPatternImages(100, 100, PixelTypes.Rgba32)]
+        public void Identity<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage();
+
+            Matrix3x2 m = Matrix3x2.Identity;
+            Rectangle r = new(25, 25, 50, 50);
+            image.Mutate(x => x.Transform(r, m, new Size(100, 100), KnownResamplers.Bicubic));
+            image.DebugSave(provider);
+            image.CompareToReferenceOutput(ValidatorComparer, provider);
+        }
+
+        [Theory]
+        [WithTestPatternImages(100, 100, PixelTypes.Rgba32, 0.0001F)]
+        [WithTestPatternImages(100, 100, PixelTypes.Rgba32, 57F)]
+        [WithTestPatternImages(100, 100, PixelTypes.Rgba32, 0F)]
+        public void Transform_With_Custom_Dimensions<TPixel>(TestImageProvider<TPixel> provider, float radians)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage();
+
+            var m = Matrix3x2.CreateRotation(radians, new Vector2(50, 50));
+            Rectangle r = new(25, 25, 50, 50);
+            image.Mutate(x => x.Transform(r, m, new Size(100, 100), KnownResamplers.Bicubic));
+            image.DebugSave(provider, testOutputDetails: radians);
+            image.CompareToReferenceOutput(ValidatorComparer, provider, testOutputDetails: radians);
+        }
+
         private static IResampler GetResampler(string name)
         {
             PropertyInfo property = typeof(KnownResamplers).GetTypeInfo().GetProperty(name);

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/AffineTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/AffineTransformTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Numerics;
 using System.Reflection;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
@@ -222,6 +223,16 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
             provider.RunBufferCapacityLimitProcessorTest(
                 bufferCapacityInPixelRows,
                 c => c.Transform(builder));
+        }
+
+        [Fact]
+        public void Issue1911()
+        {
+            using var image = new Image<Rgba32>(100, 100);
+            image.Mutate(x => x = x.Transform(new Rectangle(0, 0, 99, 100), Matrix3x2.Identity, new Size(99, 100), KnownResamplers.Lanczos2));
+
+            Assert.Equal(99, image.Width);
+            Assert.Equal(100, image.Height);
         }
 
         private static IResampler GetResampler(string name)

--- a/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
@@ -147,6 +147,16 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
             }
         }
 
+        [Fact]
+        public void Issue1911()
+        {
+            using var image = new Image<Rgba32>(100, 100);
+            image.Mutate(x => x = x.Transform(new Rectangle(0, 0, 99, 100), Matrix4x4.Identity, new Size(99, 100), KnownResamplers.Lanczos2));
+
+            Assert.Equal(99, image.Width);
+            Assert.Equal(100, image.Height);
+        }
+
         private static IResampler GetResampler(string name)
         {
             PropertyInfo property = typeof(KnownResamplers).GetTypeInfo().GetProperty(name);

--- a/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/ProjectiveTransformTests.cs
@@ -157,6 +157,36 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
             Assert.Equal(100, image.Height);
         }
 
+        [Theory]
+        [WithTestPatternImages(100, 100, PixelTypes.Rgba32)]
+        public void Identity<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage();
+
+            Matrix4x4 m = Matrix4x4.Identity;
+            Rectangle r = new(25, 25, 50, 50);
+            image.Mutate(x => x.Transform(r, m, new Size(100, 100), KnownResamplers.Bicubic));
+            image.DebugSave(provider);
+            image.CompareToReferenceOutput(ValidatorComparer, provider);
+        }
+
+        [Theory]
+        [WithTestPatternImages(100, 100, PixelTypes.Rgba32, 0.0001F)]
+        [WithTestPatternImages(100, 100, PixelTypes.Rgba32, 57F)]
+        [WithTestPatternImages(100, 100, PixelTypes.Rgba32, 0F)]
+        public void Transform_With_Custom_Dimensions<TPixel>(TestImageProvider<TPixel> provider, float radians)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage();
+
+            Matrix4x4 m = Matrix4x4.CreateRotationX(radians, new Vector3(50, 50, 1F)) * Matrix4x4.CreateRotationY(radians, new Vector3(50, 50, 1F));
+            Rectangle r = new(25, 25, 50, 50);
+            image.Mutate(x => x.Transform(r, m, new Size(100, 100), KnownResamplers.Bicubic));
+            image.DebugSave(provider, testOutputDetails: radians);
+            image.CompareToReferenceOutput(ValidatorComparer, provider, testOutputDetails: radians);
+        }
+
         private static IResampler GetResampler(string name)
         {
             PropertyInfo property = typeof(KnownResamplers).GetTypeInfo().GetProperty(name);

--- a/tests/ImageSharp.Tests/Quantization/PixelSamplingStrategyTests.cs
+++ b/tests/ImageSharp.Tests/Quantization/PixelSamplingStrategyTests.cs
@@ -75,7 +75,7 @@ namespace SixLabors.ImageSharp.Tests.Quantization
             var white = new L8(255);
             for (int y = 0; y < region.Height; y++)
             {
-                region.GetRowSpan(y).Fill(white);
+                region.DangerousGetRowSpan(y).Fill(white);
             }
         }
 

--- a/tests/Images/External/ReferenceOutput/AffineTransformTests/Identity_Rgba32_TestPattern100x100.png
+++ b/tests/Images/External/ReferenceOutput/AffineTransformTests/Identity_Rgba32_TestPattern100x100.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da8229605bda413676a42f587df250a743540e6e00c04eacb1e622f223e19595
+size 3564

--- a/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_FromSourceRectangle1_Rgba32_TestPattern96x48.png
+++ b/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_FromSourceRectangle1_Rgba32_TestPattern96x48.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b01d54838d678b61c3b7a1c7e76ff9a60b3f5f4faef5af848231177eac956eb1
-size 1262
+oid sha256:bbe1ffaf7b801fd92724438cc810fd0c5506e0a907b970c4f0bf5bec3627ca2a
+size 551

--- a/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_FromSourceRectangle2_Rgba32_TestPattern96x48.png
+++ b/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_FromSourceRectangle2_Rgba32_TestPattern96x48.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d34394771605c2a70cc23f3841592c20d22a68aaabf2ad6e8aba7348a181afb3
-size 531
+oid sha256:b45933471a1af1b6d4112240e1bc6b6187065a872043ddbf917200ce9e8cc84b
+size 371

--- a/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_0.0001.png
+++ b/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_0.0001.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd3b29b530e221618f65cd5e493b21fe3c27804fde7664636b7bb002f72abbb2
+size 3663

--- a/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_0.png
+++ b/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da8229605bda413676a42f587df250a743540e6e00c04eacb1e622f223e19595
+size 3564

--- a/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_57.png
+++ b/tests/Images/External/ReferenceOutput/AffineTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_57.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a35757fef08a6fd9b37e719d5be7a82d5ff79f0395e082f697d9ebe9c7f03cc8
+size 5748

--- a/tests/Images/External/ReferenceOutput/ProjectiveTransformTests/Identity_Rgba32_TestPattern100x100.png
+++ b/tests/Images/External/ReferenceOutput/ProjectiveTransformTests/Identity_Rgba32_TestPattern100x100.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da8229605bda413676a42f587df250a743540e6e00c04eacb1e622f223e19595
+size 3564

--- a/tests/Images/External/ReferenceOutput/ProjectiveTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_0.0001.png
+++ b/tests/Images/External/ReferenceOutput/ProjectiveTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_0.0001.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39c25539c3c9b8926bf65c041df693a60617bbe8653bb72357bde5ab6342c59c
+size 3618

--- a/tests/Images/External/ReferenceOutput/ProjectiveTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_0.png
+++ b/tests/Images/External/ReferenceOutput/ProjectiveTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da8229605bda413676a42f587df250a743540e6e00c04eacb1e622f223e19595
+size 3564

--- a/tests/Images/External/ReferenceOutput/ProjectiveTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_57.png
+++ b/tests/Images/External/ReferenceOutput/ProjectiveTransformTests/Transform_With_Custom_Dimensions_Rgba32_TestPattern100x100_57.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b1fc95fdf07c7443147205afffb157aa82f94818cfbb833a615c42f584fbda0
+size 5070


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #1911 

- Fixes a situation where given source and destination rectangles can cause an `ImageProcessingException` during transforms when an identity matrix is passed.
- Renames ` Buffer2DRegion{T}.GetRowSpan(y)` adding the `Dangerous` prefix to match other implementations. CC @antonfirsov 
- Removes the exception wrapping from the base cloning processor #1827 

<!-- Thanks for contributing to ImageSharp! -->
