### PR TITLE
Ensure ResizeProcessor working buffer is contiguous

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
@@ -88,7 +88,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
             this.transposedFirstPassBuffer = configuration.MemoryAllocator.Allocate2D<Vector4>(
                 this.workerHeight,
                 destWidth,
-                AllocationOptions.Clean);
+                preferContiguosImageBuffers: true,
+                options: AllocationOptions.Clean);
 
             this.tempRowBuffer = configuration.MemoryAllocator.Allocate<Vector4>(this.sourceRectangle.Width);
             this.tempColumnBuffer = configuration.MemoryAllocator.Allocate<Vector4>(destWidth);

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -669,5 +669,17 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
                 Assert.Equal(height, image.Height);
             }
         }
+
+        [Theory]
+        [WithBasicTestPatternImages(20, 20, PixelTypes.Rgba32)]
+        public void Issue1625_LimitedAllocator<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            provider.LimitAllocatorBufferCapacity().InBytes(1000);
+            provider.RunValidatingProcessorTest(
+                x => x.Resize(30, 30),
+                appendPixelTypeToFileName: false,
+                appendSourceFileOrDescription: false);
+        }
     }
 }

--- a/tests/Images/External/ReferenceOutput/ResizeTests/Issue1625_LimitedAllocator.png
+++ b/tests/Images/External/ReferenceOutput/ResizeTests/Issue1625_LimitedAllocator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bedaced9c302ff735319f189d867b6a722ed4eade63152b67cf07881f8b3964d
+size 289


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Fixes #1625.
