### PR TITLE
Webp encoder now defaults to lossy, if nothing else is specified

### DIFF
--- a/src/ImageSharp/Formats/Webp/IWebpEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Webp/IWebpEncoderOptions.cs
@@ -10,6 +10,7 @@ namespace SixLabors.ImageSharp.Formats.Webp
     {
         /// <summary>
         /// Gets the webp file format used. Either lossless or lossy.
+        /// Defaults to lossy.
         /// </summary>
         WebpFileFormatType? FileFormat { get; }
 

--- a/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
@@ -70,6 +70,7 @@ namespace SixLabors.ImageSharp.Formats.Webp
 
         /// <summary>
         /// Indicating what file format compression should be used.
+        /// Defaults to lossy.
         /// </summary>
         private readonly WebpFileFormatType? fileFormat;
 
@@ -112,32 +113,18 @@ namespace SixLabors.ImageSharp.Formats.Webp
             Guard.NotNull(stream, nameof(stream));
 
             this.configuration = image.GetConfiguration();
-            bool lossy;
+            bool lossless;
             if (this.fileFormat is not null)
             {
-                lossy = this.fileFormat == WebpFileFormatType.Lossy;
+                lossless = this.fileFormat == WebpFileFormatType.Lossless;
             }
             else
             {
                 WebpMetadata webpMetadata = image.Metadata.GetWebpMetadata();
-                lossy = webpMetadata.FileFormat == WebpFileFormatType.Lossy;
+                lossless = webpMetadata.FileFormat == WebpFileFormatType.Lossless;
             }
 
-            if (lossy)
-            {
-                using var enc = new Vp8Encoder(
-                    this.memoryAllocator,
-                    this.configuration,
-                    image.Width,
-                    image.Height,
-                    this.quality,
-                    this.method,
-                    this.entropyPasses,
-                    this.filterStrength,
-                    this.spatialNoiseShaping);
-                enc.Encode(image, stream);
-            }
-            else
+            if (lossless)
             {
                 using var enc = new Vp8LEncoder(
                     this.memoryAllocator,
@@ -149,6 +136,20 @@ namespace SixLabors.ImageSharp.Formats.Webp
                     this.transparentColorMode,
                     this.nearLossless,
                     this.nearLosslessQuality);
+                enc.Encode(image, stream);
+            }
+            else
+            {
+                using var enc = new Vp8Encoder(
+                    this.memoryAllocator,
+                    this.configuration,
+                    image.Width,
+                    image.Height,
+                    this.quality,
+                    this.method,
+                    this.entropyPasses,
+                    this.filterStrength,
+                    this.spatialNoiseShaping);
                 enc.Encode(image, stream);
             }
         }

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
         private static string TestImageLossyFullPath => Path.Combine(TestEnvironment.InputImagesDirectoryFullPath, Lossy.NoFilter06);
 
         [Theory]
-        [WithFile(Flag, PixelTypes.Rgba32, WebpFileFormatType.Lossless)] // if its not a webp input image, it should default to lossless.
+        [WithFile(Flag, PixelTypes.Rgba32, WebpFileFormatType.Lossy)] // If its not a webp input image, it should default to lossy.
         [WithFile(Lossless.NoTransform1, PixelTypes.Rgba32, WebpFileFormatType.Lossless)]
         [WithFile(Lossy.Bike, PixelTypes.Rgba32, WebpFileFormatType.Lossy)]
         public void Encode_PreserveRatio<TPixel>(TestImageProvider<TPixel> provider, WebpFileFormatType expectedFormat)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

To match `libwebp` behavior, the Webp encoder now defaults to lossy, if nothing else is specified.