### PR TITLE
Fixed decoding grayscale jpegs with exotic sampling factors

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
@@ -42,6 +42,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
             // High depth images
             TestImages.Jpeg.Baseline.Testorig12bit,
+
+            // Grayscale jpeg with 2x2 sampling factors (not a usual thing to encounter in the wild)
+            TestImages.Jpeg.Baseline.GrayscaleSampling2x2,
         };
 
         public static string[] ProgressiveTestJpegs =

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -223,6 +223,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string Winter444_Interleaved = "Jpg/baseline/winter444_interleaved.jpg";
                 public const string Metadata = "Jpg/baseline/Metadata-test-file.jpg";
                 public const string ExtendedXmp = "Jpg/baseline/extended-xmp.jpg";
+                public const string GrayscaleSampling2x2 = "Jpg/baseline/grayscale_sampling22.jpg";
 
                 public static readonly string[] All =
                 {

--- a/tests/Images/External/ReferenceOutput/JpegDecoderTests/DecodeBaselineJpeg_grayscale_sampling22.png
+++ b/tests/Images/External/ReferenceOutput/JpegDecoderTests/DecodeBaselineJpeg_grayscale_sampling22.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad22f28d20ea0ceda983a138b3bf9503ed836d779ed75a313f668329c910665e
+size 168405

--- a/tests/Images/Input/Jpg/baseline/grayscale_sampling22.jpg
+++ b/tests/Images/Input/Jpg/baseline/grayscale_sampling22.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5cc8572082a54944d48b3e4f49e6c441871f6eb2b616fbbbfb025f20e0aeff5
+size 45066


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes https://github.com/SixLabors/ImageSharp/issues/1978. ~~Issue author didn't respond (yet) whether we can use attached image in the test suite so~~ I've created a test image based on one of grayscale images from the test suit:

![before](https://user-images.githubusercontent.com/20967409/152663317-66326cd1-ef74-4cd4-b542-f3a081eaeecb.png)


This image after decode-encode on current master:

![after](https://user-images.githubusercontent.com/20967409/152663319-3fd610c9-d674-4cb8-a0c3-49f3abd73b40.png)