### PR TITLE
Optimize Crc32 for arm

### DIFF
--- a/src/ImageSharp/Compression/Zlib/Crc32.cs
+++ b/src/ImageSharp/Compression/Zlib/Crc32.cs
@@ -74,7 +74,8 @@ namespace SixLabors.ImageSharp.Compression.Zlib
             {
                 return ~CalculateArm64(~crc, buffer);
             }
-            else if (ArmCrc32.IsSupported)
+
+            if (ArmCrc32.IsSupported)
             {
                 return ~CalculateArm(~crc, buffer);
             }

--- a/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
@@ -58,7 +58,14 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Fact]
         public void RunCalculateCrcTest_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunCalculateCrcTest, HwIntrinsics.DisableHWIntrinsic);
 
-        private static void RunCalculateCrcTest() => CalculateCrcAndCompareToReference(4096);
+        private static void RunCalculateCrcTest()
+        {
+            int[] testData = { 0, 8, 215, 1024, 1024 + 15, 2034, 4096 };
+            for (int i = 0; i < testData.Length; i++)
+            {
+                CalculateCrcAndCompareToReference(testData[i]);
+            }
+        }
 #endif
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using SixLabors.ImageSharp.Compression.Zlib;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 using Xunit;
 using SharpCrc32 = ICSharpCode.SharpZipLib.Checksum.Crc32;
 
@@ -15,10 +16,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
-        public void ReturnsCorrectWhenEmpty(uint input)
-        {
-            Assert.Equal(input, Crc32.Calculate(input, default));
-        }
+        public void CalculateCrc_ReturnsCorrectResultWhenEmpty(uint input) => Assert.Equal(input, Crc32.Calculate(input, default));
 
         [Theory]
         [InlineData(0)]
@@ -28,24 +26,51 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [InlineData(1024 + 15)]
         [InlineData(2034)]
         [InlineData(4096)]
-        public void MatchesReference(int length)
+        public void CalculateCrc_MatchesReference(int length)
         {
-            var data = GetBuffer(length);
+            // arrange
+            byte[] data = GetBuffer(length);
             var crc = new SharpCrc32();
             crc.Update(data);
-
             long expected = crc.Value;
+
+            // act
             long actual = Crc32.Calculate(data);
 
+            // assert
             Assert.Equal(expected, actual);
         }
 
         private static byte[] GetBuffer(int length)
         {
-            var data = new byte[length];
+            byte[] data = new byte[length];
             new Random(1).NextBytes(data);
 
             return data;
         }
+
+#if SUPPORTS_RUNTIME_INTRINSICS
+        [Fact]
+        public void RunCalculateCrcTest_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunCalculateCrcTest, HwIntrinsics.AllowAll);
+
+        [Fact]
+        public void RunCalculateCrcTest_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunCalculateCrcTest, HwIntrinsics.DisableHWIntrinsic);
+
+        private static void RunCalculateCrcTest()
+        {
+            // arrange
+            int length = 4096;
+            byte[] data = GetBuffer(length);
+            var crc = new SharpCrc32();
+            crc.Update(data);
+            long expected = crc.Value;
+
+            // act
+            long actual = Crc32.Calculate(data);
+
+            // assert
+            Assert.Equal(expected, actual);
+        }
+#endif
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/Crc32Tests.cs
@@ -26,7 +26,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [InlineData(1024 + 15)]
         [InlineData(2034)]
         [InlineData(4096)]
-        public void CalculateCrc_MatchesReference(int length)
+        public void CalculateCrc_MatchesReference(int length) => CalculateCrcAndCompareToReference(length);
+
+        private static void CalculateCrcAndCompareToReference(int length)
         {
             // arrange
             byte[] data = GetBuffer(length);
@@ -56,21 +58,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [Fact]
         public void RunCalculateCrcTest_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunCalculateCrcTest, HwIntrinsics.DisableHWIntrinsic);
 
-        private static void RunCalculateCrcTest()
-        {
-            // arrange
-            int length = 4096;
-            byte[] data = GetBuffer(length);
-            var crc = new SharpCrc32();
-            crc.Update(data);
-            long expected = crc.Value;
-
-            // act
-            long actual = Crc32.Calculate(data);
-
-            // assert
-            Assert.Equal(expected, actual);
-        }
+        private static void RunCalculateCrcTest() => CalculateCrcAndCompareToReference(4096);
 #endif
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities
     /// </summary>
     public static class FeatureTestRunner
     {
-        private static readonly char[] SplitChars = new[] { ',', ' ' };
+        private static readonly char[] SplitChars = { ',', ' ' };
 
         /// <summary>
         /// Allows the deserialization of parameters passed to the feature test.
@@ -349,7 +349,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities
 
         internal static Dictionary<HwIntrinsics, string> ToFeatureKeyValueCollection(this HwIntrinsics intrinsics)
         {
-            // Loop through and translate the given values into COMPlus equivaluents
+            // Loop through and translate the given values into COMPlus equivalents.
             var features = new Dictionary<HwIntrinsics, string>();
             foreach (string intrinsic in intrinsics.ToString("G").Split(SplitChars, StringSplitOptions.RemoveEmptyEntries))
             {
@@ -407,6 +407,12 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities
         DisableBMI1 = 1 << 14,
         DisableBMI2 = 1 << 15,
         DisableLZCNT = 1 << 16,
-        AllowAll = 1 << 17
+        DisableArm64AdvSimd = 1 << 17,
+        DisableArm64Crc32 = 1 << 18,
+        DisableArm64Dp = 1 << 19,
+        DisableArm64Aes = 1 << 20,
+        DisableArm64Sha1 = 1 << 21,
+        DisableArm64Sha256 = 1 << 22,
+        AllowAll = 1 << 23
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
@@ -7,6 +7,10 @@ using System.Linq;
 using System.Numerics;
 #if SUPPORTS_RUNTIME_INTRINSICS
 using System.Runtime.Intrinsics.X86;
+using Aes = System.Runtime.Intrinsics.X86.Aes;
+#if NET5_0_OR_GREATER
+using System.Runtime.Intrinsics.Arm;
+#endif
 #endif
 using Xunit;
 using Xunit.Abstractions;
@@ -16,11 +20,11 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
     public class FeatureTestRunnerTests
     {
         public static TheoryData<HwIntrinsics, string[]> Intrinsics =>
-            new TheoryData<HwIntrinsics, string[]>
+            new()
             {
-                { HwIntrinsics.DisableAES | HwIntrinsics.AllowAll, new string[] { "EnableAES", "AllowAll" } },
-                { HwIntrinsics.DisableSIMD | HwIntrinsics.DisableHWIntrinsic, new string[] { "FeatureSIMD", "EnableHWIntrinsic" } },
-                { HwIntrinsics.DisableSSE42 | HwIntrinsics.DisableAVX, new string[] { "EnableSSE42", "EnableAVX" } }
+                { HwIntrinsics.DisableAES | HwIntrinsics.AllowAll, new[] { "EnableAES", "AllowAll" } },
+                { HwIntrinsics.DisableSIMD | HwIntrinsics.DisableHWIntrinsic, new[] { "FeatureSIMD", "EnableHWIntrinsic" } },
+                { HwIntrinsics.DisableSSE42 | HwIntrinsics.DisableAVX, new[] { "EnableSSE42", "EnableAVX" } }
             };
 
         [Theory]
@@ -56,12 +60,9 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
         }
 
         [Fact]
-        public void CanLimitHwIntrinsicSIMDFeatures()
-        {
-            FeatureTestRunner.RunWithHwIntrinsicsFeature(
+        public void CanLimitHwIntrinsicSIMDFeatures() => FeatureTestRunner.RunWithHwIntrinsicsFeature(
                 () => Assert.False(Vector.IsHardwareAccelerated),
                 HwIntrinsics.DisableSIMD);
-        }
 
 #if SUPPORTS_RUNTIME_INTRINSICS
         [Fact]
@@ -121,6 +122,14 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
                         Assert.False(Bmi1.IsSupported);
                         Assert.False(Bmi2.IsSupported);
                         Assert.False(Lzcnt.IsSupported);
+#if NET5_0_OR_GREATER
+                        Assert.False(AdvSimd.IsSupported);
+                        Assert.False(System.Runtime.Intrinsics.Arm.Aes.IsSupported);
+                        Assert.False(Crc32.IsSupported);
+                        Assert.False(Dp.IsSupported);
+                        Assert.False(Sha1.IsSupported);
+                        Assert.False(Sha256.IsSupported);
+#endif
                         break;
                     case HwIntrinsics.DisableSSE:
                         Assert.False(Sse.IsSupported);
@@ -167,6 +176,26 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
                     case HwIntrinsics.DisableLZCNT:
                         Assert.False(Lzcnt.IsSupported);
                         break;
+#if NET5_0_OR_GREATER
+                    case HwIntrinsics.DisableArm64AdvSimd:
+                        Assert.False(AdvSimd.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Aes:
+                        Assert.False(System.Runtime.Intrinsics.Arm.Aes.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Crc32:
+                        Assert.False(Crc32.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Dp:
+                        Assert.False(Dp.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Sha1:
+                        Assert.False(Sha1.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Sha256:
+                        Assert.False(Sha256.IsSupported);
+                        break;
+#endif
 #endif
                 }
             }
@@ -226,6 +255,14 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
                         Assert.False(Bmi1.IsSupported);
                         Assert.False(Bmi2.IsSupported);
                         Assert.False(Lzcnt.IsSupported);
+#if NET5_0_OR_GREATER
+                        Assert.False(AdvSimd.IsSupported);
+                        Assert.False(System.Runtime.Intrinsics.Arm.Aes.IsSupported);
+                        Assert.False(Crc32.IsSupported);
+                        Assert.False(Dp.IsSupported);
+                        Assert.False(Sha1.IsSupported);
+                        Assert.False(Sha256.IsSupported);
+#endif
                         break;
                     case HwIntrinsics.DisableSSE:
                         Assert.False(Sse.IsSupported);
@@ -272,6 +309,26 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
                     case HwIntrinsics.DisableLZCNT:
                         Assert.False(Lzcnt.IsSupported);
                         break;
+#if NET5_0_OR_GREATER
+                    case HwIntrinsics.DisableArm64AdvSimd:
+                        Assert.False(AdvSimd.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Aes:
+                        Assert.False(System.Runtime.Intrinsics.Arm.Aes.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Crc32:
+                        Assert.False(Crc32.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Dp:
+                        Assert.False(Dp.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Sha1:
+                        Assert.False(Sha1.IsSupported);
+                        break;
+                    case HwIntrinsics.DisableArm64Sha256:
+                        Assert.False(Sha256.IsSupported);
+                        break;
+#endif
 #endif
                 }
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds a fast path in Crc32 for arm and arm64

Some benchmarks for the arm64 path:

Current (LUT):
|             Method | Count |     Mean |    Error |   StdDev |
|------------------- |------ |---------:|---------:|---------:|
| SixLaborsCalculate |  1024 | 14.54 us | 0.001 us | 0.001 us |
| SixLaborsCalculate |  2048 | 29.07 us | 0.003 us | 0.002 us |
| SixLaborsCalculate |  4096 | 58.14 us | 0.008 us | 0.008 us |

arm crc32 instructions without loop unrolling:
|             Method | Count |       Mean |   Error |  StdDev |
|------------------- |------ |-----------:|--------:|--------:|
| SixLaborsCalculate |  1024 |   833.0 ns | 7.47 ns | 6.62 ns |
| SixLaborsCalculate |  2048 | 1,557.8 ns | 0.17 ns | 0.14 ns |
| SixLaborsCalculate |  4096 | 3,044.1 ns | 0.75 ns | 0.70 ns |

This PR:
|             Method | Count |       Mean |   Error |  StdDev |
|------------------- |------ |-----------:|--------:|--------:|
| SixLaborsCalculate |  1024 |   584.8 ns | 0.07 ns | 0.06 ns |
| SixLaborsCalculate |  2048 | 1,145.8 ns | 0.12 ns | 0.11 ns |
| SixLaborsCalculate |  4096 | 2,262.1 ns | 0.35 ns | 0.29 ns |
<!-- Thanks for contributing to ImageSharp! -->
