### PR TITLE
Respect PreferContiguousImageBuffers in decoders

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
@@ -111,7 +111,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
             this.pixelRowsPerStep = majorVerticalSamplingFactor * blockPixelHeight;
 
             // pixel buffer for resulting image
-            this.pixelBuffer = allocator.Allocate2D<TPixel>(frame.PixelWidth, frame.PixelHeight);
+            this.pixelBuffer = allocator.Allocate2D<TPixel>(
+                frame.PixelWidth,
+                frame.PixelHeight,
+                this.configuration.PreferContiguousImageBuffers);
             this.paddedProxyPixelRow = allocator.Allocate<TPixel>(frame.PixelWidth + 3);
 
             // component processors from spectral to Rgba32

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -37,8 +37,10 @@ namespace SixLabors.ImageSharp
             ImageMetadata metadata)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            Buffer2D<TPixel> uninitializedMemoryBuffer =
-                configuration.MemoryAllocator.Allocate2D<TPixel>(width, height);
+            Buffer2D<TPixel> uninitializedMemoryBuffer = configuration.MemoryAllocator.Allocate2D<TPixel>(
+                    width,
+                    height,
+                    configuration.PreferContiguousImageBuffers);
             return new Image<TPixel>(configuration, uninitializedMemoryBuffer.FastMemoryGroup, width, height, metadata);
         }
 

--- a/tests/ImageSharp.Tests/Image/LargeImageIntegrationTests.cs
+++ b/tests/ImageSharp.Tests/Image/LargeImageIntegrationTests.cs
@@ -51,8 +51,7 @@ namespace SixLabors.ImageSharp.Tests
         public void PreferContiguousImageBuffers_LoadImage_BufferIsContiguous(string formatOuter)
         {
             // Run remotely to avoid large allocation in the test process:
-            // RemoteExecutor.Invoke(RunTest).Dispose();
-            RunTest(formatOuter);
+            RemoteExecutor.Invoke(RunTest, formatOuter).Dispose();
 
             static void RunTest(string formatInner)
             {

--- a/tests/ImageSharp.Tests/Image/LargeImageIntegrationTests.cs
+++ b/tests/ImageSharp.Tests/Image/LargeImageIntegrationTests.cs
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Tests
 
                 using var image = new Image<Rgba32>(configuration, 2048, 2048);
                 Assert.True(image.DangerousTryGetSinglePixelMemory(out Memory<Rgba32> mem));
-                Assert.Equal(8192 * 4096, mem.Length);
+                Assert.Equal(2048 * 2048, mem.Length);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #1983.
