### PR TITLE
Tiff Decoder option to decode only first frame

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.IO;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 

--- a/src/ImageSharp/Formats/Tiff/ITiffDecoderOptions.cs
+++ b/src/ImageSharp/Formats/Tiff/ITiffDecoderOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using SixLabors.ImageSharp.Metadata;
+
 namespace SixLabors.ImageSharp.Formats.Tiff
 {
     /// <summary>
@@ -12,5 +14,10 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         /// Gets a value indicating whether the metadata should be ignored when the image is being decoded.
         /// </summary>
         bool IgnoreMetadata { get; }
+
+        /// <summary>
+        /// Gets the decoding mode for multi-frame images.
+        /// </summary>
+        FrameDecodingMode DecodingMode { get; }
     }
 }

--- a/src/ImageSharp/Formats/Tiff/README.md
+++ b/src/ImageSharp/Formats/Tiff/README.md
@@ -25,7 +25,7 @@
 
 ## Implementation Status
 
-- The Decoder currently only supports a single frame per image.
+- The Decoder currently only supports decoding multiframe images, which have the same dimensions.
 - Some compression formats are not yet supported. See the list below.
 
 ### Deviations from the TIFF spec (to be fixed)

--- a/src/ImageSharp/Formats/Tiff/TiffDecoder.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoder.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Formats.Tiff
@@ -17,6 +18,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         /// Gets or sets a value indicating whether the metadata should be ignored when the image is being decoded.
         /// </summary>
         public bool IgnoreMetadata { get; set; }
+
+        /// <summary>
+        /// Gets or sets the decoding mode for multi-frame images.
+        /// </summary>
+        public FrameDecodingMode DecodingMode { get; set; }
 
         /// <inheritdoc/>
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -4,6 +4,7 @@
 // ReSharper disable InconsistentNaming
 using System;
 using System.IO;
+using SixLabors.ImageSharp.Formats.Tiff;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
@@ -364,6 +365,17 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [WithFile(RgbPackbitsMultistrip, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_PackBitsCompressed<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(MultiFrameMipMap, PixelTypes.Rgba32)]
+        public void CanDecodeJustOneFrame<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage(new TiffDecoder() { DecodingMode = FrameDecodingMode.First }))
+            {
+                Assert.Equal(1, image.Frames.Count);
+            }
+        }
 
         [Theory]
         [WithFile(RgbJpegCompressed, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -867,6 +867,7 @@ namespace SixLabors.ImageSharp.Tests
             public const string MultiframeDeflateWithPreview = "Tiff/multipage_deflate_withPreview.tiff";
             public const string MultiframeDifferentSize = "Tiff/multipage_differentSize.tiff";
             public const string MultiframeDifferentVariants = "Tiff/multipage_differentVariants.tiff";
+            public const string MultiFrameMipMap = "Tiff/SKC1H3.tiff";
 
             public const string LittleEndianByteOrder = "Tiff/little_endian.tiff";
 

--- a/tests/Images/Input/Tiff/SKC1H3.tiff
+++ b/tests/Images/Input/Tiff/SKC1H3.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:938bbf1c0f8bdbea0c632bb8d51c1150f757f88b3779d7fa18c296a3a3f61e9b
+size 13720193


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

As discussed in #1982, this adds the TiffDecoder option `FrameDecodingMode`, which allows to decode only the first frame.