### PR TITLE
Gif decoder. Fix memory access violations.

### DIFF
--- a/ImageSharp.sln
+++ b/ImageSharp.sln
@@ -142,6 +142,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Gif", "Gif", "{EE3FB0B3-1C3
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "issues", "issues", "{BF8DFDC1-CEE5-4A37-B216-D3085360C776}"
 	ProjectSection(SolutionItems) = preProject
+		tests\Images\Input\Gif\issues\bugzilla-55918.gif = tests\Images\Input\Gif\issues\bugzilla-55918.gif
+		tests\Images\Input\Gif\issues\issue1505_argumentoutofrange.png = tests\Images\Input\Gif\issues\issue1505_argumentoutofrange.png
+		tests\Images\Input\Gif\issues\issue1530.gif = tests\Images\Input\Gif\issues\issue1530.gif
+		tests\Images\Input\Gif\issues\issue1668_invalidcolorindex.gif = tests\Images\Input\Gif\issues\issue1668_invalidcolorindex.gif
+		tests\Images\Input\Gif\issues\issue1962_tiniest_gif_1st.gif = tests\Images\Input\Gif\issues\issue1962_tiniest_gif_1st.gif
+		tests\Images\Input\Gif\issues\issue2012_drona1.gif = tests\Images\Input\Gif\issues\issue2012_drona1.gif
+		tests\Images\Input\Gif\issues\issue2012_Stronghold-Crusader-Extreme-Cover.gif = tests\Images\Input\Gif\issues\issue2012_Stronghold-Crusader-Extreme-Cover.gif
 		tests\Images\Input\Gif\issues\issue403_baddescriptorwidth.gif = tests\Images\Input\Gif\issues\issue403_baddescriptorwidth.gif
 		tests\Images\Input\Gif\issues\issue405_badappextlength252-2.gif = tests\Images\Input\Gif\issues\issue405_badappextlength252-2.gif
 		tests\Images\Input\Gif\issues\issue405_badappextlength252.gif = tests\Images\Input\Gif\issues\issue405_badappextlength252.gif

--- a/src/ImageSharp/Common/Extensions/StreamExtensions.cs
+++ b/src/ImageSharp/Common/Extensions/StreamExtensions.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp
     internal static class StreamExtensions
     {
         /// <summary>
-        /// Writes data from a stream into the provided buffer.
+        /// Writes data from a stream from the provided buffer.
         /// </summary>
         /// <param name="stream">The stream.</param>
         /// <param name="buffer">The buffer.</param>

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -410,9 +410,9 @@ namespace SixLabors.ImageSharp.Formats.Gif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ReadFrameIndices(Buffer2D<byte> indices)
         {
-            int dataSize = this.stream.ReadByte();
+            int minCodeSize = this.stream.ReadByte();
             using var lzwDecoder = new LzwDecoder(this.Configuration.MemoryAllocator, this.stream);
-            lzwDecoder.DecodePixels(dataSize, indices);
+            lzwDecoder.DecodePixels(minCodeSize, indices);
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -378,8 +378,8 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 }
 
                 indices = this.Configuration.MemoryAllocator.Allocate2D<byte>(this.imageDescriptor.Width, this.imageDescriptor.Height, AllocationOptions.Clean);
-
                 this.ReadFrameIndices(indices);
+
                 Span<byte> rawColorTable = default;
                 if (localColorTable != null)
                 {

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -265,10 +265,14 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 this.stream.Read(this.buffer, 0, GifConstants.ApplicationBlockSize);
                 bool isXmp = this.buffer.AsSpan().StartsWith(GifConstants.XmpApplicationIdentificationBytes);
 
-                if (isXmp)
+                if (isXmp && !this.IgnoreMetadata)
                 {
-                    var extension = GifXmpApplicationExtension.Read(this.stream);
-                    this.metadata.XmpProfile = new XmpProfile(extension.Data);
+                    var extension = GifXmpApplicationExtension.Read(this.stream, this.MemoryAllocator);
+                    if (extension.Data.Length > 0)
+                    {
+                        this.metadata.XmpProfile = new XmpProfile(extension.Data);
+                    }
+
                     return;
                 }
                 else

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -123,7 +123,8 @@ namespace SixLabors.ImageSharp.Formats.Gif
             this.WriteComments(gifMetadata, stream);
 
             // Write application extensions.
-            this.WriteApplicationExtensions(stream, image.Frames.Count, gifMetadata.RepeatCount, metadata.XmpProfile);
+            XmpProfile xmpProfile = image.Metadata.XmpProfile ?? image.Frames.RootFrame.Metadata.XmpProfile;
+            this.WriteApplicationExtensions(stream, image.Frames.Count, gifMetadata.RepeatCount, xmpProfile);
 
             if (useGlobalTable)
             {
@@ -137,7 +138,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
             // Clean up.
             quantized.Dispose();
 
-            // TODO: Write extension etc
             stream.WriteByte(GifConstants.EndIntroducer);
         }
 

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -428,26 +428,31 @@ namespace SixLabors.ImageSharp.Formats.Gif
             where TGifExtension : struct, IGifExtension
         {
             IMemoryOwner<byte> owner = null;
-            Span<byte> buffer;
+            Span<byte> extensionBuffer;
             int extensionSize = extension.ContentLength;
-            if (extensionSize > this.buffer.Length - 3)
+
+            if (extensionSize == 0)
+            {
+                return;
+            }
+            else if (extensionSize > this.buffer.Length - 3)
             {
                 owner = this.memoryAllocator.Allocate<byte>(extensionSize + 3);
-                buffer = owner.GetSpan();
+                extensionBuffer = owner.GetSpan();
             }
             else
             {
-                buffer = this.buffer;
+                extensionBuffer = this.buffer;
             }
 
-            buffer[0] = GifConstants.ExtensionIntroducer;
-            buffer[1] = extension.Label;
+            extensionBuffer[0] = GifConstants.ExtensionIntroducer;
+            extensionBuffer[1] = extension.Label;
 
-            extension.WriteTo(buffer.Slice(2));
+            extension.WriteTo(extensionBuffer.Slice(2));
 
-            buffer[extensionSize + 2] = GifConstants.Terminator;
+            extensionBuffer[extensionSize + 2] = GifConstants.Terminator;
 
-            stream.Write(buffer, 0, extensionSize + 3);
+            stream.Write(extensionBuffer, 0, extensionSize + 3);
             owner?.Dispose();
         }
 

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 // Don't attempt to decode the frame indices.
                 // Theoretically we could determine a min code size from the length of the provided
                 // color palette but we won't bother since the image is most likely corrupted.
-                ThrowBadMinimumCode();
+                GifThrowHelper.ThrowInvalidImageContentException("Gif Image does not contain a valid LZW minimum code.");
             }
 
             // The resulting index table length.
@@ -263,8 +263,5 @@ namespace SixLabors.ImageSharp.Formats.Gif
             this.suffix.Dispose();
             this.pixelStack.Dispose();
         }
-
-        [MethodImpl(InliningOptions.ColdPath)]
-        public static void ThrowBadMinimumCode() => throw new InvalidImageContentException("Gif Image does not contain a valid LZW minimum code.");
     }
 }

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -68,15 +68,19 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="pixels">The pixel array to decode to.</param>
         public void DecodePixels(int dataSize, Buffer2D<byte> pixels)
         {
-            Guard.MustBeLessThanOrEqualTo(1 << dataSize, MaxStackSize, nameof(dataSize));
+            // Calculate the clear code. The value of the clear code is 2 ^ dataSize
+            int clearCode = 1 << dataSize;
+            if (clearCode > MaxStackSize)
+            {
+                // Don't attempt to decode the frame indices.
+                // The image is most likely corrupted.
+                return;
+            }
 
             // The resulting index table length.
             int width = pixels.Width;
             int height = pixels.Height;
             int length = width * height;
-
-            // Calculate the clear code. The value of the clear code is 2 ^ dataSize
-            int clearCode = 1 << dataSize;
 
             int codeSize = dataSize + 1;
 

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -68,7 +68,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <param name="pixels">The pixel array to decode to.</param>
         public void DecodePixels(int dataSize, Buffer2D<byte> pixels)
         {
-            Guard.MustBeLessThan(dataSize, int.MaxValue, nameof(dataSize));
+            Guard.MustBeLessThanOrEqualTo(1 << dataSize, MaxStackSize, nameof(dataSize));
 
             // The resulting index table length.
             int width = pixels.Width;

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -64,17 +64,22 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// <summary>
         /// Decodes and decompresses all pixel indices from the stream.
         /// </summary>
-        /// <param name="dataSize">Size of the data.</param>
+        /// <param name="minCodeSize">Minimum code size of the data.</param>
         /// <param name="pixels">The pixel array to decode to.</param>
-        public void DecodePixels(int dataSize, Buffer2D<byte> pixels)
+        public void DecodePixels(int minCodeSize, Buffer2D<byte> pixels)
         {
-            // Calculate the clear code. The value of the clear code is 2 ^ dataSize
-            int clearCode = 1 << dataSize;
-            if (clearCode > MaxStackSize)
+            // Calculate the clear code. The value of the clear code is 2 ^ minCodeSize
+            int clearCode = 1 << minCodeSize;
+
+            // It is possible to specify a larger LZW minimum code size than the palette length in bits
+            // which may leave a gap in the codes where no colors are assigned.
+            // http://www.matthewflickinger.com/lab/whatsinagif/lzw_image_data.asp#lzw_compression
+            if (minCodeSize < 2 || clearCode > MaxStackSize)
             {
                 // Don't attempt to decode the frame indices.
-                // The image is most likely corrupted.
-                return;
+                // Theoretically we could determine a min code size from the length of the provided
+                // color palette but we won't bother since the image is most likely corrupted.
+                ThrowBadMinimumCode();
             }
 
             // The resulting index table length.
@@ -82,7 +87,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             int height = pixels.Height;
             int length = width * height;
 
-            int codeSize = dataSize + 1;
+            int codeSize = minCodeSize + 1;
 
             // Calculate the end code
             int endCode = clearCode + 1;
@@ -169,7 +174,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
                     if (code == clearCode)
                     {
                         // Reset the decoder
-                        codeSize = dataSize + 1;
+                        codeSize = minCodeSize + 1;
                         codeMask = (1 << codeSize) - 1;
                         availableCode = clearCode + 2;
                         oldCode = NullCode;
@@ -258,5 +263,8 @@ namespace SixLabors.ImageSharp.Formats.Gif
             this.suffix.Dispose();
             this.pixelStack.Dispose();
         }
+
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowBadMinimumCode() => throw new InvalidImageContentException("Gif Image does not contain a valid LZW minimum code.");
     }
 }

--- a/src/ImageSharp/Formats/Gif/Sections/GifGraphicControlExtension.cs
+++ b/src/ImageSharp/Formats/Gif/Sections/GifGraphicControlExtension.cs
@@ -71,13 +71,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
             dest = this;
 
-            return 5;
+            return ((IGifExtension)this).ContentLength;
         }
 
         public static GifGraphicControlExtension Parse(ReadOnlySpan<byte> buffer)
-        {
-            return MemoryMarshal.Cast<byte, GifGraphicControlExtension>(buffer)[0];
-        }
+            => MemoryMarshal.Cast<byte, GifGraphicControlExtension>(buffer)[0];
 
         public static byte GetPackedValue(GifDisposalMethod disposalMethod, bool userInputFlag = false, bool transparencyFlag = false)
         {

--- a/src/ImageSharp/Formats/Gif/Sections/GifNetscapeLoopingApplicationExtension.cs
+++ b/src/ImageSharp/Formats/Gif/Sections/GifNetscapeLoopingApplicationExtension.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             // 0 means loop indefinitely. Count is set as play n + 1 times.
             BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(14, 2), this.RepeatCount);
 
-            return 16; // Length - Introducer + Label + Terminator.
+            return this.ContentLength; // Length - Introducer + Label + Terminator.
         }
     }
 }

--- a/src/ImageSharp/Formats/Gif/Sections/GifXmpApplicationExtension.cs
+++ b/src/ImageSharp/Formats/Gif/Sections/GifXmpApplicationExtension.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
         // size          : 1
         // identifier    : 11
         // magic trailer : 257
-        public int ContentLength => this.Data.Length + 269;
+        public int ContentLength => (this.Data.Length > 0) ? this.Data.Length + 269 : 0;
 
         /// <summary>
         /// Gets the raw Data.
@@ -50,12 +50,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
         public int WriteTo(Span<byte> buffer)
         {
-            int totalSize = this.ContentLength;
-            if (buffer.Length < totalSize)
-            {
-                ThrowInsufficientMemory();
-            }
-
             int bytesWritten = 0;
             buffer[bytesWritten++] = GifConstants.ApplicationBlockSize;
 
@@ -77,7 +71,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
             buffer[bytesWritten++] = 0x00;
 
-            return totalSize;
+            return this.ContentLength;
         }
 
         private static byte[] ReadXmpData(Stream stream, MemoryAllocator allocator)
@@ -100,8 +94,5 @@ namespace SixLabors.ImageSharp.Formats.Gif
                 bytes.WriteByte((byte)b);
             }
         }
-
-        private static void ThrowInsufficientMemory()
-            => throw new InsufficientMemoryException("Unable to write XMP metadata to GIF image");
     }
 }

--- a/src/ImageSharp/Formats/Gif/Sections/GifXmpApplicationExtension.cs
+++ b/src/ImageSharp/Formats/Gif/Sections/GifXmpApplicationExtension.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using SixLabors.ImageSharp.Metadata.Profiles.Xmp;
+using SixLabors.ImageSharp.IO;
+using SixLabors.ImageSharp.Memory;
 
 namespace SixLabors.ImageSharp.Formats.Gif
 {
@@ -14,7 +14,10 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
         public byte Label => GifConstants.ApplicationExtensionLabel;
 
-        public int ContentLength => this.Data.Length + 269; // 12 + Data Length + 1 + 256
+        // size          : 1
+        // identifier    : 11
+        // magic trailer : 257
+        public int ContentLength => this.Data.Length + 269;
 
         /// <summary>
         /// Gets the raw Data.
@@ -25,40 +28,23 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// Reads the XMP metadata from the specified stream.
         /// </summary>
         /// <param name="stream">The stream to read from.</param>
+        /// <param name="allocator">The memory allocator.</param>
         /// <returns>The XMP metadata</returns>
         /// <exception cref="ImageFormatException">Thrown if the XMP block is not properly terminated.</exception>
-        public static GifXmpApplicationExtension Read(Stream stream)
+        public static GifXmpApplicationExtension Read(Stream stream, MemoryAllocator allocator)
         {
-            // Read data in blocks, until an \0 character is encountered.
-            // We overshoot, indicated by the terminatorIndex variable.
-            const int bufferSize = 256;
-            var list = new List<byte[]>();
-            int terminationIndex = -1;
-            while (terminationIndex < 0)
+            byte[] xmpBytes = ReadXmpData(stream, allocator);
+
+            // Exclude the "magic trailer", see XMP Specification Part 3, 1.1.2 GIF
+            int xmpLength = xmpBytes.Length - 256; // 257 - unread 0x0
+            byte[] buffer = Array.Empty<byte>();
+            if (xmpLength > 0)
             {
-                byte[] temp = new byte[bufferSize];
-                int bytesRead = stream.Read(temp);
-                list.Add(temp);
-                terminationIndex = Array.IndexOf(temp, (byte)1);
+                buffer = new byte[xmpLength];
+                xmpBytes.AsSpan(0, xmpLength).CopyTo(buffer);
+                stream.Skip(1); // Skip the terminator.
             }
 
-            // Pack all the blocks (except magic trailer) into one single array again.
-            int dataSize = ((list.Count - 1) * bufferSize) + terminationIndex;
-            byte[] buffer = new byte[dataSize];
-            Span<byte> bufferSpan = buffer;
-            int pos = 0;
-            for (int j = 0; j < list.Count - 1; j++)
-            {
-                list[j].CopyTo(bufferSpan.Slice(pos));
-                pos += bufferSize;
-            }
-
-            // Last one only needs the portion until terminationIndex copied over.
-            Span<byte> lastBytes = list[list.Count - 1];
-            lastBytes.Slice(0, terminationIndex).CopyTo(bufferSpan.Slice(pos));
-
-            // Skip the remainder of the magic trailer.
-            stream.Skip(258 - (bufferSize - terminationIndex));
             return new GifXmpApplicationExtension(buffer);
         }
 
@@ -67,7 +53,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             int totalSize = this.ContentLength;
             if (buffer.Length < totalSize)
             {
-                throw new InsufficientMemoryException("Unable to write XMP metadata to GIF image");
+                ThrowInsufficientMemory();
             }
 
             int bytesWritten = 0;
@@ -93,5 +79,29 @@ namespace SixLabors.ImageSharp.Formats.Gif
 
             return totalSize;
         }
+
+        private static byte[] ReadXmpData(Stream stream, MemoryAllocator allocator)
+        {
+            using ChunkedMemoryStream bytes = new(allocator);
+
+            // XMP data doesn't have a fixed length nor is there an indicator of the length.
+            // So we simply read one byte at a time until we hit the 0x0 value at the end
+            // of the magic trailer or the end of the stream.
+            // Using ChunkedMemoryStream reduces the array resize allocation normally associated
+            // with writing from a non fixed-size buffer.
+            while (true)
+            {
+                int b = stream.ReadByte();
+                if (b <= 0)
+                {
+                    return bytes.ToArray();
+                }
+
+                bytes.WriteByte((byte)b);
+            }
+        }
+
+        private static void ThrowInsufficientMemory()
+            => throw new InsufficientMemoryException("Unable to write XMP metadata to GIF image");
     }
 }

--- a/src/ImageSharp/Metadata/ImageMetadata.cs
+++ b/src/ImageSharp/Metadata/ImageMetadata.cs
@@ -68,6 +68,7 @@ namespace SixLabors.ImageSharp.Metadata
             this.ExifProfile = other.ExifProfile?.DeepClone();
             this.IccProfile = other.IccProfile?.DeepClone();
             this.IptcProfile = other.IptcProfile?.DeepClone();
+            this.XmpProfile = other.XmpProfile?.DeepClone();
         }
 
         /// <summary>
@@ -175,7 +176,7 @@ namespace SixLabors.ImageSharp.Metadata
         }
 
         /// <inheritdoc/>
-        public ImageMetadata DeepClone() => new ImageMetadata(this);
+        public ImageMetadata DeepClone() => new(this);
 
         /// <summary>
         /// Synchronizes the profiles with the current metadata.

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -278,6 +278,23 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         public void Issue2012BadMinCode<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
+            Exception ex = Record.Exception(
+                () =>
+                {
+                    using Image<TPixel> image = provider.GetImage();
+                    image.DebugSave(provider);
+                });
+
+            Assert.NotNull(ex);
+            Assert.Contains("Gif Image does not contain a valid LZW minimum code.", ex.Message);
+        }
+
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=55918
+        [Theory]
+        [WithFile(TestImages.Gif.Issues.DeferredClearCode, PixelTypes.Rgba32)]
+        public void IssueDeferredClearCode<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
             using Image<TPixel> image = provider.GetImage();
 
             image.DebugSave(provider);

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -271,5 +271,17 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
             image.DebugSave(provider);
             image.CompareFirstFrameToReferenceOutput(ImageComparer.Exact, provider);
         }
+
+        // https://github.com/SixLabors/ImageSharp/issues/2012
+        [Theory]
+        [WithFile(TestImages.Gif.Issues.Issue2012BadMinCode, PixelTypes.Rgba32)]
+        public void Issue2012BadMinCode<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage();
+
+            image.DebugSave(provider);
+            image.CompareFirstFrameToReferenceOutput(ImageComparer.Exact, provider);
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -259,5 +259,17 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
 
             image.CompareFirstFrameToReferenceOutput(ImageComparer.Exact, provider);
         }
+
+        // https://github.com/SixLabors/ImageSharp/issues/2012
+        [Theory]
+        [WithFile(TestImages.Gif.Issues.Issue2012EmptyXmp, PixelTypes.Rgba32)]
+        public void Issue2012EmptyXmp<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage();
+
+            image.DebugSave(provider);
+            image.CompareFirstFrameToReferenceOutput(ImageComparer.Exact, provider);
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpMetaDataTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
@@ -66,7 +67,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
         [Theory]
         [WithFile(TestImages.Webp.Lossy.WithXmp, PixelTypes.Rgba32, false)]
         [WithFile(TestImages.Webp.Lossy.WithXmp, PixelTypes.Rgba32, true)]
-        public async void IgnoreMetadata_ControlsWhetherXmpIsParsed<TPixel>(TestImageProvider<TPixel> provider, bool ignoreMetadata)
+        public async Task IgnoreMetadata_ControlsWhetherXmpIsParsed<TPixel>(TestImageProvider<TPixel> provider, bool ignoreMetadata)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             var decoder = new WebpDecoder { IgnoreMetadata = ignoreMetadata };

--- a/tests/ImageSharp.Tests/Metadata/Profiles/XMP/XmpProfileTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/XMP/XmpProfileTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Gif;
@@ -31,7 +32,7 @@ namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.Xmp
 
         [Theory]
         [WithFile(TestImages.Gif.Receipt, PixelTypes.Rgba32)]
-        public async void ReadXmpMetadata_FromGif_Works<TPixel>(TestImageProvider<TPixel> provider)
+        public async Task ReadXmpMetadata_FromGif_Works<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = await provider.GetImageAsync(GifDecoder))
@@ -45,7 +46,7 @@ namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.Xmp
         [WithFile(TestImages.Jpeg.Baseline.Lake, PixelTypes.Rgba32)]
         [WithFile(TestImages.Jpeg.Baseline.Metadata, PixelTypes.Rgba32)]
         [WithFile(TestImages.Jpeg.Baseline.ExtendedXmp, PixelTypes.Rgba32)]
-        public async void ReadXmpMetadata_FromJpg_Works<TPixel>(TestImageProvider<TPixel> provider)
+        public async Task ReadXmpMetadata_FromJpg_Works<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = await provider.GetImageAsync(JpegDecoder))
@@ -57,7 +58,7 @@ namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.Xmp
 
         [Theory]
         [WithFile(TestImages.Png.XmpColorPalette, PixelTypes.Rgba32)]
-        public async void ReadXmpMetadata_FromPng_Works<TPixel>(TestImageProvider<TPixel> provider)
+        public async Task ReadXmpMetadata_FromPng_Works<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = await provider.GetImageAsync(PngDecoder))
@@ -69,7 +70,7 @@ namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.Xmp
 
         [Theory]
         [WithFile(TestImages.Tiff.SampleMetadata, PixelTypes.Rgba32)]
-        public async void ReadXmpMetadata_FromTiff_Works<TPixel>(TestImageProvider<TPixel> provider)
+        public async Task ReadXmpMetadata_FromTiff_Works<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = await provider.GetImageAsync(TiffDecoder))
@@ -81,7 +82,7 @@ namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.Xmp
 
         [Theory]
         [WithFile(TestImages.Webp.Lossy.WithXmp, PixelTypes.Rgba32)]
-        public async void ReadXmpMetadata_FromWebp_Works<TPixel>(TestImageProvider<TPixel> provider)
+        public async Task ReadXmpMetadata_FromWebp_Works<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = await provider.GetImageAsync(WebpDecoder))
@@ -157,7 +158,7 @@ namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.Xmp
         }
 
         [Fact]
-        public async void WritingJpeg_PreservesExtendedXmpProfile()
+        public async Task WritingJpeg_PreservesExtendedXmpProfile()
         {
             // arrange
             var provider = TestImageProvider<Rgba32>.File(TestImages.Jpeg.Baseline.ExtendedXmp);

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -452,6 +452,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string Issue1530 = "Gif/issues/issue1530.gif";
                 public const string InvalidColorIndex = "Gif/issues/issue1668_invalidcolorindex.gif";
                 public const string Issue1962NoColorTable = "Gif/issues/issue1962_tiniest_gif_1st.gif";
+                public const string Issue2012EmptyXmp = "Gif/issues/issue2012_Stronghold-Crusader-Extreme-Cover.gif";
             }
 
             public static readonly string[] All = { Rings, Giphy, Cheers, Trans, Kumin, Leo, Ratio4x1, Ratio1x4 };

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -448,6 +448,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string BadAppExtLength = "Gif/issues/issue405_badappextlength252.gif";
                 public const string BadAppExtLength_2 = "Gif/issues/issue405_badappextlength252-2.gif";
                 public const string BadDescriptorWidth = "Gif/issues/issue403_baddescriptorwidth.gif";
+                public const string DeferredClearCode = "Gif/issues/bugzilla-55918.gif";
                 public const string Issue1505 = "Gif/issues/issue1505_argumentoutofrange.png";
                 public const string Issue1530 = "Gif/issues/issue1530.gif";
                 public const string InvalidColorIndex = "Gif/issues/issue1668_invalidcolorindex.gif";

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -453,6 +453,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string InvalidColorIndex = "Gif/issues/issue1668_invalidcolorindex.gif";
                 public const string Issue1962NoColorTable = "Gif/issues/issue1962_tiniest_gif_1st.gif";
                 public const string Issue2012EmptyXmp = "Gif/issues/issue2012_Stronghold-Crusader-Extreme-Cover.gif";
+                public const string Issue2012BadMinCode = "Gif/issues/issue2012_drona1.gif";
             }
 
             public static readonly string[] All = { Rings, Giphy, Cheers, Trans, Kumin, Leo, Ratio4x1, Ratio1x4 };

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012BadMinCode_Rgba32_issue2012_drona1.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012BadMinCode_Rgba32_issue2012_drona1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf4bc93479140b05b25066eb10c33fa9f82c617828a56526d47f5a8c72035ef0
+size 1871

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012BadMinCode_Rgba32_issue2012_drona1.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012BadMinCode_Rgba32_issue2012_drona1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf4bc93479140b05b25066eb10c33fa9f82c617828a56526d47f5a8c72035ef0
-size 1871

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012EmptyXmp_Rgba32_issue2012_Stronghold-Crusader-Extreme-Cover.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012EmptyXmp_Rgba32_issue2012_Stronghold-Crusader-Extreme-Cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ba8295d8a4b087d6c19fbad7e97cef7b5ce1a69b9c4c4f79cee6bc77e41f236
+size 62778

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueDeferredClearCode_Rgba32_bugzilla-55918.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueDeferredClearCode_Rgba32_bugzilla-55918.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b33733518b855b25c5e9a1b2f5c93cacf0699a40a459dde795b0ed91a978909
+size 12776

--- a/tests/Images/Input/Gif/issues/bugzilla-55918.gif
+++ b/tests/Images/Input/Gif/issues/bugzilla-55918.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d11148669a093c2e39be62bc3482c5863362d28c03c7f26c5a2386d5de28c339
+size 14551

--- a/tests/Images/Input/Gif/issues/issue2012_Stronghold-Crusader-Extreme-Cover.gif
+++ b/tests/Images/Input/Gif/issues/issue2012_Stronghold-Crusader-Extreme-Cover.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97f8fdbabfbd9663bf9940dc33f81edf330b62789d1aa573ae85a520903723e5
+size 77498

--- a/tests/Images/Input/Gif/issues/issue2012_drona1.gif
+++ b/tests/Images/Input/Gif/issues/issue2012_drona1.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbb23b2a19e314969c6da99374ae133d834d76c3f0ab9df4a7edc9334bb065e6
+size 10508


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #2012

- Fixes `GifXmpApplicationExtension` by using a more robust (_handles empty profiles_) and less allocation heavy reader.
- Provides protection against invalid memory operations in `LzwDecoder`
- Fixes cloning of `XmpProfile` when cloning `ImageMetadata`

Integrity of reencoded metadata has been tested externally using ExifTools

<!-- Thanks for contributing to ImageSharp! -->
