### PR TITLE
Fix issue in PNG identify method to skip "uninteresting" chunks, incl…

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -336,6 +336,14 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 break;
                             case PngChunkType.End:
                                 goto EOF;
+
+                            default:
+                                if (this.colorMetadataOnly)
+                                {
+                                    this.SkipChunkDataAndCrc(chunk);
+                                }
+
+                                break;
                         }
                     }
                     finally
@@ -1397,8 +1405,6 @@ namespace SixLabors.ImageSharp.Formats.Png
             if (this.colorMetadataOnly && type != PngChunkType.Header && type != PngChunkType.Transparency)
             {
                 chunk = new PngChunk(length, type);
-
-                this.SkipChunkDataAndCrc(chunk);
 
                 return true;
             }

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -336,9 +336,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 break;
                             case PngChunkType.End:
                                 goto EOF;
-                            default:
-                                this.SkipChunkDataAndCrc(chunk);
-                                break;
                         }
                     }
                     finally
@@ -1400,6 +1397,8 @@ namespace SixLabors.ImageSharp.Formats.Png
             if (this.colorMetadataOnly && type != PngChunkType.Header && type != PngChunkType.Transparency)
             {
                 chunk = new PngChunk(length, type);
+
+                this.SkipChunkDataAndCrc(chunk);
 
                 return true;
             }

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -336,6 +336,9 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 break;
                             case PngChunkType.End:
                                 goto EOF;
+                            default:
+                                this.SkipChunkDataAndCrc(chunk);
+                                break;
                         }
                     }
                     finally


### PR DESCRIPTION
…uding sBIT.

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
Add a default clause in the PNG Identify method to skip over "uninteresting" chunks so that the data is properly read. 
This fixes issue #2018 

<!-- Thanks for contributing to ImageSharp! -->
