### PR TITLE
PNG: Throw exception, if palette chunk is missing

### DIFF
--- a/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
+++ b/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
@@ -240,6 +240,11 @@ namespace SixLabors.ImageSharp.Formats.Png
             byte[] paletteAlpha)
             where TPixel : unmanaged, IPixel<TPixel>
         {
+            if (palette.IsEmpty)
+            {
+                PngThrowHelper.ThrowMissingPalette();
+            }
+
             TPixel pixel = default;
             ref byte scanlineSpanRef = ref MemoryMarshal.GetReference(scanlineSpan);
             ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);

--- a/src/ImageSharp/Formats/Png/PngThrowHelper.cs
+++ b/src/ImageSharp/Formats/Png/PngThrowHelper.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         public static void ThrowNoData() => throw new InvalidImageContentException("PNG Image does not contain a data chunk");
 
         [MethodImpl(InliningOptions.ColdPath)]
-        public static void ThrowMissingPalette() => throw new InvalidImageContentException("PNG Image does not contain palette chunk");
+        public static void ThrowMissingPalette() => throw new InvalidImageContentException("PNG Image does not contain a palette chunk");
 
         [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowInvalidChunkType() => throw new InvalidImageContentException("Invalid PNG data.");

--- a/src/ImageSharp/Formats/Png/PngThrowHelper.cs
+++ b/src/ImageSharp/Formats/Png/PngThrowHelper.cs
@@ -22,6 +22,9 @@ namespace SixLabors.ImageSharp.Formats.Png
         public static void ThrowNoData() => throw new InvalidImageContentException("PNG Image does not contain a data chunk");
 
         [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowMissingPalette() => throw new InvalidImageContentException("PNG Image does not contain palette chunk");
+
+        [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowInvalidChunkType() => throw new InvalidImageContentException("Invalid PNG data.");
 
         [MethodImpl(InliningOptions.ColdPath)]

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -266,6 +266,22 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         }
 
         [Theory]
+        [WithFile(TestImages.Png.Bad.MissingPaletteChunk1, PixelTypes.Rgba32)]
+        [WithFile(TestImages.Png.Bad.MissingPaletteChunk2, PixelTypes.Rgba32)]
+        public void Decode_MissingPaletteChunk_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Exception ex = Record.Exception(
+                () =>
+                {
+                    using Image<TPixel> image = provider.GetImage(PngDecoder);
+                    image.DebugSave(provider);
+                });
+            Assert.NotNull(ex);
+            Assert.Contains("PNG Image does not contain palette chunk", ex.Message);
+        }
+
+        [Theory]
         [WithFile(TestImages.Png.Bad.BitDepthZero, PixelTypes.Rgba32)]
         [WithFile(TestImages.Png.Bad.BitDepthThree, PixelTypes.Rgba32)]
         public void Decode_InvalidBitDepth_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -278,7 +278,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                     image.DebugSave(provider);
                 });
             Assert.NotNull(ex);
-            Assert.Contains("PNG Image does not contain palette chunk", ex.Message);
+            Assert.Contains("PNG Image does not contain a palette chunk", ex.Message);
         }
 
         [Theory]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -127,6 +127,8 @@ namespace SixLabors.ImageSharp.Tests
                 public const string MissingDataChunk = "Png/xdtn0g01.png";
                 public const string WrongCrcDataChunk = "Png/xcsn0g01.png";
                 public const string CorruptedChunk = "Png/big-corrupted-chunk.png";
+                public const string MissingPaletteChunk1 = "Png/missing_plte.png";
+                public const string MissingPaletteChunk2 = "Png/missing_plte_2.png";
 
                 // Zlib errors.
                 public const string ZlibOverflow = "Png/zlib-overflow.png";

--- a/tests/Images/Input/Png/missing_plte.png
+++ b/tests/Images/Input/Png/missing_plte.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73fd17a394f8258f4767986bc427c0160277819349c937f18cb29044e7549bc8
+size 506

--- a/tests/Images/Input/Png/missing_plte_2.png
+++ b/tests/Images/Input/Png/missing_plte_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:797844db61a937c6f31ecb392c8416fbf106017413ba55c6576e0b1fcfc1cf9c
+size 597


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR changes the PNG decoder to throw an appropriate exception, if the palette chunk is missing.