### PR TITLE
PNG: Ignore invalid gamma chunks

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -429,10 +429,16 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <param name="pngMetadata">The metadata to read to.</param>
         /// <param name="data">The data containing physical data.</param>
         private void ReadGammaChunk(PngMetadata pngMetadata, ReadOnlySpan<byte> data)
+        {
+            if (data.Length < 4)
+            {
+                PngThrowHelper.ThrowInvalidGamma();
+            }
 
-            // The value is encoded as a 4-byte unsigned integer, representing gamma times 100000.
             // For example, a gamma of 1/2.2 would be stored as 45455.
-            => pngMetadata.Gamma = BinaryPrimitives.ReadUInt32BigEndian(data) * 1e-5F;
+            // The value is encoded as a 4-byte unsigned integer, representing gamma times 100000.
+            pngMetadata.Gamma = BinaryPrimitives.ReadUInt32BigEndian(data) * 1e-5F;
+        }
 
         /// <summary>
         /// Initializes the image and various buffers needed for processing

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -432,7 +432,8 @@ namespace SixLabors.ImageSharp.Formats.Png
         {
             if (data.Length < 4)
             {
-                PngThrowHelper.ThrowInvalidGamma();
+                // Ignore invalid gamma chunks.
+                return;
             }
 
             // For example, a gamma of 1/2.2 would be stored as 45455.

--- a/src/ImageSharp/Formats/Png/PngThrowHelper.cs
+++ b/src/ImageSharp/Formats/Png/PngThrowHelper.cs
@@ -25,6 +25,9 @@ namespace SixLabors.ImageSharp.Formats.Png
         public static void ThrowMissingPalette() => throw new InvalidImageContentException("PNG Image does not contain a palette chunk");
 
         [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowInvalidGamma() => throw new InvalidImageContentException("PNG Image does not contain enough data for the gamma chunk");
+
+        [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowInvalidChunkType() => throw new InvalidImageContentException("Invalid PNG data.");
 
         [MethodImpl(InliningOptions.ColdPath)]

--- a/src/ImageSharp/Formats/Png/PngThrowHelper.cs
+++ b/src/ImageSharp/Formats/Png/PngThrowHelper.cs
@@ -25,9 +25,6 @@ namespace SixLabors.ImageSharp.Formats.Png
         public static void ThrowMissingPalette() => throw new InvalidImageContentException("PNG Image does not contain a palette chunk");
 
         [MethodImpl(InliningOptions.ColdPath)]
-        public static void ThrowInvalidGamma() => throw new InvalidImageContentException("PNG Image does not contain enough data for the gamma chunk");
-
-        [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowInvalidChunkType() => throw new InvalidImageContentException("Invalid PNG data.");
 
         [MethodImpl(InliningOptions.ColdPath)]

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -282,6 +282,21 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         }
 
         [Theory]
+        [WithFile(TestImages.Png.Bad.InvalidGammaChunk, PixelTypes.Rgba32)]
+        public void Decode_InvalidGammaChunk_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Exception ex = Record.Exception(
+                () =>
+                {
+                    using Image<TPixel> image = provider.GetImage(PngDecoder);
+                    image.DebugSave(provider);
+                });
+            Assert.NotNull(ex);
+            Assert.Contains("PNG Image does not contain enough data for the gamma chunk", ex.Message);
+        }
+
+        [Theory]
         [WithFile(TestImages.Png.Bad.BitDepthZero, PixelTypes.Rgba32)]
         [WithFile(TestImages.Png.Bad.BitDepthThree, PixelTypes.Rgba32)]
         public void Decode_InvalidBitDepth_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -283,7 +283,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
         [Theory]
         [WithFile(TestImages.Png.Bad.InvalidGammaChunk, PixelTypes.Rgba32)]
-        public void Decode_InvalidGammaChunk_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
+        public void Decode_InvalidGammaChunk_Ignored<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             Exception ex = Record.Exception(
@@ -292,8 +292,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                     using Image<TPixel> image = provider.GetImage(PngDecoder);
                     image.DebugSave(provider);
                 });
-            Assert.NotNull(ex);
-            Assert.Contains("PNG Image does not contain enough data for the gamma chunk", ex.Message);
+            Assert.Null(ex);
         }
 
         [Theory]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -129,6 +129,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string CorruptedChunk = "Png/big-corrupted-chunk.png";
                 public const string MissingPaletteChunk1 = "Png/missing_plte.png";
                 public const string MissingPaletteChunk2 = "Png/missing_plte_2.png";
+                public const string InvalidGammaChunk = "Png/length_gama.png";
 
                 // Zlib errors.
                 public const string ZlibOverflow = "Png/zlib-overflow.png";

--- a/tests/Images/Input/Png/length_gama.png
+++ b/tests/Images/Input/Png/length_gama.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:824766b34739727c722e88611d7b55401452c2970cd433f56e5f9f1b36d6950d
+size 1285


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR handles another edge case when the gamma chunk does not contain enough data.
