### PR TITLE
Workaround GC.GetMemoryInfo() ARM32 issue

### DIFF
--- a/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
@@ -74,9 +74,11 @@ namespace SixLabors.ImageSharp.Memory
             this.nonPoolAllocator = new UnmanagedMemoryAllocator(unmanagedBufferSizeInBytes);
         }
 
+#if NETCOREAPP3_1_OR_GREATER
         // This delegate allows overriding the method returning the available system memory,
         // so we can test our workaround for https://github.com/dotnet/runtime/issues/65466
         internal static Func<long> GetTotalAvailableMemoryBytes { get; set; } = () => GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+#endif
 
         /// <inheritdoc />
         protected internal override int GetBufferCapacityInBytes() => this.poolBufferSizeInBytes;

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -379,5 +379,18 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
                 g1.GetSpan()[0] = 42;
             }
         }
+
+        [Fact]
+        public void Issue2001_NegativeMemoryReportedByGc()
+        {
+            RemoteExecutor.Invoke(RunTest).Dispose();
+
+            static void RunTest()
+            {
+                // Emulate GC.GetGCMemoryInfo() issue https://github.com/dotnet/runtime/issues/65466
+                UniformUnmanagedMemoryPoolMemoryAllocator.GetTotalAvailableMemoryBytes = () => -402354176;
+                _ = MemoryAllocator.Create();
+            }
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -380,6 +380,7 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
             }
         }
 
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void Issue2001_NegativeMemoryReportedByGc()
         {
@@ -392,5 +393,6 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
                 _ = MemoryAllocator.Create();
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Workaround dotnet/runtime#65466 by using the constant fallback pool size if negative memory is reported.

Fixes #2001.