### PR TITLE
Add support for decoding gray tiff with jpeg compression

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/GrayJpegSpectralConverter.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/GrayJpegSpectralConverter.cs
@@ -8,24 +8,22 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
 {
     /// <summary>
-    /// Spectral converter for YCbCr TIFF's which use the JPEG compression.
-    /// The jpeg data should be always treated as RGB color space.
+    /// Spectral converter for gray TIFF's which use the JPEG compression.
     /// </summary>
     /// <typeparam name="TPixel">The type of the pixel.</typeparam>
-    internal sealed class RgbJpegSpectralConverter<TPixel> : SpectralConverter<TPixel>
+    internal sealed class GrayJpegSpectralConverter<TPixel> : SpectralConverter<TPixel>
         where TPixel : unmanaged, IPixel<TPixel>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RgbJpegSpectralConverter{TPixel}"/> class.
-        /// This Spectral converter will always convert the pixel data to RGB color.
+        /// Initializes a new instance of the <see cref="GrayJpegSpectralConverter{TPixel}"/> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
-        public RgbJpegSpectralConverter(Configuration configuration)
+        public GrayJpegSpectralConverter(Configuration configuration)
             : base(configuration)
         {
         }
 
         /// <inheritdoc/>
-        protected override JpegColorConverterBase GetColorConverter(JpegFrame frame, IRawJpegData jpegData) => JpegColorConverterBase.GetConverter(JpegColorSpace.RGB, frame.Precision);
+        protected override JpegColorConverterBase GetColorConverter(JpegFrame frame, IRawJpegData jpegData) => JpegColorConverterBase.GetConverter(JpegColorSpace.Grayscale, frame.Precision);
     }
 }

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/JpegTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/JpegTiffCompression.cs
@@ -62,7 +62,6 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
                         using SpectralConverter<L8> spectralConverterGray = new GrayJpegSpectralConverter<L8>(this.configuration);
                         var scanDecoderGray = new HuffmanScanDecoder(stream, spectralConverterGray, CancellationToken.None);
                         jpegDecoder.LoadTables(this.jpegTables, scanDecoderGray);
-                        scanDecoderGray.ResetInterval = 0;
                         jpegDecoder.ParseStream(stream, scanDecoderGray, CancellationToken.None);
 
                         // TODO: Should we pass through the CancellationToken from the tiff decoder?
@@ -79,7 +78,6 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
                             new RgbJpegSpectralConverter<Rgb24>(this.configuration) : new SpectralConverter<Rgb24>(this.configuration);
                         var scanDecoder = new HuffmanScanDecoder(stream, spectralConverter, CancellationToken.None);
                         jpegDecoder.LoadTables(this.jpegTables, scanDecoder);
-                        scanDecoder.ResetInterval = 0;
                         jpegDecoder.ParseStream(stream, scanDecoder, CancellationToken.None);
 
                         // TODO: Should we pass through the CancellationToken from the tiff decoder?

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/JpegTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/JpegTiffCompression.cs
@@ -9,7 +9,6 @@ using SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
 using SixLabors.ImageSharp.Formats.Tiff.Constants;
 using SixLabors.ImageSharp.IO;
 using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
@@ -55,17 +54,43 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
             {
                 using var jpegDecoder = new JpegDecoderCore(this.configuration, new JpegDecoder());
 
-                // If the PhotometricInterpretation is YCbCr we explicitly assume the JPEG data is in RGB color space.
-                // There seems no other way to determine that the JPEG data is RGB colorspace (no APP14 marker, componentId's are not RGB).
-                using SpectralConverter<Rgb24> spectralConverter = this.photometricInterpretation == TiffPhotometricInterpretation.YCbCr ?
-                    new RgbJpegSpectralConverter<Rgb24>(this.configuration) : new SpectralConverter<Rgb24>(this.configuration);
-                var scanDecoder = new HuffmanScanDecoder(stream, spectralConverter, CancellationToken.None);
-                jpegDecoder.LoadTables(this.jpegTables, scanDecoder);
-                scanDecoder.ResetInterval = 0;
-                jpegDecoder.ParseStream(stream, scanDecoder, CancellationToken.None);
+                switch (this.photometricInterpretation)
+                {
+                    case TiffPhotometricInterpretation.BlackIsZero:
+                    case TiffPhotometricInterpretation.WhiteIsZero:
+                    {
+                        using SpectralConverter<L8> spectralConverterGray = new GrayJpegSpectralConverter<L8>(this.configuration);
+                        var scanDecoderGray = new HuffmanScanDecoder(stream, spectralConverterGray, CancellationToken.None);
+                        jpegDecoder.LoadTables(this.jpegTables, scanDecoderGray);
+                        scanDecoderGray.ResetInterval = 0;
+                        jpegDecoder.ParseStream(stream, scanDecoderGray, CancellationToken.None);
 
-                // TODO: Should we pass through the CancellationToken from the tiff decoder?
-                CopyImageBytesToBuffer(buffer, spectralConverter.GetPixelBuffer(CancellationToken.None));
+                        // TODO: Should we pass through the CancellationToken from the tiff decoder?
+                        CopyImageBytesToBuffer(buffer, spectralConverterGray.GetPixelBuffer(CancellationToken.None));
+                        break;
+                    }
+
+                    // If the PhotometricInterpretation is YCbCr we explicitly assume the JPEG data is in RGB color space.
+                    // There seems no other way to determine that the JPEG data is RGB colorspace (no APP14 marker, componentId's are not RGB).
+                    case TiffPhotometricInterpretation.YCbCr:
+                    case TiffPhotometricInterpretation.Rgb:
+                    {
+                        using SpectralConverter<Rgb24> spectralConverter = this.photometricInterpretation == TiffPhotometricInterpretation.YCbCr ?
+                            new RgbJpegSpectralConverter<Rgb24>(this.configuration) : new SpectralConverter<Rgb24>(this.configuration);
+                        var scanDecoder = new HuffmanScanDecoder(stream, spectralConverter, CancellationToken.None);
+                        jpegDecoder.LoadTables(this.jpegTables, scanDecoder);
+                        scanDecoder.ResetInterval = 0;
+                        jpegDecoder.ParseStream(stream, scanDecoder, CancellationToken.None);
+
+                        // TODO: Should we pass through the CancellationToken from the tiff decoder?
+                        CopyImageBytesToBuffer(buffer, spectralConverter.GetPixelBuffer(CancellationToken.None));
+                        break;
+                    }
+
+                    default:
+                        TiffThrowHelper.ThrowNotSupported($"Jpeg compressed tiff with photometric interpretation {this.photometricInterpretation} is not supported");
+                        break;
+                }
             }
             else
             {
@@ -80,6 +105,18 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
             for (int y = 0; y < pixelBuffer.Height; y++)
             {
                 Span<Rgb24> pixelRowSpan = pixelBuffer.DangerousGetRowSpan(y);
+                Span<byte> rgbBytes = MemoryMarshal.AsBytes(pixelRowSpan);
+                rgbBytes.CopyTo(buffer.Slice(offset));
+                offset += rgbBytes.Length;
+            }
+        }
+
+        private static void CopyImageBytesToBuffer(Span<byte> buffer, Buffer2D<L8> pixelBuffer)
+        {
+            int offset = 0;
+            for (int y = 0; y < pixelBuffer.Height; y++)
+            {
+                Span<L8> pixelRowSpan = pixelBuffer.DangerousGetRowSpan(y);
                 Span<byte> rgbBytes = MemoryMarshal.AsBytes(pixelRowSpan);
                 rgbBytes.CopyTo(buffer.Slice(offset));
                 offset += rgbBytes.Length;

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -370,6 +370,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [WithFile(RgbWithStripsJpegCompressed, PixelTypes.Rgba32)]
         [WithFile(YCbCrJpegCompressed, PixelTypes.Rgba32)]
         [WithFile(RgbJpegCompressedNoJpegTable, PixelTypes.Rgba32)]
+        [WithFile(GrayscaleJpegCompressed, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_JpegCompressed<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, useExactComparer: false);
 

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -772,6 +772,7 @@ namespace SixLabors.ImageSharp.Tests
 
             public const string GrayscaleDeflateMultistrip = "Tiff/grayscale_deflate_multistrip.tiff";
             public const string GrayscaleUncompressed = "Tiff/grayscale_uncompressed.tiff";
+            public const string GrayscaleJpegCompressed = "Tiff/JpegCompressedGray.tiff";
             public const string PaletteDeflateMultistrip = "Tiff/palette_grayscale_deflate_multistrip.tiff";
             public const string PaletteUncompressed = "Tiff/palette_uncompressed.tiff";
             public const string RgbDeflate = "Tiff/rgb_deflate.tiff";

--- a/tests/Images/Input/Tiff/JpegCompressedGray.tiff
+++ b/tests/Images/Input/Tiff/JpegCompressedGray.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:868afd018d025ed7636f1155c1b1f64ba8a36153b56c7598e8dee18ce770cd5a
+size 539660


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR adds support for decoding gray tiff with jpeg compression.

Fixes #2030