### PR TITLE
Allow pad to work for non-alpha pixel formats

### DIFF
--- a/src/ImageSharp/Processing/Extensions/Transforms/PadExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/Transforms/PadExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.ImageSharp.Processing
@@ -34,9 +34,10 @@ namespace SixLabors.ImageSharp.Processing
                 Size = new Size(width, height),
                 Mode = ResizeMode.BoxPad,
                 Sampler = KnownResamplers.NearestNeighbor,
+                PadColor = color
             };
 
-            return color.Equals(default) ? source.Resize(options) : source.Resize(options).BackgroundColor(color);
+            return source.Resize(options);
         }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor.cs
@@ -21,18 +21,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
 
             (Size size, Rectangle rectangle) = ResizeHelper.CalculateTargetLocationAndBounds(sourceSize, options);
 
-            this.Sampler = options.Sampler;
+            this.Options = options;
             this.DestinationWidth = size.Width;
             this.DestinationHeight = size.Height;
             this.DestinationRectangle = rectangle;
-            this.Compand = options.Compand;
-            this.PremultiplyAlpha = options.PremultiplyAlpha;
         }
-
-        /// <summary>
-        /// Gets the sampler to perform the resize operation.
-        /// </summary>
-        public IResampler Sampler { get; }
 
         /// <summary>
         /// Gets the destination width.
@@ -50,14 +43,9 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms
         public Rectangle DestinationRectangle { get; }
 
         /// <summary>
-        /// Gets a value indicating whether to compress or expand individual pixel color values on processing.
+        /// Gets the resize options.
         /// </summary>
-        public bool Compand { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether to premultiply the alpha (if it exists) during the resize operation.
-        /// </summary>
-        public bool PremultiplyAlpha { get; }
+        public ResizeOptions Options { get; }
 
         /// <inheritdoc />
         public override ICloningImageProcessor<TPixel> CreatePixelSpecificCloningProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)

--- a/src/ImageSharp/Processing/ResizeOptions.cs
+++ b/src/ImageSharp/Processing/ResizeOptions.cs
@@ -51,5 +51,10 @@ namespace SixLabors.ImageSharp.Processing
         /// the alpha (if it exists) during the resize operation.
         /// </summary>
         public bool PremultiplyAlpha { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the color to use as a background when padding an image.
+        /// </summary>
+        public Color PadColor { get; set; }
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/PadTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/PadTest.cs
@@ -20,41 +20,37 @@ namespace SixLabors.ImageSharp.Tests.Processing.Processors.Transforms
         public void ImageShouldPad<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            using (Image<TPixel> image = provider.GetImage())
-            {
-                image.Mutate(x => x.Pad(image.Width + 50, image.Height + 50));
-                image.DebugSave(provider);
+            using Image<TPixel> image = provider.GetImage();
+            image.Mutate(x => x.Pad(image.Width + 50, image.Height + 50));
+            image.DebugSave(provider);
 
-                // Check pixels are empty
-                for (int y = 0; y < 25; y++)
+            // Check pixels are empty
+            for (int y = 0; y < 25; y++)
+            {
+                for (int x = 0; x < 25; x++)
                 {
-                    for (int x = 0; x < 25; x++)
-                    {
-                        Assert.Equal(default, image[x, y]);
-                    }
+                    Assert.Equal(default, image[x, y]);
                 }
             }
         }
 
         [Theory]
-        [WithFileCollection(nameof(CommonTestImages), PixelTypes.Rgba32)]
+        [WithFileCollection(nameof(CommonTestImages), PixelTypes.Rgba32 | PixelTypes.Rgb24)]
         public void ImageShouldPadWithBackgroundColor<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            var color = Color.Red;
+            Color color = Color.Red;
             TPixel expected = color.ToPixel<TPixel>();
-            using (Image<TPixel> image = provider.GetImage())
-            {
-                image.Mutate(x => x.Pad(image.Width + 50, image.Height + 50, color));
-                image.DebugSave(provider);
+            using Image<TPixel> image = provider.GetImage();
+            image.Mutate(x => x.Pad(image.Width + 50, image.Height + 50, color));
+            image.DebugSave(provider);
 
-                // Check pixels are filled
-                for (int y = 0; y < 25; y++)
+            // Check pixels are filled
+            for (int y = 0; y < 25; y++)
+            {
+                for (int x = 0; x < 25; x++)
                 {
-                    for (int x = 0; x < 25; x++)
-                    {
-                        Assert.Equal(expected, image[x, y]);
-                    }
+                    Assert.Equal(expected, image[x, y]);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processing/Transforms/PadTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/PadTest.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
 
             Assert.Equal(width, resizeProcessor.DestinationWidth);
             Assert.Equal(height, resizeProcessor.DestinationHeight);
-            Assert.Equal(sampler, resizeProcessor.Sampler);
+            Assert.Equal(sampler, resizeProcessor.Options.Sampler);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/ResizeTests.cs
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
 
             Assert.Equal(width, resizeProcessor.DestinationWidth);
             Assert.Equal(height, resizeProcessor.DestinationHeight);
-            Assert.Equal(sampler, resizeProcessor.Sampler);
+            Assert.Equal(sampler, resizeProcessor.Options.Sampler);
         }
 
         [Fact]
@@ -52,8 +52,8 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
 
             Assert.Equal(width, resizeProcessor.DestinationWidth);
             Assert.Equal(height, resizeProcessor.DestinationHeight);
-            Assert.Equal(sampler, resizeProcessor.Sampler);
-            Assert.Equal(compand, resizeProcessor.Compand);
+            Assert.Equal(sampler, resizeProcessor.Options.Sampler);
+            Assert.Equal(compand, resizeProcessor.Options.Compand);
         }
 
         [Fact]
@@ -78,8 +78,8 @@ namespace SixLabors.ImageSharp.Tests.Processing.Transforms
 
             Assert.Equal(width, resizeProcessor.DestinationWidth);
             Assert.Equal(height, resizeProcessor.DestinationHeight);
-            Assert.Equal(sampler, resizeProcessor.Sampler);
-            Assert.Equal(compand, resizeProcessor.Compand);
+            Assert.Equal(sampler, resizeProcessor.Options.Sampler);
+            Assert.Equal(compand, resizeProcessor.Options.Compand);
 
             // Ensure options are not altered.
             Assert.Equal(width, resizeOptions.Size.Width);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds a new property  `ResizeOptions.PadColor` of type Color which allows choosing a background color to pad images with.
This property color is then applied via the built in `ImageFrame<TPixel>.Clear(TPixel color)` which allows background color filling in non-alpha aware pixel formats like `Rgb24`.

<!-- Thanks for contributing to ImageSharp! -->
