### PR TITLE
Add ARM versions of PNG filters

### DIFF
--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -96,7 +96,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
             ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
 
-            Vector128<byte> d = Vector128<byte>.Zero;
+            Vector64<byte> d = Vector64<byte>.Zero;
 
             int rb = scanline.Length;
             int offset = 1;
@@ -104,11 +104,11 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             while (rb >= bytesPerBatch)
             {
                 ref byte scanRef = ref Unsafe.Add(ref scanBaseRef, offset);
-                Vector128<byte> a = d;
-                Vector128<byte> b = Vector128.CreateScalar(Unsafe.As<byte, int>(ref Unsafe.Add(ref prevBaseRef, offset))).AsByte();
-                d = Vector128.CreateScalar(Unsafe.As<byte, int>(ref scanRef)).AsByte();
+                Vector64<byte> a = d;
+                Vector64<byte> b = Vector64.CreateScalar(Unsafe.As<byte, int>(ref Unsafe.Add(ref prevBaseRef, offset))).AsByte();
+                d = Vector64.CreateScalar(Unsafe.As<byte, int>(ref scanRef)).AsByte();
 
-                Vector128<byte> avg = AdvSimd.FusedAddHalving(a, b);
+                Vector64<byte> avg = AdvSimd.FusedAddHalving(a, b);
                 d = AdvSimd.Add(d, avg);
 
                 Unsafe.As<byte, int>(ref scanRef) = d.AsInt32().ToScalar();

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         {
             ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
 
-            Vector128<byte> d = Vector128<byte>.Zero;
+            Vector64<byte> d = Vector64<byte>.Zero;
 
             int rb = scanline.Length;
             int offset = 1;
@@ -87,8 +87,8 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             while (rb >= bytesPerBatch)
             {
                 ref byte scanRef = ref Unsafe.Add(ref scanBaseRef, offset);
-                Vector128<byte> a = d;
-                d = Vector128.CreateScalar(Unsafe.As<byte, int>(ref scanRef)).AsByte();
+                Vector64<byte> a = d;
+                d = Vector64.CreateScalar(Unsafe.As<byte, int>(ref scanRef)).AsByte();
 
                 d = AdvSimd.Add(d, a);
 

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -5,9 +5,11 @@ using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics.Arm;
 
 #if SUPPORTS_RUNTIME_INTRINSICS
+#if NET5_0_OR_GREATER
+using System.Runtime.Intrinsics.Arm;
+#endif
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -121,7 +121,6 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         }
 
 #if NET5_0_OR_GREATER
-
         private static void DecodeArm(Span<byte> scanline, Span<byte> previousScanline)
         {
             ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR adds ARM intrinsics versions of the PNG filter methods.

Benchmark results for random data of size 1024, which could be a typical image row:

```
BenchmarkDotNet=v0.13.1, OS=ubuntu 20.04
Unknown processor
.NET SDK=5.0.402
  [Host]     : .NET 5.0.11 (5.0.1121.47308), Arm64 RyuJIT
  DefaultJob : .NET 5.0.11 (5.0.1121.47308), Arm64 RyuJIT


|        Method |        Mean |    Error |   StdDev |
|-------------- |------------:|---------:|---------:|
|      UpScalar |  2,568.1 ns |  0.74 ns |  0.66 ns |
|         UpArm |    438.2 ns |  0.10 ns |  0.08 ns |
|     SubScalar |  3,130.6 ns |  0.15 ns |  0.13 ns |
|        SubArm |    864.5 ns |  0.04 ns |  0.03 ns |
| AverageScalar |  4,278.0 ns |  0.90 ns |  0.75 ns |
|    AverageArm |  1,154.6 ns |  0.20 ns |  0.19 ns |
|   PaethScalar | 15,902.9 ns | 55.09 ns | 43.01 ns |
|      PaethArm |  5,022.5 ns |  2.32 ns |  2.17 ns |


CPU info:

Architecture:        aarch64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              6
On-line CPU(s) list: 0-5
Thread(s) per core:  1
Core(s) per socket:  3
Socket(s):           2
Vendor ID:           ARM
Model:               4
Model name:          Cortex-A53
Stepping:            r0p4
CPU max MHz:         1896.0000
CPU min MHz:         100.0000
BogoMIPS:            48.00
Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32
```

**note: The target branch is arm, not main, as ARM will be considered experimental for a while**