### PR TITLE
Add support for decoding Tiff images with UnassociatedAlphaData

### DIFF
--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgba16161616TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgba16161616TiffColor{TPixel}.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.ImageSharp.Formats.Tiff.Utils;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
+{
+    /// <summary>
+    /// Implements the 'RGB' photometric interpretation with an alpha channel and with 16 bits for each channel.
+    /// </summary>
+    internal class Rgba16161616TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        private readonly bool isBigEndian;
+
+        private readonly Configuration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Rgba16161616TiffColor{TPixel}" /> class.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="isBigEndian">if set to <c>true</c> decodes the pixel data as big endian, otherwise as little endian.</param>
+        public Rgba16161616TiffColor(Configuration configuration, bool isBigEndian)
+        {
+            this.configuration = configuration;
+            this.isBigEndian = isBigEndian;
+        }
+
+        /// <inheritdoc/>
+        public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
+        {
+            // Note: due to an issue with netcore 2.1 and default values and unpredictable behavior with those,
+            // we define our own defaults as a workaround. See: https://github.com/dotnet/runtime/issues/55623
+            Rgba64 rgba = TiffUtils.Rgba64Default;
+            var color = default(TPixel);
+            color.FromVector4(TiffUtils.Vector4Default);
+
+            int offset = 0;
+
+            for (int y = top; y < top + height; y++)
+            {
+                Span<TPixel> pixelRow = pixels.DangerousGetRowSpan(y).Slice(left, width);
+
+                if (this.isBigEndian)
+                {
+                    for (int x = 0; x < pixelRow.Length; x++)
+                    {
+                        ulong r = TiffUtils.ConvertToUShortBigEndian(data.Slice(offset, 2));
+                        offset += 2;
+                        ulong g = TiffUtils.ConvertToUShortBigEndian(data.Slice(offset, 2));
+                        offset += 2;
+                        ulong b = TiffUtils.ConvertToUShortBigEndian(data.Slice(offset, 2));
+                        offset += 2;
+                        ulong a = TiffUtils.ConvertToUShortBigEndian(data.Slice(offset, 2));
+                        offset += 2;
+
+                        pixelRow[x] = TiffUtils.ColorFromRgba64(rgba, r, g, b, a, color);
+                    }
+                }
+                else
+                {
+                    int byteCount = pixelRow.Length * 8;
+                    PixelOperations<TPixel>.Instance.FromRgba64Bytes(
+                        this.configuration,
+                        data.Slice(offset, byteCount),
+                        pixelRow,
+                        pixelRow.Length);
+
+                    offset += byteCount;
+                }
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgba24242424TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgba24242424TiffColor{TPixel}.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.ImageSharp.Formats.Tiff.Utils;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
+{
+    /// <summary>
+    /// Implements the 'RGB' photometric interpretation with an alpha channel and with 24 bits for each channel.
+    /// </summary>
+    internal class Rgba24242424TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        private readonly bool isBigEndian;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Rgba24242424TiffColor{TPixel}" /> class.
+        /// </summary>
+        /// <param name="isBigEndian">if set to <c>true</c> decodes the pixel data as big endian, otherwise as little endian.</param>
+        public Rgba24242424TiffColor(bool isBigEndian) => this.isBigEndian = isBigEndian;
+
+        /// <inheritdoc/>
+        public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
+        {
+            // Note: due to an issue with netcore 2.1 and default values and unpredictable behavior with those,
+            // we define our own defaults as a workaround. See: https://github.com/dotnet/runtime/issues/55623
+            var color = default(TPixel);
+            color.FromVector4(TiffUtils.Vector4Default);
+            int offset = 0;
+            byte[] buffer = new byte[4];
+            int bufferStartIdx = this.isBigEndian ? 1 : 0;
+
+            Span<byte> bufferSpan = buffer.AsSpan(bufferStartIdx);
+            for (int y = top; y < top + height; y++)
+            {
+                Span<TPixel> pixelRow = pixels.DangerousGetRowSpan(y).Slice(left, width);
+
+                if (this.isBigEndian)
+                {
+                    for (int x = 0; x < pixelRow.Length; x++)
+                    {
+                        data.Slice(offset, 3).CopyTo(bufferSpan);
+                        ulong r = TiffUtils.ConvertToUIntBigEndian(buffer);
+                        offset += 3;
+
+                        data.Slice(offset, 3).CopyTo(bufferSpan);
+                        ulong g = TiffUtils.ConvertToUIntBigEndian(buffer);
+                        offset += 3;
+
+                        data.Slice(offset, 3).CopyTo(bufferSpan);
+                        ulong b = TiffUtils.ConvertToUIntBigEndian(buffer);
+                        offset += 3;
+
+                        data.Slice(offset, 3).CopyTo(bufferSpan);
+                        ulong a = TiffUtils.ConvertToUIntBigEndian(buffer);
+                        offset += 3;
+
+                        pixelRow[x] = TiffUtils.ColorScaleTo32Bit(r, g, b, a, color);
+                    }
+                }
+                else
+                {
+                    for (int x = 0; x < pixelRow.Length; x++)
+                    {
+                        data.Slice(offset, 3).CopyTo(bufferSpan);
+                        ulong r = TiffUtils.ConvertToUIntLittleEndian(buffer);
+                        offset += 3;
+
+                        data.Slice(offset, 3).CopyTo(bufferSpan);
+                        ulong g = TiffUtils.ConvertToUIntLittleEndian(buffer);
+                        offset += 3;
+
+                        data.Slice(offset, 3).CopyTo(bufferSpan);
+                        ulong b = TiffUtils.ConvertToUIntLittleEndian(buffer);
+                        offset += 3;
+
+                        data.Slice(offset, 3).CopyTo(bufferSpan);
+                        ulong a = TiffUtils.ConvertToUIntLittleEndian(buffer);
+                        offset += 3;
+
+                        pixelRow[x] = TiffUtils.ColorScaleTo32Bit(r, g, b, a, color);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgba32323232TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgba32323232TiffColor{TPixel}.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.ImageSharp.Formats.Tiff.Utils;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
+{
+    /// <summary>
+    /// Implements the 'RGB' photometric interpretation with an alpha channel and with 32 bits for each channel.
+    /// </summary>
+    internal class Rgba32323232TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        private readonly bool isBigEndian;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Rgba32323232TiffColor{TPixel}" /> class.
+        /// </summary>
+        /// <param name="isBigEndian">if set to <c>true</c> decodes the pixel data as big endian, otherwise as little endian.</param>
+        public Rgba32323232TiffColor(bool isBigEndian) => this.isBigEndian = isBigEndian;
+
+        /// <inheritdoc/>
+        public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
+        {
+            // Note: due to an issue with netcore 2.1 and default values and unpredictable behavior with those,
+            // we define our own defaults as a workaround. See: https://github.com/dotnet/runtime/issues/55623
+            var color = default(TPixel);
+            color.FromVector4(TiffUtils.Vector4Default);
+            int offset = 0;
+
+            for (int y = top; y < top + height; y++)
+            {
+                Span<TPixel> pixelRow = pixels.DangerousGetRowSpan(y).Slice(left, width);
+
+                if (this.isBigEndian)
+                {
+                    for (int x = 0; x < pixelRow.Length; x++)
+                    {
+                        ulong r = TiffUtils.ConvertToUIntBigEndian(data.Slice(offset, 4));
+                        offset += 4;
+
+                        ulong g = TiffUtils.ConvertToUIntBigEndian(data.Slice(offset, 4));
+                        offset += 4;
+
+                        ulong b = TiffUtils.ConvertToUIntBigEndian(data.Slice(offset, 4));
+                        offset += 4;
+
+                        ulong a = TiffUtils.ConvertToUIntBigEndian(data.Slice(offset, 4));
+                        offset += 4;
+
+                        pixelRow[x] = TiffUtils.ColorScaleTo32Bit(r, g, b, a, color);
+                    }
+                }
+                else
+                {
+                    for (int x = 0; x < pixelRow.Length; x++)
+                    {
+                        ulong r = TiffUtils.ConvertToUIntLittleEndian(data.Slice(offset, 4));
+                        offset += 4;
+
+                        ulong g = TiffUtils.ConvertToUIntLittleEndian(data.Slice(offset, 4));
+                        offset += 4;
+
+                        ulong b = TiffUtils.ConvertToUIntLittleEndian(data.Slice(offset, 4));
+                        offset += 4;
+
+                        ulong a = TiffUtils.ConvertToUIntLittleEndian(data.Slice(offset, 4));
+                        offset += 4;
+
+                        pixelRow[x] = TiffUtils.ColorScaleTo32Bit(r, g, b, a, color);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgba8888TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/Rgba8888TiffColor{TPixel}.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
+{
+    /// <summary>
+    /// Implements the 'RGB' photometric interpretation with an alpha channel and 8 bits per channel.
+    /// </summary>
+    internal class Rgba8888TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        private readonly Configuration configuration;
+
+        public Rgba8888TiffColor(Configuration configuration) => this.configuration = configuration;
+
+        /// <inheritdoc/>
+        public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
+        {
+            int offset = 0;
+
+            for (int y = top; y < top + height; y++)
+            {
+                Span<TPixel> pixelRow = pixels.DangerousGetRowSpan(y).Slice(left, width);
+                int byteCount = pixelRow.Length * 4;
+                PixelOperations<TPixel>.Instance.FromRgba32Bytes(
+                    this.configuration,
+                    data.Slice(offset, byteCount),
+                    pixelRow,
+                    pixelRow.Length);
+
+                offset += byteCount;
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/RgbaFloat32323232TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/RgbaFloat32323232TiffColor{TPixel}.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Numerics;
+using SixLabors.ImageSharp.Formats.Tiff.Utils;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
+{
+    /// <summary>
+    /// Implements the 'RGB' photometric interpretation with an alpha channel and with 32 bits for each channel.
+    /// </summary>
+    internal class RgbaFloat32323232TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        private readonly bool isBigEndian;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RgbaFloat32323232TiffColor{TPixel}" /> class.
+        /// </summary>
+        /// <param name="isBigEndian">if set to <c>true</c> decodes the pixel data as big endian, otherwise as little endian.</param>
+        public RgbaFloat32323232TiffColor(bool isBigEndian) => this.isBigEndian = isBigEndian;
+
+        /// <inheritdoc/>
+        public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
+        {
+            // Note: due to an issue with netcore 2.1 and default values and unpredictable behavior with those,
+            // we define our own defaults as a workaround. See: https://github.com/dotnet/runtime/issues/55623
+            var color = default(TPixel);
+            color.FromVector4(TiffUtils.Vector4Default);
+            int offset = 0;
+            byte[] buffer = new byte[4];
+
+            for (int y = top; y < top + height; y++)
+            {
+                Span<TPixel> pixelRow = pixels.DangerousGetRowSpan(y).Slice(left, width);
+
+                if (this.isBigEndian)
+                {
+                    for (int x = 0; x < pixelRow.Length; x++)
+                    {
+                        data.Slice(offset, 4).CopyTo(buffer);
+                        Array.Reverse(buffer);
+                        float r = BitConverter.ToSingle(buffer, 0);
+                        offset += 4;
+
+                        data.Slice(offset, 4).CopyTo(buffer);
+                        Array.Reverse(buffer);
+                        float g = BitConverter.ToSingle(buffer, 0);
+                        offset += 4;
+
+                        data.Slice(offset, 4).CopyTo(buffer);
+                        Array.Reverse(buffer);
+                        float b = BitConverter.ToSingle(buffer, 0);
+                        offset += 4;
+
+                        data.Slice(offset, 4).CopyTo(buffer);
+                        Array.Reverse(buffer);
+                        float a = BitConverter.ToSingle(buffer, 0);
+                        offset += 4;
+
+                        var colorVector = new Vector4(r, g, b, a);
+                        color.FromVector4(colorVector);
+                        pixelRow[x] = color;
+                    }
+                }
+                else
+                {
+                    for (int x = 0; x < pixelRow.Length; x++)
+                    {
+                        data.Slice(offset, 4).CopyTo(buffer);
+                        float r = BitConverter.ToSingle(buffer, 0);
+                        offset += 4;
+
+                        data.Slice(offset, 4).CopyTo(buffer);
+                        float g = BitConverter.ToSingle(buffer, 0);
+                        offset += 4;
+
+                        data.Slice(offset, 4).CopyTo(buffer);
+                        float b = BitConverter.ToSingle(buffer, 0);
+                        offset += 4;
+
+                        data.Slice(offset, 4).CopyTo(buffer);
+                        float a = BitConverter.ToSingle(buffer, 0);
+                        offset += 4;
+
+                        var colorVector = new Vector4(r, g, b, a);
+                        color.FromVector4(colorVector);
+                        pixelRow[x] = color;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/RgbaTiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/RgbaTiffColor{TPixel}.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Numerics;
+using SixLabors.ImageSharp.Formats.Tiff.Utils;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
+{
+    /// <summary>
+    /// Implements the 'RGB' photometric interpretation with alpha channel (for all bit depths).
+    /// </summary>
+    internal class RgbaTiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        private readonly float rFactor;
+
+        private readonly float gFactor;
+
+        private readonly float bFactor;
+
+        private readonly float aFactor;
+
+        private readonly ushort bitsPerSampleR;
+
+        private readonly ushort bitsPerSampleG;
+
+        private readonly ushort bitsPerSampleB;
+
+        private readonly ushort bitsPerSampleA;
+
+        public RgbaTiffColor(TiffBitsPerSample bitsPerSample)
+        {
+            this.bitsPerSampleR = bitsPerSample.Channel0;
+            this.bitsPerSampleG = bitsPerSample.Channel1;
+            this.bitsPerSampleB = bitsPerSample.Channel2;
+            this.bitsPerSampleA = bitsPerSample.Channel3;
+
+            this.rFactor = (1 << this.bitsPerSampleR) - 1.0f;
+            this.gFactor = (1 << this.bitsPerSampleG) - 1.0f;
+            this.bFactor = (1 << this.bitsPerSampleB) - 1.0f;
+            this.aFactor = (1 << this.bitsPerSampleA) - 1.0f;
+        }
+
+        /// <inheritdoc/>
+        public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
+        {
+            var color = default(TPixel);
+
+            var bitReader = new BitReader(data);
+
+            for (int y = top; y < top + height; y++)
+            {
+                Span<TPixel> pixelRow = pixels.DangerousGetRowSpan(y).Slice(left, width);
+                for (int x = 0; x < pixelRow.Length; x++)
+                {
+                    float r = bitReader.ReadBits(this.bitsPerSampleR) / this.rFactor;
+                    float g = bitReader.ReadBits(this.bitsPerSampleG) / this.gFactor;
+                    float b = bitReader.ReadBits(this.bitsPerSampleB) / this.bFactor;
+                    float a = bitReader.ReadBits(this.bitsPerSampleB) / this.aFactor;
+
+                    color.FromVector4(new Vector4(r, g, b, a));
+                    pixelRow[x] = color;
+                }
+
+                bitReader.NextRow();
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorDecoderFactory{TPixel}.cs
@@ -116,6 +116,38 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);
 
+                case TiffColorType.Rgba2222:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 2
+                        && bitsPerSample.Channel2 == 2
+                        && bitsPerSample.Channel1 == 2
+                        && bitsPerSample.Channel0 == 2,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbaTiffColor<TPixel>(bitsPerSample);
+
+                case TiffColorType.Rgb333:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 3
+                        && bitsPerSample.Channel2 == 3
+                        && bitsPerSample.Channel1 == 3
+                        && bitsPerSample.Channel0 == 3,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbTiffColor<TPixel>(bitsPerSample);
+
+                case TiffColorType.Rgba3333:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 3
+                        && bitsPerSample.Channel2 == 3
+                        && bitsPerSample.Channel1 == 3
+                        && bitsPerSample.Channel0 == 3,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbaTiffColor<TPixel>(bitsPerSample);
+
                 case TiffColorType.Rgb444:
                     DebugGuard.IsTrue(
                         bitsPerSample.Channels == 3
@@ -125,6 +157,59 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new Rgb444TiffColor<TPixel>();
+
+                case TiffColorType.Rgba4444:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 4
+                        && bitsPerSample.Channel2 == 4
+                        && bitsPerSample.Channel1 == 4
+                        && bitsPerSample.Channel0 == 4,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbaTiffColor<TPixel>(bitsPerSample);
+
+                case TiffColorType.Rgb555:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 3
+                        && bitsPerSample.Channel2 == 5
+                        && bitsPerSample.Channel1 == 5
+                        && bitsPerSample.Channel0 == 5,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbTiffColor<TPixel>(bitsPerSample);
+
+                case TiffColorType.Rgba5555:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 5
+                        && bitsPerSample.Channel2 == 5
+                        && bitsPerSample.Channel1 == 5
+                        && bitsPerSample.Channel0 == 5,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbaTiffColor<TPixel>(bitsPerSample);
+
+                case TiffColorType.Rgb666:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 3
+                        && bitsPerSample.Channel2 == 6
+                        && bitsPerSample.Channel1 == 6
+                        && bitsPerSample.Channel0 == 6,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbTiffColor<TPixel>(bitsPerSample);
+
+                case TiffColorType.Rgba6666:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 6
+                        && bitsPerSample.Channel2 == 6
+                        && bitsPerSample.Channel1 == 6
+                        && bitsPerSample.Channel0 == 6,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbaTiffColor<TPixel>(bitsPerSample);
 
                 case TiffColorType.Rgb888:
                     DebugGuard.IsTrue(
@@ -136,6 +221,17 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new Rgb888TiffColor<TPixel>(configuration);
 
+                case TiffColorType.Rgba8888:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 8
+                        && bitsPerSample.Channel2 == 8
+                        && bitsPerSample.Channel1 == 8
+                        && bitsPerSample.Channel0 == 8,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new Rgba8888TiffColor<TPixel>(configuration);
+
                 case TiffColorType.Rgb101010:
                     DebugGuard.IsTrue(
                         bitsPerSample.Channels == 3
@@ -145,6 +241,17 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);
+
+                case TiffColorType.Rgba10101010:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 10
+                        && bitsPerSample.Channel2 == 10
+                        && bitsPerSample.Channel1 == 10
+                        && bitsPerSample.Channel0 == 10,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbaTiffColor<TPixel>(bitsPerSample);
 
                 case TiffColorType.Rgb121212:
                     DebugGuard.IsTrue(
@@ -156,6 +263,17 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);
 
+                case TiffColorType.Rgba12121212:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 12
+                        && bitsPerSample.Channel2 == 12
+                        && bitsPerSample.Channel1 == 12
+                        && bitsPerSample.Channel0 == 12,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbaTiffColor<TPixel>(bitsPerSample);
+
                 case TiffColorType.Rgb141414:
                     DebugGuard.IsTrue(
                         bitsPerSample.Channels == 3
@@ -165,6 +283,17 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbTiffColor<TPixel>(bitsPerSample);
+
+                case TiffColorType.Rgba14141414:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 14
+                        && bitsPerSample.Channel2 == 14
+                        && bitsPerSample.Channel1 == 14
+                        && bitsPerSample.Channel0 == 14,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbaTiffColor<TPixel>(bitsPerSample);
 
                 case TiffColorType.Rgb161616:
                     DebugGuard.IsTrue(
@@ -176,6 +305,17 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new Rgb161616TiffColor<TPixel>(configuration, isBigEndian: byteOrder == ByteOrder.BigEndian);
 
+                case TiffColorType.Rgba16161616:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 16
+                        && bitsPerSample.Channel2 == 16
+                        && bitsPerSample.Channel1 == 16
+                        && bitsPerSample.Channel0 == 16,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new Rgba16161616TiffColor<TPixel>(configuration, isBigEndian: byteOrder == ByteOrder.BigEndian);
+
                 case TiffColorType.Rgb242424:
                     DebugGuard.IsTrue(
                         bitsPerSample.Channels == 3
@@ -185,6 +325,17 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new Rgb242424TiffColor<TPixel>(isBigEndian: byteOrder == ByteOrder.BigEndian);
+
+                case TiffColorType.Rgba24242424:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 24
+                        && bitsPerSample.Channel2 == 24
+                        && bitsPerSample.Channel1 == 24
+                        && bitsPerSample.Channel0 == 24,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new Rgba24242424TiffColor<TPixel>(isBigEndian: byteOrder == ByteOrder.BigEndian);
 
                 case TiffColorType.Rgb323232:
                     DebugGuard.IsTrue(
@@ -196,6 +347,17 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new Rgb323232TiffColor<TPixel>(isBigEndian: byteOrder == ByteOrder.BigEndian);
 
+                case TiffColorType.Rgba32323232:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 32
+                        && bitsPerSample.Channel2 == 32
+                        && bitsPerSample.Channel1 == 32
+                        && bitsPerSample.Channel0 == 32,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new Rgba32323232TiffColor<TPixel>(isBigEndian: byteOrder == ByteOrder.BigEndian);
+
                 case TiffColorType.RgbFloat323232:
                     DebugGuard.IsTrue(
                         bitsPerSample.Channels == 3
@@ -205,6 +367,17 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                         "bitsPerSample");
                     DebugGuard.IsTrue(colorMap == null, "colorMap");
                     return new RgbFloat323232TiffColor<TPixel>(isBigEndian: byteOrder == ByteOrder.BigEndian);
+
+                case TiffColorType.RgbaFloat32323232:
+                    DebugGuard.IsTrue(
+                        bitsPerSample.Channels == 4
+                        && bitsPerSample.Channel3 == 32
+                        && bitsPerSample.Channel2 == 32
+                        && bitsPerSample.Channel1 == 32
+                        && bitsPerSample.Channel0 == 32,
+                        "bitsPerSample");
+                    DebugGuard.IsTrue(colorMap == null, "colorMap");
+                    return new RgbaFloat32323232TiffColor<TPixel>(isBigEndian: byteOrder == ByteOrder.BigEndian);
 
                 case TiffColorType.PaletteColor:
                     DebugGuard.NotNull(colorMap, "colorMap");

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/TiffColorType.cs
@@ -104,9 +104,49 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         Rgb222,
 
         /// <summary>
+        /// RGBA color image with 2 bits for each channel.
+        /// </summary>
+        Rgba2222,
+
+        /// <summary>
+        /// RGB color image with 3 bits for each channel.
+        /// </summary>
+        Rgb333,
+
+        /// <summary>
+        /// RGBA color image with 3 bits for each channel.
+        /// </summary>
+        Rgba3333,
+
+        /// <summary>
         /// RGB color image with 4 bits for each channel.
         /// </summary>
         Rgb444,
+
+        /// <summary>
+        /// RGBA color image with 4 bits for each channel.
+        /// </summary>
+        Rgba4444,
+
+        /// <summary>
+        /// RGB color image with 5 bits for each channel.
+        /// </summary>
+        Rgb555,
+
+        /// <summary>
+        /// RGBA color image with 5 bits for each channel.
+        /// </summary>
+        Rgba5555,
+
+        /// <summary>
+        /// RGB color image with 6 bits for each channel.
+        /// </summary>
+        Rgb666,
+
+        /// <summary>
+        /// RGBA color image with 6 bits for each channel.
+        /// </summary>
+        Rgba6666,
 
         /// <summary>
         /// RGB Full Color. Optimized implementation for 8-bit images.
@@ -114,9 +154,19 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         Rgb888,
 
         /// <summary>
+        /// RGBA Full Color with 8-bit for each channel.
+        /// </summary>
+        Rgba8888,
+
+        /// <summary>
         /// RGB color image with 10 bits for each channel.
         /// </summary>
         Rgb101010,
+
+        /// <summary>
+        /// RGBA color image with 10 bits for each channel.
+        /// </summary>
+        Rgba10101010,
 
         /// <summary>
         /// RGB color image with 12 bits for each channel.
@@ -124,9 +174,19 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         Rgb121212,
 
         /// <summary>
+        /// RGBA color image with 12 bits for each channel.
+        /// </summary>
+        Rgba12121212,
+
+        /// <summary>
         /// RGB color image with 14 bits for each channel.
         /// </summary>
         Rgb141414,
+
+        /// <summary>
+        /// RGBA color image with 14 bits for each channel.
+        /// </summary>
+        Rgba14141414,
 
         /// <summary>
         /// RGB color image with 16 bits for each channel.
@@ -134,9 +194,19 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         Rgb161616,
 
         /// <summary>
+        /// RGBA color image with 16 bits for each channel.
+        /// </summary>
+        Rgba16161616,
+
+        /// <summary>
         /// RGB color image with 24 bits for each channel.
         /// </summary>
         Rgb242424,
+
+        /// <summary>
+        /// RGBA color image with 24 bits for each channel.
+        /// </summary>
+        Rgba24242424,
 
         /// <summary>
         /// RGB color image with 32 bits for each channel.
@@ -144,9 +214,19 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         Rgb323232,
 
         /// <summary>
+        /// RGBA color image with 32 bits for each channel.
+        /// </summary>
+        Rgba32323232,
+
+        /// <summary>
         /// RGB color image with 32 bits floats for each channel.
         /// </summary>
         RgbFloat323232,
+
+        /// <summary>
+        /// RGBA color image with 32 bits floats for each channel.
+        /// </summary>
+        RgbaFloat32323232,
 
         /// <summary>
         /// RGB Full Color. Planar configuration of data. 8 Bit per color channel.

--- a/src/ImageSharp/Formats/Tiff/README.md
+++ b/src/ImageSharp/Formats/Tiff/README.md
@@ -105,7 +105,7 @@
 |Artist                     |   Y   |   Y   |                          |
 |HostComputer               |   Y   |   Y   |                          |
 |ColorMap                   |   Y   |   Y   |                          |
-|ExtraSamples               |       |   -   |                          |
+|ExtraSamples               |       |  (Y)  | Only UnassociatedAlphaData is supported so far |
 |Copyright                  |   Y   |   Y   |                          |
 
 ### Extension TIFF Tags

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         /// <summary>
         /// Gets the decoding mode for multi-frame images
         /// </summary>
-        private FrameDecodingMode decodingMode;
+        private readonly FrameDecodingMode decodingMode;
 
         /// <summary>
         /// The stream to decode from.
@@ -116,6 +116,11 @@ namespace SixLabors.ImageSharp.Formats.Tiff
         /// Gets or sets the the logical order of bits within a byte.
         /// </summary>
         public TiffFillOrder FillOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the extra samples, which can contain the alpha channel data.
+        /// </summary>
+        public TiffExtraSampleType? ExtraSamples { get; set; }
 
         /// <summary>
         /// Gets or sets the JPEG tables when jpeg compression is used.

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
@@ -29,9 +29,21 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                 TiffThrowHelper.ThrowNotSupported("Tiled images are not supported.");
             }
 
-            if (exifProfile.GetValueInternal(ExifTag.ExtraSamples) is not null)
+            IExifValue extraSamplesExifValue = exifProfile.GetValueInternal(ExifTag.ExtraSamples);
+            if (extraSamplesExifValue is not null)
             {
-                TiffThrowHelper.ThrowNotSupported("ExtraSamples is not supported.");
+                short[] extraSamples = (short[])extraSamplesExifValue.GetValue();
+                if (extraSamples.Length != 1)
+                {
+                    TiffThrowHelper.ThrowNotSupported("ExtraSamples is only supported with one extra sample for alpha data.");
+                }
+
+                var extraSamplesType = (TiffExtraSampleType)extraSamples[0];
+                options.ExtraSamples = extraSamplesType;
+                if (extraSamplesType is not TiffExtraSampleType.UnassociatedAlphaData)
+                {
+                    TiffThrowHelper.ThrowNotSupported("Decoding Tiff images with ExtraSamples is only supported with UnassociatedAlphaData.");
+                }
             }
 
             TiffFillOrder fillOrder = (TiffFillOrder?)exifProfile.GetValue(ExifTag.FillOrder)?.Value ?? TiffFillOrder.MostSignificantBitFirst;
@@ -52,7 +64,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                 sampleFormat = sampleFormats[0];
                 foreach (TiffSampleFormat format in sampleFormats)
                 {
-                    if (format != TiffSampleFormat.UnsignedInteger && format != TiffSampleFormat.Float)
+                    if (format is not TiffSampleFormat.UnsignedInteger and not TiffSampleFormat.Float)
                     {
                         TiffThrowHelper.ThrowNotSupported("ImageSharp only supports the UnsignedInteger and Float SampleFormat.");
                     }
@@ -252,12 +264,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                 case TiffPhotometricInterpretation.Rgb:
                 {
                     TiffBitsPerSample bitsPerSample = options.BitsPerSample;
-                    if (bitsPerSample.Channels != 3)
+                    if (bitsPerSample.Channels is not (3 or 4))
                     {
                         TiffThrowHelper.ThrowNotSupported("The number of samples in the TIFF BitsPerSample entry is not supported.");
                     }
 
-                    if (!(bitsPerSample.Channel0 == bitsPerSample.Channel1 && bitsPerSample.Channel1 == bitsPerSample.Channel2))
+                    if ((bitsPerSample.Channels == 3 && !(bitsPerSample.Channel0 == bitsPerSample.Channel1 && bitsPerSample.Channel1 == bitsPerSample.Channel2)) ||
+                        (bitsPerSample.Channels == 4 && !(bitsPerSample.Channel0 == bitsPerSample.Channel1 && bitsPerSample.Channel1 == bitsPerSample.Channel2 && bitsPerSample.Channel2 == bitsPerSample.Channel3)))
                     {
                         TiffThrowHelper.ThrowNotSupported("Only BitsPerSample with equal bits per channel are supported.");
                     }
@@ -270,41 +283,50 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                             case 32:
                                 if (options.SampleFormat == TiffSampleFormat.Float)
                                 {
-                                    options.ColorType = TiffColorType.RgbFloat323232;
+                                    options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.RgbFloat323232 : TiffColorType.RgbaFloat32323232;
                                     return;
                                 }
 
-                                options.ColorType = TiffColorType.Rgb323232;
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb323232 : TiffColorType.Rgba32323232;
                                 break;
 
                             case 24:
-                                options.ColorType = TiffColorType.Rgb242424;
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb242424 : TiffColorType.Rgba24242424;
                                 break;
 
                             case 16:
-                                options.ColorType = TiffColorType.Rgb161616;
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb161616 : TiffColorType.Rgba16161616;
                                 break;
 
                             case 14:
-                                options.ColorType = TiffColorType.Rgb141414;
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb141414 : TiffColorType.Rgba14141414;
                                 break;
 
                             case 12:
-                                options.ColorType = TiffColorType.Rgb121212;
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb121212 : TiffColorType.Rgba12121212;
                                 break;
 
                             case 10:
-                                options.ColorType = TiffColorType.Rgb101010;
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb101010 : TiffColorType.Rgba10101010;
                                 break;
 
                             case 8:
-                                options.ColorType = TiffColorType.Rgb888;
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb888 : TiffColorType.Rgba8888;
+                                break;
+                            case 6:
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb666 : TiffColorType.Rgba6666;
+                                break;
+                            case 5:
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb555 : TiffColorType.Rgba5555;
                                 break;
                             case 4:
-                                options.ColorType = TiffColorType.Rgb444;
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb444 : TiffColorType.Rgba4444;
+                                break;
+                            case 3:
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb333 : TiffColorType.Rgba3333;
                                 break;
                             case 2:
-                                options.ColorType = TiffColorType.Rgb222;
+                                options.ColorType = options.BitsPerSample.Channels is 3 ? TiffColorType.Rgb222 : TiffColorType.Rgba2222;
                                 break;
                             default:
                                 TiffThrowHelper.ThrowNotSupported("Bits per sample is not supported.");

--- a/src/ImageSharp/Formats/Tiff/TiffExtraSampleType.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffExtraSampleType.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Formats.Tiff
+{
+    /// <summary>
+    /// Description of extra components.
+    /// </summary>
+    internal enum TiffExtraSampleType
+    {
+        /// <summary>
+        /// The data is unspecified, not supported.
+        /// </summary>
+        UnspecifiedData = 0,
+
+        /// <summary>
+        /// The extra data is associated alpha data (with pre-multiplied color).
+        /// </summary>
+        AssociatedAlphaData = 1,
+
+        /// <summary>
+        /// The extra data is unassociated alpha data is transparency information that logically exists independent of an image;
+        /// it is commonly called a soft matte.
+        /// </summary>
+        UnassociatedAlphaData = 2
+    }
+}

--- a/src/ImageSharp/Formats/Tiff/Utils/TiffUtils.cs
+++ b/src/ImageSharp/Formats/Tiff/Utils/TiffUtils.cs
@@ -55,6 +55,15 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Utils
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TPixel ColorFromRgba64<TPixel>(Rgba64 rgba, ulong r, ulong g, ulong b, ulong a, TPixel color)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            rgba.PackedValue = r | (g << 16) | (b << 32) | (a << 48);
+            color.FromRgba64(rgba);
+            return color;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TPixel ColorScaleTo24Bit<TPixel>(ulong r, ulong g, ulong b, TPixel color)
             where TPixel : unmanaged, IPixel<TPixel>
         {
@@ -68,6 +77,15 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Utils
             where TPixel : unmanaged, IPixel<TPixel>
         {
             var colorVector = new Vector4(r * Scale32Bit, g * Scale32Bit, b * Scale32Bit, 1.0f);
+            color.FromVector4(colorVector);
+            return color;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TPixel ColorScaleTo32Bit<TPixel>(ulong r, ulong g, ulong b, ulong a, TPixel color)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            var colorVector = new Vector4(r * Scale32Bit, g * Scale32Bit, b * Scale32Bit, a);
             color.FromVector4(colorVector);
             return color;
         }

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -124,6 +124,21 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
+        [WithFile(Rgba2BitUnassociatedAlpha, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_8Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(FLowerRgb3Bit, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_9Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // Note: because the MagickReferenceDecoder fails to load the image, we only debug save them.
+            using Image<TPixel> image = provider.GetImage();
+            image.DebugSave(provider);
+        }
+
+        [Theory]
         [WithFile(Flower10BitGray, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_10Bit_Gray<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
@@ -140,9 +155,29 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
+        [WithFile(Rgba3BitUnassociatedAlpha, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_12Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // Note: because the MagickReferenceDecoder fails to load the image, we only debug save them.
+            using Image<TPixel> image = provider.GetImage();
+            image.DebugSave(provider);
+        }
+
+        [Theory]
         [WithFile(Flower14BitGray, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_14Bit_Gray<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(FLowerRgb5Bit, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_15Bit<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // Note: because the MagickReferenceDecoder fails to load the image, we only debug save them.
+            using Image<TPixel> image = provider.GetImage();
+            image.DebugSave(provider);
+        }
 
         [Theory]
         [WithFile(Flower16BitGrayLittleEndian, PixelTypes.Rgba32)]
@@ -156,6 +191,36 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [WithFile(Flower16BitGrayPredictorBigEndian, PixelTypes.Rgba32)]
         [WithFile(Flower16BitGrayPredictorLittleEndian, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_16Bit_Gray_WithPredictor<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(Rgba4BitUnassociatedAlpha, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_16Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(FLowerRgb6Bit, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_18Bit<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(Rgba5BitUnassociatedAlpha, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_20Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // Note: because the MagickReferenceDecoder fails to load the image, we only debug save them.
+            using Image<TPixel> image = provider.GetImage();
+            image.DebugSave(provider);
+        }
+
+        [Theory]
+        [WithFile(FlowerRgb888Contiguous, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_24Bit<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(Rgba6BitUnassociatedAlpha, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_24Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
@@ -208,6 +273,16 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         }
 
         [Theory]
+        [WithFile(Rgba8BitUnassociatedAlpha, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_32Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // Note: because the MagickReferenceDecoder fails to load the image, we only debug save them.
+            using Image<TPixel> image = provider.GetImage();
+            image.DebugSave(provider);
+        }
+
+        [Theory]
         [WithFile(Flower32BitGrayPredictorBigEndian, PixelTypes.Rgba32)]
         [WithFile(Flower32BitGrayPredictorLittleEndian, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_32Bit_Gray_WithPredictor<TPixel>(TestImageProvider<TPixel> provider)
@@ -221,6 +296,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [Theory]
         [WithFile(FlowerRgb121212Contiguous, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_36Bit<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(Rgba10BitUnassociatedAlphaBigEndian, PixelTypes.Rgba32)]
+        [WithFile(Rgba10BitUnassociatedAlphaLittleEndian, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_40Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
@@ -239,9 +320,21 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
+        [WithFile(Rgba12BitUnassociatedAlphaBigEndian, PixelTypes.Rgba32)]
+        [WithFile(Rgba12BitUnassociatedAlphaLittleEndian, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_48Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
         [WithFile(FlowerRgb161616PredictorBigEndian, PixelTypes.Rgba32)]
         [WithFile(FlowerRgb161616PredictorLittleEndian, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_48Bit_WithPredictor<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(Rgba14BitUnassociatedAlphaBigEndian, PixelTypes.Rgba32)]
+        [WithFile(Rgba14BitUnassociatedAlphaLittleEndian, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_56Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
         [Theory]
@@ -263,6 +356,17 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [WithFile(FlowerRgb323232Planar, PixelTypes.Rgba32)]
         [WithFile(FlowerRgb323232PlanarLittleEndian, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_96Bit<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // Note: because the MagickReferenceDecoder fails to load the image, we only debug save them.
+            using Image<TPixel> image = provider.GetImage();
+            image.DebugSave(provider);
+        }
+
+        [Theory]
+        [WithFile(Rgba24BitUnassociatedAlphaBigEndian, PixelTypes.Rgba32)]
+        [WithFile(Rgba24BitUnassociatedAlphaLittleEndian, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_96Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             // Note: because the MagickReferenceDecoder fails to load the image, we only debug save them.
@@ -298,6 +402,23 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
         [WithFile(Flower32BitFloatGrayMinIsWhite, PixelTypes.Rgba32)]
         [WithFile(Flower32BitFloatGrayMinIsWhiteLittleEndian, PixelTypes.Rgba32)]
         public void TiffDecoder_CanDecode_Float_96Bit_Gray<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            // Note: because the MagickReferenceDecoder fails to load the image, we only debug save them.
+            using Image<TPixel> image = provider.GetImage();
+            image.DebugSave(provider);
+        }
+
+        [Theory]
+        [WithFile(Rgba16BitUnassociatedAlphaBigEndian, PixelTypes.Rgba32)]
+        [WithFile(Rgba16BitUnassociatedAlphaLittleEndian, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_128Bit_UnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+        [Theory]
+        [WithFile(Rgba32BitUnassociatedAlphaBigEndian, PixelTypes.Rgba32)]
+        [WithFile(Rgba32BitUnassociatedAlphaLittleEndian, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_128Bit_WithUnassociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             // Note: because the MagickReferenceDecoder fails to load the image, we only debug save them.

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -831,6 +831,9 @@ namespace SixLabors.ImageSharp.Tests
             public const string Flower2BitPalette = "Tiff/flower-palette-02.tiff";
             public const string Flower4BitPalette = "Tiff/flower-palette-04.tiff";
             public const string Flower4BitPaletteGray = "Tiff/flower-minisblack-04.tiff";
+            public const string FLowerRgb3Bit = "Tiff/flower-rgb-3bit.tiff";
+            public const string FLowerRgb5Bit = "Tiff/flower-rgb-5bit.tiff";
+            public const string FLowerRgb6Bit = "Tiff/flower-rgb-6bit.tiff";
             public const string Flower6BitGray = "Tiff/flower-minisblack-06.tiff";
             public const string Flower8BitGray = "Tiff/flower-minisblack-08.tiff";
             public const string Flower10BitGray = "Tiff/flower-minisblack-10.tiff";
@@ -854,6 +857,26 @@ namespace SixLabors.ImageSharp.Tests
             public const string Flower32BitGrayMinIsWhiteLittleEndian = "Tiff/flower-miniswhite-32_lsb.tiff";
             public const string Flower32BitGrayPredictorBigEndian = "Tiff/flower-minisblack-32_msb_deflate_predictor.tiff";
             public const string Flower32BitGrayPredictorLittleEndian = "Tiff/flower-minisblack-32_lsb_deflate_predictor.tiff";
+
+            // Images with alpha channel.
+            public const string Rgba2BitUnassociatedAlpha = "Tiff/RgbaUnassociatedAlpha2bit.tiff";
+            public const string Rgba3BitUnassociatedAlpha = "Tiff/RgbaUnassociatedAlpha3bit.tiff";
+            public const string Rgba4BitUnassociatedAlpha = "Tiff/RgbaUnassociatedAlpha4bit.tiff";
+            public const string Rgba5BitUnassociatedAlpha = "Tiff/RgbaUnassociatedAlpha5bit.tiff";
+            public const string Rgba6BitUnassociatedAlpha = "Tiff/RgbaUnassociatedAlpha6bit.tiff";
+            public const string Rgba8BitUnassociatedAlpha = "Tiff/RgbaUnassociatedAlpha8bit.tiff";
+            public const string Rgba10BitUnassociatedAlphaBigEndian = "Tiff/RgbaUnassociatedAlpha10bit_msb.tiff";
+            public const string Rgba10BitUnassociatedAlphaLittleEndian = "Tiff/RgbaUnassociatedAlpha10bit_msb.tiff";
+            public const string Rgba12BitUnassociatedAlphaBigEndian = "Tiff/RgbaUnassociatedAlpha12bit_msb.tiff";
+            public const string Rgba12BitUnassociatedAlphaLittleEndian = "Tiff/RgbaUnassociatedAlpha12bit_msb.tiff";
+            public const string Rgba14BitUnassociatedAlphaBigEndian = "Tiff/RgbaUnassociatedAlpha14bit_msb.tiff";
+            public const string Rgba14BitUnassociatedAlphaLittleEndian = "Tiff/RgbaUnassociatedAlpha14bit_msb.tiff";
+            public const string Rgba16BitUnassociatedAlphaBigEndian = "Tiff/RgbaUnassociatedAlpha16bit_msb.tiff";
+            public const string Rgba16BitUnassociatedAlphaLittleEndian = "Tiff/RgbaUnassociatedAlpha16bit_msb.tiff";
+            public const string Rgba24BitUnassociatedAlphaBigEndian = "Tiff/RgbaUnassociatedAlpha24bit_msb.tiff";
+            public const string Rgba24BitUnassociatedAlphaLittleEndian = "Tiff/RgbaUnassociatedAlpha24bit_msb.tiff";
+            public const string Rgba32BitUnassociatedAlphaBigEndian = "Tiff/RgbaUnassociatedAlpha32bit_msb.tiff";
+            public const string Rgba32BitUnassociatedAlphaLittleEndian = "Tiff/RgbaUnassociatedAlpha32bit_msb.tiff";
 
             public const string Issues1716Rgb161616BitLittleEndian = "Tiff/Issues/Issue1716.tiff";
             public const string Issues1891 = "Tiff/Issues/Issue1891.tiff";

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha10bit_lsb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha10bit_lsb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f78ef11e4044d13ea3bf699e33472a708df3a5cc817dc41edb4df184f127f2b
+size 294278

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha10bit_msb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha10bit_msb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9c2d6f4e16677d9fdfb38cc2bfb7df05eedbb8dc0e3c26a6dba9b427c2c698a
+size 294278

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha12bit_lsb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha12bit_lsb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53e9ff25da2a2a7a613328cfaf33799df51fe150586fb8de52070e8cc8830d97
+size 353078

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha12bit_msb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha12bit_msb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caff76e01bc39b7a295f01a11e3787a6487ac002af5586dd956166a9c91eb048
+size 353078

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha14bit_lsb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha14bit_lsb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9193b6a194be970b2cfb26369fa487fd6ec2f1656af11df2e48f1d6b0971bbf8
+size 411878

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha14bit_msb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha14bit_msb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:888bc84af8dffc4565b215412a8a2bb56f0c78211a082b893d87595cd9f555c1
+size 411878

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha16bit_lsb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha16bit_lsb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eae92c012ad56c084929e0a2aff7c93091224d9f8ab7f52f71b845792d6b763
+size 470678

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha16bit_msb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha16bit_msb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbab54f221956215266c35bfd26fdfb123e092e3836e2401b9f24e1c5b23516e
+size 470678

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha24bit_lsb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha24bit_lsb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd9fa514619604275cede0b4747291db2f8e5ad02095565c891ace2b537d6336
+size 705878

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha24bit_msb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha24bit_msb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:915ca9bbda952fc9ac78b44be07dab603948d51fb1a274935905e73cfe5bb0b9
+size 705878

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha2bit.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha2bit.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f650c49faed4fd19b5527a0771489110090948e4ed33daa53b42c1776e288d89
+size 59078

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha32bit_lsb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha32bit_lsb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cad4c5f42d77539ce1f67efa7e0ed1fa4f5dd32b3269e5862453d878c6b18d7
+size 941078

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha32bit_msb.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha32bit_msb.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8874322776b8620573c26a3c84b8c7c9bf0aeaa7d68a7fef009f8838d14dca5b
+size 941078

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha3bit.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha3bit.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0d89ddcda8525799b90c1cb4a15f3ea1cf399c2259017f219b1d09876161587
+size 88478

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha4bit.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha4bit.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be006e56c2c2f34686293e8a5f4397a7bf873ff927d4dd0808cac90310569254
+size 117878

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha5bit.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha5bit.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2928f06ef146625f5c696272901a63644699e3410dc155b7e4e470009a7f6dfc
+size 147278

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha6bit.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha6bit.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:514ce84d3506aab7360b24f63aa1da1ea66abd9b1e534a12487d03486a7e593b
+size 176678

--- a/tests/Images/Input/Tiff/RgbaUnassociatedAlpha8bit.tiff
+++ b/tests/Images/Input/Tiff/RgbaUnassociatedAlpha8bit.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:234401d70156cc748a67992919f8780bb855bc5e87e404b573f61b5eb4817dcf
+size 266816

--- a/tests/Images/Input/Tiff/flower-rgb-3bit.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-3bit.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b778a97467b1475c47c71b5f029c23b0962309095b8702cfc81c8fbaf4b8edb
+size 3886

--- a/tests/Images/Input/Tiff/flower-rgb-5bit.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-5bit.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44a53ffce2bfd3f1010a1fe232c8010708458880230f11b75ea3ef16b5164ce1
+size 6208

--- a/tests/Images/Input/Tiff/flower-rgb-6bit.tiff
+++ b/tests/Images/Input/Tiff/flower-rgb-6bit.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d1db5b448aa9d61dd38dfb86e91e04fd0779a9c68cc2073913bcee3c635b5fe
+size 7412


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR adds support for decoding Tiff images with UnassociatedAlphaData. This is the first step in supporting decoding tiff images with `ExtraSamples`.

/cc @IldarKhayrutdinov 