### PR TITLE
AVX conversions for Luminance and Rgb

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/LuminanceForwardConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/LuminanceForwardConverter{TPixel}.cs
@@ -103,9 +103,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             ref Vector256<float> destRef = ref yBlock.V0;
 
             const int bytesPerL8Stride = 8;
-            for (int i = 0; i < 8; i++)
+            for (nint i = 0; i < 8; i++)
             {
-                Unsafe.Add(ref destRef, i) = Avx2.ConvertToVector256Single(Avx2.ConvertToVector256Int32(Unsafe.AddByteOffset(ref l8ByteSpan, (IntPtr)(bytesPerL8Stride * i))));
+                Unsafe.Add(ref destRef, i) = Avx2.ConvertToVector256Single(Avx2.ConvertToVector256Int32(Unsafe.AddByteOffset(ref l8ByteSpan, bytesPerL8Stride * i)));
             }
 #endif
         }

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/LuminanceForwardConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/LuminanceForwardConverter{TPixel}.cs
@@ -2,8 +2,13 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#if SUPPORTS_RUNTIME_INTRINSICS
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -74,6 +79,44 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             ref Block8x8F yBlock = ref this.Y;
             ref L8 l8Start = ref MemoryMarshal.GetReference(this.l8Span);
 
+            if (RgbToYCbCrConverterVectorized.IsSupported)
+            {
+                ConvertAvx(ref l8Start, ref yBlock);
+            }
+            else
+            {
+                ConvertScalar(ref l8Start, ref yBlock);
+            }
+        }
+
+        /// <summary>
+        /// Converts 8x8 L8 pixel matrix to 8x8 Block of floats using Avx2 Intrinsics.
+        /// </summary>
+        /// <param name="l8Start">Start of span of L8 pixels with size of 64</param>
+        /// <param name="yBlock">8x8 destination matrix of Luminance(Y) converted data</param>
+        private static void ConvertAvx(ref L8 l8Start, ref Block8x8F yBlock)
+        {
+            Debug.Assert(RgbToYCbCrConverterVectorized.IsSupported, "AVX2 is required to run this converter");
+
+#if SUPPORTS_RUNTIME_INTRINSICS
+            ref Vector128<byte> l8ByteSpan = ref Unsafe.As<L8, Vector128<byte>>(ref l8Start);
+            ref Vector256<float> destRef = ref yBlock.V0;
+
+            const int bytesPerL8Stride = 8;
+            for (int i = 0; i < 8; i++)
+            {
+                Unsafe.Add(ref destRef, i) = Avx2.ConvertToVector256Single(Avx2.ConvertToVector256Int32(Unsafe.AddByteOffset(ref l8ByteSpan, (IntPtr)(bytesPerL8Stride * i))));
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Converts 8x8 L8 pixel matrix to 8x8 Block of floats.
+        /// </summary>
+        /// <param name="l8Start">Start of span of L8 pixels with size of 64</param>
+        /// <param name="yBlock">8x8 destination matrix of Luminance(Y) converted data</param>
+        private static void ConvertScalar(ref L8 l8Start, ref Block8x8F yBlock)
+        {
             for (int i = 0; i < Block8x8F.Size; i++)
             {
                 ref L8 c = ref Unsafe.Add(ref l8Start, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbForwardConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbForwardConverter{TPixel}.cs
@@ -2,8 +2,13 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#if SUPPORTS_RUNTIME_INTRINSICS
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -94,10 +99,56 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             ref Block8x8F greenBlock = ref this.G;
             ref Block8x8F blueBlock = ref this.B;
 
-            CopyToBlock(this.rgbSpan, ref redBlock, ref greenBlock, ref blueBlock);
+            if (RgbToYCbCrConverterVectorized.IsSupported)
+            {
+                ConvertAvx(this.rgbSpan, ref redBlock, ref greenBlock, ref blueBlock);
+            }
+            else
+            {
+                ConvertScalar(this.rgbSpan, ref redBlock, ref greenBlock, ref blueBlock);
+            }
         }
 
-        private static void CopyToBlock(Span<Rgb24> rgbSpan, ref Block8x8F redBlock, ref Block8x8F greenBlock, ref Block8x8F blueBlock)
+        /// <summary>
+        /// Converts 8x8 RGB24 pixel matrix to 8x8 Block of floats using Avx2 Intrinsics.
+        /// </summary>
+        /// <param name="rgbSpan">Span of Rgb24 pixels with size of 64</param>
+        /// <param name="rBlock">8x8 destination matrix of Red converted data</param>
+        /// <param name="gBlock">8x8 destination matrix of Blue converted data</param>
+        /// <param name="bBlock">8x8 destination matrix of Green converted data</param>
+        private static void ConvertAvx(Span<Rgb24> rgbSpan, ref Block8x8F rBlock, ref Block8x8F gBlock, ref Block8x8F bBlock)
+        {
+            Debug.Assert(RgbToYCbCrConverterVectorized.IsSupported, "AVX2 is required to run this converter");
+
+#if SUPPORTS_RUNTIME_INTRINSICS
+            ref Vector256<byte> rgbByteSpan = ref Unsafe.As<Rgb24, Vector256<byte>>(ref MemoryMarshal.GetReference(rgbSpan));
+            ref Vector256<float> redRef = ref rBlock.V0;
+            ref Vector256<float> greenRef = ref gBlock.V0;
+            ref Vector256<float> blueRef = ref bBlock.V0;
+            var zero = Vector256.Create(0).AsByte();
+
+            var extractToLanesMask = Unsafe.As<byte, Vector256<uint>>(ref MemoryMarshal.GetReference(RgbToYCbCrConverterVectorized.MoveFirst24BytesToSeparateLanes));
+            var extractRgbMask = Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(RgbToYCbCrConverterVectorized.ExtractRgb));
+            Vector256<byte> rgb, rg, bx;
+
+            const int bytesPerRgbStride = 24;
+            for (int i = 0; i < 8; i++)
+            {
+                rgb = Avx2.PermuteVar8x32(Unsafe.AddByteOffset(ref rgbByteSpan, (IntPtr)(bytesPerRgbStride * i)).AsUInt32(), extractToLanesMask).AsByte();
+
+                rgb = Avx2.Shuffle(rgb, extractRgbMask);
+
+                rg = Avx2.UnpackLow(rgb, zero);
+                bx = Avx2.UnpackHigh(rgb, zero);
+
+                Unsafe.Add(ref redRef, i) = Avx.ConvertToVector256Single(Avx2.UnpackLow(rg, zero).AsInt32());
+                Unsafe.Add(ref greenRef, i) = Avx.ConvertToVector256Single(Avx2.UnpackHigh(rg, zero).AsInt32());
+                Unsafe.Add(ref blueRef, i) = Avx.ConvertToVector256Single(Avx2.UnpackLow(bx, zero).AsInt32());
+            }
+#endif
+        }
+
+        private static void ConvertScalar(Span<Rgb24> rgbSpan, ref Block8x8F redBlock, ref Block8x8F greenBlock, ref Block8x8F blueBlock)
         {
             ref Rgb24 rgbStart = ref MemoryMarshal.GetReference(rgbSpan);
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbForwardConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbForwardConverter{TPixel}.cs
@@ -132,9 +132,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
             Vector256<byte> rgb, rg, bx;
 
             const int bytesPerRgbStride = 24;
-            for (int i = 0; i < 8; i++)
+            for (nint i = 0; i < 8; i++)
             {
-                rgb = Avx2.PermuteVar8x32(Unsafe.AddByteOffset(ref rgbByteSpan, (IntPtr)(bytesPerRgbStride * i)).AsUInt32(), extractToLanesMask).AsByte();
+                rgb = Avx2.PermuteVar8x32(Unsafe.AddByteOffset(ref rgbByteSpan, bytesPerRgbStride * i).AsUInt32(), extractToLanesMask).AsByte();
 
                 rgb = Avx2.Shuffle(rgb, extractRgbMask);
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterVectorized.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrConverterVectorized.cs
@@ -60,13 +60,13 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder
 
 #if SUPPORTS_RUNTIME_INTRINSICS
 
-        private static ReadOnlySpan<byte> MoveFirst24BytesToSeparateLanes => new byte[]
+        internal static ReadOnlySpan<byte> MoveFirst24BytesToSeparateLanes => new byte[]
         {
             0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 6, 0, 0, 0,
             3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 7, 0, 0, 0
         };
 
-        private static ReadOnlySpan<byte> ExtractRgb => new byte[]
+        internal static ReadOnlySpan<byte> ExtractRgb => new byte[]
         {
             0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11, 0xFF, 0xFF, 0xFF, 0xFF,
             0, 3, 6, 9, 1, 4, 7, 10, 2, 5, 8, 11, 0xFF, 0xFF, 0xFF, 0xFF


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided _benchmark_ coverage for my change (where applicable)

### Description
This PR fixed #1763

Implemented AVX versions of Luminance and RGB conversions in JPEG Encoding, as described in the issue.
Added Benchmarks for these cases.

Results with and without AVX:
|                                  Method | Quality |     Mean |    Error |   StdDev |
|---------------------------------------- |-------- |---------:|---------:|---------:|
|     ImageSharp (greyscale) Jpeg 4:0:0 |      75 | 12.90 ms | 0.074 ms | 0.069 ms |
| ImageSharp (greyscale) Jpeg 4:0:0 AVX |      75 | 11.96 ms | 0.076 ms | 0.072 ms |
|                   ImageSharp Jpeg rgb |      75 | 28.45 ms | 0.130 ms | 0.115 ms |
|               ImageSharp Jpeg rgb AVX |      75 | 26.22 ms | 0.051 ms | 0.046 ms |
|     ImageSharp (greyscale) Jpeg 4:0:0 |      90 | 16.23 ms | 0.273 ms | 0.255 ms |
| ImageSharp (greyscale) Jpeg 4:0:0 AVX |      90 | 15.15 ms | 0.234 ms | 0.219 ms |
|                   ImageSharp Jpeg rgb |      90 | 36.84 ms | 0.258 ms | 0.241 ms |
|               ImageSharp Jpeg rgb AVX |      90 | 34.56 ms | 0.111 ms | 0.104 ms |
|     ImageSharp (greyscale) Jpeg 4:0:0 |     100 | 20.57 ms | 0.080 ms | 0.075 ms |
| ImageSharp (greyscale) Jpeg 4:0:0 AVX |     100 | 19.55 ms | 0.070 ms | 0.086 ms |
|                   ImageSharp Jpeg rgb |     100 | 54.64 ms | 0.102 ms | 0.090 ms |
|               ImageSharp Jpeg rgb AVX |     100 | 51.67 ms | 0.112 ms | 0.105 ms |

