### PR TITLE
Fix issue with app1 parsing

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -677,7 +677,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         }
 
         /// <summary>
-        /// Processes the App1 marker retrieving any stored metadata
+        /// Processes the App1 marker retrieving any stored metadata.
         /// </summary>
         /// <param name="stream">The input stream.</param>
         /// <param name="remaining">The remaining bytes in the segment block.</param>
@@ -687,7 +687,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             const int XmpMarkerLength = 29;
             if (remaining < ExifMarkerLength || this.IgnoreMetadata)
             {
-                // Skip the application header length
+                // Skip the application header length.
                 stream.Skip(remaining);
                 return;
             }
@@ -697,12 +697,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 JpegThrowHelper.ThrowInvalidImageContentException("Bad App1 Marker length.");
             }
 
-            // XMP marker is the longest, so read at least that many bytes into temp.
+            // XMP marker is the longer then the EXIF marker, so first try read the EXIF marker bytes.
             stream.Read(this.temp, 0, ExifMarkerLength);
+            remaining -= ExifMarkerLength;
 
             if (ProfileResolver.IsProfile(this.temp, ProfileResolver.ExifMarker))
             {
-                remaining -= ExifMarkerLength;
                 this.hasExif = true;
                 byte[] profile = new byte[remaining];
                 stream.Read(profile, 0, remaining);
@@ -713,7 +713,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 }
                 else
                 {
-                    // If the EXIF information exceeds 64K, it will be split over multiple APP1 markers
+                    // If the EXIF information exceeds 64K, it will be split over multiple APP1 markers.
                     this.ExtendProfile(ref this.exifData, profile);
                 }
 
@@ -722,9 +722,10 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
 
             if (ProfileResolver.IsProfile(this.temp, ProfileResolver.XmpMarker.Slice(0, ExifMarkerLength)))
             {
-                stream.Read(this.temp, 0, XmpMarkerLength - ExifMarkerLength);
-                remaining -= XmpMarkerLength;
-                if (ProfileResolver.IsProfile(this.temp, ProfileResolver.XmpMarker.Slice(ExifMarkerLength)))
+                int remainingXmpMarkerBytes = XmpMarkerLength - ExifMarkerLength;
+                stream.Read(this.temp, ExifMarkerLength, remainingXmpMarkerBytes);
+                remaining -= remainingXmpMarkerBytes;
+                if (ProfileResolver.IsProfile(this.temp, ProfileResolver.XmpMarker))
                 {
                     this.hasXmp = true;
                     byte[] profile = new byte[remaining];
@@ -736,7 +737,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                     }
                     else
                     {
-                        // If the XMP information exceeds 64K, it will be split over multiple APP1 markers
+                        // If the XMP information exceeds 64K, it will be split over multiple APP1 markers.
                         this.ExtendProfile(ref this.xmpData, profile);
                     }
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Metadata;

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -21,7 +21,7 @@ using Xunit.Abstractions;
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
     // TODO: Scatter test cases into multiple test classes
-     [Trait("Format", "Jpg")]
+    [Trait("Format", "Jpg")]
     public partial class JpegDecoderTests
     {
         public const PixelTypes CommonNonDefaultPixelTypes = PixelTypes.Rgba32 | PixelTypes.Argb32 | PixelTypes.Bgr24 | PixelTypes.RgbaVector;
@@ -65,7 +65,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
         private ITestOutputHelper Output { get; }
 
-        private static JpegDecoder JpegDecoder => new JpegDecoder();
+        private static JpegDecoder JpegDecoder => new();
 
         [Fact]
         public void ParseStream_BasicPropertiesAreCorrect()
@@ -204,6 +204,19 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         [Theory]
         [WithFile(TestImages.Jpeg.Issues.WrongColorSpace, PixelTypes.Rgba32)]
         public void Issue1732_DecodesWithRgbColorSpace<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage(JpegDecoder))
+            {
+                image.DebugSave(provider);
+                image.CompareToOriginal(provider);
+            }
+        }
+
+        // https://github.com/SixLabors/ImageSharp/issues/2057
+        [Theory]
+        [WithFile(TestImages.Jpeg.Issues.Issue2057App1Parsing, PixelTypes.Rgba32)]
+        public void Issue2057_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using (Image<TPixel> image = provider.GetImage(JpegDecoder))

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -262,6 +262,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string MalformedUnsupportedComponentCount = "Jpg/issues/issue-1900-malformed-unsupported-255-components.jpg";
                 public const string MultipleApp01932 = "Jpg/issues/issue-1932-app0-resolution.jpg";
                 public const string InvalidIptcTag = "Jpg/issues/Issue1942InvalidIptcTag.jpg";
+                public const string Issue2057App1Parsing = "Jpg/issues/Issue2057-App1Parsing.jpg";
 
                 public static class Fuzz
                 {

--- a/tests/Images/Input/Jpg/issues/Issue2057-App1Parsing.jpg
+++ b/tests/Images/Input/Jpg/issues/Issue2057-App1Parsing.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7048dee15946bf981e5b0d2481ffcb8a64684fddca07172275b13a05f01b6b63
+size 1631109


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR fixes an issue with APP1 parsing: the remaining bytes was not calculated correctly when it was not an EXIF or XMP profile.

Related to #2057