### PR TITLE
Add non-generic overload for ExifProfile.CreateThumbnail<TPixel>().

### DIFF
--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
@@ -124,6 +124,14 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
         /// <summary>
         /// Returns the thumbnail in the EXIF profile when available.
         /// </summary>
+        /// <returns>
+        /// The <see cref="Image"/>.
+        /// </returns>
+        public Image CreateThumbnail() => this.CreateThumbnail<Rgba32>();
+
+        /// <summary>
+        /// Returns the thumbnail in the EXIF profile when available.
+        /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>
         /// The <see cref="Image{TPixel}"/>.

--- a/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifProfileTests.cs
@@ -354,10 +354,15 @@ namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.Exif
 
             TestProfile(profile);
 
-            using Image<Rgba32> thumbnail = profile.CreateThumbnail<Rgba32>();
+            using Image thumbnail = profile.CreateThumbnail();
             Assert.NotNull(thumbnail);
             Assert.Equal(256, thumbnail.Width);
             Assert.Equal(170, thumbnail.Height);
+
+            using Image<Rgba32> genericThumbnail = profile.CreateThumbnail<Rgba32>();
+            Assert.NotNull(genericThumbnail);
+            Assert.Equal(256, genericThumbnail.Width);
+            Assert.Equal(170, genericThumbnail.Height);
         }
 
         [Fact]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Add non-generic overload defaulting to Rgba32. Fix #1995

<!-- Thanks for contributing to ImageSharp! -->
