### PR TITLE
Add missing decoder sanitation checks

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -221,7 +221,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         private void ReadGraphicalControlExtension()
         {
-            this.stream.Read(this.buffer, 0, 6);
+            int bytesRead = this.stream.Read(this.buffer, 0, 6);
+            if (bytesRead != 6)
+            {
+                GifThrowHelper.ThrowInvalidImageContentException("Not enough data to read the graphic control extension");
+            }
 
             this.graphicsControlExtension = GifGraphicControlExtension.Parse(this.buffer);
         }
@@ -231,7 +235,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         private void ReadImageDescriptor()
         {
-            this.stream.Read(this.buffer, 0, 9);
+            int bytesRead = this.stream.Read(this.buffer, 0, 9);
+            if (bytesRead != 9)
+            {
+                GifThrowHelper.ThrowInvalidImageContentException("Not enough data to read the image descriptor");
+            }
 
             this.imageDescriptor = GifImageDescriptor.Parse(this.buffer);
             if (this.imageDescriptor.Height == 0 || this.imageDescriptor.Width == 0)
@@ -245,7 +253,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         private void ReadLogicalScreenDescriptor()
         {
-            this.stream.Read(this.buffer, 0, 7);
+            int bytesRead = this.stream.Read(this.buffer, 0, 7);
+            if (bytesRead != 7)
+            {
+                GifThrowHelper.ThrowInvalidImageContentException("Not enough data to read the logical screen descriptor");
+            }
 
             this.logicalScreenDescriptor = GifLogicalScreenDescriptor.Parse(this.buffer);
         }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -722,7 +722,14 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
 
             if (ProfileResolver.IsProfile(this.temp, ProfileResolver.XmpMarker.Slice(0, ExifMarkerLength)))
             {
-                int remainingXmpMarkerBytes = XmpMarkerLength - ExifMarkerLength;
+                const int remainingXmpMarkerBytes = XmpMarkerLength - ExifMarkerLength;
+                if (remaining < remainingXmpMarkerBytes || this.IgnoreMetadata)
+                {
+                    // Skip the application header length.
+                    stream.Skip(remaining);
+                    return;
+                }
+
                 stream.Read(this.temp, ExifMarkerLength, remainingXmpMarkerBytes);
                 remaining -= remainingXmpMarkerBytes;
                 if (ProfileResolver.IsProfile(this.temp, ProfileResolver.XmpMarker))

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -1334,8 +1334,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 component.ACHuffmanTableId = acTableIndex;
             }
 
-            // 3 bytes: Progressive scan decoding data
-            stream.Read(this.temp, 0, 3);
+            // 3 bytes: Progressive scan decoding data.
+            int bytesRead = stream.Read(this.temp, 0, 3);
+            if (bytesRead != 3)
+            {
+                JpegThrowHelper.ThrowInvalidImageContentException("Not enough data to read progressive scan decoding data");
+            }
 
             int spectralStart = this.temp[0];
             this.scanDecoder.SpectralStart = spectralStart;

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -1362,7 +1362,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         [MethodImpl(InliningOptions.ShortMethod)]
         private ushort ReadUint16(BufferedReadStream stream)
         {
-            stream.Read(this.markerBuffer, 0, 2);
+            int bytesRead = stream.Read(this.markerBuffer, 0, 2);
+            if (bytesRead != 2)
+            {
+                JpegThrowHelper.ThrowInvalidImageContentException("jpeg stream does not contain enough data, could not read ushort.");
+            }
+
             return BinaryPrimitives.ReadUInt16BigEndian(this.markerBuffer);
         }
     }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -232,7 +232,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             using var stream = new BufferedReadStream(this.Configuration, ms);
 
             // Check for the Start Of Image marker.
-            stream.Read(this.markerBuffer, 0, 2);
+            int bytesRead = stream.Read(this.markerBuffer, 0, 2);
+            if (bytesRead != 2)
+            {
+                JpegThrowHelper.ThrowInvalidImageContentException("Not enough data to read the SOI marker");
+            }
+
             var fileMarker = new JpegFileMarker(this.markerBuffer[1], 0);
             if (fileMarker.Marker != JpegConstants.Markers.SOI)
             {
@@ -240,7 +245,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             }
 
             // Read next marker.
-            stream.Read(this.markerBuffer, 0, 2);
+            bytesRead = stream.Read(this.markerBuffer, 0, 2);
+            if (bytesRead != 2)
+            {
+                JpegThrowHelper.ThrowInvalidImageContentException("Not enough data to read marker");
+            }
+
             byte marker = this.markerBuffer[1];
             fileMarker = new JpegFileMarker(marker, (int)stream.Position - 2);
 
@@ -273,7 +283,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
                 }
 
                 // Read next marker.
-                stream.Read(this.markerBuffer, 0, 2);
+                bytesRead = stream.Read(this.markerBuffer, 0, 2);
+                if (bytesRead != 2)
+                {
+                    JpegThrowHelper.ThrowInvalidImageContentException("Not enough data to read marker");
+                }
+
                 fileMarker = new JpegFileMarker(this.markerBuffer[1], 0);
             }
         }

--- a/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
@@ -426,6 +426,7 @@ namespace SixLabors.ImageSharp.Formats.Webp
         /// <param name="features">The webp image features.</param>
         private void ParseOptionalExtendedChunks(WebpChunkType chunkType, WebpFeatures features)
         {
+            int bytesRead;
             switch (chunkType)
             {
                 case WebpChunkType.Iccp:
@@ -437,7 +438,12 @@ namespace SixLabors.ImageSharp.Formats.Webp
                     else
                     {
                         byte[] iccpData = new byte[iccpChunkSize];
-                        this.currentStream.Read(iccpData, 0, (int)iccpChunkSize);
+                        bytesRead = this.currentStream.Read(iccpData, 0, (int)iccpChunkSize);
+                        if (bytesRead != iccpChunkSize)
+                        {
+                            WebpThrowHelper.ThrowInvalidImageContentException("Not enough data to read the iccp chunk");
+                        }
+
                         var profile = new IccProfile(iccpData);
                         if (profile.CheckIsValid())
                         {
@@ -456,7 +462,12 @@ namespace SixLabors.ImageSharp.Formats.Webp
                     else
                     {
                         byte[] exifData = new byte[exifChunkSize];
-                        this.currentStream.Read(exifData, 0, (int)exifChunkSize);
+                        bytesRead = this.currentStream.Read(exifData, 0, (int)exifChunkSize);
+                        if (bytesRead != exifChunkSize)
+                        {
+                            WebpThrowHelper.ThrowInvalidImageContentException("Not enough data to read the exif chunk");
+                        }
+
                         var profile = new ExifProfile(exifData);
                         this.Metadata.ExifProfile = profile;
                     }
@@ -472,7 +483,12 @@ namespace SixLabors.ImageSharp.Formats.Webp
                     else
                     {
                         byte[] xmpData = new byte[xmpChunkSize];
-                        this.currentStream.Read(xmpData, 0, (int)xmpChunkSize);
+                        bytesRead = this.currentStream.Read(xmpData, 0, (int)xmpChunkSize);
+                        if (bytesRead != xmpChunkSize)
+                        {
+                            WebpThrowHelper.ThrowInvalidImageContentException("Not enough data to read the xmp chunk");
+                        }
+
                         var profile = new XmpProfile(xmpData);
                         this.Metadata.XmpProfile = profile;
                     }
@@ -488,7 +504,12 @@ namespace SixLabors.ImageSharp.Formats.Webp
                     features.AlphaChunkHeader = (byte)this.currentStream.ReadByte();
                     int alphaDataSize = (int)(alphaChunkSize - 1);
                     features.AlphaData = this.memoryAllocator.Allocate<byte>(alphaDataSize);
-                    this.currentStream.Read(features.AlphaData.Memory.Span, 0, alphaDataSize);
+                    bytesRead = this.currentStream.Read(features.AlphaData.Memory.Span, 0, alphaDataSize);
+                    if (bytesRead != alphaDataSize)
+                    {
+                        WebpThrowHelper.ThrowInvalidImageContentException("Not enough data to read the alpha chunk");
+                    }
+
                     break;
                 default:
                     WebpThrowHelper.ThrowImageFormatException("Unexpected chunk followed VP8X header");

--- a/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
@@ -465,22 +465,18 @@ namespace SixLabors.ImageSharp.Formats.Webp
         /// <param name="features">The webp image features.</param>
         private void ParseOptionalExtendedChunks(WebpChunkType chunkType, WebpFeatures features)
         {
-            int bytesRead;
             switch (chunkType)
             {
                 case WebpChunkType.Iccp:
                     this.ReadIccProfile();
-
                     break;
 
                 case WebpChunkType.Exif:
                     this.ReadExifProfile();
-
                     break;
 
                 case WebpChunkType.Xmp:
                     this.ReadXmpProfile();
-
                     break;
 
                 case WebpChunkType.Animation:
@@ -492,7 +488,7 @@ namespace SixLabors.ImageSharp.Formats.Webp
                     features.AlphaChunkHeader = (byte)this.currentStream.ReadByte();
                     int alphaDataSize = (int)(alphaChunkSize - 1);
                     features.AlphaData = this.memoryAllocator.Allocate<byte>(alphaDataSize);
-                    bytesRead = this.currentStream.Read(features.AlphaData.Memory.Span, 0, alphaDataSize);
+                    int bytesRead = this.currentStream.Read(features.AlphaData.Memory.Span, 0, alphaDataSize);
                     if (bytesRead != alphaDataSize)
                     {
                         WebpThrowHelper.ThrowInvalidImageContentException("Not enough data to read the alpha chunk");
@@ -556,7 +552,8 @@ namespace SixLabors.ImageSharp.Formats.Webp
                 int bytesRead = this.currentStream.Read(exifData, 0, (int)exifChunkSize);
                 if (bytesRead != exifChunkSize)
                 {
-                    WebpThrowHelper.ThrowInvalidImageContentException("Not enough data to read the exif chunk");
+                    // Ignore invalid chunk.
+                    return;
                 }
 
                 var profile = new ExifProfile(exifData);
@@ -580,7 +577,8 @@ namespace SixLabors.ImageSharp.Formats.Webp
                 int bytesRead = this.currentStream.Read(xmpData, 0, (int)xmpChunkSize);
                 if (bytesRead != xmpChunkSize)
                 {
-                    WebpThrowHelper.ThrowInvalidImageContentException("Not enough data to read the xmp chunk");
+                    // Ignore invalid chunk.
+                    return;
                 }
 
                 var profile = new XmpProfile(xmpData);

--- a/src/ImageSharp/Formats/Webp/WebpThrowHelper.cs
+++ b/src/ImageSharp/Formats/Webp/WebpThrowHelper.cs
@@ -9,6 +9,13 @@ namespace SixLabors.ImageSharp.Formats.Webp
     internal static class WebpThrowHelper
     {
         /// <summary>
+        /// Cold path optimization for throwing <see cref="InvalidImageContentException"/>'s.
+        /// </summary>
+        /// <param name="errorMessage">The error message for the exception.</param>
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowInvalidImageContentException(string errorMessage) => throw new InvalidImageContentException(errorMessage);
+
+        /// <summary>
         /// Cold path optimization for throwing <see cref="ImageFormatException"/>-s
         /// </summary>
         /// <param name="errorMessage">The error message for the exception.</param>

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpMetaDataTests.cs
@@ -150,5 +150,17 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
             Assert.NotNull(actualExif);
             Assert.Equal(expectedExif.Values.Count, actualExif.Values.Count);
         }
+
+        [Theory]
+        [WithFile(TestImages.Webp.Lossy.WithExifNotEnoughData, PixelTypes.Rgba32)]
+        public void WebpDecoder_ThrowInvalidImageContentException_OnWithInvalidExifData<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> =>
+            Assert.Throws<InvalidImageContentException>(
+                () =>
+                {
+                    using (provider.GetImage(WebpDecoder))
+                    {
+                    }
+                });
     }
 }

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpMetaDataTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats.Webp;
@@ -153,14 +154,14 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
 
         [Theory]
         [WithFile(TestImages.Webp.Lossy.WithExifNotEnoughData, PixelTypes.Rgba32)]
-        public void WebpDecoder_ThrowInvalidImageContentException_OnWithInvalidExifData<TPixel>(TestImageProvider<TPixel> provider)
-            where TPixel : unmanaged, IPixel<TPixel> =>
-            Assert.Throws<InvalidImageContentException>(
-                () =>
-                {
-                    using (provider.GetImage(WebpDecoder))
-                    {
-                    }
-                });
+        public void WebpDecoder_IgnoresInvalidExifChunk<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Exception ex = Record.Exception(() =>
+            {
+                using Image<TPixel> image = provider.GetImage();
+            });
+            Assert.Null(ex);
+        }
     }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -635,6 +635,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 public const string Earth = "Webp/earth_lossy.webp";
                 public const string WithExif = "Webp/exif_lossy.webp";
+                public const string WithExifNotEnoughData = "Webp/exif_lossy_not_enough_data.webp";
                 public const string WithIccp = "Webp/lossy_with_iccp.webp";
                 public const string WithXmp = "Webp/xmp_lossy.webp";
                 public const string BikeSmall = "Webp/bike_lossless_small.webp";

--- a/tests/Images/Input/Webp/exif_lossy.webp
+++ b/tests/Images/Input/Webp/exif_lossy.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdf4e9b20af4168f4177d33f7f502906343bbaaae2af9b90e1531bd4452b317b
-size 40765
+oid sha256:5c53967bfefcfece8cd4411740c1c394e75864ca61a7a9751df3b28e727c0205
+size 68646

--- a/tests/Images/Input/Webp/exif_lossy_not_enough_data.webp
+++ b/tests/Images/Input/Webp/exif_lossy_not_enough_data.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdf4e9b20af4168f4177d33f7f502906343bbaaae2af9b90e1531bd4452b317b
+size 40765


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
A PR to add additional sanitation checks with a view to fix #2075 

Any additional sanitation fixes added to other open branches should be added here.

<!-- Thanks for contributing to ImageSharp! -->
