### PR TITLE
Fix chunk data memory leak when decoding PNG

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1359,6 +1359,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             {
                 if (chunk.Type == PngChunkType.Data)
                 {
+                    chunk.Data?.Dispose();
                     return chunk.Length;
                 }
 

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -125,6 +125,9 @@ namespace SixLabors.ImageSharp.Tests
             // Discussion 1875: https://github.com/SixLabors/ImageSharp/discussions/1875
             public const string Issue1875 = "Png/raw-profile-type-exif.png";
 
+            // Issue 2080; https://github.com/SixLabors/ImageSharp/issues/2080
+            public const string Issue2080 = "Png/issues/Issue_2080.png";
+
             public static class Bad
             {
                 public const string MissingDataChunk = "Png/xdtn0g01.png";

--- a/tests/Images/Input/Png/issues/Issue_2080.png
+++ b/tests/Images/Input/Png/issues/Issue_2080.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c55f158082ea062c14342b339ad46ecf792b90ebb5530c327e31a1ad04b01ba0
+size 79613


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Added missing `PngChunk.Dispose` call to avoid memory leak in `PngDecoderCore`

All relevant information in issue #2080 

<!-- Thanks for contributing to ImageSharp! -->
