### PR TITLE
Memory allocation allocation tracker test helper

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,6 +27,7 @@
     <InternalsVisibleTo Include="ImageSharp.Benchmarks" Key="$(SixLaborsPublicKey)" />
     <InternalsVisibleTo Include="ImageSharp.Tests.ProfilingSandbox" Key="$(SixLaborsPublicKey)" />
     <InternalsVisibleTo Include="SixLabors.ImageSharp.Tests" Key="$(SixLaborsPublicKey)" />
+    <InternalsVisibleTo Include="SixLabors.ImageSharp.Drawing.Tests" Key="$(SixLaborsPublicKey)" />
   </ItemGroup>
 
 </Project>

--- a/src/ImageSharp/Diagnostics/MemoryDiagnostics.cs
+++ b/src/ImageSharp/Diagnostics/MemoryDiagnostics.cs
@@ -15,10 +15,8 @@ namespace SixLabors.ImageSharp.Diagnostics
     /// </summary>
     public static class MemoryDiagnostics
     {
-        private static int totalUndisposedAllocationCount;
-
-        private static UndisposedAllocationDelegate undisposedAllocation;
-        private static int undisposedAllocationSubscriptionCounter;
+        internal static readonly InteralMemoryDiagnostics Default = new();
+        private static AsyncLocal<InteralMemoryDiagnostics> localInstance = null;
         private static readonly object SyncRoot = new();
 
         /// <summary>
@@ -28,56 +26,116 @@ namespace SixLabors.ImageSharp.Diagnostics
         /// </summary>
         public static event UndisposedAllocationDelegate UndisposedAllocation
         {
-            add
+            add => Current.UndisposedAllocation += value;
+            remove => Current.UndisposedAllocation -= value;
+        }
+
+        internal static InteralMemoryDiagnostics Current
+        {
+            get
             {
-                lock (SyncRoot)
+                if (localInstance != null && localInstance.Value != null)
                 {
-                    undisposedAllocationSubscriptionCounter++;
-                    undisposedAllocation += value;
+                    return localInstance.Value;
                 }
+
+                return Default;
             }
 
-            remove
+            set
             {
-                lock (SyncRoot)
+                if (localInstance == null)
                 {
-                    undisposedAllocation -= value;
-                    undisposedAllocationSubscriptionCounter--;
+                    lock (SyncRoot)
+                    {
+                        localInstance ??= new AsyncLocal<InteralMemoryDiagnostics>();
+                    }
                 }
+
+                localInstance.Value = value;
             }
         }
 
         /// <summary>
         /// Gets a value indicating the total number of memory resource objects leaked to the finalizer.
         /// </summary>
-        public static int TotalUndisposedAllocationCount => totalUndisposedAllocationCount;
+        public static int TotalUndisposedAllocationCount => Current.TotalUndisposedAllocationCount;
 
-        internal static bool UndisposedAllocationSubscribed => Volatile.Read(ref undisposedAllocationSubscriptionCounter) > 0;
+        internal static bool UndisposedAllocationSubscribed => Current.UndisposedAllocationSubscribed;
 
-        internal static void IncrementTotalUndisposedAllocationCount() =>
-            Interlocked.Increment(ref totalUndisposedAllocationCount);
+        internal static void IncrementTotalUndisposedAllocationCount() => Current.IncrementTotalUndisposedAllocationCount();
 
-        internal static void DecrementTotalUndisposedAllocationCount() =>
-            Interlocked.Decrement(ref totalUndisposedAllocationCount);
+        internal static void DecrementTotalUndisposedAllocationCount() => Current.DecrementTotalUndisposedAllocationCount();
 
         internal static void RaiseUndisposedMemoryResource(string allocationStackTrace)
+            => Current.RaiseUndisposedMemoryResource(allocationStackTrace);
+
+        internal class InteralMemoryDiagnostics
         {
-            if (undisposedAllocation is null)
+            private int totalUndisposedAllocationCount;
+
+            private UndisposedAllocationDelegate undisposedAllocation;
+            private int undisposedAllocationSubscriptionCounter;
+            private readonly object syncRoot = new();
+
+            /// <summary>
+            /// Fires when an ImageSharp object's undisposed memory resource leaks to the finalizer.
+            /// The event brings significant overhead, and is intended to be used for troubleshooting only.
+            /// For production diagnostics, use <see cref="TotalUndisposedAllocationCount"/>.
+            /// </summary>
+            public event UndisposedAllocationDelegate UndisposedAllocation
             {
-                return;
+                add
+                {
+                    lock (this.syncRoot)
+                    {
+                        this.undisposedAllocationSubscriptionCounter++;
+                        this.undisposedAllocation += value;
+                    }
+                }
+
+                remove
+                {
+                    lock (this.syncRoot)
+                    {
+                        this.undisposedAllocation -= value;
+                        this.undisposedAllocationSubscriptionCounter--;
+                    }
+                }
             }
 
-            // Schedule on the ThreadPool, to avoid user callback messing up the finalizer thread.
+            /// <summary>
+            /// Gets a value indicating the total number of memory resource objects leaked to the finalizer.
+            /// </summary>
+            public int TotalUndisposedAllocationCount => this.totalUndisposedAllocationCount;
+
+            internal bool UndisposedAllocationSubscribed => Volatile.Read(ref this.undisposedAllocationSubscriptionCounter) > 0;
+
+            internal void IncrementTotalUndisposedAllocationCount() =>
+                Interlocked.Increment(ref this.totalUndisposedAllocationCount);
+
+            internal void DecrementTotalUndisposedAllocationCount() =>
+                Interlocked.Decrement(ref this.totalUndisposedAllocationCount);
+
+            internal void RaiseUndisposedMemoryResource(string allocationStackTrace)
+            {
+                if (this.undisposedAllocation is null)
+                {
+                    return;
+                }
+
+                // Schedule on the ThreadPool, to avoid user callback messing up the finalizer thread.
 #if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
-            ThreadPool.QueueUserWorkItem(
-                stackTrace => undisposedAllocation?.Invoke(stackTrace),
-                allocationStackTrace,
-                preferLocal: false);
+                ThreadPool.QueueUserWorkItem(
+                    stackTrace => this.undisposedAllocation?.Invoke(stackTrace),
+                    allocationStackTrace,
+                    preferLocal: false);
 #else
             ThreadPool.QueueUserWorkItem(
-                stackTrace => undisposedAllocation?.Invoke((string)stackTrace),
+                stackTrace => this.undisposedAllocation?.Invoke((string)stackTrace),
                 allocationStackTrace);
 #endif
+            }
         }
     }
 }

--- a/src/ImageSharp/Diagnostics/MemoryDiagnostics.cs
+++ b/src/ImageSharp/Diagnostics/MemoryDiagnostics.cs
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Diagnostics
         internal static event Action MemoryAllocated;
 
         /// <summary>
-        /// Fires when ImageSharp releases allocated from a MemoryAllocator
+        /// Fires when ImageSharp releases memory allocated from a MemoryAllocator
         /// </summary>
         internal static event Action MemoryReleased;
 

--- a/src/ImageSharp/Diagnostics/MemoryDiagnostics.cs
+++ b/src/ImageSharp/Diagnostics/MemoryDiagnostics.cs
@@ -17,6 +17,10 @@ namespace SixLabors.ImageSharp.Diagnostics
     {
         internal static readonly InteralMemoryDiagnostics Default = new();
         private static AsyncLocal<InteralMemoryDiagnostics> localInstance = null;
+
+        // the async local end up out of scope during finalizers so putting into thte internal class is useless
+        private static UndisposedAllocationDelegate undisposedAllocation;
+        private static int undisposedAllocationSubscriptionCounter;
         private static readonly object SyncRoot = new();
 
         /// <summary>
@@ -26,8 +30,23 @@ namespace SixLabors.ImageSharp.Diagnostics
         /// </summary>
         public static event UndisposedAllocationDelegate UndisposedAllocation
         {
-            add => Current.UndisposedAllocation += value;
-            remove => Current.UndisposedAllocation -= value;
+            add
+            {
+                lock (SyncRoot)
+                {
+                    undisposedAllocationSubscriptionCounter++;
+                    undisposedAllocation += value;
+                }
+            }
+
+            remove
+            {
+                lock (SyncRoot)
+                {
+                    undisposedAllocation -= value;
+                    undisposedAllocationSubscriptionCounter--;
+                }
+            }
         }
 
         internal static InteralMemoryDiagnostics Current
@@ -61,81 +80,46 @@ namespace SixLabors.ImageSharp.Diagnostics
         /// </summary>
         public static int TotalUndisposedAllocationCount => Current.TotalUndisposedAllocationCount;
 
-        internal static bool UndisposedAllocationSubscribed => Current.UndisposedAllocationSubscribed;
+        internal static bool UndisposedAllocationSubscribed => Volatile.Read(ref undisposedAllocationSubscriptionCounter) > 0;
 
         internal static void IncrementTotalUndisposedAllocationCount() => Current.IncrementTotalUndisposedAllocationCount();
 
         internal static void DecrementTotalUndisposedAllocationCount() => Current.DecrementTotalUndisposedAllocationCount();
 
         internal static void RaiseUndisposedMemoryResource(string allocationStackTrace)
-            => Current.RaiseUndisposedMemoryResource(allocationStackTrace);
+        {
+            if (undisposedAllocation is null)
+            {
+                return;
+            }
+
+            // Schedule on the ThreadPool, to avoid user callback messing up the finalizer thread.
+#if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
+            ThreadPool.QueueUserWorkItem(
+                stackTrace => undisposedAllocation?.Invoke(stackTrace),
+                allocationStackTrace,
+                preferLocal: false);
+#else
+            ThreadPool.QueueUserWorkItem(
+                stackTrace => undisposedAllocation?.Invoke((string)stackTrace),
+                allocationStackTrace);
+#endif
+        }
 
         internal class InteralMemoryDiagnostics
         {
             private int totalUndisposedAllocationCount;
-
-            private UndisposedAllocationDelegate undisposedAllocation;
-            private int undisposedAllocationSubscriptionCounter;
-            private readonly object syncRoot = new();
-
-            /// <summary>
-            /// Fires when an ImageSharp object's undisposed memory resource leaks to the finalizer.
-            /// The event brings significant overhead, and is intended to be used for troubleshooting only.
-            /// For production diagnostics, use <see cref="TotalUndisposedAllocationCount"/>.
-            /// </summary>
-            public event UndisposedAllocationDelegate UndisposedAllocation
-            {
-                add
-                {
-                    lock (this.syncRoot)
-                    {
-                        this.undisposedAllocationSubscriptionCounter++;
-                        this.undisposedAllocation += value;
-                    }
-                }
-
-                remove
-                {
-                    lock (this.syncRoot)
-                    {
-                        this.undisposedAllocation -= value;
-                        this.undisposedAllocationSubscriptionCounter--;
-                    }
-                }
-            }
 
             /// <summary>
             /// Gets a value indicating the total number of memory resource objects leaked to the finalizer.
             /// </summary>
             public int TotalUndisposedAllocationCount => this.totalUndisposedAllocationCount;
 
-            internal bool UndisposedAllocationSubscribed => Volatile.Read(ref this.undisposedAllocationSubscriptionCounter) > 0;
-
             internal void IncrementTotalUndisposedAllocationCount() =>
                 Interlocked.Increment(ref this.totalUndisposedAllocationCount);
 
             internal void DecrementTotalUndisposedAllocationCount() =>
                 Interlocked.Decrement(ref this.totalUndisposedAllocationCount);
-
-            internal void RaiseUndisposedMemoryResource(string allocationStackTrace)
-            {
-                if (this.undisposedAllocation is null)
-                {
-                    return;
-                }
-
-                // Schedule on the ThreadPool, to avoid user callback messing up the finalizer thread.
-#if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
-                ThreadPool.QueueUserWorkItem(
-                    stackTrace => this.undisposedAllocation?.Invoke(stackTrace),
-                    allocationStackTrace,
-                    preferLocal: false);
-#else
-                ThreadPool.QueueUserWorkItem(
-                    stackTrace => this.undisposedAllocation?.Invoke((string)stackTrace),
-                    allocationStackTrace);
-#endif
-            }
         }
     }
 }

--- a/src/ImageSharp/Diagnostics/MemoryDiagnostics.cs
+++ b/src/ImageSharp/Diagnostics/MemoryDiagnostics.cs
@@ -131,9 +131,9 @@ namespace SixLabors.ImageSharp.Diagnostics
                     allocationStackTrace,
                     preferLocal: false);
 #else
-            ThreadPool.QueueUserWorkItem(
-                stackTrace => this.undisposedAllocation?.Invoke((string)stackTrace),
-                allocationStackTrace);
+                ThreadPool.QueueUserWorkItem(
+                    stackTrace => this.undisposedAllocation?.Invoke((string)stackTrace),
+                    allocationStackTrace);
 #endif
             }
         }

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -122,11 +122,12 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         public Image<TPixel> Decode<TPixel>(BufferedReadStream stream, CancellationToken cancellationToken)
             where TPixel : unmanaged, IPixel<TPixel>
         {
+            Image<TPixel> image = null;
             try
             {
                 int bytesPerColorMapEntry = this.ReadImageHeaders(stream, out bool inverted, out byte[] palette);
 
-                var image = new Image<TPixel>(this.Configuration, this.infoHeader.Width, this.infoHeader.Height, this.metadata);
+                image = new Image<TPixel>(this.Configuration, this.infoHeader.Width, this.infoHeader.Height, this.metadata);
 
                 Buffer2D<TPixel> pixels = image.GetRootFramePixelBuffer();
 
@@ -193,7 +194,13 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             }
             catch (IndexOutOfRangeException e)
             {
+                image?.Dispose();
                 throw new ImageFormatException("Bitmap does not have a valid format.", e);
+            }
+            catch
+            {
+                image?.Dispose();
+                throw;
             }
         }
 

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -151,11 +151,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
                     }
                 }
             }
-            //catch
-            //{
-            //    image?.Dispose();
-            //    throw;
-            //}
             finally
             {
                 this.globalColorTable?.Dispose();

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -151,6 +151,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
                     }
                 }
             }
+            //catch
+            //{
+            //    image?.Dispose();
+            //    throw;
+            //}
             finally
             {
                 this.globalColorTable?.Dispose();

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
@@ -95,7 +95,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
                 }
             }
 
-            return this.pixelBuffer;
+            var buffer = this.pixelBuffer;
+            this.pixelBuffer = null;
+            return buffer;
         }
 
         /// <inheritdoc/>
@@ -210,6 +212,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
 
             this.rgbBuffer?.Dispose();
             this.paddedProxyPixelRow?.Dispose();
+            this.pixelBuffer?.Dispose();
         }
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -187,27 +187,20 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using var spectralConverter = new SpectralConverter<TPixel>(this.Configuration);
-            try
-            {
-                var scanDecoder = new HuffmanScanDecoder(stream, spectralConverter, cancellationToken);
 
-                this.ParseStream(stream, scanDecoder, cancellationToken);
-                this.InitExifProfile();
-                this.InitIccProfile();
-                this.InitIptcProfile();
-                this.InitXmpProfile();
-                this.InitDerivedMetadataProperties();
+            var scanDecoder = new HuffmanScanDecoder(stream, spectralConverter, cancellationToken);
 
-                return new Image<TPixel>(
-                    this.Configuration,
-                    spectralConverter.GetPixelBuffer(cancellationToken),
-                    this.Metadata);
-            }
-            catch
-            {
-                this.Frame?.Dispose();
-                throw;
-            }
+            this.ParseStream(stream, scanDecoder, cancellationToken);
+            this.InitExifProfile();
+            this.InitIccProfile();
+            this.InitIptcProfile();
+            this.InitXmpProfile();
+            this.InitDerivedMetadataProperties();
+
+            return new Image<TPixel>(
+                this.Configuration,
+                spectralConverter.GetPixelBuffer(cancellationToken),
+                this.Metadata);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -187,20 +187,27 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using var spectralConverter = new SpectralConverter<TPixel>(this.Configuration);
+            try
+            {
+                var scanDecoder = new HuffmanScanDecoder(stream, spectralConverter, cancellationToken);
 
-            var scanDecoder = new HuffmanScanDecoder(stream, spectralConverter, cancellationToken);
+                this.ParseStream(stream, scanDecoder, cancellationToken);
+                this.InitExifProfile();
+                this.InitIccProfile();
+                this.InitIptcProfile();
+                this.InitXmpProfile();
+                this.InitDerivedMetadataProperties();
 
-            this.ParseStream(stream, scanDecoder, cancellationToken);
-            this.InitExifProfile();
-            this.InitIccProfile();
-            this.InitIptcProfile();
-            this.InitXmpProfile();
-            this.InitDerivedMetadataProperties();
-
-            return new Image<TPixel>(
-                this.Configuration,
-                spectralConverter.GetPixelBuffer(cancellationToken),
-                this.Metadata);
+                return new Image<TPixel>(
+                    this.Configuration,
+                    spectralConverter.GetPixelBuffer(cancellationToken),
+                    this.Metadata);
+            }
+            catch
+            {
+                this.Frame?.Dispose();
+                throw;
+            }
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1367,7 +1367,6 @@ namespace SixLabors.ImageSharp.Formats.Png
             {
                 if (chunk.Type == PngChunkType.Data)
                 {
-                    chunk.Data?.Dispose();
                     return chunk.Length;
                 }
 

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1367,6 +1367,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             {
                 if (chunk.Type == PngChunkType.Data)
                 {
+                    chunk.Data?.Dispose();
                     return chunk.Length;
                 }
 

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/JpegTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/JpegTiffCompression.cs
@@ -65,7 +65,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
                         jpegDecoder.ParseStream(stream, scanDecoderGray, CancellationToken.None);
 
                         // TODO: Should we pass through the CancellationToken from the tiff decoder?
-                        CopyImageBytesToBuffer(buffer, spectralConverterGray.GetPixelBuffer(CancellationToken.None));
+                        using var decompressedBuffer = spectralConverterGray.GetPixelBuffer(CancellationToken.None);
+                        CopyImageBytesToBuffer(buffer, decompressedBuffer);
                         break;
                     }
 
@@ -81,7 +82,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
                         jpegDecoder.ParseStream(stream, scanDecoder, CancellationToken.None);
 
                         // TODO: Should we pass through the CancellationToken from the tiff decoder?
-                        CopyImageBytesToBuffer(buffer, spectralConverter.GetPixelBuffer(CancellationToken.None));
+                        using var decompressedBuffer = spectralConverter.GetPixelBuffer(CancellationToken.None);
+                        CopyImageBytesToBuffer(buffer, decompressedBuffer);
                         break;
                     }
 

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -240,8 +240,8 @@ namespace SixLabors.ImageSharp.Formats.Tiff
             var stripOffsetsArray = (Array)tags.GetValueInternal(ExifTag.StripOffsets).GetValue();
             var stripByteCountsArray = (Array)tags.GetValueInternal(ExifTag.StripByteCounts).GetValue();
 
-            IMemoryOwner<ulong> stripOffsetsMemory = this.ConvertNumbers(stripOffsetsArray, out Span<ulong> stripOffsets);
-            IMemoryOwner<ulong> stripByteCountsMemory = this.ConvertNumbers(stripByteCountsArray, out Span<ulong> stripByteCounts);
+            using IMemoryOwner<ulong> stripOffsetsMemory = this.ConvertNumbers(stripOffsetsArray, out Span<ulong> stripOffsets);
+            using IMemoryOwner<ulong> stripByteCountsMemory = this.ConvertNumbers(stripByteCountsArray, out Span<ulong> stripByteCounts);
 
             if (this.PlanarConfiguration == TiffPlanarConfiguration.Planar)
             {
@@ -262,8 +262,6 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     cancellationToken);
             }
 
-            stripOffsetsMemory?.Dispose();
-            stripByteCountsMemory?.Dispose();
             return frame;
         }
 

--- a/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
@@ -85,7 +85,6 @@ namespace SixLabors.ImageSharp.Formats.Webp
             Image<TPixel> image = null;
             try
             {
-
                 this.Metadata = new ImageMetadata();
                 this.currentStream = stream;
 

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -20,6 +20,7 @@ using static SixLabors.ImageSharp.Tests.TestImages.Bmp;
 namespace SixLabors.ImageSharp.Tests.Formats.Bmp
 {
     [Trait("Format", "Bmp")]
+    [ValidateDisposedMemoryAllocations]
     public class BmpDecoderTests
     {
         public const PixelTypes CommonNonDefaultPixelTypes = PixelTypes.Rgba32 | PixelTypes.Bgra32 | PixelTypes.RgbaVector;

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -18,6 +18,7 @@ using Xunit;
 namespace SixLabors.ImageSharp.Tests.Formats.Gif
 {
     [Trait("Format", "Gif")]
+    [ValidateDisposedMemoryAllocations]
     public class GifDecoderTests
     {
         private const PixelTypes TestPixelTypes = PixelTypes.Rgba32 | PixelTypes.RgbaVector | PixelTypes.Argb32;

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
@@ -179,11 +179,16 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             var testFile = TestFile.Create(imagePath);
             using (var stream = new MemoryStream(testFile.Bytes, false))
             {
-                IImageInfo imageInfo = useIdentify
-                ? ((IImageInfoDetector)decoder).Identify(Configuration.Default, stream, default)
-                : decoder.Decode<Rgba32>(Configuration.Default, stream, default);
-
-                test(imageInfo);
+                if (useIdentify)
+                {
+                    IImageInfo imageInfo = ((IImageInfoDetector)decoder).Identify(Configuration.Default, stream, default);
+                    test(imageInfo);
+                }
+                else
+                {
+                    using var img = decoder.Decode<Rgba32>(Configuration.Default, stream, default);
+                    test(img);
+                }
             }
         }
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -22,6 +22,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
     // TODO: Scatter test cases into multiple test classes
     [Trait("Format", "Jpg")]
+    [ValidateDisposedMemoryAllocations]
     public partial class JpegDecoderTests
     {
         public const PixelTypes CommonNonDefaultPixelTypes = PixelTypes.Rgba32 | PixelTypes.Argb32 | PixelTypes.Bgr24 | PixelTypes.RgbaVector;

--- a/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
@@ -11,6 +11,7 @@ using static SixLabors.ImageSharp.Tests.TestImages.Pbm;
 namespace SixLabors.ImageSharp.Tests.Formats.Pbm
 {
     [Trait("Format", "Pbm")]
+    [ValidateDisposedMemoryAllocations]
     public class PbmDecoderTests
     {
         [Theory]

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -108,9 +108,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using Image<TPixel> image = provider.GetImage(PngDecoder);
-            //var testFile = TestFile.Create(provider.SourceFileOrDescription);
-            //using Image<TPixel> image = Image.Load<TPixel>(provider.Configuration, testFile.Bytes, PngDecoder);
-
             image.DebugSave(provider);
             image.CompareToOriginal(provider, ImageComparer.Exact);
         }

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -103,10 +103,14 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), PixelTypes.Rgba32)]
+        [ValidateDisposedMemoryAllocations]
         public void Decode<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using Image<TPixel> image = provider.GetImage(PngDecoder);
+            //var testFile = TestFile.Create(provider.SourceFileOrDescription);
+            //using Image<TPixel> image = Image.Load<TPixel>(provider.Configuration, testFile.Bytes, PngDecoder);
+
             image.DebugSave(provider);
             image.CompareToOriginal(provider, ImageComparer.Exact);
         }

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 namespace SixLabors.ImageSharp.Tests.Formats.Png
 {
     [Trait("Format", "Png")]
+    [ValidateDisposedMemoryAllocations]
     public partial class PngDecoderTests
     {
         private const PixelTypes TestPixelTypes = PixelTypes.Rgba32 | PixelTypes.RgbaVector | PixelTypes.Argb32;
@@ -103,7 +104,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
         [Theory]
         [WithFileCollection(nameof(CommonTestImages), PixelTypes.Rgba32)]
-        [ValidateDisposedMemoryAllocations]
         public void Decode<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
@@ -16,6 +16,7 @@ using static SixLabors.ImageSharp.Tests.TestImages.Tga;
 namespace SixLabors.ImageSharp.Tests.Formats.Tga
 {
     [Trait("Format", "Tga")]
+    [ValidateDisposedMemoryAllocations]
     public class TgaDecoderTests
     {
         private static TgaDecoder TgaDecoder => new();

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -14,6 +14,7 @@ using static SixLabors.ImageSharp.Tests.TestImages.Tiff;
 namespace SixLabors.ImageSharp.Tests.Formats.Tiff
 {
     [Trait("Format", "Tiff")]
+    [ValidateDisposedMemoryAllocations]
     public class TiffDecoderTests : TiffDecoderBaseTester
     {
         public static readonly string[] MultiframeTestImages = Multiframes;

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpDecoderTests.cs
@@ -13,6 +13,7 @@ using static SixLabors.ImageSharp.Tests.TestImages.Webp;
 namespace SixLabors.ImageSharp.Tests.Formats.Webp
 {
     [Trait("Format", "Webp")]
+    [ValidateDisposedMemoryAllocations]
     public class WebpDecoderTests
     {
         private static WebpDecoder WebpDecoder => new();

--- a/tests/ImageSharp.Tests/Image/ImageTests.LoadPixelData.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.LoadPixelData.cs
@@ -14,6 +14,7 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
+            [ValidateDisposedMemoryAllocations]
             public void FromPixels(bool useSpan)
             {
                 Rgba32[] data = { Color.Black, Color.White, Color.White, Color.Black, };

--- a/tests/ImageSharp.Tests/Image/LargeImageIntegrationTests.cs
+++ b/tests/ImageSharp.Tests/Image/LargeImageIntegrationTests.cs
@@ -55,6 +55,8 @@ namespace SixLabors.ImageSharp.Tests
 
             static void RunTest(string formatInner)
             {
+                using IDisposable mem = MemoryAllocatorValidator.MonitorAllocations();
+
                 Configuration configuration = Configuration.Default.Clone();
                 configuration.PreferContiguousImageBuffers = true;
                 IImageEncoder encoder = configuration.ImageFormatsManager.FindEncoder(

--- a/tests/ImageSharp.Tests/MemoryAllocatorValidator.cs
+++ b/tests/ImageSharp.Tests/MemoryAllocatorValidator.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Diagnostics;
+using SixLabors.ImageSharp.Diagnostics;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests
+{
+    public static class MemoryAllocatorValidator
+    {
+        public static IDisposable MonitorAllocations(int max = 0)
+        {
+            MemoryDiagnostics.Current = new();
+            return new TestMemoryAllocatorDisposable(max);
+        }
+
+        public static void ValidateAllocation(int max = 0)
+        {
+            var count = MemoryDiagnostics.TotalUndisposedAllocationCount;
+            var pass = count <= max;
+            Assert.True(pass, $"Expected a max of {max} undisposed buffers but found {count}");
+
+            if (count > 0)
+            {
+                Debug.WriteLine("We should have Zero undisposed memory allocations.");
+            }
+
+            MemoryDiagnostics.Current = null;
+        }
+
+        public struct TestMemoryAllocatorDisposable : IDisposable
+        {
+            private readonly int max;
+
+            public TestMemoryAllocatorDisposable(int max) => this.max = max;
+
+            public void Dispose()
+                => ValidateAllocation(this.max);
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageComparingUtils.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageComparingUtils.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison
             }
 
             var testFile = TestFile.Create(path);
-            Image<Rgba32> magickImage = DecodeWithMagick<Rgba32>(new FileInfo(testFile.FullPath));
+            using Image<Rgba32> magickImage = DecodeWithMagick<Rgba32>(new FileInfo(testFile.FullPath));
             if (useExactComparer)
             {
                 ImageComparer.Exact.VerifySimilarity(magickImage, image);

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using SixLabors.ImageSharp.Diagnostics;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
@@ -158,8 +159,13 @@ namespace SixLabors.ImageSharp.Tests
                     return this.LoadImage(decoder);
                 }
 
-                var key = new Key(this.PixelType, this.FilePath, decoder);
+                // do cache so we can track allocation correctly when validating memory
+                if (MemoryDiagnostics.Current != MemoryDiagnostics.Default)
+                {
+                    return this.LoadImage(decoder);
+                }
 
+                var key = new Key(this.PixelType, this.FilePath, decoder);
                 Image<TPixel> cachedImage = Cache.GetOrAdd(key, _ => this.LoadImage(decoder));
 
                 return cachedImage.Clone(this.Configuration);

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
@@ -159,8 +159,8 @@ namespace SixLabors.ImageSharp.Tests
                     return this.LoadImage(decoder);
                 }
 
-                // do cache so we can track allocation correctly when validating memory
-                if (MemoryDiagnostics.Current != MemoryDiagnostics.Default)
+                // do not cache so we can track allocation correctly when validating memory
+                if (MemoryAllocatorValidator.MonitoringAllocations)
                 {
                     return this.LoadImage(decoder);
                 }

--- a/tests/ImageSharp.Tests/ValidateDisposedMemoryAllocationsAttribute.cs
+++ b/tests/ImageSharp.Tests/ValidateDisposedMemoryAllocationsAttribute.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace SixLabors.ImageSharp.Tests
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class ValidateDisposedMemoryAllocationsAttribute : BeforeAfterTestAttribute
+    {
+        private readonly int max = 0;
+
+        public ValidateDisposedMemoryAllocationsAttribute()
+            : this(0)
+        {
+        }
+
+        public ValidateDisposedMemoryAllocationsAttribute(int max)
+        {
+            this.max = max;
+            if (max > 0)
+            {
+                Debug.WriteLine("Needs fixing, we shoudl have Zero undisposed memory allocations.");
+            }
+        }
+
+        public override void Before(MethodInfo methodUnderTest)
+            => MemoryAllocatorValidator.MonitorAllocations(this.max); // the disposable isn't important cause the validate below does the same thing
+
+        public override void After(MethodInfo methodUnderTest)
+            => MemoryAllocatorValidator.ValidateAllocation(this.max);
+    }
+}

--- a/tests/ImageSharp.Tests/ValidateDisposedMemoryAllocationsAttribute.cs
+++ b/tests/ImageSharp.Tests/ValidateDisposedMemoryAllocationsAttribute.cs
@@ -11,26 +11,23 @@ namespace SixLabors.ImageSharp.Tests
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class ValidateDisposedMemoryAllocationsAttribute : BeforeAfterTestAttribute
     {
-        private readonly int max = 0;
+        private readonly int expected = 0;
 
         public ValidateDisposedMemoryAllocationsAttribute()
             : this(0)
         {
         }
 
-        public ValidateDisposedMemoryAllocationsAttribute(int max)
-        {
-            this.max = max;
-            if (max > 0)
-            {
-                Debug.WriteLine("Needs fixing, we shoudl have Zero undisposed memory allocations.");
-            }
-        }
+        public ValidateDisposedMemoryAllocationsAttribute(int expected)
+            => this.expected = expected;
 
         public override void Before(MethodInfo methodUnderTest)
-            => MemoryAllocatorValidator.MonitorAllocations(this.max); // the disposable isn't important cause the validate below does the same thing
+            => MemoryAllocatorValidator.MonitorAllocations();
 
         public override void After(MethodInfo methodUnderTest)
-            => MemoryAllocatorValidator.ValidateAllocation(this.max);
+        {
+            MemoryAllocatorValidator.ValidateAllocations(this.expected);
+            MemoryAllocatorValidator.StopMonitoringAllocations();
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This adds some new test helpers APIs + updates the `MemoryDiagnostics` class to consistently track the memory buffers per test.

Also adds 2 helpers in to the tests 
1. `ValidateDisposedMemoryAllocationsAttribute` - This attributes a can be applied to test classes and `Fact`/`Theory`s directly to automatically apply the memory application tracking and validation.
2. `MemoryAllocatorValidator` static class can be used in places the attribute is not appropriate, i.e. inside Remote Executors.

I've also applied some fixes targeting the Decoder tests

this includes the fix from #2081 (which I will merge into this PR so we don't loose attribute of the fix) if we decide this approach is suitable...otherwise we should just merge that one.

