### PR TITLE
Added sanity check for every jpeg marker

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegThrowHelper.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegThrowHelper.cs
@@ -26,6 +26,9 @@ namespace SixLabors.ImageSharp.Formats.Jpeg
         public static void ThrowBadMarker(string marker, int length) => throw new InvalidImageContentException($"Marker {marker} has bad length {length}.");
 
         [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowNotEnoughBytesForMarker(byte marker) => throw new InvalidImageContentException($"Input stream does not have enough bytes to parse declared contents of the {marker:X2} marker.");
+
+        [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowBadQuantizationTableIndex(int index) => throw new InvalidImageContentException($"Bad Quantization Table index {index}.");
 
         [MethodImpl(InliningOptions.ColdPath)]

--- a/src/ImageSharp/IO/BufferedReadStream.cs
+++ b/src/ImageSharp/IO/BufferedReadStream.cs
@@ -115,6 +115,15 @@ namespace SixLabors.ImageSharp.IO
         public override bool CanWrite { get; } = false;
 
         /// <summary>
+        /// Gets remaining byte count available to read.
+        /// </summary>
+        public long RemainingBytes
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this.Length - this.Position;
+        }
+
+        /// <summary>
         /// Gets the underlying stream.
         /// </summary>
         public Stream BaseStream

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
@@ -105,6 +105,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException1693A,
             TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException1693B,
             TestImages.Jpeg.Issues.Fuzz.IndexOutOfRangeException824C,
+            TestImages.Jpeg.Issues.Fuzz.NullReferenceException2085,
         };
 
         private static readonly Dictionary<string, float> CustomToleranceValues = new()

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -292,6 +292,7 @@ namespace SixLabors.ImageSharp.Tests
                     public const string AccessViolationException922 = "Jpg/issues/fuzz/Issue922-AccessViolationException.jpg";
                     public const string IndexOutOfRangeException1693A = "Jpg/issues/fuzz/Issue1693-IndexOutOfRangeException-A.jpg";
                     public const string IndexOutOfRangeException1693B = "Jpg/issues/fuzz/Issue1693-IndexOutOfRangeException-B.jpg";
+                    public const string NullReferenceException2085 = "Jpg/issues/fuzz/Issue2085-NullReferenceException.jpg";
                 }
             }
 

--- a/tests/Images/Input/Jpg/issues/fuzz/Issue2085-NullReferenceException.jpg
+++ b/tests/Images/Input/Jpg/issues/fuzz/Issue2085-NullReferenceException.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d478beff34179fda26238a44434607c276f55438ee96824c5af8c0188d358d8d
+size 234


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Discussed at https://github.com/SixLabors/ImageSharp/pull/2077. Now before even trying to parse any jpeg marker decoder would check whether input stream has enough bytes available thus there's no need to check any `stream.Read(...)` call for return value.

Closes https://github.com/SixLabors/ImageSharp/issues/2085.