### PR TITLE
Fixed string exif value corner case exception

### DIFF
--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
@@ -79,16 +79,8 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
             return CharacterCodeBytesLength + count;
         }
 
-        public static unsafe int Write(Encoding encoding, string value, Span<byte> destination)
-        {
-            fixed (char* c = value)
-            {
-                fixed (byte* b = destination)
-                {
-                    return encoding.GetBytes(c, value.Length, b, destination.Length);
-                }
-            }
-        }
+        public static unsafe int Write(Encoding encoding, string value, Span<byte> destination) =>
+            encoding.GetBytes(value.AsSpan(), destination);
 
         private static bool TryDetect(ReadOnlySpan<byte> buffer, out CharacterCode code)
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
@@ -84,6 +84,11 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Exif
             => encoding.GetBytes(value.AsSpan(), destination);
 #else
         {
+            if (value.Length == 0)
+            {
+                return 0;
+            }
+
             fixed (char* c = value)
             {
                 fixed (byte* b = destination)

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
@@ -33,7 +33,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             TestImages.Jpeg.Issues.ExifGetString750Load,
             TestImages.Jpeg.Issues.ExifGetString750Transform,
             TestImages.Jpeg.Issues.BadSubSampling1076,
-            TestImages.Jpeg.Issues.ValidExifArgumentNullExceptionOnEncode,
 
             // LibJpeg can open this despite the invalid density units.
             TestImages.Jpeg.Issues.Fuzz.ArgumentOutOfRangeException825B,

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Images.cs
@@ -33,6 +33,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             TestImages.Jpeg.Issues.ExifGetString750Load,
             TestImages.Jpeg.Issues.ExifGetString750Transform,
             TestImages.Jpeg.Issues.BadSubSampling1076,
+            TestImages.Jpeg.Issues.ValidExifArgumentNullExceptionOnEncode,
 
             // LibJpeg can open this despite the invalid density units.
             TestImages.Jpeg.Issues.Fuzz.ArgumentOutOfRangeException825B,

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.Metadata.cs
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         public void Encode_WithValidExifProfile_DoesNotThrowException<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            Exception exception = Record.Exception(() =>
+            Exception ex = Record.Exception(() =>
             {
                 var encoder = new JpegEncoder();
                 var stream = new MemoryStream();
@@ -27,7 +27,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 image.Save(stream, encoder);
             });
 
-            Assert.Null(exception);
+            Assert.Null(ex);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.Metadata.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.IO;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.PixelFormats;
+
+using Xunit;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Jpg
+{
+    [Trait("Format", "Jpg")]
+    public partial class JpegEncoderTests
+    {
+        [Theory]
+        [WithFile(TestImages.Jpeg.Issues.ValidExifArgumentNullExceptionOnEncode, PixelTypes.Rgba32)]
+        public void Encode_WithValidExifProfile_DoesNotThrowException<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Exception exception = Record.Exception(() =>
+            {
+                var encoder = new JpegEncoder();
+                var stream = new MemoryStream();
+
+                using Image<TPixel> image = provider.GetImage(JpegDecoder);
+                image.Save(stream, encoder);
+            });
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 {
     [Trait("Format", "Jpg")]
-    public class JpegEncoderTests
+    public partial class JpegEncoderTests
     {
         private static JpegEncoder JpegEncoder => new();
 

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -264,6 +264,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string InvalidIptcTag = "Jpg/issues/Issue1942InvalidIptcTag.jpg";
                 public const string Issue2057App1Parsing = "Jpg/issues/Issue2057-App1Parsing.jpg";
                 public const string ExifNullArrayTag = "Jpg/issues/issue-2056-exif-null-array.jpg";
+                public const string ValidExifArgumentNullExceptionOnEncode = "Jpg/issues/Issue2087-exif-null-reference-on-encode.jpg";
 
                 public static class Fuzz
                 {

--- a/tests/Images/Input/Jpg/issues/Issue2087-exif-null-reference-on-encode.jpg
+++ b/tests/Images/Input/Jpg/issues/Issue2087-exif-null-reference-on-encode.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d41a41180a3371d0c4a724b40a4c86f6f975dab6be9da96964a484818770394
+size 30715


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes https://github.com/SixLabors/ImageSharp/issues/2087.

Given image from linked issue contains empty user comment tag which is written last. Allocated buffer is passed as `Span` which is sliced during different exif values rendering to the given buffer. This exact situation led to copying zero bytes to zero-length span aaaaand looks like .net treats empty spans with valid memory pointer as null pointer thus mentioned `ArgumentNullException`.

Fix is fairly simple: use spans instead of working with raw pointers without any fixed statements (love this performance side effect) and unsafe stuff, `Encoding.GetBytes(ReadOnlySpan, Span)` respects empty spans.

~~P.S.
Waiting for issue image usage approval from the issue author.~~