### PR TITLE
Obsolete ImageFormat out params and return on Metadata

### DIFF
--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -166,8 +166,13 @@ namespace SixLabors.ImageSharp
                 return null;
             }
 
-            IImageInfo info = detector?.Identify(config, stream, cancellationToken);
-            info.Metadata.OrigionalImageFormat = format;
+            IImageInfo info = detector.Identify(config, stream, cancellationToken);
+
+            if (info is not null)
+            {
+                info.Metadata.OrigionalImageFormat = format;
+            }
+
             return info;
         }
     }

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -121,29 +121,31 @@ namespace SixLabors.ImageSharp
         /// <returns>
         /// A new <see cref="Image{TPixel}"/>.
         /// </returns>
-        private static (Image<TPixel> Image, IImageFormat Format) Decode<TPixel>(Stream stream, Configuration config, CancellationToken cancellationToken = default)
+        private static Image<TPixel> Decode<TPixel>(Stream stream, Configuration config, CancellationToken cancellationToken = default)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             IImageDecoder decoder = DiscoverDecoder(stream, config, out IImageFormat format);
             if (decoder is null)
             {
-                return (null, null);
+                return null;
             }
 
             Image<TPixel> img = decoder.Decode<TPixel>(config, stream, cancellationToken);
-            return (img, format);
+            img.Metadata.OrigionalImageFormat = format;
+            return img;
         }
 
-        private static (Image Image, IImageFormat Format) Decode(Stream stream, Configuration config, CancellationToken cancellationToken = default)
+        private static Image Decode(Stream stream, Configuration config, CancellationToken cancellationToken = default)
         {
             IImageDecoder decoder = DiscoverDecoder(stream, config, out IImageFormat format);
             if (decoder is null)
             {
-                return (null, null);
+                return null;
             }
 
             Image img = decoder.Decode(config, stream, cancellationToken);
-            return (img, format);
+            img.Metadata.OrigionalImageFormat = format;
+            return img;
         }
 
         /// <summary>
@@ -155,17 +157,18 @@ namespace SixLabors.ImageSharp
         /// <returns>
         /// The <see cref="IImageInfo"/> or null if a suitable info detector is not found.
         /// </returns>
-        private static (IImageInfo ImageInfo, IImageFormat Format) InternalIdentity(Stream stream, Configuration config, CancellationToken cancellationToken = default)
+        private static IImageInfo InternalIdentity(Stream stream, Configuration config, CancellationToken cancellationToken = default)
         {
             IImageDecoder decoder = DiscoverDecoder(stream, config, out IImageFormat format);
 
             if (decoder is not IImageInfoDetector detector)
             {
-                return (null, null);
+                return null;
             }
 
             IImageInfo info = detector?.Identify(config, stream, cancellationToken);
-            return (info, format);
+            info.Metadata.OrigionalImageFormat = format;
+            return info;
         }
     }
 }

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -49,39 +49,25 @@ namespace SixLabors.ImageSharp
         /// <returns>
         /// The <see cref="IImageInfo"/> or null if suitable info detector not found.
         /// </returns>
-        public static IImageInfo Identify(byte[] data) => Identify(data, out IImageFormat _);
-
-        /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
-        /// </summary>
-        /// <param name="data">The byte array containing encoded image data to read the header from.</param>
-        /// <param name="format">The format type of the decoded image.</param>
-        /// <exception cref="ArgumentNullException">The data is null.</exception>
-        /// <exception cref="NotSupportedException">The data is not readable.</exception>
-        /// <returns>
-        /// The <see cref="IImageInfo"/> or null if suitable info detector not found.
-        /// </returns>
-        public static IImageInfo Identify(byte[] data, out IImageFormat format) => Identify(Configuration.Default, data, out format);
+        public static IImageInfo Identify(byte[] data) => Identify(Configuration.Default, data);
 
         /// <summary>
         /// Reads the raw image information from the specified stream without fully decoding it.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="data">The byte array containing encoded image data to read the header from.</param>
-        /// <param name="format">The format type of the decoded image.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
         /// <exception cref="ArgumentNullException">The data is null.</exception>
         /// <exception cref="NotSupportedException">The data is not readable.</exception>
         /// <returns>
-        /// The <see cref="IImageInfo"/> or null if suitable info detector is not found.
+        /// The <see cref="IImageInfo"/> or null if suitable info detector not found.
         /// </returns>
-        public static IImageInfo Identify(Configuration configuration, byte[] data, out IImageFormat format)
+        public static IImageInfo Identify(Configuration configuration, byte[] data)
         {
             Guard.NotNull(data, nameof(data));
 
             using (var stream = new MemoryStream(data, 0, data.Length, false, true))
             {
-                return Identify(configuration, stream, out format);
+                return Identify(configuration, stream);
             }
         }
 
@@ -112,21 +98,6 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte array.
         /// </summary>
-        /// <param name="data">The byte array containing image data.</param>
-        /// <param name="format">The mime type of the decoded image.</param>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <exception cref="ArgumentNullException">The data is null.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static Image<TPixel> Load<TPixel>(byte[] data, out IImageFormat format)
-            where TPixel : unmanaged, IPixel<TPixel>
-            => Load<TPixel>(Configuration.Default, data, out format);
-
-        /// <summary>
-        /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte array.
-        /// </summary>
         /// <param name="configuration">The configuration options.</param>
         /// <param name="data">The byte array containing encoded image data.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
@@ -144,30 +115,6 @@ namespace SixLabors.ImageSharp
             using (var stream = new MemoryStream(data, 0, data.Length, false, true))
             {
                 return Load<TPixel>(configuration, stream);
-            }
-        }
-
-        /// <summary>
-        /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte array.
-        /// </summary>
-        /// <param name="configuration">The configuration options.</param>
-        /// <param name="data">The byte array containing encoded image data.</param>
-        /// <param name="format">The <see cref="IImageFormat"/> of the decoded image.</param>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The data is null.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static Image<TPixel> Load<TPixel>(Configuration configuration, byte[] data, out IImageFormat format)
-            where TPixel : unmanaged, IPixel<TPixel>
-        {
-            Guard.NotNull(data, nameof(data));
-
-            using (var stream = new MemoryStream(data, 0, data.Length, false, true))
-            {
-                return Load<TPixel>(configuration, stream, out format);
             }
         }
 
@@ -270,20 +217,6 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte span.
         /// </summary>
-        /// <param name="data">The byte span containing image data.</param>
-        /// <param name="format">The mime type of the decoded image.</param>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
-        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static Image<TPixel> Load<TPixel>(ReadOnlySpan<byte> data, out IImageFormat format)
-            where TPixel : unmanaged, IPixel<TPixel>
-            => Load<TPixel>(Configuration.Default, data, out format);
-
-        /// <summary>
-        /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte span.
-        /// </summary>
         /// <param name="data">The byte span containing encoded image data.</param>
         /// <param name="decoder">The decoder.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
@@ -346,47 +279,6 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte span.
-        /// </summary>
-        /// <param name="configuration">The configuration options.</param>
-        /// <param name="data">The byte span containing image data.</param>
-        /// <param name="format">The <see cref="IImageFormat"/> of the decoded image.</param>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
-        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static unsafe Image<TPixel> Load<TPixel>(
-            Configuration configuration,
-            ReadOnlySpan<byte> data,
-            out IImageFormat format)
-            where TPixel : unmanaged, IPixel<TPixel>
-        {
-            fixed (byte* ptr = &data.GetPinnableReference())
-            {
-                using (var stream = new UnmanagedMemoryStream(ptr, data.Length))
-                {
-                    return Load<TPixel>(configuration, stream, out format);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Load a new instance of <see cref="Image"/> from the given encoded byte array.
-        /// </summary>
-        /// <param name="data">The byte array containing image data.</param>
-        /// <param name="format">The detected format.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The data is null.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
-        /// <returns>The <see cref="Image"/>.</returns>
-        public static Image Load(byte[] data, out IImageFormat format)
-            => Load(Configuration.Default, data, out format);
-
-        /// <summary>
         /// Load a new instance of <see cref="Image"/> from the given encoded byte array.
         /// </summary>
         /// <param name="data">The byte array containing encoded image data.</param>
@@ -411,7 +303,12 @@ namespace SixLabors.ImageSharp
         /// <exception cref="NotSupportedException">Image format is not supported.</exception>
         /// <returns>The <see cref="Image"/>.</returns>
         public static Image Load(Configuration configuration, byte[] data)
-            => Load(configuration, data, out _);
+        {
+            using (var stream = new MemoryStream(data, 0, data.Length, false, true))
+            {
+                return Load(configuration, stream);
+            }
+        }
 
         /// <summary>
         /// Load a new instance of <see cref="Image"/> from the given encoded byte array.
@@ -430,26 +327,6 @@ namespace SixLabors.ImageSharp
             using (var stream = new MemoryStream(data, 0, data.Length, false, true))
             {
                 return Load(configuration, stream, decoder);
-            }
-        }
-
-        /// <summary>
-        /// Load a new instance of <see cref="Image"/> from the given encoded byte array.
-        /// </summary>
-        /// <param name="configuration">The configuration for the decoder.</param>
-        /// <param name="data">The byte array containing image data.</param>
-        /// <param name="format">The mime type of the decoded image.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The data is null.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
-        /// <returns>The <see cref="Image"/>.</returns>
-        public static Image Load(Configuration configuration, byte[] data, out IImageFormat format)
-        {
-            using (var stream = new MemoryStream(data, 0, data.Length, false, true))
-            {
-                return Load(configuration, stream, out format);
             }
         }
 
@@ -479,26 +356,21 @@ namespace SixLabors.ImageSharp
             => Load(Configuration.Default, data, decoder);
 
         /// <summary>
-        /// Load a new instance of <see cref="Image"/> from the given encoded byte array.
-        /// </summary>
-        /// <param name="data">The byte span containing image data.</param>
-        /// <param name="format">The detected format.</param>
-        /// <exception cref="ArgumentNullException">The decoder is null.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
-        /// <returns>The <see cref="Image"/>.</returns>
-        public static Image Load(ReadOnlySpan<byte> data, out IImageFormat format)
-            => Load(Configuration.Default, data, out format);
-
-        /// <summary>
         /// Decodes a new instance of <see cref="Image"/> from the given encoded byte span.
         /// </summary>
         /// <param name="configuration">The configuration options.</param>
         /// <param name="data">The byte span containing image data.</param>
         /// <returns>The <see cref="Image"/>.</returns>
-        public static Image Load(Configuration configuration, ReadOnlySpan<byte> data)
-            => Load(configuration, data, out _);
+        public static unsafe Image Load(Configuration configuration, ReadOnlySpan<byte> data)
+        {
+            fixed (byte* ptr = &data.GetPinnableReference())
+            {
+                using (var stream = new UnmanagedMemoryStream(ptr, data.Length))
+                {
+                    return Load(configuration, stream);
+                }
+            }
+        }
 
         /// <summary>
         /// Load a new instance of <see cref="Image"/> from the given encoded byte span.
@@ -522,31 +394,6 @@ namespace SixLabors.ImageSharp
                 using (var stream = new UnmanagedMemoryStream(ptr, data.Length))
                 {
                     return Load(configuration, stream, decoder);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Load a new instance of <see cref="Image"/> from the given encoded byte span.
-        /// </summary>
-        /// <param name="configuration">The configuration options.</param>
-        /// <param name="data">The byte span containing image data.</param>
-        /// <param name="format">The <see cref="IImageFormat"/> of the decoded image.</param>>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
-        /// <returns>The <see cref="Image"/>.</returns>
-        public static unsafe Image Load(
-            Configuration configuration,
-            ReadOnlySpan<byte> data,
-            out IImageFormat format)
-        {
-            fixed (byte* ptr = &data.GetPinnableReference())
-            {
-                using (var stream = new UnmanagedMemoryStream(ptr, data.Length))
-                {
-                    return Load(configuration, stream, out format);
                 }
             }
         }

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp
         /// The <see cref="IImageInfo"/> or null if a suitable info detector is not found.
         /// </returns>
         public static IImageInfo Identify(Stream stream)
-            => Identify(stream, out IImageFormat _);
+            => Identify(Configuration.Default, stream);
 
         /// <summary>
         /// Reads the raw image information from the specified stream without fully decoding it.
@@ -99,20 +99,6 @@ namespace SixLabors.ImageSharp
         /// <summary>
         /// Reads the raw image information from the specified stream without fully decoding it.
         /// </summary>
-        /// <param name="stream">The image stream to read the header from.</param>
-        /// <param name="format">The format type of the decoded image.</param>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>
-        /// The <see cref="IImageInfo"/> or null if a suitable info detector is not found.
-        /// </returns>
-        public static IImageInfo Identify(Stream stream, out IImageFormat format)
-            => Identify(Configuration.Default, stream, out format);
-
-        /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
-        /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="stream">The image stream to read the information from.</param>
         /// <exception cref="ArgumentNullException">The configuration is null.</exception>
@@ -123,7 +109,7 @@ namespace SixLabors.ImageSharp
         /// The <see cref="IImageInfo"/> or null if a suitable info detector is not found.
         /// </returns>
         public static IImageInfo Identify(Configuration configuration, Stream stream)
-            => Identify(configuration, stream, out _);
+            => WithSeekableStream(configuration, stream, s => InternalIdentity(s, configuration ?? Configuration.Default));
 
         /// <summary>
         /// Reads the raw image information from the specified stream without fully decoding it.
@@ -139,105 +125,15 @@ namespace SixLabors.ImageSharp
         /// A <see cref="Task{IImageInfo}"/> representing the asynchronous operation or null if
         /// a suitable detector is not found.
         /// </returns>
-        public static async Task<IImageInfo> IdentifyAsync(
-            Configuration configuration,
-            Stream stream,
-            CancellationToken cancellationToken = default)
-        {
-            (IImageInfo ImageInfo, IImageFormat Format) res = await IdentifyWithFormatAsync(configuration, stream, cancellationToken).ConfigureAwait(false);
-            return res.ImageInfo;
-        }
-
-        /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
-        /// </summary>
-        /// <param name="configuration">The configuration.</param>
-        /// <param name="stream">The image stream to read the information from.</param>
-        /// <param name="format">The format type of the decoded image.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>
-        /// The <see cref="IImageInfo"/> or null if a suitable info detector is not found.
-        /// </returns>
-        public static IImageInfo Identify(Configuration configuration, Stream stream, out IImageFormat format)
-        {
-            (IImageInfo ImageInfo, IImageFormat Format) data = WithSeekableStream(configuration, stream, s => InternalIdentity(s, configuration ?? Configuration.Default));
-
-            format = data.Format;
-            return data.ImageInfo;
-        }
-
-        /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
-        /// </summary>
-        /// <param name="stream">The image stream to read the information from.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>
-        /// The <see cref="Task{ValueTuple}"/> representing the asynchronous operation with the parameter type
-        /// <see cref="IImageInfo"/> property set to null if suitable info detector is not found.
-        /// </returns>
-        public static Task<(IImageInfo ImageInfo, IImageFormat Format)> IdentifyWithFormatAsync(
-            Stream stream,
-            CancellationToken cancellationToken = default)
-            => IdentifyWithFormatAsync(Configuration.Default, stream, cancellationToken);
-
-        /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
-        /// </summary>
-        /// <param name="configuration">The configuration.</param>
-        /// <param name="stream">The image stream to read the information from.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>
-        /// The <see cref="Task{ValueTuple}"/> representing the asynchronous operation with the parameter type
-        /// <see cref="IImageInfo"/> property set to null if suitable info detector is not found.
-        /// </returns>
-        public static Task<(IImageInfo ImageInfo, IImageFormat Format)> IdentifyWithFormatAsync(
+        public static Task<IImageInfo> IdentifyAsync(
             Configuration configuration,
             Stream stream,
             CancellationToken cancellationToken = default)
             => WithSeekableStreamAsync(
-                configuration,
-                stream,
-                (s, ct) => InternalIdentity(s, configuration ?? Configuration.Default, ct),
-                cancellationToken);
-
-        /// <summary>
-        /// Decode a new instance of the <see cref="Image"/> class from the given stream.
-        /// The pixel format is selected by the decoder.
-        /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="format">The format type of the decoded image.</param>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>The <see cref="Image"/>.</returns>
-        public static Image Load(Stream stream, out IImageFormat format)
-            => Load(Configuration.Default, stream, out format);
-
-        /// <summary>
-        /// Decode a new instance of the <see cref="Image"/> class from the given stream.
-        /// The pixel format is selected by the decoder.
-        /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>A <see cref="Task{ValueTuple}"/> representing the asynchronous operation.</returns>
-        public static Task<(Image Image, IImageFormat Format)> LoadWithFormatAsync(Stream stream, CancellationToken cancellationToken = default)
-            => LoadWithFormatAsync(Configuration.Default, stream, cancellationToken);
+              configuration,
+              stream,
+              (s, ct) => InternalIdentity(s, configuration ?? Configuration.Default, ct),
+              cancellationToken);
 
         /// <summary>
         /// Decode a new instance of the <see cref="Image"/> class from the given stream.
@@ -356,7 +252,13 @@ namespace SixLabors.ImageSharp
         /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
         /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
         /// <returns>A new <see cref="Image"/>.</returns>
-        public static Image Load(Configuration configuration, Stream stream) => Load(configuration, stream, out _);
+        public static Image Load(Configuration configuration, Stream stream)
+        {
+            Image image = WithSeekableStream(configuration, stream, s => Decode(s, configuration));
+            ThrowMissingDecoderIfNull(image, configuration);
+
+            return image;
+        }
 
         /// <summary>
         /// Decode a new instance of the <see cref="Image"/> class from the given stream.
@@ -372,9 +274,15 @@ namespace SixLabors.ImageSharp
         /// <returns>A <see cref="Task{Image}"/> representing the asynchronous operation.</returns>
         public static async Task<Image> LoadAsync(Configuration configuration, Stream stream, CancellationToken cancellationToken = default)
         {
-            (Image Image, IImageFormat Format) fmt = await LoadWithFormatAsync(configuration, stream, cancellationToken)
-                .ConfigureAwait(false);
-            return fmt.Image;
+            Image image = await WithSeekableStreamAsync(
+                   configuration,
+                   stream,
+                   (s, ct) => Decode(s, configuration, ct),
+                   cancellationToken)
+               .ConfigureAwait(false);
+            ThrowMissingDecoderIfNull(image, configuration);
+
+            return image;
         }
 
         /// <summary>
@@ -405,36 +313,6 @@ namespace SixLabors.ImageSharp
         public static Task<Image<TPixel>> LoadAsync<TPixel>(Stream stream, CancellationToken cancellationToken = default)
             where TPixel : unmanaged, IPixel<TPixel>
             => LoadAsync<TPixel>(Configuration.Default, stream, cancellationToken);
-
-        /// <summary>
-        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
-        /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="format">The format type of the decoded image.</param>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static Image<TPixel> Load<TPixel>(Stream stream, out IImageFormat format)
-            where TPixel : unmanaged, IPixel<TPixel>
-            => Load<TPixel>(Configuration.Default, stream, out format);
-
-        /// <summary>
-        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
-        /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <returns>A <see cref="Task{ValueTuple}"/> representing the asynchronous operation.</returns>
-        public static Task<(Image<TPixel> Image, IImageFormat Format)> LoadWithFormatAsync<TPixel>(Stream stream, CancellationToken cancellationToken = default)
-            where TPixel : unmanaged, IPixel<TPixel>
-            => LoadWithFormatAsync<TPixel>(Configuration.Default, stream, cancellationToken);
 
         /// <summary>
         /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
@@ -528,125 +406,11 @@ namespace SixLabors.ImageSharp
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
         public static Image<TPixel> Load<TPixel>(Configuration configuration, Stream stream)
             where TPixel : unmanaged, IPixel<TPixel>
-            => Load<TPixel>(configuration, stream, out IImageFormat _);
-
-        /// <summary>
-        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
-        /// </summary>
-        /// <param name="configuration">The configuration options.</param>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="format">The format type of the decoded image.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static Image<TPixel> Load<TPixel>(Configuration configuration, Stream stream, out IImageFormat format)
-            where TPixel : unmanaged, IPixel<TPixel>
         {
-            (Image<TPixel> Image, IImageFormat Format) data = WithSeekableStream(configuration, stream, s => Decode<TPixel>(s, configuration));
+            Image<TPixel> image = WithSeekableStream(configuration, stream, s => Decode<TPixel>(s, configuration));
+            ThrowMissingDecoderIfNull(image, configuration);
 
-            format = data.Format;
-
-            if (data.Image != null)
-            {
-                return data.Image;
-            }
-
-            var sb = new StringBuilder();
-            sb.AppendLine("Image cannot be loaded. Available decoders:");
-
-            foreach (KeyValuePair<IImageFormat, IImageDecoder> val in configuration.ImageFormatsManager.ImageDecoders)
-            {
-                sb.AppendFormat(" - {0} : {1}{2}", val.Key.Name, val.Value.GetType().Name, Environment.NewLine);
-            }
-
-            throw new UnknownImageFormatException(sb.ToString());
-        }
-
-        /// <summary>
-        /// Create a new instance of the <see cref="Image"/> class from the given stream.
-        /// </summary>
-        /// <param name="configuration">The configuration options.</param>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>A <see cref="Task{ValueTuple}"/> representing the asynchronous operation.</returns>
-        public static async Task<(Image Image, IImageFormat Format)> LoadWithFormatAsync(
-            Configuration configuration,
-            Stream stream,
-            CancellationToken cancellationToken = default)
-        {
-            (Image Image, IImageFormat Format) data = await WithSeekableStreamAsync(
-                    configuration,
-                    stream,
-                    (s, ct) => Decode(s, configuration, ct),
-                    cancellationToken)
-                .ConfigureAwait(false);
-
-            if (data.Image != null)
-            {
-                return data;
-            }
-
-            var sb = new StringBuilder();
-            sb.AppendLine("Image cannot be loaded. Available decoders:");
-
-            foreach (KeyValuePair<IImageFormat, IImageDecoder> val in configuration.ImageFormatsManager.ImageDecoders)
-            {
-                sb.AppendFormat(" - {0} : {1}{2}", val.Key.Name, val.Value.GetType().Name, Environment.NewLine);
-            }
-
-            throw new UnknownImageFormatException(sb.ToString());
-        }
-
-        /// <summary>
-        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
-        /// </summary>
-        /// <param name="configuration">The configuration options.</param>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <returns>A <see cref="Task{ValueTuple}"/> representing the asynchronous operation.</returns>
-        public static async Task<(Image<TPixel> Image, IImageFormat Format)> LoadWithFormatAsync<TPixel>(
-            Configuration configuration,
-            Stream stream,
-            CancellationToken cancellationToken = default)
-            where TPixel : unmanaged, IPixel<TPixel>
-        {
-            (Image<TPixel> Image, IImageFormat Format) data =
-                await WithSeekableStreamAsync(
-                    configuration,
-                    stream,
-                    (s, ct) => Decode<TPixel>(s, configuration, ct),
-                    cancellationToken)
-                .ConfigureAwait(false);
-
-            if (data.Image != null)
-            {
-                return data;
-            }
-
-            var sb = new StringBuilder();
-            sb.AppendLine("Image cannot be loaded. Available decoders:");
-
-            foreach (KeyValuePair<IImageFormat, IImageDecoder> val in configuration.ImageFormatsManager.ImageDecoders)
-            {
-                sb.AppendFormat(" - {0} : {1}{2}", val.Key.Name, val.Value.GetType().Name, Environment.NewLine);
-            }
-
-            throw new UnknownImageFormatException(sb.ToString());
+            return image;
         }
 
         /// <summary>
@@ -668,44 +432,28 @@ namespace SixLabors.ImageSharp
             CancellationToken cancellationToken = default)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            (Image<TPixel> img, _) = await LoadWithFormatAsync<TPixel>(configuration, stream, cancellationToken)
-                .ConfigureAwait(false);
-            return img;
-        }
+            Image<TPixel> image =
+              await WithSeekableStreamAsync(
+                  configuration,
+                  stream,
+                  (s, ct) => Decode<TPixel>(s, configuration, ct),
+                  cancellationToken)
+              .ConfigureAwait(false);
 
-        /// <summary>
-        /// Decode a new instance of the <see cref="Image"/> class from the given stream.
-        /// The pixel format is selected by the decoder.
-        /// </summary>
-        /// <param name="configuration">The configuration options.</param>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="format">The format type of the decoded image.</param>
-        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
-        /// <exception cref="ArgumentNullException">The stream is null.</exception>
-        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
-        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
-        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
-        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static Image Load(Configuration configuration, Stream stream, out IImageFormat format)
-        {
-            (Image Img, IImageFormat Format) data = WithSeekableStream(configuration, stream, s => Decode(s, configuration));
-
-            format = data.Format;
-
-            if (data.Img != null)
+            if (image == null)
             {
-                return data.Img;
+                var sb = new StringBuilder();
+                sb.AppendLine("Image cannot be loaded. Available decoders:");
+
+                foreach (KeyValuePair<IImageFormat, IImageDecoder> val in configuration.ImageFormatsManager.ImageDecoders)
+                {
+                    sb.AppendFormat(" - {0} : {1}{2}", val.Key.Name, val.Value.GetType().Name, Environment.NewLine);
+                }
+
+                throw new UnknownImageFormatException(sb.ToString());
             }
 
-            var sb = new StringBuilder();
-            sb.AppendLine("Image cannot be loaded. Available decoders:");
-
-            foreach (KeyValuePair<IImageFormat, IImageDecoder> val in configuration.ImageFormatsManager.ImageDecoders)
-            {
-                sb.AppendFormat(" - {0} : {1}{2}", val.Key.Name, val.Value.GetType().Name, Environment.NewLine);
-            }
-
-            throw new UnknownImageFormatException(sb.ToString());
+            return image;
         }
 
         /// <summary>
@@ -787,6 +535,22 @@ namespace SixLabors.ImageSharp
             memoryStream.Position = 0;
 
             return action(memoryStream, cancellationToken);
+        }
+
+        private static void ThrowMissingDecoderIfNull(Image image, Configuration configuration)
+        {
+            if (image == null)
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("Image cannot be loaded. Available decoders:");
+
+                foreach (KeyValuePair<IImageFormat, IImageDecoder> val in configuration.ImageFormatsManager.ImageDecoders)
+                {
+                    sb.AppendFormat(" - {0} : {1}{2}", val.Key.Name, val.Value.GetType().Name, Environment.NewLine);
+                }
+
+                throw new UnknownImageFormatException(sb.ToString());
+            }
         }
     }
 }

--- a/src/ImageSharp/Image.ObsoleteApis.cs
+++ b/src/ImageSharp/Image.ObsoleteApis.cs
@@ -1,0 +1,612 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp
+{
+    /// <content>
+    /// Old obsolete APIs
+    /// </content>
+    public abstract partial class Image
+    {
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="data">The byte array containing encoded image data to read the header from.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The data is null.</exception>
+        /// <exception cref="NotSupportedException">The data is not readable.</exception>
+        /// <returns>
+        /// The <see cref="IImageInfo"/> or null if suitable info detector not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static IImageInfo Identify(byte[] data, out IImageFormat format) => Identify(Configuration.Default, data, out format);
+
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="data">The byte array containing encoded image data to read the header from.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The data is null.</exception>
+        /// <exception cref="NotSupportedException">The data is not readable.</exception>
+        /// <returns>
+        /// The <see cref="IImageInfo"/> or null if suitable info detector is not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static IImageInfo Identify(Configuration configuration, byte[] data, out IImageFormat format)
+        {
+            IImageInfo info = Identify(configuration, data);
+            format = info.Metadata?.OrigionalImageFormat;
+            return info;
+        }
+
+        /// <summary>
+        /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte array.
+        /// </summary>
+        /// <param name="data">The byte array containing image data.</param>
+        /// <param name="format">The mime type of the decoded image.</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <exception cref="ArgumentNullException">The data is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image<TPixel> Load<TPixel>(byte[] data, out IImageFormat format)
+            where TPixel : unmanaged, IPixel<TPixel>
+            => Load<TPixel>(Configuration.Default, data, out format);
+
+        /// <summary>
+        /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte array.
+        /// </summary>
+        /// <param name="configuration">The configuration options.</param>
+        /// <param name="data">The byte array containing encoded image data.</param>
+        /// <param name="format">The <see cref="IImageFormat"/> of the decoded image.</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The data is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image<TPixel> Load<TPixel>(Configuration configuration, byte[] data, out IImageFormat format)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Guard.NotNull(data, nameof(data));
+
+            using (var stream = new MemoryStream(data, 0, data.Length, false, true))
+            {
+                return Load<TPixel>(configuration, stream, out format);
+            }
+        }
+
+        /// <summary>
+        /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte span.
+        /// </summary>
+        /// <param name="data">The byte span containing image data.</param>
+        /// <param name="format">The mime type of the decoded image.</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image<TPixel> Load<TPixel>(ReadOnlySpan<byte> data, out IImageFormat format)
+            where TPixel : unmanaged, IPixel<TPixel>
+            => Load<TPixel>(Configuration.Default, data, out format);
+
+        /// <summary>
+        /// Load a new instance of <see cref="Image{TPixel}"/> from the given encoded byte span.
+        /// </summary>
+        /// <param name="configuration">The configuration options.</param>
+        /// <param name="data">The byte span containing image data.</param>
+        /// <param name="format">The <see cref="IImageFormat"/> of the decoded image.</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static unsafe Image<TPixel> Load<TPixel>(
+            Configuration configuration,
+            ReadOnlySpan<byte> data,
+            out IImageFormat format)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            fixed (byte* ptr = &data.GetPinnableReference())
+            {
+                using (var stream = new UnmanagedMemoryStream(ptr, data.Length))
+                {
+                    return Load<TPixel>(configuration, stream, out format);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Load a new instance of <see cref="Image"/> from the given encoded byte array.
+        /// </summary>
+        /// <param name="data">The byte array containing image data.</param>
+        /// <param name="format">The detected format.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The data is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <returns>The <see cref="Image"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image Load(byte[] data, out IImageFormat format)
+            => Load(Configuration.Default, data, out format);
+
+        /// <summary>
+        /// Load a new instance of <see cref="Image"/> from the given encoded byte array.
+        /// </summary>
+        /// <param name="configuration">The configuration for the decoder.</param>
+        /// <param name="data">The byte array containing image data.</param>
+        /// <param name="format">The mime type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The data is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <returns>The <see cref="Image"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image Load(Configuration configuration, byte[] data, out IImageFormat format)
+        {
+            var img = Load(configuration, data);
+            format = img?.Metadata.OrigionalImageFormat;
+            return img;
+        }
+
+        /// <summary>
+        /// Load a new instance of <see cref="Image"/> from the given encoded byte array.
+        /// </summary>
+        /// <param name="data">The byte span containing image data.</param>
+        /// <param name="format">The detected format.</param>
+        /// <exception cref="ArgumentNullException">The decoder is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <returns>The <see cref="Image"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image Load(ReadOnlySpan<byte> data, out IImageFormat format)
+            => Load(Configuration.Default, data, out format);
+
+        /// <summary>
+        /// Load a new instance of <see cref="Image"/> from the given encoded byte span.
+        /// </summary>
+        /// <param name="configuration">The configuration options.</param>
+        /// <param name="data">The byte span containing image data.</param>
+        /// <param name="format">The <see cref="IImageFormat"/> of the decoded image.</param>>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <returns>The <see cref="Image"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static unsafe Image Load(
+            Configuration configuration,
+            ReadOnlySpan<byte> data,
+            out IImageFormat format)
+        {
+            var image = Load(configuration, data);
+            format = image.Metadata.OrigionalImageFormat;
+            return image;
+        }
+
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="filePath">The image file to open and to read the header from.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <returns>
+        /// The <see cref="IImageInfo"/> or null if suitable info detector not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static IImageInfo Identify(string filePath, out IImageFormat format)
+            => Identify(Configuration.Default, filePath, out format);
+
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="filePath">The image file to open and to read the header from.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <returns>
+        /// The <see cref="IImageInfo"/> or null if suitable info detector is not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static IImageInfo Identify(Configuration configuration, string filePath, out IImageFormat format)
+        {
+            IImageInfo info = Identify(configuration, filePath);
+            format = info?.Metadata?.OrigionalImageFormat;
+            return info;
+        }
+
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="filePath">The image file to open and to read the header from.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <returns>
+        /// The <see cref="Task{ValueTuple}"/> representing the asynchronous operation with the parameter type
+        /// <see cref="IImageInfo"/> property set to null if suitable info detector is not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Task<(IImageInfo ImageInfo, IImageFormat Format)> IdentifyWithFormatAsync(
+            string filePath,
+            CancellationToken cancellationToken = default)
+            => IdentifyWithFormatAsync(Configuration.Default, filePath, cancellationToken);
+
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="filePath">The image file to open and to read the header from.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <returns>
+        /// The <see cref="Task{ValueTuple}"/> representing the asynchronous operation with the parameter type
+        /// <see cref="IImageInfo"/> property set to null if suitable info detector is not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static async Task<(IImageInfo ImageInfo, IImageFormat Format)> IdentifyWithFormatAsync(
+            Configuration configuration,
+            string filePath,
+            CancellationToken cancellationToken = default)
+        {
+            IImageInfo info = await IdentifyAsync(configuration, filePath, cancellationToken)
+                    .ConfigureAwait(false);
+            return (info, info?.Metadata?.OrigionalImageFormat);
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image"/> class from the given file.
+        /// </summary>
+        /// <param name="path">The file path to the image.</param>
+        /// <param name="format">The mime type of the decoded image.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>A new <see cref="Image{Rgba32}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image Load(string path, out IImageFormat format)
+            => Load(Configuration.Default, path, out format);
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given file.
+        /// </summary>
+        /// <param name="path">The file path to the image.</param>
+        /// <param name="format">The mime type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The path is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image<TPixel> Load<TPixel>(string path, out IImageFormat format)
+            where TPixel : unmanaged, IPixel<TPixel>
+            => Load<TPixel>(Configuration.Default, path, out format);
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given file.
+        /// </summary>
+        /// <param name="configuration">The configuration options.</param>
+        /// <param name="path">The file path to the image.</param>
+        /// <param name="format">The mime type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The path is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image<TPixel> Load<TPixel>(Configuration configuration, string path, out IImageFormat format)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Guard.NotNull(configuration, nameof(configuration));
+            Guard.NotNull(path, nameof(path));
+
+            using (Stream stream = configuration.FileSystem.OpenRead(path))
+            {
+                return Load<TPixel>(configuration, stream, out format);
+            }
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image"/> class from the given file.
+        /// The pixel type is selected by the decoder.
+        /// </summary>
+        /// <param name="configuration">The configuration options.</param>
+        /// <param name="path">The file path to the image.</param>
+        /// <param name="format">The mime type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The path is null.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="NotSupportedException">Image format is not supported.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image Load(Configuration configuration, string path, out IImageFormat format)
+        {
+            Image img = Load(configuration, path);
+            format = img.Metadata.OrigionalImageFormat;
+            return img;
+        }
+
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="stream">The image stream to read the header from.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>
+        /// The <see cref="IImageInfo"/> or null if a suitable info detector is not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static IImageInfo Identify(Stream stream, out IImageFormat format)
+            => Identify(Configuration.Default, stream, out format);
+
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="stream">The image stream to read the information from.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>
+        /// The <see cref="IImageInfo"/> or null if a suitable info detector is not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static IImageInfo Identify(Configuration configuration, Stream stream, out IImageFormat format)
+        {
+            IImageInfo imageInfo = Identify(configuration, stream);
+            format = imageInfo?.Metadata?.OrigionalImageFormat;
+            return imageInfo;
+        }
+
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="stream">The image stream to read the information from.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>
+        /// The <see cref="Task{ValueTuple}"/> representing the asynchronous operation with the parameter type
+        /// <see cref="IImageInfo"/> property set to null if suitable info detector is not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Task<(IImageInfo ImageInfo, IImageFormat Format)> IdentifyWithFormatAsync(
+            Stream stream,
+            CancellationToken cancellationToken = default)
+            => IdentifyWithFormatAsync(Configuration.Default, stream, cancellationToken);
+
+        /// <summary>
+        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="stream">The image stream to read the information from.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>
+        /// The <see cref="Task{ValueTuple}"/> representing the asynchronous operation with the parameter type
+        /// <see cref="IImageInfo"/> property set to null if suitable info detector is not found.
+        /// </returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static async Task<(IImageInfo ImageInfo, IImageFormat Format)> IdentifyWithFormatAsync(
+            Configuration configuration,
+            Stream stream,
+            CancellationToken cancellationToken = default)
+        {
+            var info = await IdentifyAsync(configuration, stream, cancellationToken);
+
+            return (info, info.Metadata?.OrigionalImageFormat);
+        }
+
+        /// <summary>
+        /// Decode a new instance of the <see cref="Image"/> class from the given stream.
+        /// The pixel format is selected by the decoder.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>The <see cref="Image"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image Load(Stream stream, out IImageFormat format)
+            => Load(Configuration.Default, stream, out format);
+
+        /// <summary>
+        /// Decode a new instance of the <see cref="Image"/> class from the given stream.
+        /// The pixel format is selected by the decoder.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>A <see cref="Task{ValueTuple}"/> representing the asynchronous operation.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Task<(Image Image, IImageFormat Format)> LoadWithFormatAsync(Stream stream, CancellationToken cancellationToken = default)
+            => LoadWithFormatAsync(Configuration.Default, stream, cancellationToken);
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image<TPixel> Load<TPixel>(Stream stream, out IImageFormat format)
+            where TPixel : unmanaged, IPixel<TPixel>
+            => Load<TPixel>(Configuration.Default, stream, out format);
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A <see cref="Task{ValueTuple}"/> representing the asynchronous operation.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Task<(Image<TPixel> Image, IImageFormat Format)> LoadWithFormatAsync<TPixel>(Stream stream, CancellationToken cancellationToken = default)
+            where TPixel : unmanaged, IPixel<TPixel>
+            => LoadWithFormatAsync<TPixel>(Configuration.Default, stream, cancellationToken);
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
+        /// </summary>
+        /// <param name="configuration">The configuration options.</param>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image<TPixel> Load<TPixel>(Configuration configuration, Stream stream, out IImageFormat format)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Image<TPixel> image = WithSeekableStream(configuration, stream, s => Decode<TPixel>(s, configuration));
+            format = image.Metadata.OrigionalImageFormat;
+            return image;
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image"/> class from the given stream.
+        /// </summary>
+        /// <param name="configuration">The configuration options.</param>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>A <see cref="Task{ValueTuple}"/> representing the asynchronous operation.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static async Task<(Image Image, IImageFormat Format)> LoadWithFormatAsync(
+            Configuration configuration,
+            Stream stream,
+            CancellationToken cancellationToken = default)
+        {
+            Image image = await LoadAsync(configuration, stream, cancellationToken);
+            return (image, image.Metadata?.OrigionalImageFormat);
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given stream.
+        /// </summary>
+        /// <param name="configuration">The configuration options.</param>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A <see cref="Task{ValueTuple}"/> representing the asynchronous operation.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static async Task<(Image<TPixel> Image, IImageFormat Format)> LoadWithFormatAsync<TPixel>(
+            Configuration configuration,
+            Stream stream,
+            CancellationToken cancellationToken = default)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Image<TPixel> image = await LoadAsync<TPixel>(configuration, stream, cancellationToken);
+            return (image, image.Metadata?.OrigionalImageFormat);
+        }
+
+        /// <summary>
+        /// Decode a new instance of the <see cref="Image"/> class from the given stream.
+        /// The pixel format is selected by the decoder.
+        /// </summary>
+        /// <param name="configuration">The configuration options.</param>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="format">The format type of the decoded image.</param>
+        /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+        /// <exception cref="ArgumentNullException">The stream is null.</exception>
+        /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
+        /// <exception cref="UnknownImageFormatException">Image format not recognised.</exception>
+        /// <exception cref="InvalidImageContentException">Image contains invalid content.</exception>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        [Obsolete("Format accessable from Metadata.OriginalImageFormat")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Image Load(Configuration configuration, Stream stream, out IImageFormat format)
+        {
+            var img = Load(configuration, stream);
+            format = img.Metadata?.OrigionalImageFormat;
+            return img;
+        }
+    }
+}

--- a/src/ImageSharp/ImageInfo.cs
+++ b/src/ImageSharp/ImageInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Formats;
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp
             this.PixelType = pixelType;
             this.Width = width;
             this.Height = height;
-            this.Metadata = metadata;
+            this.Metadata = metadata ?? new ImageMetadata();
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Metadata/ImageMetadata.cs
+++ b/src/ImageSharp/Metadata/ImageMetadata.cs
@@ -69,6 +69,8 @@ namespace SixLabors.ImageSharp.Metadata
             this.IccProfile = other.IccProfile?.DeepClone();
             this.IptcProfile = other.IptcProfile?.DeepClone();
             this.XmpProfile = other.XmpProfile?.DeepClone();
+
+            this.OrigionalImageFormat = other.OrigionalImageFormat;
         }
 
         /// <summary>
@@ -153,6 +155,11 @@ namespace SixLabors.ImageSharp.Metadata
         /// Gets or sets the IPTC profile.
         /// </summary>
         public IptcProfile IptcProfile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the origional format the image was decode from.
+        /// </summary>
+        public IImageFormat OrigionalImageFormat { get; set; }
 
         /// <summary>
         /// Gets the metadata value associated with the specified key.

--- a/tests/ImageSharp.Tests/Formats/Bmp/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/ImageExtensionsTest.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
@@ -23,10 +22,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                 image.SaveAsBmp(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/bmp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/bmp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -40,10 +37,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                 await image.SaveAsBmpAsync(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/bmp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/bmp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -57,10 +52,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                 image.SaveAsBmp(file, new BmpEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/bmp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/bmp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -74,10 +67,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                 await image.SaveAsBmpAsync(file, new BmpEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/bmp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/bmp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -92,10 +83,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/bmp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/bmp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -109,11 +98,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
             }
 
             memoryStream.Position = 0;
-
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/bmp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/bmp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -127,11 +113,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
             }
 
             memoryStream.Position = 0;
-
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/bmp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/bmp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -145,11 +128,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
             }
 
             memoryStream.Position = 0;
-
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/bmp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/bmp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
+++ b/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
@@ -168,10 +168,10 @@ namespace SixLabors.ImageSharp.Tests.Formats
             foreach (TestFile file in Files)
             {
                 byte[] serialized;
-                using (var image = Image.Load(file.Bytes, out IImageFormat mimeType))
+                using (var image = Image.Load(file.Bytes))
                 using (var memoryStream = new MemoryStream())
                 {
-                    image.Save(memoryStream, mimeType);
+                    image.Save(memoryStream, image.Metadata.OrigionalImageFormat);
                     memoryStream.Flush();
                     serialized = memoryStream.ToArray();
                 }
@@ -210,7 +210,6 @@ namespace SixLabors.ImageSharp.Tests.Formats
         [InlineData(100, 100, "tiff")]
         [InlineData(100, 10, "tiff")]
         [InlineData(10, 100, "tiff")]
-
         public void CanIdentifyImageLoadedFromBytes(int width, int height, string extension)
         {
             using (var image = Image.LoadPixelData(new Rgba32[width * height], width, height))
@@ -227,15 +226,28 @@ namespace SixLabors.ImageSharp.Tests.Formats
                     Assert.Equal(imageInfo.Height, height);
                     memoryStream.Position = 0;
 
-                    imageInfo = Image.Identify(memoryStream, out IImageFormat detectedFormat);
-
-                    Assert.Equal(format, detectedFormat);
+                    imageInfo = Image.Identify(memoryStream);
+                    Assert.Equal(format, imageInfo.Metadata.OrigionalImageFormat);
                 }
             }
         }
 
         [Fact]
         public void IdentifyReturnsNullWithInvalidStream()
+        {
+            var invalid = new byte[10];
+
+            using (var memoryStream = new MemoryStream(invalid))
+            {
+                IImageInfo imageInfo = Image.Identify(memoryStream);
+
+                Assert.Null(imageInfo);
+            }
+        }
+
+        [Fact]
+        [Obsolete]
+        public void IdentifyReturnsNullWithInvalidStream_Obsolete()
         {
             var invalid = new byte[10];
 

--- a/tests/ImageSharp.Tests/Formats/Gif/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/ImageExtensionsTest.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
@@ -23,10 +22,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 image.SaveAsGif(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/gif", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/gif", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -40,10 +37,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 await image.SaveAsGifAsync(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/gif", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/gif", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -57,10 +52,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 image.SaveAsGif(file, new GifEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/gif", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/gif", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -74,10 +67,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
                 await image.SaveAsGifAsync(file, new GifEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/gif", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/gif", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -92,10 +83,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/gif", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/gif", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -109,11 +98,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
             }
 
             memoryStream.Position = 0;
-
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/gif", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/gif", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -127,11 +113,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
             }
 
             memoryStream.Position = 0;
-
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/gif", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/gif", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -145,11 +128,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
             }
 
             memoryStream.Position = 0;
-
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/gif", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/gif", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ImageExtensionsTest.cs
@@ -24,10 +24,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 image.SaveAsJpeg(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/jpeg", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/jpeg", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -41,10 +39,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 await image.SaveAsJpegAsync(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/jpeg", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/jpeg", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -58,10 +54,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 image.SaveAsJpeg(file, new JpegEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/jpeg", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/jpeg", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -75,10 +69,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 await image.SaveAsJpegAsync(file, new JpegEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/jpeg", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/jpeg", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -93,10 +85,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/jpeg", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/jpeg", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -111,10 +101,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/jpeg", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/jpeg", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -129,10 +117,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/jpeg", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/jpeg", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -147,10 +133,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/jpeg", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/jpeg", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Pbm/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/ImageExtensionsTest.cs
@@ -23,10 +23,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Pbm
                 image.SaveAsPbm(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/x-portable-pixmap", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/x-portable-pixmap", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -40,10 +38,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Pbm
                 await image.SaveAsPbmAsync(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/x-portable-pixmap", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/x-portable-pixmap", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -57,10 +53,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Pbm
                 image.SaveAsPbm(file, new PbmEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/x-portable-pixmap", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/x-portable-pixmap", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -74,10 +68,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Pbm
                 await image.SaveAsPbmAsync(file, new PbmEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/x-portable-pixmap", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/x-portable-pixmap", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -92,10 +84,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Pbm
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/x-portable-pixmap", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/x-portable-pixmap", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -110,10 +100,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Pbm
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/x-portable-pixmap", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/x-portable-pixmap", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -128,10 +116,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Pbm
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/x-portable-pixmap", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/x-portable-pixmap", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -146,10 +132,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Pbm
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/x-portable-pixmap", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/x-portable-pixmap", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Png/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/ImageExtensionsTest.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
@@ -24,10 +23,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 image.SaveAsPng(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/png", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -41,10 +38,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 await image.SaveAsPngAsync(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/png", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -58,10 +53,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 image.SaveAsPng(file, new PngEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/png", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -75,10 +68,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 await image.SaveAsPngAsync(file, new PngEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/png", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -93,10 +84,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/png", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -111,10 +100,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/png", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -129,10 +116,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/png", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -147,10 +132,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/png", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Tga/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/ImageExtensionsTest.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Tga;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
@@ -23,10 +22,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
                 image.SaveAsTga(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/tga", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/tga", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -40,10 +37,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
                 await image.SaveAsTgaAsync(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/tga", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/tga", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -57,10 +52,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
                 image.SaveAsTga(file, new TgaEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/tga", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/tga", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -74,10 +67,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
                 await image.SaveAsTgaAsync(file, new TgaEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/tga", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/tga", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -92,10 +83,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/tga", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/tga", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -110,10 +99,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/tga", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/tga", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -128,10 +115,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/tga", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/tga", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -146,10 +131,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/tga", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/tga", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaFileHeaderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaFileHeaderTests.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
 
             Assert.Throws<UnknownImageFormatException>(() =>
             {
-                using (Image.Load(Configuration.Default, stream, out IImageFormat _))
+                using (Image.Load(Configuration.Default, stream))
                 {
                 }
             });

--- a/tests/ImageSharp.Tests/Formats/Tiff/ImageExtensionsTest.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/ImageExtensionsTest.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Tiff;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
@@ -24,10 +23,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
                 image.SaveAsTiff(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/tiff", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/tiff", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -41,10 +38,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
                 await image.SaveAsTiffAsync(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/tiff", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/tiff", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -58,10 +53,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
                 image.SaveAsTiff(file, new TiffEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/tiff", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/tiff", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -75,10 +68,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
                 await image.SaveAsTiffAsync(file, new TiffEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/tiff", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/tiff", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -93,10 +84,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/tiff", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/tiff", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -111,10 +100,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/tiff", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/tiff", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -129,10 +116,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/tiff", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/tiff", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -147,10 +132,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/tiff", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/tiff", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -274,7 +274,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
 
         [Theory]
         [WithFile(Rgba6BitAssociatedAlpha, PixelTypes.Rgba32)]
-        public void TiffDecoder_CanDecode_24Bit_WithAssociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)            
+        public void TiffDecoder_CanDecode_24Bit_WithAssociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             if (TestEnvironment.IsMacOS)

--- a/tests/ImageSharp.Tests/Formats/WebP/ImageExtensionsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/ImageExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
@@ -24,10 +23,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
                 image.SaveAsWebp(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/webp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/webp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -41,10 +38,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
                 await image.SaveAsWebpAsync(file);
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/webp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/webp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -58,10 +53,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
                 image.SaveAsWebp(file, new WebpEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/webp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/webp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -75,10 +68,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
                 await image.SaveAsWebpAsync(file, new WebpEncoder());
             }
 
-            using (Image.Load(file, out IImageFormat mime))
-            {
-                Assert.Equal("image/webp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(file);
+            Assert.Equal("image/webp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -93,10 +84,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/webp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/webp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -111,10 +100,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/webp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/webp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -129,10 +116,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/webp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/webp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
 
         [Fact]
@@ -147,10 +132,8 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
 
             memoryStream.Position = 0;
 
-            using (Image.Load(memoryStream, out IImageFormat mime))
-            {
-                Assert.Equal("image/webp", mime.DefaultMimeType);
-            }
+            using var img = Image.Load(memoryStream);
+            Assert.Equal("image/webp", img.Metadata.OrigionalImageFormat.DefaultMimeType);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Image/ImageTests.Decode_Cancellation.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Decode_Cancellation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -87,6 +87,7 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
+            [Obsolete]
             public async Task IdentifyWithFormatAsync_CustomConfiguration_Stream(bool isInputStreamSeekable)
             {
                 this.isTestStreamSeekable = isInputStreamSeekable;
@@ -96,6 +97,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public async Task IdentifyWithFormatAsync_CustomConfiguration_Path()
             {
                 this.isTestStreamSeekable = true;
@@ -105,6 +107,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public async Task IdentifyWithFormatAsync_DefaultConfiguration_Stream()
             {
                 _ = Task.Factory.StartNew(this.DoCancel, TaskCreationOptions.LongRunning);

--- a/tests/ImageSharp.Tests/Image/ImageTests.Identify.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Identify.cs
@@ -25,8 +25,6 @@ namespace SixLabors.ImageSharp.Tests
 
             private static byte[] ActualImageBytes => TestFile.Create(TestImages.Bmp.F).Bytes;
 
-            private IImageInfo LocalImageInfo => this.localImageInfoMock.Object;
-
             private IImageFormat LocalImageFormat => this.localImageFormatMock.Object;
 
             private static readonly IImageFormat ExpectedGlobalFormat =
@@ -46,7 +44,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 IImageInfo info = Image.Identify(this.LocalConfiguration, this.ByteArray);
 
-                Assert.Equal(this.LocalImageInfo, info);
+                Assert.Equal(this.localImageInfo, info);
                 Assert.Equal(this.LocalImageFormat, info.Metadata.OrigionalImageFormat);
             }
 
@@ -64,7 +62,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 IImageInfo info = Image.Identify(this.LocalConfiguration, this.MockFilePath);
 
-                Assert.Equal(this.LocalImageInfo, info);
+                Assert.Equal(this.localImageInfo, info);
                 Assert.Equal(this.LocalImageFormat, info.Metadata.OrigionalImageFormat);
             }
 
@@ -120,7 +118,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 IImageInfo info = Image.Identify(this.LocalConfiguration, this.DataStream);
 
-                Assert.Equal(this.LocalImageInfo, info);
+                Assert.Equal(this.localImageInfo, info);
                 Assert.Equal(this.LocalImageFormat, info.Metadata.OrigionalImageFormat);
             }
 
@@ -129,7 +127,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 IImageInfo info = Image.Identify(this.LocalConfiguration, this.DataStream);
 
-                Assert.Equal(this.LocalImageInfo, info);
+                Assert.Equal(this.localImageInfo, info);
             }
 
             [Fact]
@@ -248,7 +246,7 @@ namespace SixLabors.ImageSharp.Tests
             public async Task FromPathAsync_CustomConfiguration()
             {
                 IImageInfo info = await Image.IdentifyAsync(this.LocalConfiguration, this.MockFilePath);
-                Assert.Equal(this.LocalImageInfo, info);
+                Assert.Equal(this.localImageInfo, info);
             }
 
             [Fact]
@@ -282,7 +280,7 @@ namespace SixLabors.ImageSharp.Tests
                 var asyncStream = new AsyncStreamWrapper(this.DataStream, () => false);
                 IImageInfo info = await Image.IdentifyAsync(this.LocalConfiguration, asyncStream);
 
-                Assert.Equal(this.LocalImageInfo, info);
+                Assert.Equal(this.localImageInfo, info);
                 Assert.Equal(this.LocalImageFormat, info.Metadata.OrigionalImageFormat);
             }
 

--- a/tests/ImageSharp.Tests/Image/ImageTests.Identify.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Identify.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
@@ -34,37 +35,37 @@ namespace SixLabors.ImageSharp.Tests
             [Fact]
             public void FromBytes_GlobalConfiguration()
             {
-                IImageInfo info = Image.Identify(ActualImageBytes, out IImageFormat type);
+                IImageInfo info = Image.Identify(ActualImageBytes);
 
                 Assert.Equal(ExpectedImageSize, info.Size());
-                Assert.Equal(ExpectedGlobalFormat, type);
+                Assert.Equal(ExpectedGlobalFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
             public void FromBytes_CustomConfiguration()
             {
-                IImageInfo info = Image.Identify(this.LocalConfiguration, this.ByteArray, out IImageFormat type);
+                IImageInfo info = Image.Identify(this.LocalConfiguration, this.ByteArray);
 
                 Assert.Equal(this.LocalImageInfo, info);
-                Assert.Equal(this.LocalImageFormat, type);
+                Assert.Equal(this.LocalImageFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
             public void FromFileSystemPath_GlobalConfiguration()
             {
-                IImageInfo info = Image.Identify(ActualImagePath, out IImageFormat type);
+                IImageInfo info = Image.Identify(ActualImagePath);
 
                 Assert.NotNull(info);
-                Assert.Equal(ExpectedGlobalFormat, type);
+                Assert.Equal(ExpectedGlobalFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
             public void FromFileSystemPath_CustomConfiguration()
             {
-                IImageInfo info = Image.Identify(this.LocalConfiguration, this.MockFilePath, out IImageFormat type);
+                IImageInfo info = Image.Identify(this.LocalConfiguration, this.MockFilePath);
 
                 Assert.Equal(this.LocalImageInfo, info);
-                Assert.Equal(this.LocalImageFormat, type);
+                Assert.Equal(this.LocalImageFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
@@ -72,10 +73,10 @@ namespace SixLabors.ImageSharp.Tests
             {
                 using (var stream = new MemoryStream(ActualImageBytes))
                 {
-                    IImageInfo info = Image.Identify(stream, out IImageFormat type);
+                    IImageInfo info = Image.Identify(stream);
 
                     Assert.NotNull(info);
-                    Assert.Equal(ExpectedGlobalFormat, type);
+                    Assert.Equal(ExpectedGlobalFormat, info.Metadata.OrigionalImageFormat);
                 }
             }
 
@@ -96,10 +97,10 @@ namespace SixLabors.ImageSharp.Tests
                 using var stream = new MemoryStream(ActualImageBytes);
                 using var nonSeekableStream = new NonSeekableStream(stream);
 
-                IImageInfo info = Image.Identify(nonSeekableStream, out IImageFormat type);
+                IImageInfo info = Image.Identify(nonSeekableStream);
 
                 Assert.NotNull(info);
-                Assert.Equal(ExpectedGlobalFormat, type);
+                Assert.Equal(ExpectedGlobalFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
@@ -114,12 +115,13 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public void FromStream_CustomConfiguration()
             {
-                IImageInfo info = Image.Identify(this.LocalConfiguration, this.DataStream, out IImageFormat type);
+                IImageInfo info = Image.Identify(this.LocalConfiguration, this.DataStream);
 
                 Assert.Equal(this.LocalImageInfo, info);
-                Assert.Equal(this.LocalImageFormat, type);
+                Assert.Equal(this.LocalImageFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
@@ -131,12 +133,12 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public void WhenNoMatchingFormatFound_ReturnsNull()
             {
-                IImageInfo info = Image.Identify(new Configuration(), this.DataStream, out IImageFormat type);
+                IImageInfo info = Image.Identify(new Configuration(), this.DataStream);
 
                 Assert.Null(info);
-                Assert.Null(type);
             }
 
             [Fact]
@@ -178,15 +180,16 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public async Task FromStreamAsync_GlobalConfiguration()
             {
                 using (var stream = new MemoryStream(ActualImageBytes))
                 {
                     var asyncStream = new AsyncStreamWrapper(stream, () => false);
-                    (IImageInfo ImageInfo, IImageFormat Format) res = await Image.IdentifyWithFormatAsync(asyncStream);
+                    IImageInfo info = await Image.IdentifyAsync(asyncStream);
 
-                    Assert.Equal(ExpectedImageSize, res.ImageInfo.Size());
-                    Assert.Equal(ExpectedGlobalFormat, res.Format);
+                    Assert.Equal(ExpectedImageSize, info.Size());
+                    Assert.Equal(ExpectedGlobalFormat, info.Metadata.OrigionalImageFormat);
                 }
             }
 
@@ -209,10 +212,10 @@ namespace SixLabors.ImageSharp.Tests
                 using var nonSeekableStream = new NonSeekableStream(stream);
 
                 var asyncStream = new AsyncStreamWrapper(nonSeekableStream, () => false);
-                (IImageInfo ImageInfo, IImageFormat Format) res = await Image.IdentifyWithFormatAsync(asyncStream);
+                IImageInfo info = await Image.IdentifyAsync(asyncStream);
 
-                Assert.Equal(ExpectedImageSize, res.ImageInfo.Size());
-                Assert.Equal(ExpectedGlobalFormat, res.Format);
+                Assert.Equal(ExpectedImageSize, info.Size());
+                Assert.Equal(ExpectedGlobalFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
@@ -251,18 +254,18 @@ namespace SixLabors.ImageSharp.Tests
             [Fact]
             public async Task IdentifyWithFormatAsync_FromPath_CustomConfiguration()
             {
-                (IImageInfo ImageInfo, IImageFormat Format) info = await Image.IdentifyWithFormatAsync(this.LocalConfiguration, this.MockFilePath);
-                Assert.NotNull(info.ImageInfo);
-                Assert.Equal(this.LocalImageFormat, info.Format);
+                IImageInfo info = await Image.IdentifyAsync(this.LocalConfiguration, this.MockFilePath);
+                Assert.NotNull(info);
+                Assert.Equal(this.LocalImageFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
             public async Task IdentifyWithFormatAsync_FromPath_GlobalConfiguration()
             {
-                (IImageInfo ImageInfo, IImageFormat Format) res = await Image.IdentifyWithFormatAsync(ActualImagePath);
+                IImageInfo info = await Image.IdentifyAsync(ActualImagePath);
 
-                Assert.Equal(ExpectedImageSize, res.ImageInfo.Size());
-                Assert.Equal(ExpectedGlobalFormat, res.Format);
+                Assert.Equal(ExpectedImageSize, info.Size());
+                Assert.Equal(ExpectedGlobalFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
@@ -277,19 +280,19 @@ namespace SixLabors.ImageSharp.Tests
             public async Task FromStreamAsync_CustomConfiguration()
             {
                 var asyncStream = new AsyncStreamWrapper(this.DataStream, () => false);
-                (IImageInfo ImageInfo, IImageFormat Format) info = await Image.IdentifyWithFormatAsync(this.LocalConfiguration, asyncStream);
+                IImageInfo info = await Image.IdentifyAsync(this.LocalConfiguration, asyncStream);
 
-                Assert.Equal(this.LocalImageInfo, info.ImageInfo);
-                Assert.Equal(this.LocalImageFormat, info.Format);
+                Assert.Equal(this.LocalImageInfo, info);
+                Assert.Equal(this.LocalImageFormat, info.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
             public async Task WhenNoMatchingFormatFoundAsync_ReturnsNull()
             {
                 var asyncStream = new AsyncStreamWrapper(this.DataStream, () => false);
-                (IImageInfo ImageInfo, IImageFormat Format) info = await Image.IdentifyWithFormatAsync(new Configuration(), asyncStream);
+                IImageInfo info = await Image.IdentifyAsync(new Configuration(), asyncStream);
 
-                Assert.Null(info.ImageInfo);
+                Assert.Null(info);
             }
         }
     }

--- a/tests/ImageSharp.Tests/Image/ImageTests.ImageLoadTestBase.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.ImageLoadTestBase.cs
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Tests
 
             protected Mock<IImageFormat> localImageFormatMock;
 
-            protected Mock<IImageInfo> localImageInfoMock;
+            protected IImageInfo localImageInfo = new ImageInfo(null, 0, 0, new ImageSharp.Metadata.ImageMetadata());
 
             protected readonly string MockFilePath = Guid.NewGuid().ToString();
 
@@ -59,11 +59,10 @@ namespace SixLabors.ImageSharp.Tests
                 this.localStreamReturnImageRgba32 = new Image<Rgba32>(1, 1);
                 this.localStreamReturnImageAgnostic = new Image<Bgra4444>(1, 1);
 
-                this.localImageInfoMock = new Mock<IImageInfo>();
                 this.localImageFormatMock = new Mock<IImageFormat>();
 
                 var detector = new Mock<IImageInfoDetector>();
-                detector.Setup(x => x.Identify(It.IsAny<Configuration>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>())).Returns(this.localImageInfoMock.Object);
+                detector.Setup(x => x.Identify(It.IsAny<Configuration>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>())).Returns(() => this.localImageInfo);
 
                 this.localDecoder = detector.As<IImageDecoder>();
                 this.localDecoder.Setup(x => x.Decode<Rgba32>(It.IsAny<Configuration>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_PassLocalConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_PassLocalConfiguration.cs
@@ -54,6 +54,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public void Configuration_Path_OutFormat_Specific()
             {
                 var img = Image.Load<Rgba32>(this.TopLevelConfiguration, this.MockFilePath, out IImageFormat format);
@@ -65,12 +66,35 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            public void Configuration_Path_Format_Specific()
+            {
+                var img = Image.Load<Rgba32>(this.TopLevelConfiguration, this.MockFilePath);
+
+                Assert.NotNull(img);
+                Assert.Equal(this.TestFormat, img.Metadata.OrigionalImageFormat);
+
+                this.TestFormat.VerifySpecificDecodeCall<Rgba32>(this.Marker, this.TopLevelConfiguration);
+            }
+
+            [Fact]
+            [Obsolete]
             public void Configuration_Path_OutFormat_Agnostic()
             {
                 var img = Image.Load(this.TopLevelConfiguration, this.MockFilePath, out IImageFormat format);
 
                 Assert.NotNull(img);
                 Assert.Equal(this.TestFormat, format);
+
+                this.TestFormat.VerifyAgnosticDecodeCall(this.Marker, this.TopLevelConfiguration);
+            }
+
+            [Fact]
+            public void Configuration_Path_Format_Agnostic()
+            {
+                var img = Image.Load(this.TopLevelConfiguration, this.MockFilePath);
+
+                Assert.NotNull(img);
+                Assert.Equal(this.TestFormat, img.Metadata.OrigionalImageFormat);
 
                 this.TestFormat.VerifyAgnosticDecodeCall(this.Marker, this.TopLevelConfiguration);
             }

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_UseDefaultConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FileSystemPath_UseDefaultConfiguration.cs
@@ -86,6 +86,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public void Path_OutFormat_Specific()
             {
                 using var img = Image.Load<Rgba32>(this.Path, out IImageFormat format);
@@ -94,11 +95,28 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            public void Path_Format_Specific()
+            {
+                using var img = Image.Load<Rgba32>(this.Path);
+                VerifyDecodedImage(img);
+                Assert.IsType<BmpFormat>(img.Metadata.OrigionalImageFormat);
+            }
+
+            [Fact]
+            [Obsolete]
             public void Path_OutFormat_Agnostic()
             {
                 using var img = Image.Load(this.Path, out IImageFormat format);
                 VerifyDecodedImage(img);
                 Assert.IsType<BmpFormat>(format);
+            }
+
+            [Fact]
+            public void Path_Format_Agnostic()
+            {
+                using var img = Image.Load(this.Path);
+                VerifyDecodedImage(img);
+                Assert.IsType<BmpFormat>(img.Metadata.OrigionalImageFormat);
             }
 
             [Fact]

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FromBytes_PassLocalConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FromBytes_PassLocalConfiguration.cs
@@ -78,6 +78,7 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
+            [Obsolete]
             public void Configuration_Bytes_OutFormat_Specific(bool useSpan)
             {
                 IImageFormat format;
@@ -94,6 +95,22 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
+            public void Configuration_Bytes_Format_Specific(bool useSpan)
+            {
+                var img = useSpan ?
+                              Image.Load<Bgr24>(this.TopLevelConfiguration, this.ByteSpan) :
+                              Image.Load<Bgr24>(this.TopLevelConfiguration, this.ByteArray);
+
+                Assert.NotNull(img);
+                Assert.Equal(this.TestFormat, img.Metadata.OrigionalImageFormat);
+
+                this.TestFormat.VerifySpecificDecodeCall<Bgr24>(this.Marker, this.TopLevelConfiguration);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            [Obsolete]
             public void Configuration_Bytes_OutFormat_Agnostic(bool useSpan)
             {
                 IImageFormat format;
@@ -103,6 +120,21 @@ namespace SixLabors.ImageSharp.Tests
 
                 Assert.NotNull(img);
                 Assert.Equal(this.TestFormat, format);
+
+                this.TestFormat.VerifyAgnosticDecodeCall(this.Marker, this.TopLevelConfiguration);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void Configuration_Bytes_Format_Agnostic(bool useSpan)
+            {
+                var img = useSpan ?
+                              Image.Load(this.TopLevelConfiguration, this.ByteSpan) :
+                              Image.Load(this.TopLevelConfiguration, this.ByteArray);
+
+                Assert.NotNull(img);
+                Assert.Equal(this.TestFormat, img.Metadata.OrigionalImageFormat);
 
                 this.TestFormat.VerifyAgnosticDecodeCall(this.Marker, this.TopLevelConfiguration);
             }

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FromBytes_UseGlobalConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FromBytes_UseGlobalConfiguration.cs
@@ -70,6 +70,7 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
+            [Obsolete]
             public void Bytes_OutFormat_Specific(bool useSpan)
             {
                 IImageFormat format;
@@ -83,6 +84,19 @@ namespace SixLabors.ImageSharp.Tests
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
+            public void Bytes_Format_Specific(bool useSpan)
+            {
+                using (var img = useSpan ? Image.Load<Rgba32>(ByteSpan) : Image.Load<Rgba32>(ByteArray))
+                {
+                    VerifyDecodedImage(img);
+                    Assert.IsType<BmpFormat>(img.Metadata.OrigionalImageFormat);
+                }
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            [Obsolete]
             public void Bytes_OutFormat_Agnostic(bool useSpan)
             {
                 IImageFormat format;
@@ -90,6 +104,18 @@ namespace SixLabors.ImageSharp.Tests
                 {
                     VerifyDecodedImage(img);
                     Assert.IsType<BmpFormat>(format);
+                }
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void Bytes_Out_Agnostic(bool useSpan)
+            {
+                using (var img = useSpan ? Image.Load(ByteSpan) : Image.Load(ByteArray))
+                {
+                    VerifyDecodedImage(img);
+                    Assert.IsType<BmpFormat>(img.Metadata.OrigionalImageFormat);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FromStream_PassLocalConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FromStream_PassLocalConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Formats;
@@ -79,6 +80,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public void Configuration_Stream_OutFormat_Specific()
             {
                 var img = Image.Load<Rgba32>(this.TopLevelConfiguration, this.DataStream, out IImageFormat format);
@@ -90,12 +92,35 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            public void Configuration_Stream_Format_Specific()
+            {
+                var img = Image.Load<Rgba32>(this.TopLevelConfiguration, this.DataStream);
+
+                Assert.NotNull(img);
+                Assert.Equal(this.TestFormat, img.Metadata.OrigionalImageFormat);
+
+                this.TestFormat.VerifySpecificDecodeCall<Rgba32>(this.Marker, this.TopLevelConfiguration);
+            }
+
+            [Fact]
+            [Obsolete]
             public void Configuration_Stream_OutFormat_Agnostic()
             {
                 var img = Image.Load(this.TopLevelConfiguration, this.DataStream, out IImageFormat format);
 
                 Assert.NotNull(img);
                 Assert.Equal(this.TestFormat, format);
+
+                this.TestFormat.VerifyAgnosticDecodeCall(this.Marker, this.TopLevelConfiguration);
+            }
+
+            [Fact]
+            public void Configuration_Stream_Format_Agnostic()
+            {
+                var img = Image.Load(this.TopLevelConfiguration, this.DataStream);
+
+                Assert.NotNull(img);
+                Assert.Equal(this.TestFormat, img.Metadata.OrigionalImageFormat);
 
                 this.TestFormat.VerifyAgnosticDecodeCall(this.Marker, this.TopLevelConfiguration);
             }

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FromStream_ThrowsRightException.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FromStream_ThrowsRightException.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 Assert.Throws<UnknownImageFormatException>(() =>
                 {
-                    using (Image.Load(Configuration.Default, this.Stream, out IImageFormat format))
+                    using (Image.Load(Configuration.Default, this.Stream))
                     {
                     }
                 });
@@ -34,7 +34,7 @@ namespace SixLabors.ImageSharp.Tests
             {
                 Assert.Throws<UnknownImageFormatException>(() =>
                 {
-                    using (Image.Load<Rgba32>(Configuration.Default, this.Stream, out IImageFormat format))
+                    using (Image.Load<Rgba32>(Configuration.Default, this.Stream))
                     {
                     }
                 });

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FromStream_UseDefaultConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FromStream_UseDefaultConfiguration.cs
@@ -54,12 +54,23 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public void Stream_OutFormat_Specific()
             {
                 using (var img = Image.Load<Rgba32>(this.Stream, out IImageFormat format))
                 {
                     VerifyDecodedImage(img);
                     Assert.IsType<BmpFormat>(format);
+                }
+            }
+
+            [Fact]
+            public void Stream_Format_Specific()
+            {
+                using (var img = Image.Load<Rgba32>(this.Stream))
+                {
+                    VerifyDecodedImage(img);
+                    Assert.IsType<BmpFormat>(img.Metadata.OrigionalImageFormat);
                 }
             }
 
@@ -82,6 +93,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public void Stream_OutFormat_Agnostic()
             {
                 using (var img = Image.Load(this.Stream, out IImageFormat format))
@@ -92,6 +104,17 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            public void Stream_Format_Agnostic()
+            {
+                using (var img = Image.Load(this.Stream))
+                {
+                    VerifyDecodedImage(img);
+                    Assert.IsType<BmpFormat>(img.Metadata.OrigionalImageFormat);
+                }
+            }
+
+            [Fact]
+            [Obsolete]
             public async Task Async_Stream_OutFormat_Agnostic()
             {
                 this.AllowSynchronousIO = false;
@@ -101,6 +124,15 @@ namespace SixLabors.ImageSharp.Tests
                     VerifyDecodedImage(formattedImage.Image);
                     Assert.IsType<BmpFormat>(formattedImage.Format);
                 }
+            }
+
+            [Fact]
+            public async Task Async_Stream_Format_Agnostic()
+            {
+                this.AllowSynchronousIO = false;
+                using var formattedImage = await Image.LoadAsync(this.Stream);
+                VerifyDecodedImage(formattedImage);
+                Assert.IsType<BmpFormat>(formattedImage.Metadata.OrigionalImageFormat);
             }
 
             [Fact]
@@ -124,6 +156,7 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            [Obsolete]
             public async Task Async_Stream_OutFormat_Specific()
             {
                 this.AllowSynchronousIO = false;
@@ -133,6 +166,15 @@ namespace SixLabors.ImageSharp.Tests
                     VerifyDecodedImage(formattedImage.Image);
                     Assert.IsType<BmpFormat>(formattedImage.Format);
                 }
+            }
+
+            [Fact]
+            public async Task Async_Stream_Format_Specific()
+            {
+                this.AllowSynchronousIO = false;
+                using var formattedImage = await Image.LoadAsync<Rgba32>(this.Stream);
+                VerifyDecodedImage(formattedImage);
+                Assert.IsType<BmpFormat>(formattedImage.Metadata.OrigionalImageFormat);
             }
 
             [Fact]

--- a/tests/ImageSharp.Tests/Image/ImageTests.Save.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Save.cs
@@ -27,10 +27,8 @@ namespace SixLabors.ImageSharp.Tests
                     image.Save(file);
                 }
 
-                using (Image.Load(file, out IImageFormat mime))
-                {
-                    Assert.Equal("image/png", mime.DefaultMimeType);
-                }
+                using var img = Image.Load(file);
+                Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
             }
 
             [Fact]
@@ -60,10 +58,8 @@ namespace SixLabors.ImageSharp.Tests
                     image.Save(file, new PngEncoder());
                 }
 
-                using (Image.Load(file, out IImageFormat mime))
-                {
-                    Assert.Equal("image/png", mime.DefaultMimeType);
-                }
+                using var img = Image.Load(file);
+                Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
             }
 
             [Fact]

--- a/tests/ImageSharp.Tests/Image/ImageTests.SaveAsync.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.SaveAsync.cs
@@ -31,10 +31,8 @@ namespace SixLabors.ImageSharp.Tests
                     await image.SaveAsync(file);
                 }
 
-                using (Image.Load(file, out IImageFormat mime))
-                {
-                    Assert.Equal("image/png", mime.DefaultMimeType);
-                }
+                using var img = Image.Load(file);
+                Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
             }
 
             [Fact]
@@ -64,10 +62,8 @@ namespace SixLabors.ImageSharp.Tests
                     await image.SaveAsync(file, new PngEncoder());
                 }
 
-                using (Image.Load(file, out IImageFormat mime))
-                {
-                    Assert.Equal("image/png", mime.DefaultMimeType);
-                }
+                using var img = Image.Load(file);
+                Assert.Equal("image/png", img.Metadata.OrigionalImageFormat.DefaultMimeType);
             }
 
             [Theory]
@@ -92,12 +88,11 @@ namespace SixLabors.ImageSharp.Tests
 
                         stream.Position = 0;
 
-                        (Image Image, IImageFormat Format) imf = await Image.LoadWithFormatAsync(stream);
+                        using var img = Image.Load(stream);
+                        var actualFormat = img.Metadata.OrigionalImageFormat;
 
-                        Assert.Equal(format, imf.Format);
-                        Assert.Equal(mimeType, imf.Format.DefaultMimeType);
-
-                        imf.Image.Dispose();
+                        Assert.Equal(format, actualFormat);
+                        Assert.Equal(mimeType, actualFormat.DefaultMimeType);
                     }
                 }
             }


### PR DESCRIPTION
### Proposal
This goes along with the https://github.com/SixLabors/ImageSharp/discussions/2090 proposal so show the impact to the API.

### Description
Obsoletes all the overloads of `Image.Load` that return on `IImageFormat`, removes all internal dependencies on those APIs, returns `OrginalImageFormat` on all images/identify call sites.

`out IImageFormat` overloads no depend on non `out` versions rather than the other way around.