### PR TITLE
Use .NET 6 only

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,58 +15,37 @@ jobs:
       matrix:
         options:
           - os: ubuntu-latest
-            framework: net6.0
-            sdk: 6.0.x
+            framework: net7.0
+            sdk: 7.0.x
             sdk-preview: true
             runtime: -x64
             codecov: false
           - os: macos-latest
-            framework: net6.0
-            sdk: 6.0.x
+            framework: net7.0
+            sdk: 7.0.x
             sdk-preview: true
             runtime: -x64
             codecov: false
           - os: windows-latest
-            framework: net6.0
-            sdk: 6.0.x
+            framework: net7.0
+            sdk: 7.0.x
             sdk-preview: true
             runtime: -x64
             codecov: false
           - os: ubuntu-latest
-            framework: net5.0
+            framework: net6.0
+            sdk: 6.0.x
             runtime: -x64
             codecov: false
           - os: macos-latest
-            framework: net5.0
+            framework: net6.0
+            sdk: 6.0.x
             runtime: -x64
             codecov: false
           - os: windows-latest
-            framework: net5.0
+            framework: net6.0
+            sdk: 6.0.x
             runtime: -x64
-            codecov: false
-          - os: ubuntu-latest
-            framework: netcoreapp3.1
-            runtime: -x64
-            codecov: false
-          - os: macos-latest
-            framework: netcoreapp3.1
-            runtime: -x64
-            codecov: false
-          - os: windows-latest
-            framework: netcoreapp3.1
-            runtime: -x64
-            codecov: false
-          - os: windows-latest
-            framework: netcoreapp2.1
-            runtime: -x64
-            codecov: false
-          - os: windows-latest
-            framework: net472
-            runtime: -x64
-            codecov: false
-          - os: windows-latest
-            framework: net472
-            runtime: -x86
             codecov: false
 
     runs-on: ${{matrix.options.os}}
@@ -113,10 +92,8 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: |
+            7.0.x
             6.0.x
-            5.0.x
-            3.1.x
-            2.1.x
 
       - name: DotNet Build
         if: ${{ matrix.options.sdk-preview != true }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -91,6 +91,7 @@ jobs:
       - name: DotNet Setup
         uses: actions/setup-dotnet@v1
         with:
+          include-prerelease: true
           dotnet-version: |
             7.0.x
             6.0.x

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         options:
           - os: ubuntu-latest
-            framework: netcoreapp3.1
+            framework: net6.0
             runtime: -x64
             codecov: true
 
@@ -53,6 +53,12 @@ jobs:
           path: ~/.nuget
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
           restore-keys: ${{ runner.os }}-nuget-
+
+      - name: DotNet Setup
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            6.0.x
 
       - name: DotNet Build
         shell: pwsh

--- a/ImageSharp.sln
+++ b/ImageSharp.sln
@@ -654,43 +654,25 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug-InnerLoop|Any CPU = Debug-InnerLoop|Any CPU
 		Release|Any CPU = Release|Any CPU
-		Release-InnerLoop|Any CPU = Release-InnerLoop|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2AA31A1F-142C-43F4-8687-09ABCA4B3A26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2AA31A1F-142C-43F4-8687-09ABCA4B3A26}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2AA31A1F-142C-43F4-8687-09ABCA4B3A26}.Debug-InnerLoop|Any CPU.ActiveCfg = Debug-InnerLoop|Any CPU
-		{2AA31A1F-142C-43F4-8687-09ABCA4B3A26}.Debug-InnerLoop|Any CPU.Build.0 = Debug-InnerLoop|Any CPU
 		{2AA31A1F-142C-43F4-8687-09ABCA4B3A26}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2AA31A1F-142C-43F4-8687-09ABCA4B3A26}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2AA31A1F-142C-43F4-8687-09ABCA4B3A26}.Release-InnerLoop|Any CPU.ActiveCfg = Release-InnerLoop|Any CPU
-		{2AA31A1F-142C-43F4-8687-09ABCA4B3A26}.Release-InnerLoop|Any CPU.Build.0 = Release-InnerLoop|Any CPU
 		{EA3000E9-2A91-4EC4-8A68-E566DEBDC4F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EA3000E9-2A91-4EC4-8A68-E566DEBDC4F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EA3000E9-2A91-4EC4-8A68-E566DEBDC4F6}.Debug-InnerLoop|Any CPU.ActiveCfg = Debug-InnerLoop|Any CPU
-		{EA3000E9-2A91-4EC4-8A68-E566DEBDC4F6}.Debug-InnerLoop|Any CPU.Build.0 = Debug-InnerLoop|Any CPU
 		{EA3000E9-2A91-4EC4-8A68-E566DEBDC4F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA3000E9-2A91-4EC4-8A68-E566DEBDC4F6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EA3000E9-2A91-4EC4-8A68-E566DEBDC4F6}.Release-InnerLoop|Any CPU.ActiveCfg = Release-InnerLoop|Any CPU
-		{EA3000E9-2A91-4EC4-8A68-E566DEBDC4F6}.Release-InnerLoop|Any CPU.Build.0 = Release-InnerLoop|Any CPU
 		{2BF743D8-2A06-412D-96D7-F448F00C5EA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2BF743D8-2A06-412D-96D7-F448F00C5EA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2BF743D8-2A06-412D-96D7-F448F00C5EA5}.Debug-InnerLoop|Any CPU.ActiveCfg = Debug-InnerLoop|Any CPU
-		{2BF743D8-2A06-412D-96D7-F448F00C5EA5}.Debug-InnerLoop|Any CPU.Build.0 = Debug-InnerLoop|Any CPU
 		{2BF743D8-2A06-412D-96D7-F448F00C5EA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2BF743D8-2A06-412D-96D7-F448F00C5EA5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2BF743D8-2A06-412D-96D7-F448F00C5EA5}.Release-InnerLoop|Any CPU.ActiveCfg = Release-InnerLoop|Any CPU
-		{2BF743D8-2A06-412D-96D7-F448F00C5EA5}.Release-InnerLoop|Any CPU.Build.0 = Release-InnerLoop|Any CPU
 		{FC527290-2F22-432C-B77B-6E815726B02C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FC527290-2F22-432C-B77B-6E815726B02C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FC527290-2F22-432C-B77B-6E815726B02C}.Debug-InnerLoop|Any CPU.ActiveCfg = Debug-InnerLoop|Any CPU
-		{FC527290-2F22-432C-B77B-6E815726B02C}.Debug-InnerLoop|Any CPU.Build.0 = Debug-InnerLoop|Any CPU
 		{FC527290-2F22-432C-B77B-6E815726B02C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC527290-2F22-432C-B77B-6E815726B02C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FC527290-2F22-432C-B77B-6E815726B02C}.Release-InnerLoop|Any CPU.ActiveCfg = Release-InnerLoop|Any CPU
-		{FC527290-2F22-432C-B77B-6E815726B02C}.Release-InnerLoop|Any CPU.Build.0 = Release-InnerLoop|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -12,50 +12,29 @@
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageTags>Image Resize Crop Gif Jpg Jpeg Bitmap Pbm Png Tga Tiff WebP NetCore</PackageTags>
     <Description>A new, fully featured, fully managed, cross-platform, 2D graphics API for .NET</Description>
-    <Configurations>Debug;Release;Debug-InnerLoop;Release-InnerLoop</Configurations>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <PropertyGroup>
-    <!--Bump to V2 prior to tagged release.-->
-    <MinVerMinimumMajorMinor>2.0</MinVerMinimumMajorMinor>
+    <!--Bump to V3 prior to tagged release.-->
+    <MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
   </PropertyGroup>
 
   <Choose>
     <When Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(SIXLABORS_TESTING) == true">
-      <PropertyGroup>
-        <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
-      <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
   <ItemGroup>
     <None Include="..\..\shared-infrastructure\branding\icons\imagesharp\sixlabors.imagesharp.128.png" Pack="true" PackagePath="" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) OR '$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
+++ b/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
@@ -9,7 +9,7 @@
     <DebugType>portable</DebugType>
     <!--Used to hide test project from dotnet test-->
     <IsTestProject>false</IsTestProject>
-    <Configurations>Debug;Release;Debug-InnerLoop;Release-InnerLoop</Configurations>
+    <Configurations>Debug;Release</Configurations>
     <!-- Uncomment this to run benchmarks depending on Colorful or Pfim (colorspaces and TGA): -->
     <!--<SignAssembly>false</SignAssembly>-->
   </PropertyGroup>
@@ -17,17 +17,12 @@
   <Choose>
     <When Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
-      <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/ImageSharp.Tests.ProfilingSandbox.csproj
@@ -12,24 +12,19 @@
     <!--Used to hide test project from dotnet test-->
     <IsTestProject>false</IsTestProject>
     <EnsureNETCoreAppRuntime>false</EnsureNETCoreAppRuntime>
-    <Configurations>Debug;Release;Debug-InnerLoop;Release-InnerLoop</Configurations>
+    <Configurations>Debug;Release</Configurations>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 
   <Choose>
     <When Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
-      <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/tests/ImageSharp.Tests.ProfilingSandbox/LoadResizeSaveParallelMemoryStress.cs
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/LoadResizeSaveParallelMemoryStress.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using CommandLine;

--- a/tests/ImageSharp.Tests/Formats/Jpg/DCTTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/DCTTests.cs
@@ -149,11 +149,11 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 // 1. AllowAll - call avx/fma implementation
                 // 2. DisableFMA - call avx without fma implementation
                 // 3. DisableAvx - call sse implementation
-                // 4. DisableSIMD - call Vector4 fallback implementation
+                // 4. DisableHWIntrinsic - call Vector4 fallback implementation
                 FeatureTestRunner.RunWithHwIntrinsicsFeature(
                     RunTest,
                     seed,
-                    HwIntrinsics.AllowAll | HwIntrinsics.DisableFMA | HwIntrinsics.DisableAVX | HwIntrinsics.DisableSIMD);
+                    HwIntrinsics.AllowAll | HwIntrinsics.DisableFMA | HwIntrinsics.DisableAVX | HwIntrinsics.DisableHWIntrinsic);
             }
 
             // Forward transform
@@ -200,11 +200,11 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 // 1. AllowAll - call avx/fma implementation
                 // 2. DisableFMA - call avx without fma implementation
                 // 3. DisableAvx - call Vector4 implementation
-                // 4. DisableSIMD - call scalar fallback implementation
+                // 4. DisableHWIntrinsic - call scalar fallback implementation
                 FeatureTestRunner.RunWithHwIntrinsicsFeature(
                     RunTest,
                     seed,
-                    HwIntrinsics.AllowAll | HwIntrinsics.DisableFMA | HwIntrinsics.DisableAVX | HwIntrinsics.DisableSIMD);
+                    HwIntrinsics.AllowAll | HwIntrinsics.DisableFMA | HwIntrinsics.DisableAVX | HwIntrinsics.DisableHWIntrinsic);
             }
         }
     }

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderFilterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderFilterTests.cs
@@ -39,7 +39,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             FeatureTestRunner.RunWithHwIntrinsicsFeature(
                 RunTest,
-                HwIntrinsics.DisableSIMD);
+                HwIntrinsics.DisableHWIntrinsic);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             FeatureTestRunner.RunWithHwIntrinsicsFeature(
                 RunTest,
-                HwIntrinsics.DisableSIMD);
+                HwIntrinsics.DisableHWIntrinsic);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             FeatureTestRunner.RunWithHwIntrinsicsFeature(
                 RunTest,
-                HwIntrinsics.DisableSIMD);
+                HwIntrinsics.DisableHWIntrinsic);
         }
 
         [Fact]
@@ -179,7 +179,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
 
             FeatureTestRunner.RunWithHwIntrinsicsFeature(
                 RunTest,
-                HwIntrinsics.DisableSIMD);
+                HwIntrinsics.DisableHWIntrinsic);
         }
 
         [Fact]

--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -6,23 +6,18 @@
     <AssemblyName>SixLabors.ImageSharp.Tests</AssemblyName>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <RootNamespace>SixLabors.ImageSharp.Tests</RootNamespace>
-    <Configurations>Debug;Release;Debug-InnerLoop;Release-InnerLoop</Configurations>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <Choose>
     <When Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(Configuration.EndsWith('InnerLoop')) == true">
-      <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -47,7 +42,6 @@
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Condition="'$(IsOSX)'=='true'" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="System.Drawing.Common" />
-    <PackageReference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
@@ -356,10 +356,6 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities
                 var key = (HwIntrinsics)Enum.Parse(typeof(HwIntrinsics), intrinsic);
                 switch (intrinsic)
                 {
-                    case nameof(HwIntrinsics.DisableSIMD):
-                        features.Add(key, "FeatureSIMD");
-                        break;
-
                     case nameof(HwIntrinsics.AllowAll):
 
                         // Not a COMPlus value. We filter in calling method.
@@ -390,23 +386,22 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities
     {
         // Use flags so we can pass multiple values without using params.
         // Don't base on 0 or use inverse for All as that doesn't translate to string values.
-        DisableSIMD = 1 << 0,
-        DisableHWIntrinsic = 1 << 1,
-        DisableSSE = 1 << 2,
-        DisableSSE2 = 1 << 3,
-        DisableAES = 1 << 4,
-        DisablePCLMULQDQ = 1 << 5,
-        DisableSSE3 = 1 << 6,
-        DisableSSSE3 = 1 << 7,
-        DisableSSE41 = 1 << 8,
-        DisableSSE42 = 1 << 9,
-        DisablePOPCNT = 1 << 10,
-        DisableAVX = 1 << 11,
-        DisableFMA = 1 << 12,
-        DisableAVX2 = 1 << 13,
-        DisableBMI1 = 1 << 14,
-        DisableBMI2 = 1 << 15,
-        DisableLZCNT = 1 << 16,
-        AllowAll = 1 << 17
+        DisableHWIntrinsic = 1 << 0,
+        DisableSSE = 1 << 1,
+        DisableSSE2 = 1 << 2,
+        DisableAES = 1 << 3,
+        DisablePCLMULQDQ = 1 << 4,
+        DisableSSE3 = 1 << 5,
+        DisableSSSE3 = 1 << 6,
+        DisableSSE41 = 1 << 7,
+        DisableSSE42 = 1 << 8,
+        DisablePOPCNT = 1 << 9,
+        DisableAVX = 1 << 10,
+        DisableFMA = 1 << 11,
+        DisableAVX2 = 1 << 12,
+        DisableBMI1 = 1 << 13,
+        DisableBMI2 = 1 << 14,
+        DisableLZCNT = 1 << 15,
+        AllowAll = 1 << 16
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
@@ -16,10 +16,10 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
     public class FeatureTestRunnerTests
     {
         public static TheoryData<HwIntrinsics, string[]> Intrinsics =>
-            new TheoryData<HwIntrinsics, string[]>
+            new()
             {
                 { HwIntrinsics.DisableAES | HwIntrinsics.AllowAll, new string[] { "EnableAES", "AllowAll" } },
-                { HwIntrinsics.DisableSIMD | HwIntrinsics.DisableHWIntrinsic, new string[] { "FeatureSIMD", "EnableHWIntrinsic" } },
+                { HwIntrinsics.DisableHWIntrinsic, new string[] { "EnableHWIntrinsic" } },
                 { HwIntrinsics.DisableSSE42 | HwIntrinsics.DisableAVX, new string[] { "EnableSSE42", "EnableAVX" } }
             };
 
@@ -54,18 +54,6 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
                 () => Assert.True(Vector.IsHardwareAccelerated),
                 HwIntrinsics.AllowAll);
         }
-
-#if !NET7_0_OR_GREATER
-        // COMPlus_EnableSIMD isn't thing anymore.
-        // https://github.com/dotnet/runtime/issues/66206
-        [Fact]
-        public void CanLimitHwIntrinsicSIMDFeatures()
-        {
-            FeatureTestRunner.RunWithHwIntrinsicsFeature(
-                () => Assert.False(Vector.IsHardwareAccelerated),
-                HwIntrinsics.DisableSIMD);
-        }
-#endif
 
 #if SUPPORTS_RUNTIME_INTRINSICS
         [Fact]
@@ -105,13 +93,6 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
 
                 switch ((HwIntrinsics)Enum.Parse(typeof(HwIntrinsics), intrinsic))
                 {
-#if !NET7_0_OR_GREATER
-                    // COMPlus_EnableSIMD isn't thing anymore.
-                    // https://github.com/dotnet/runtime/issues/66206
-                    case HwIntrinsics.DisableSIMD:
-                        Assert.False(Vector.IsHardwareAccelerated);
-                        break;
-#endif
 #if SUPPORTS_RUNTIME_INTRINSICS
                     case HwIntrinsics.DisableHWIntrinsic:
                         Assert.False(Sse.IsSupported);
@@ -214,13 +195,6 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
 
                 switch ((HwIntrinsics)Enum.Parse(typeof(HwIntrinsics), intrinsic))
                 {
-#if !NET7_0_OR_GREATER
-                    // COMPlus_EnableSIMD isn't thing anymore.
-                    // https://github.com/dotnet/runtime/issues/66206
-                    case HwIntrinsics.DisableSIMD:
-                        Assert.False(Vector.IsHardwareAccelerated, nameof(Vector.IsHardwareAccelerated));
-                        break;
-#endif
 #if SUPPORTS_RUNTIME_INTRINSICS
                     case HwIntrinsics.DisableHWIntrinsic:
                         Assert.False(Sse.IsSupported);

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
@@ -55,6 +55,9 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
                 HwIntrinsics.AllowAll);
         }
 
+#if !NET7_0_OR_GREATER
+        // COMPlus_EnableSIMD isn't thing anymore.
+        // https://github.com/dotnet/runtime/issues/66206
         [Fact]
         public void CanLimitHwIntrinsicSIMDFeatures()
         {
@@ -62,6 +65,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
                 () => Assert.False(Vector.IsHardwareAccelerated),
                 HwIntrinsics.DisableSIMD);
         }
+#endif
 
 #if SUPPORTS_RUNTIME_INTRINSICS
         [Fact]
@@ -101,9 +105,13 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
 
                 switch ((HwIntrinsics)Enum.Parse(typeof(HwIntrinsics), intrinsic))
                 {
+#if !NET7_0_OR_GREATER
+                    // COMPlus_EnableSIMD isn't thing anymore.
+                    // https://github.com/dotnet/runtime/issues/66206
                     case HwIntrinsics.DisableSIMD:
                         Assert.False(Vector.IsHardwareAccelerated);
                         break;
+#endif
 #if SUPPORTS_RUNTIME_INTRINSICS
                     case HwIntrinsics.DisableHWIntrinsic:
                         Assert.False(Sse.IsSupported);
@@ -206,9 +214,13 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests
 
                 switch ((HwIntrinsics)Enum.Parse(typeof(HwIntrinsics), intrinsic))
                 {
+#if !NET7_0_OR_GREATER
+                    // COMPlus_EnableSIMD isn't thing anymore.
+                    // https://github.com/dotnet/runtime/issues/66206
                     case HwIntrinsics.DisableSIMD:
                         Assert.False(Vector.IsHardwareAccelerated, nameof(Vector.IsHardwareAccelerated));
                         break;
+#endif
 #if SUPPORTS_RUNTIME_INTRINSICS
                     case HwIntrinsics.DisableHWIntrinsic:
                         Assert.False(Sse.IsSupported);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Reduces our target framework collection to .NET 6 only (.NET 7 when CI testing preview). See https://github.com/SixLabors/ImageSharp/discussions/2072

I'll do a follow up PR to clear out any compiler conditionals for items with guaranteed support. 
e.g `#if SUPPORTS_RUNTIME_INTRINSICS`
<!-- Thanks for contributing to ImageSharp! -->
