### PR TITLE
 Use ReadOnlySpan<byte> static data compiler optimization in more places

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -16,8 +16,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
     /// </summary>
     internal static unsafe class QuantEnc
     {
-        private static readonly byte[] Zigzag = { 0, 1, 4, 8, 5, 2, 3, 6, 9, 12, 13, 10, 7, 11, 14, 15 };
-
         private static readonly ushort[] WeightY = { 38, 32, 20, 9, 32, 28, 17, 7, 20, 17, 10, 4, 9, 7, 4, 2 };
 
         private const int MaxLevel = 2047;
@@ -46,6 +44,9 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         private const int C2 = 8;    // fraction of error sent to the 4x4 block on the right
         private const int DSHIFT = 4;
         private const int DSCALE = 1;   // storage descaling, needed to make the error fit byte
+
+        // This uses C#'s optimization to refer to the static data segment of the assembly, no allocation occurs.
+        private static ReadOnlySpan<byte> Zigzag => new byte[] { 0, 1, 4, 8, 5, 2, 3, 6, 9, 12, 13, 10, 7, 11, 14, 15 };
 
         public static void PickBestIntra16(Vp8EncIterator it, ref Vp8ModeScore rd, Vp8SegmentInfo[] segmentInfos, Vp8EncProba proba)
         {

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Matrix.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Matrix.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
+
 namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 {
     internal unsafe struct Vp8Matrix
@@ -12,10 +14,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             new[] { 96, 108 },
             new[] { 110, 115 }
         };
-
-        // Sharpening by (slightly) raising the hi-frequency coeffs.
-        // Hack-ish but helpful for mid-bitrate range. Use with care.
-        private static readonly byte[] FreqSharpening = { 0, 30, 60, 90, 30, 60, 90, 90, 60, 90, 90, 90, 90, 90, 90, 90 };
 
         /// <summary>
         /// Number of descaling bits for sharpening bias.
@@ -46,6 +44,11 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         /// The frequency boosters for slight sharpening.
         /// </summary>
         public fixed short Sharpen[16];
+
+        // Sharpening by (slightly) raising the hi-frequency coeffs.
+        // Hack-ish but helpful for mid-bitrate range. Use with care.
+        // This uses C#'s optimization to refer to the static data segment of the assembly, no allocation occurs.
+        private static ReadOnlySpan<byte> FreqSharpening => new byte[] { 0, 30, 60, 90, 30, 60, 90, 90, 60, 90, 90, 90, 90, 90, 90, 90 };
 
         /// <summary>
         /// Returns the average quantizer.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Use the ReadOnlySpan<byte> static data compiler optimization in 2 more places. 

