### PR TITLE
Replace Array.Clear(array, 0, array.Length) calls with Array.Clear(array)

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8EncIterator.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8EncIterator.cs
@@ -874,7 +874,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
             this.SetCountDown(this.mbw * this.mbh);
             this.InitTop();
 
-            Array.Clear(this.BitCount, 0, this.BitCount.Length);
+            Array.Clear(this.BitCount);
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8ModeScore.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8ModeScore.cs
@@ -97,11 +97,11 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
 
         public void Clear()
         {
-            Array.Clear(this.YDcLevels, 0, this.YDcLevels.Length);
-            Array.Clear(this.YAcLevels, 0, this.YAcLevels.Length);
-            Array.Clear(this.UvLevels, 0, this.UvLevels.Length);
-            Array.Clear(this.ModesI4, 0, this.ModesI4.Length);
-            Array.Clear(this.Derr, 0, this.Derr.Length);
+            Array.Clear(this.YDcLevels);
+            Array.Clear(this.YAcLevels);
+            Array.Clear(this.UvLevels);
+            Array.Clear(this.ModesI4);
+            Array.Clear(this.Derr);
         }
 
         public void InitScore()

--- a/src/ImageSharp/Formats/Webp/Lossy/YuvConversion.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/YuvConversion.cs
@@ -159,7 +159,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
         private static void UpSampleSse41(Span<byte> topY, Span<byte> bottomY, Span<byte> topU, Span<byte> topV, Span<byte> curU, Span<byte> curV, Span<byte> topDst, Span<byte> bottomDst, int len, byte[] uvBuffer)
         {
             const int xStep = 3;
-            Array.Clear(uvBuffer, 0, uvBuffer.Length);
+            Array.Clear(uvBuffer);
             Span<byte> ru = uvBuffer.AsSpan(15);
             Span<byte> rv = ru.Slice(32);
 


### PR DESCRIPTION

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Replace all `Array.Clear(array, 0, array.Length);` calls with `Array.Clear(array);` (available since .NET 6).
Less code and more optimized.
