### PR TITLE
Preserve color profile when encoding bitmaps

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpColorSpace.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpColorSpace.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+// ReSharper disable InconsistentNaming
+namespace SixLabors.ImageSharp.Formats.Bmp
+{
+    /// <summary>
+    /// Enum for the different color spaces.
+    /// </summary>
+    internal enum BmpColorSpace
+    {
+        /// <summary>
+        /// This value implies that endpoints and gamma values are given in the appropriate fields.
+        /// </summary>
+        LCS_CALIBRATED_RGB = 0,
+
+        /// <summary>
+        /// The Windows default color space ('Win ').
+        /// </summary>
+        LCS_WINDOWS_COLOR_SPACE = 1466527264,
+
+        /// <summary>
+        /// Specifies that the bitmap is in sRGB color space ('sRGB').
+        /// </summary>
+        LCS_sRGB = 1934772034,
+
+        /// <summary>
+        /// This value indicates that bV5ProfileData points to the file name of the profile to use (gamma and endpoints values are ignored).
+        /// </summary>
+        PROFILE_LINKED = 1279872587,
+
+        /// <summary>
+        /// This value indicates that bV5ProfileData points to a memory buffer that contains the profile to be used (gamma and endpoints values are ignored).
+        /// </summary>
+        PROFILE_EMBEDDED = 1296188740
+    }
+}

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -1200,7 +1200,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         private void ReadInfoHeader()
         {
             Span<byte> buffer = stackalloc byte[BmpInfoHeader.MaxHeaderSize];
-            var infoHeaderStart = this.stream.Position;
+            long infoHeaderStart = this.stream.Position;
 
             // Resolution is stored in PPM.
             this.metadata = new ImageMetadata

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -1271,11 +1271,17 @@ namespace SixLabors.ImageSharp.Formats.Bmp
                 infoHeaderType = BmpInfoHeaderType.Os2Version2;
                 this.infoHeader = BmpInfoHeader.ParseOs2Version2(buffer);
             }
-            else if (headerSize >= BmpInfoHeader.SizeV4)
+            else if (headerSize == BmpInfoHeader.SizeV4)
             {
-                // >= 108 bytes
-                infoHeaderType = headerSize == BmpInfoHeader.SizeV4 ? BmpInfoHeaderType.WinVersion4 : BmpInfoHeaderType.WinVersion5;
+                // == 108 bytes
+                infoHeaderType = BmpInfoHeaderType.WinVersion4;
                 this.infoHeader = BmpInfoHeader.ParseV4(buffer);
+            }
+            else if (headerSize > BmpInfoHeader.SizeV4)
+            {
+                // > 108 bytes
+                infoHeaderType = BmpInfoHeaderType.WinVersion5;
+                this.infoHeader = BmpInfoHeader.ParseV5(buffer);
             }
             else
             {

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -79,9 +80,10 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <summary>
         /// A bitmap v4 header will only be written, if the user explicitly wants support for transparency.
         /// In this case the compression type BITFIELDS will be used.
+        /// If the image contains a color profile, a bitmap v5 header is written, which is needed to write this info.
         /// Otherwise a bitmap v3 header will be written, which is supported by almost all decoders.
         /// </summary>
-        private readonly bool writeV4Header;
+        private BmpInfoHeaderType infoHeaderType;
 
         /// <summary>
         /// The quantizer for reducing the color count for 8-Bit, 4-Bit and 1-Bit images.
@@ -97,8 +99,8 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         {
             this.memoryAllocator = memoryAllocator;
             this.bitsPerPixel = options.BitsPerPixel;
-            this.writeV4Header = options.SupportTransparency;
             this.quantizer = options.Quantizer ?? KnownQuantizers.Octree;
+            this.infoHeaderType = options.SupportTransparency ? BmpInfoHeaderType.WinVersion4 : BmpInfoHeaderType.WinVersion3;
         }
 
         /// <summary>
@@ -123,7 +125,62 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             int bytesPerLine = 4 * (((image.Width * bpp) + 31) / 32);
             this.padding = bytesPerLine - (int)(image.Width * (bpp / 8F));
 
-            // Set Resolution.
+            int colorPaletteSize = 0;
+            if (this.bitsPerPixel == BmpBitsPerPixel.Pixel8)
+            {
+                colorPaletteSize = ColorPaletteSize8Bit;
+            }
+            else if (this.bitsPerPixel == BmpBitsPerPixel.Pixel4)
+            {
+                colorPaletteSize = ColorPaletteSize4Bit;
+            }
+            else if (this.bitsPerPixel == BmpBitsPerPixel.Pixel1)
+            {
+                colorPaletteSize = ColorPaletteSize1Bit;
+            }
+
+            byte[] iccProfileData = null;
+            int iccProfileSize = 0;
+            if (metadata.IccProfile != null)
+            {
+                this.infoHeaderType = BmpInfoHeaderType.WinVersion5;
+                iccProfileData = metadata.IccProfile.ToByteArray();
+                iccProfileSize = iccProfileData.Length;
+            }
+
+            int infoHeaderSize = this.infoHeaderType switch
+            {
+                BmpInfoHeaderType.WinVersion3 => BmpInfoHeader.SizeV3,
+                BmpInfoHeaderType.WinVersion4 => BmpInfoHeader.SizeV4,
+                BmpInfoHeaderType.WinVersion5 => BmpInfoHeader.SizeV5,
+                _ => BmpInfoHeader.SizeV3
+            };
+
+            BmpInfoHeader infoHeader = this.CreateBmpInfoHeader(image.Width, image.Height, infoHeaderSize, bpp, bytesPerLine, metadata, iccProfileData);
+
+            Span<byte> buffer = stackalloc byte[infoHeaderSize];
+
+            this.WriteBitmapFileHeader(stream, infoHeaderSize, colorPaletteSize, iccProfileSize, infoHeader, buffer);
+            this.WriteBitmapInfoHeader(stream, infoHeader, buffer, infoHeaderSize);
+            this.WriteImage(stream, image.Frames.RootFrame);
+            this.WriteColorProfile(stream, metadata, buffer);
+
+            stream.Flush();
+        }
+
+        /// <summary>
+        /// Creates the bitmap information header.
+        /// </summary>
+        /// <param name="width">The width of the image.</param>
+        /// <param name="height">The height of the image.</param>
+        /// <param name="infoHeaderSize">Size of the information header.</param>
+        /// <param name="bpp">The bits per pixel.</param>
+        /// <param name="bytesPerLine">The bytes per line.</param>
+        /// <param name="metadata">The metadata.</param>
+        /// <param name="iccProfileData">The icc profile data.</param>
+        /// <returns>The bitmap information header.</returns>
+        private BmpInfoHeader CreateBmpInfoHeader(int width, int height, int infoHeaderSize, short bpp, int bytesPerLine, ImageMetadata metadata, byte[] iccProfileData)
+        {
             int hResolution = 0;
             int vResolution = 0;
 
@@ -154,20 +211,19 @@ namespace SixLabors.ImageSharp.Formats.Bmp
                 }
             }
 
-            int infoHeaderSize = this.writeV4Header ? BmpInfoHeader.SizeV4 : BmpInfoHeader.SizeV3;
             var infoHeader = new BmpInfoHeader(
                 headerSize: infoHeaderSize,
-                height: image.Height,
-                width: image.Width,
+                height: height,
+                width: width,
                 bitsPerPixel: bpp,
                 planes: 1,
-                imageSize: image.Height * bytesPerLine,
+                imageSize: height * bytesPerLine,
                 clrUsed: 0,
                 clrImportant: 0,
                 xPelsPerMeter: hResolution,
                 yPelsPerMeter: vResolution);
 
-            if (this.writeV4Header && this.bitsPerPixel == BmpBitsPerPixel.Pixel32)
+            if ((this.infoHeaderType is BmpInfoHeaderType.WinVersion4 or BmpInfoHeaderType.WinVersion5) && this.bitsPerPixel == BmpBitsPerPixel.Pixel32)
             {
                 infoHeader.AlphaMask = Rgba32AlphaMask;
                 infoHeader.RedMask = Rgba32RedMask;
@@ -176,45 +232,78 @@ namespace SixLabors.ImageSharp.Formats.Bmp
                 infoHeader.Compression = BmpCompression.BitFields;
             }
 
-            int colorPaletteSize = 0;
-            if (this.bitsPerPixel == BmpBitsPerPixel.Pixel8)
+            if (this.infoHeaderType is BmpInfoHeaderType.WinVersion5 && metadata.IccProfile != null)
             {
-                colorPaletteSize = ColorPaletteSize8Bit;
-            }
-            else if (this.bitsPerPixel == BmpBitsPerPixel.Pixel4)
-            {
-                colorPaletteSize = ColorPaletteSize4Bit;
-            }
-            else if (this.bitsPerPixel == BmpBitsPerPixel.Pixel1)
-            {
-                colorPaletteSize = ColorPaletteSize1Bit;
+                infoHeader.ProfileSize = iccProfileData.Length;
+                infoHeader.CsType = BmpColorSpace.PROFILE_EMBEDDED;
+                infoHeader.Intent = BmpRenderingIntent.LCS_GM_IMAGES;
             }
 
+            return infoHeader;
+        }
+
+        /// <summary>
+        /// Writes the color profile to the stream.
+        /// </summary>
+        /// <param name="stream">The stream to write to.</param>
+        /// <param name="metadata">The metadata.</param>
+        /// <param name="buffer">The buffer.</param>
+        private void WriteColorProfile(Stream stream, ImageMetadata metadata, Span<byte> buffer)
+        {
+            if (metadata.IccProfile != null)
+            {
+                int streamPositionAfterImageData = (int)stream.Position;
+                stream.Write(metadata.IccProfile.ToByteArray());
+                BinaryPrimitives.WriteInt32LittleEndian(buffer, streamPositionAfterImageData);
+                stream.Position = BmpFileHeader.Size + 112;
+                stream.Write(buffer.Slice(0, 4));
+            }
+        }
+
+        /// <summary>
+        /// Writes the bitmap file header.
+        /// </summary>
+        /// <param name="stream">The stream to write the header to.</param>
+        /// <param name="infoHeaderSize">Size of the bitmap information header.</param>
+        /// <param name="colorPaletteSize">Size of the color palette.</param>
+        /// <param name="iccProfileSize">The size in bytes of the color profile.</param>
+        /// <param name="infoHeader">The information header to write.</param>
+        /// <param name="buffer">The buffer to write to.</param>
+        private void WriteBitmapFileHeader(Stream stream, int infoHeaderSize, int colorPaletteSize, int iccProfileSize, BmpInfoHeader infoHeader, Span<byte> buffer)
+        {
             var fileHeader = new BmpFileHeader(
                 type: BmpConstants.TypeMarkers.Bitmap,
-                fileSize: BmpFileHeader.Size + infoHeaderSize + colorPaletteSize + infoHeader.ImageSize,
+                fileSize: BmpFileHeader.Size + infoHeaderSize + colorPaletteSize + iccProfileSize + infoHeader.ImageSize,
                 reserved: 0,
                 offset: BmpFileHeader.Size + infoHeaderSize + colorPaletteSize);
 
-            Span<byte> buffer = stackalloc byte[infoHeaderSize];
             fileHeader.WriteTo(buffer);
-
             stream.Write(buffer, 0, BmpFileHeader.Size);
+        }
 
-            if (this.writeV4Header)
+        /// <summary>
+        /// Writes the bitmap information header.
+        /// </summary>
+        /// <param name="stream">The stream to write info header into.</param>
+        /// <param name="infoHeader">The information header.</param>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="infoHeaderSize">Size of the information header.</param>
+        private void WriteBitmapInfoHeader(Stream stream, BmpInfoHeader infoHeader, Span<byte> buffer, int infoHeaderSize)
+        {
+            switch (this.infoHeaderType)
             {
-                infoHeader.WriteV4Header(buffer);
-            }
-            else
-            {
-                infoHeader.WriteV3Header(buffer);
+                case BmpInfoHeaderType.WinVersion3:
+                    infoHeader.WriteV3Header(buffer);
+                    break;
+                case BmpInfoHeaderType.WinVersion4:
+                    infoHeader.WriteV4Header(buffer);
+                    break;
+                case BmpInfoHeaderType.WinVersion5:
+                    infoHeader.WriteV5Header(buffer);
+                    break;
             }
 
             stream.Write(buffer, 0, infoHeaderSize);
-
-            this.WriteImage(stream, image.Frames.RootFrame);
-
-            stream.Flush();
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Bmp/BmpFileHeader.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpFileHeader.cs
@@ -57,10 +57,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// </summary>
         public int Offset { get; }
 
-        public static BmpFileHeader Parse(Span<byte> data)
-        {
-            return MemoryMarshal.Cast<byte, BmpFileHeader>(data)[0];
-        }
+        public static BmpFileHeader Parse(Span<byte> data) => MemoryMarshal.Cast<byte, BmpFileHeader>(data)[0];
 
         public void WriteTo(Span<byte> buffer)
         {

--- a/src/ImageSharp/Formats/Bmp/BmpInfoHeader.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpInfoHeader.cs
@@ -82,7 +82,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             int greenMask = 0,
             int blueMask = 0,
             int alphaMask = 0,
-            int csType = 0,
+            BmpColorSpace csType = 0,
             int redX = 0,
             int redY = 0,
             int redZ = 0,
@@ -94,7 +94,11 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             int blueZ = 0,
             int gammeRed = 0,
             int gammeGreen = 0,
-            int gammeBlue = 0)
+            int gammeBlue = 0,
+            BmpRenderingIntent intent = BmpRenderingIntent.Invalid,
+            int profileData = 0,
+            int profileSize = 0,
+            int reserved = 0)
         {
             this.HeaderSize = headerSize;
             this.Width = width;
@@ -124,6 +128,10 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             this.GammaRed = gammeRed;
             this.GammaGreen = gammeGreen;
             this.GammaBlue = gammeBlue;
+            this.Intent = intent;
+            this.ProfileData = profileData;
+            this.ProfileSize = profileSize;
+            this.Reserved = reserved;
         }
 
         /// <summary>
@@ -211,7 +219,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <summary>
         /// Gets or sets the Color space type. Not used yet.
         /// </summary>
-        public int CsType { get; set; }
+        public BmpColorSpace CsType { get; set; }
 
         /// <summary>
         /// Gets or sets the X coordinate of red endpoint. Not used yet.
@@ -274,20 +282,37 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         public int GammaBlue { get; set; }
 
         /// <summary>
+        /// Gets or sets the rendering intent for bitmap.
+        /// </summary>
+        public BmpRenderingIntent Intent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset, in bytes, from the beginning of the BITMAPV5HEADER structure to the start of the profile data.
+        /// </summary>
+        public int ProfileData { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size, in bytes, of embedded profile data.
+        /// </summary>
+        public int ProfileSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reserved value.
+        /// </summary>
+        public int Reserved { get; set; }
+
+        /// <summary>
         /// Parses the BITMAPCOREHEADER (BMP Version 2) consisting of the headerSize, width, height, planes, and bitsPerPixel fields (12 bytes).
         /// </summary>
         /// <param name="data">The data to parse.</param>
         /// <returns>The parsed header.</returns>
         /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd183372.aspx"/>
-        public static BmpInfoHeader ParseCore(ReadOnlySpan<byte> data)
-        {
-            return new BmpInfoHeader(
+        public static BmpInfoHeader ParseCore(ReadOnlySpan<byte> data) => new(
                 headerSize: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(0, 4)),
                 width: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(4, 2)),
                 height: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(6, 2)),
                 planes: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(8, 2)),
                 bitsPerPixel: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(10, 2)));
-        }
 
         /// <summary>
         /// Parses a short variant of the OS22XBITMAPHEADER. It is identical to the BITMAPCOREHEADER, except that the width and height
@@ -296,15 +321,12 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="data">The data to parse.</param>
         /// <returns>The parsed header.</returns>
         /// <seealso href="https://www.fileformat.info/format/os2bmp/egff.htm"/>
-        public static BmpInfoHeader ParseOs22Short(ReadOnlySpan<byte> data)
-        {
-            return new BmpInfoHeader(
+        public static BmpInfoHeader ParseOs22Short(ReadOnlySpan<byte> data) => new(
                 headerSize: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(0, 4)),
                 width: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(4, 4)),
                 height: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(8, 4)),
                 planes: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(12, 2)),
                 bitsPerPixel: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(14, 2)));
-        }
 
         /// <summary>
         /// Parses the full BMP Version 3 BITMAPINFOHEADER header (40 bytes).
@@ -312,9 +334,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="data">The data to parse.</param>
         /// <returns>The parsed header.</returns>
         /// <seealso href="http://www.fileformat.info/format/bmp/egff.htm"/>
-        public static BmpInfoHeader ParseV3(ReadOnlySpan<byte> data)
-        {
-            return new BmpInfoHeader(
+        public static BmpInfoHeader ParseV3(ReadOnlySpan<byte> data) => new(
                 headerSize: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(0, 4)),
                 width: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(4, 4)),
                 height: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(8, 4)),
@@ -326,7 +346,6 @@ namespace SixLabors.ImageSharp.Formats.Bmp
                 yPelsPerMeter: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(28, 4)),
                 clrUsed: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(32, 4)),
                 clrImportant: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(36, 4)));
-        }
 
         /// <summary>
         /// Special case of the BITMAPINFOHEADER V3 used by adobe where the color bitmasks are part of the info header instead of following it.
@@ -336,9 +355,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="withAlpha">Indicates, if the alpha bitmask is present.</param>
         /// <returns>The parsed header.</returns>
         /// <seealso href="https://forums.adobe.com/message/3272950#3272950"/>
-        public static BmpInfoHeader ParseAdobeV3(ReadOnlySpan<byte> data, bool withAlpha = true)
-        {
-            return new BmpInfoHeader(
+        public static BmpInfoHeader ParseAdobeV3(ReadOnlySpan<byte> data, bool withAlpha = true) => new(
                 headerSize: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(0, 4)),
                 width: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(4, 4)),
                 height: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(8, 4)),
@@ -354,7 +371,6 @@ namespace SixLabors.ImageSharp.Formats.Bmp
                 greenMask: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(44, 4)),
                 blueMask: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(48, 4)),
                 alphaMask: withAlpha ? BinaryPrimitives.ReadInt32LittleEndian(data.Slice(52, 4)) : 0);
-        }
 
         /// <summary>
         /// Parses a OS/2 version 2 bitmap header (64 bytes). Only the first 40 bytes are parsed which are
@@ -413,11 +429,47 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="data">The data to parse.</param>
         /// <returns>The parsed header.</returns>
         /// <seealso href="http://www.fileformat.info/format/bmp/egff.htm"/>
-        public static BmpInfoHeader ParseV4(ReadOnlySpan<byte> data)
+        public static BmpInfoHeader ParseV4(ReadOnlySpan<byte> data) => new(
+            headerSize: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(0, 4)),
+            width: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(4, 4)),
+            height: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(8, 4)),
+            planes: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(12, 2)),
+            bitsPerPixel: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(14, 2)),
+            compression: (BmpCompression)BinaryPrimitives.ReadInt32LittleEndian(data.Slice(16, 4)),
+            imageSize: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(20, 4)),
+            xPelsPerMeter: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(24, 4)),
+            yPelsPerMeter: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(28, 4)),
+            clrUsed: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(32, 4)),
+            clrImportant: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(36, 4)),
+            redMask: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(40, 4)),
+            greenMask: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(44, 4)),
+            blueMask: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(48, 4)),
+            alphaMask: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(52, 4)),
+            csType: (BmpColorSpace)BinaryPrimitives.ReadInt32LittleEndian(data.Slice(56, 4)),
+            redX: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(60, 4)),
+            redY: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(64, 4)),
+            redZ: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(68, 4)),
+            greenX: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(72, 4)),
+            greenY: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(76, 4)),
+            greenZ: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(80, 4)),
+            blueX: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(84, 4)),
+            blueY: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(88, 4)),
+            blueZ: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(92, 4)),
+            gammeRed: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(96, 4)),
+            gammeGreen: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(100, 4)),
+            gammeBlue: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(104, 4)));
+
+        /// <summary>
+        /// Parses the full BMP Version 5 BITMAPINFOHEADER header (124 bytes).
+        /// </summary>
+        /// <param name="data">The data to parse.</param>
+        /// <returns>The parsed header.</returns>
+        /// <seealso href="https://docs.microsoft.com/de-de/windows/win32/api/wingdi/ns-wingdi-bitmapv5header?redirectedfrom=MSDN"/>
+        public static BmpInfoHeader ParseV5(ReadOnlySpan<byte> data)
         {
-            if (data.Length < SizeV4)
+            if (data.Length < SizeV5)
             {
-                throw new ArgumentException(nameof(data), $"Must be {SizeV4} bytes. Was {data.Length} bytes.");
+                throw new ArgumentException(nameof(data), $"Must be {SizeV5} bytes. Was {data.Length} bytes.");
             }
 
             return MemoryMarshal.Cast<byte, BmpInfoHeader>(data)[0];

--- a/src/ImageSharp/Formats/Bmp/BmpInfoHeader.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpInfoHeader.cs
@@ -501,9 +501,35 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         /// <param name="buffer">The buffer to write to.</param>
         public void WriteV4Header(Span<byte> buffer)
         {
-            ref BmpInfoHeader dest = ref Unsafe.As<byte, BmpInfoHeader>(ref MemoryMarshal.GetReference(buffer));
-
-            dest = this;
+            buffer.Clear();
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(0, 4), SizeV4);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(4, 4), this.Width);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(8, 4), this.Height);
+            BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(12, 2), this.Planes);
+            BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(14, 2), this.BitsPerPixel);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(16, 4), (int)this.Compression);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(20, 4), this.ImageSize);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(24, 4), this.XPelsPerMeter);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(28, 4), this.YPelsPerMeter);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(32, 4), this.ClrUsed);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(36, 4), this.ClrImportant);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(40, 4), this.RedMask);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(44, 4), this.GreenMask);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(48, 4), this.BlueMask);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(52, 4), this.AlphaMask);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(56, 4), (int)this.CsType);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(60, 4), this.RedX);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(64, 4), this.RedY);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(68, 4), this.RedZ);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(72, 4), this.GreenX);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(76, 4), this.GreenY);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(80, 4), this.GreenZ);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(84, 4), this.BlueX);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(88, 4), this.BlueY);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(92, 4), this.BlueZ);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(96, 4), this.GammaRed);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(100, 4), this.GammaGreen);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(104, 4), this.GammaBlue);
         }
 
         internal void VerifyDimensions()

--- a/src/ImageSharp/Formats/Bmp/BmpInfoHeader.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpInfoHeader.cs
@@ -532,6 +532,17 @@ namespace SixLabors.ImageSharp.Formats.Bmp
             BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(104, 4), this.GammaBlue);
         }
 
+        /// <summary>
+        /// Writes a complete Bitmap V5 header to a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write to.</param>
+        public void WriteV5Header(Span<byte> buffer)
+        {
+            ref BmpInfoHeader dest = ref Unsafe.As<byte, BmpInfoHeader>(ref MemoryMarshal.GetReference(buffer));
+
+            dest = this;
+        }
+
         internal void VerifyDimensions()
         {
             const int MaximumBmpDimension = 65535;

--- a/src/ImageSharp/Formats/Bmp/BmpRenderingIntent.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpRenderingIntent.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Formats.Bmp
         Invalid = 0,
 
         /// <summary>
-        /// TMaintains saturation. Used for business charts and other situations in which undithered colors are required.
+        /// Maintains saturation. Used for business charts and other situations in which undithered colors are required.
         /// </summary>
         LCS_GM_BUSINESS = 1,
 

--- a/src/ImageSharp/Formats/Bmp/BmpRenderingIntent.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpRenderingIntent.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+// ReSharper disable InconsistentNaming
+namespace SixLabors.ImageSharp.Formats.Bmp
+{
+    /// <summary>
+    /// Enum for the different rendering intent's.
+    /// </summary>
+    internal enum BmpRenderingIntent
+    {
+        /// <summary>
+        /// Invalid default value.
+        /// </summary>
+        Invalid = 0,
+
+        /// <summary>
+        /// TMaintains saturation. Used for business charts and other situations in which undithered colors are required.
+        /// </summary>
+        LCS_GM_BUSINESS = 1,
+
+        /// <summary>
+        /// Maintains colorimetric match. Used for graphic designs and named colors.
+        /// </summary>
+        LCS_GM_GRAPHICS = 2,
+
+        /// <summary>
+        /// Maintains contrast. Used for photographs and natural images.
+        /// </summary>
+        LCS_GM_IMAGES = 4,
+
+        /// <summary>
+        /// Maintains the white point. Matches the colors to their nearest color in the destination gamut.
+        /// </summary>
+        LCS_GM_ABS_COLORIMETRIC = 8,
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -29,10 +29,10 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
 
         public static readonly string[] BitfieldsBmpFiles = BitFields;
 
-        private static BmpDecoder BmpDecoder => new BmpDecoder();
+        private static BmpDecoder BmpDecoder => new();
 
         public static readonly TheoryData<string, int, int, PixelResolutionUnit> RatioFiles =
-        new TheoryData<string, int, int, PixelResolutionUnit>
+        new()
         {
             { Car, 3780, 3780, PixelResolutionUnit.PixelsPerMeter },
             { V5Header, 3780, 3780, PixelResolutionUnit.PixelsPerMeter },

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpMetadataTests.cs
@@ -3,7 +3,7 @@
 
 using System.IO;
 using SixLabors.ImageSharp.Formats.Bmp;
-
+using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 using static SixLabors.ImageSharp.Tests.TestImages.Bmp;
 
@@ -45,6 +45,20 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                 BmpMetadata bitmapMetadata = imageInfo.Metadata.GetBmpMetadata();
                 Assert.NotNull(bitmapMetadata);
                 Assert.Equal(expectedInfoHeaderType, bitmapMetadata.InfoHeaderType);
+            }
+        }
+
+        [Theory]
+        [WithFile(IccProfile, PixelTypes.Rgba32)]
+        public void Decoder_CanReadColorProfile<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage(new BmpDecoder()))
+            {
+                ImageSharp.Metadata.ImageMetadata metaData = image.Metadata;
+                Assert.NotNull(metaData);
+                Assert.NotNull(metaData.IccProfile);
+                Assert.Equal(16, metaData.IccProfile.Entries.Length);
             }
         }
     }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -379,6 +379,7 @@ namespace SixLabors.ImageSharp.Tests
             public const string Rgb24jpeg = "Bmp/rgb24jpeg.bmp";
             public const string Rgb24png = "Bmp/rgb24png.bmp";
             public const string Rgba32v4 = "Bmp/rgba32v4.bmp";
+            public const string IccProfile = "Bmp/BMP_v5_with_ICC_2.bmp";
 
             // Bitmap images with compression type BITFIELDS.
             public const string Rgb32bfdef = "Bmp/rgb32bfdef.bmp";

--- a/tests/Images/Input/Bmp/BMP_v5_with_ICC_2.bmp
+++ b/tests/Images/Input/Bmp/BMP_v5_with_ICC_2.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b483e9a9d3f3ebdeada2eff70800002c27c046bf971206af0ecc73fa1416e6
+size 27782


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR changes the decoder to read the color profile when present and also the encoder to preserve it when encoding a bitmap.

Related to #2107 