### PR TITLE
Preserve color profile when encoding webp images

### DIFF
--- a/src/ImageSharp/Formats/Webp/BitWriter/BitWriterBase.cs
+++ b/src/ImageSharp/Formats/Webp/BitWriter/BitWriterBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.IO;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using SixLabors.ImageSharp.Metadata.Profiles.Xmp;
 
 namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
@@ -179,15 +180,40 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
         }
 
         /// <summary>
+        /// Writes the color profile to the stream.
+        /// </summary>
+        /// <param name="stream">The stream to write to.</param>
+        /// <param name="iccProfileBytes">The color profile bytes.</param>
+        protected void WriteColorProfile(Stream stream, byte[] iccProfileBytes)
+        {
+            uint size = (uint)iccProfileBytes.Length;
+
+            Span<byte> buf = this.scratchBuffer.AsSpan(0, 4);
+            BinaryPrimitives.WriteUInt32BigEndian(buf, (uint)WebpChunkType.Iccp);
+            stream.Write(buf);
+            BinaryPrimitives.WriteUInt32LittleEndian(buf, size);
+            stream.Write(buf);
+
+            stream.Write(iccProfileBytes);
+
+            // Add padding byte if needed.
+            if ((size & 1) == 1)
+            {
+                stream.WriteByte(0);
+            }
+        }
+
+        /// <summary>
         /// Writes a VP8X header to the stream.
         /// </summary>
         /// <param name="stream">The stream to write to.</param>
         /// <param name="exifProfile">A exif profile or null, if it does not exist.</param>
         /// <param name="xmpProfile">A XMP profile or null, if it does not exist.</param>
+        /// <param name="iccProfile">The color profile.</param>
         /// <param name="width">The width of the image.</param>
         /// <param name="height">The height of the image.</param>
         /// <param name="hasAlpha">Flag indicating, if a alpha channel is present.</param>
-        protected void WriteVp8XHeader(Stream stream, ExifProfile exifProfile, XmpProfile xmpProfile, uint width, uint height, bool hasAlpha)
+        protected void WriteVp8XHeader(Stream stream, ExifProfile exifProfile, XmpProfile xmpProfile, IccProfile iccProfile, uint width, uint height, bool hasAlpha)
         {
             if (width > MaxDimension || height > MaxDimension)
             {
@@ -217,6 +243,12 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             {
                 // Set alpha bit.
                 flags |= 16;
+            }
+
+            if (iccProfile != null)
+            {
+                // Set iccp flag.
+                flags |= 32;
             }
 
             Span<byte> buf = this.scratchBuffer.AsSpan(0, 4);

--- a/src/ImageSharp/Formats/Webp/BitWriter/BitWriterBase.cs
+++ b/src/ImageSharp/Formats/Webp/BitWriter/BitWriterBase.cs
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
         }
 
         /// <summary>
-        /// Calculates the chunk size of EXIF or XMP metadata.
+        /// Calculates the chunk size of EXIF, XMP or ICCP metadata.
         /// </summary>
         /// <param name="metadataBytes">The metadata profile bytes.</param>
         /// <returns>The metadata chunk size in bytes.</returns>
@@ -209,11 +209,11 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
         /// <param name="stream">The stream to write to.</param>
         /// <param name="exifProfile">A exif profile or null, if it does not exist.</param>
         /// <param name="xmpProfile">A XMP profile or null, if it does not exist.</param>
-        /// <param name="iccProfile">The color profile.</param>
+        /// <param name="iccProfileBytes">The color profile bytes.</param>
         /// <param name="width">The width of the image.</param>
         /// <param name="height">The height of the image.</param>
         /// <param name="hasAlpha">Flag indicating, if a alpha channel is present.</param>
-        protected void WriteVp8XHeader(Stream stream, ExifProfile exifProfile, XmpProfile xmpProfile, IccProfile iccProfile, uint width, uint height, bool hasAlpha)
+        protected void WriteVp8XHeader(Stream stream, ExifProfile exifProfile, XmpProfile xmpProfile, byte[] iccProfileBytes, uint width, uint height, bool hasAlpha)
         {
             if (width > MaxDimension || height > MaxDimension)
             {
@@ -245,7 +245,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
                 flags |= 16;
             }
 
-            if (iccProfile != null)
+            if (iccProfileBytes != null)
             {
                 // Set iccp flag.
                 flags |= 32;

--- a/src/ImageSharp/Formats/Webp/BitWriter/Vp8BitWriter.cs
+++ b/src/ImageSharp/Formats/Webp/BitWriter/Vp8BitWriter.cs
@@ -481,7 +481,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             riffSize += WebpConstants.TagSize + WebpConstants.ChunkHeaderSize + vp8Size;
 
             // Emit headers and partition #0
-            this.WriteWebpHeaders(stream, size0, vp8Size, riffSize, isVp8X, width, height, exifProfile, xmpProfile, iccProfile, hasAlpha, alphaData, alphaDataIsCompressed);
+            this.WriteWebpHeaders(stream, size0, vp8Size, riffSize, isVp8X, width, height, exifProfile, xmpProfile, iccProfileBytes, hasAlpha, alphaData, alphaDataIsCompressed);
             bitWriterPartZero.WriteToStream(stream);
 
             // Write the encoded image to the stream.
@@ -679,7 +679,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             uint height,
             ExifProfile exifProfile,
             XmpProfile xmpProfile,
-            IccProfile iccProfile,
+            byte[] iccProfileBytes,
             bool hasAlpha,
             Span<byte> alphaData,
             bool alphaDataIsCompressed)
@@ -689,11 +689,11 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             // Write VP8X, header if necessary.
             if (isVp8X)
             {
-                this.WriteVp8XHeader(stream, exifProfile, xmpProfile, iccProfile, width, height, hasAlpha);
+                this.WriteVp8XHeader(stream, exifProfile, xmpProfile, iccProfileBytes, width, height, hasAlpha);
 
-                if (iccProfile != null)
+                if (iccProfileBytes != null)
                 {
-                    this.WriteColorProfile(stream, iccProfile.ToByteArray());
+                    this.WriteColorProfile(stream, iccProfileBytes);
                 }
 
                 if (hasAlpha)

--- a/src/ImageSharp/Formats/Webp/BitWriter/Vp8BitWriter.cs
+++ b/src/ImageSharp/Formats/Webp/BitWriter/Vp8BitWriter.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.IO;
 using SixLabors.ImageSharp.Formats.Webp.Lossy;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using SixLabors.ImageSharp.Metadata.Profiles.Xmp;
 
 namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
@@ -406,6 +407,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
         /// <param name="stream">The stream to write to.</param>
         /// <param name="exifProfile">The exif profile.</param>
         /// <param name="xmpProfile">The XMP profile.</param>
+        /// <param name="iccProfile">The color profile.</param>
         /// <param name="width">The width of the image.</param>
         /// <param name="height">The height of the image.</param>
         /// <param name="hasAlpha">Flag indicating, if a alpha channel is present.</param>
@@ -415,6 +417,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             Stream stream,
             ExifProfile exifProfile,
             XmpProfile xmpProfile,
+            IccProfile iccProfile,
             uint width,
             uint height,
             bool hasAlpha,
@@ -424,6 +427,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             bool isVp8X = false;
             byte[] exifBytes = null;
             byte[] xmpBytes = null;
+            byte[] iccProfileBytes = null;
             uint riffSize = 0;
             if (exifProfile != null)
             {
@@ -437,6 +441,13 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
                 isVp8X = true;
                 xmpBytes = xmpProfile.Data;
                 riffSize += this.MetadataChunkSize(xmpBytes);
+            }
+
+            if (iccProfile != null)
+            {
+                isVp8X = true;
+                iccProfileBytes = iccProfile.ToByteArray();
+                riffSize += this.MetadataChunkSize(iccProfileBytes);
             }
 
             if (hasAlpha)
@@ -457,7 +468,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
 
             var bitWriterPartZero = new Vp8BitWriter(expectedSize);
 
-            // Partition #0 with header and partition sizes
+            // Partition #0 with header and partition sizes.
             uint size0 = this.GeneratePartition0(bitWriterPartZero);
 
             uint vp8Size = WebpConstants.Vp8FrameHeaderSize + size0;
@@ -465,12 +476,12 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             uint pad = vp8Size & 1;
             vp8Size += pad;
 
-            // Compute RIFF size
+            // Compute RIFF size.
             // At the minimum it is: "WEBPVP8 nnnn" + VP8 data size.
             riffSize += WebpConstants.TagSize + WebpConstants.ChunkHeaderSize + vp8Size;
 
             // Emit headers and partition #0
-            this.WriteWebpHeaders(stream, size0, vp8Size, riffSize, isVp8X, width, height, exifProfile, xmpProfile, hasAlpha, alphaData, alphaDataIsCompressed);
+            this.WriteWebpHeaders(stream, size0, vp8Size, riffSize, isVp8X, width, height, exifProfile, xmpProfile, iccProfile, hasAlpha, alphaData, alphaDataIsCompressed);
             bitWriterPartZero.WriteToStream(stream);
 
             // Write the encoded image to the stream.
@@ -668,6 +679,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             uint height,
             ExifProfile exifProfile,
             XmpProfile xmpProfile,
+            IccProfile iccProfile,
             bool hasAlpha,
             Span<byte> alphaData,
             bool alphaDataIsCompressed)
@@ -677,7 +689,13 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             // Write VP8X, header if necessary.
             if (isVp8X)
             {
-                this.WriteVp8XHeader(stream, exifProfile, xmpProfile, width, height, hasAlpha);
+                this.WriteVp8XHeader(stream, exifProfile, xmpProfile, iccProfile, width, height, hasAlpha);
+
+                if (iccProfile != null)
+                {
+                    this.WriteColorProfile(stream, iccProfile.ToByteArray());
+                }
+
                 if (hasAlpha)
                 {
                     this.WriteAlphaChunk(stream, alphaData, alphaDataIsCompressed);

--- a/src/ImageSharp/Formats/Webp/BitWriter/Vp8LBitWriter.cs
+++ b/src/ImageSharp/Formats/Webp/BitWriter/Vp8LBitWriter.cs
@@ -149,7 +149,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             if (exifProfile != null)
             {
                 isVp8X = true;
-                riffSize += ExtendedFileChunkSize;
                 exifBytes = exifProfile.ToByteArray();
                 riffSize += this.MetadataChunkSize(exifBytes);
             }
@@ -157,7 +156,6 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             if (xmpProfile != null)
             {
                 isVp8X = true;
-                riffSize += ExtendedFileChunkSize;
                 xmpBytes = xmpProfile.Data;
                 riffSize += this.MetadataChunkSize(xmpBytes);
             }
@@ -165,9 +163,13 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             if (iccProfile != null)
             {
                 isVp8X = true;
-                riffSize += ExtendedFileChunkSize;
                 iccBytes = iccProfile.ToByteArray();
                 riffSize += this.MetadataChunkSize(iccBytes);
+            }
+
+            if (isVp8X)
+            {
+                riffSize += ExtendedFileChunkSize;
             }
 
             this.Finish();
@@ -182,7 +184,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.BitWriter
             // Write VP8X, header if necessary.
             if (isVp8X)
             {
-                this.WriteVp8XHeader(stream, exifProfile, xmpProfile, iccProfile, width, height, hasAlpha);
+                this.WriteVp8XHeader(stream, exifProfile, xmpProfile, iccBytes, width, height, hasAlpha);
 
                 if (iccBytes != null)
                 {

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -255,7 +255,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless
             this.EncodeStream(image);
 
             // Write bytes from the bitwriter buffer to the stream.
-            this.bitWriter.WriteEncodedImageToStream(stream, metadata.ExifProfile, metadata.XmpProfile, (uint)width, (uint)height, hasAlpha);
+            this.bitWriter.WriteEncodedImageToStream(stream, metadata.ExifProfile, metadata.XmpProfile, metadata.IccProfile, (uint)width, (uint)height, hasAlpha);
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
@@ -378,6 +378,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy
                 stream,
                 metadata.ExifProfile,
                 metadata.XmpProfile,
+                metadata.IccProfile,
                 (uint)width,
                 (uint)height,
                 hasAlpha,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR changes the webp encoder to preserve the color profile when encoding an image.

Related to #2107 