### PR TITLE
Preserve color profile when encoding PNG images

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1186,7 +1186,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         private void ReadColorProfileChunk(ImageMetadata metadata, ReadOnlySpan<byte> data)
         {
             int zeroIndex = data.IndexOf((byte)0);
-            if (zeroIndex < PngConstants.MinTextKeywordLength || zeroIndex > PngConstants.MaxTextKeywordLength)
+            if (zeroIndex is < PngConstants.MinTextKeywordLength or > PngConstants.MaxTextKeywordLength)
             {
                 return;
             }

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -90,7 +90,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <summary>
         /// The color profile name.
         /// </summary>
-        private const string ProfileName = "ICC Profile";
+        private const string ColorProfileName = "ICC Profile";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PngEncoderCore" /> class.
@@ -718,16 +718,15 @@ namespace SixLabors.ImageSharp.Formats.Png
                 return;
             }
 
-            string profileName = "ICC Profile";
             byte[] iccProfileBytes = metaData.IccProfile.ToByteArray();
 
             byte[] compressedData = this.GetZlibCompressedBytes(iccProfileBytes);
-            int payloadLength = profileName.Length + compressedData.Length + 2;
+            int payloadLength = ColorProfileName.Length + compressedData.Length + 2;
             using (IMemoryOwner<byte> owner = this.memoryAllocator.Allocate<byte>(payloadLength))
             {
                 Span<byte> outputBytes = owner.GetSpan();
-                PngConstants.Encoding.GetBytes(profileName).CopyTo(outputBytes);
-                int bytesWritten = profileName.Length;
+                PngConstants.Encoding.GetBytes(ColorProfileName).CopyTo(outputBytes);
+                int bytesWritten = ColorProfileName.Length;
                 outputBytes[bytesWritten++] = 0; // Null separator.
                 outputBytes[bytesWritten++] = 0; // Compression.
                 compressedData.CopyTo(outputBytes.Slice(bytesWritten));

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -694,11 +694,13 @@ namespace SixLabors.ImageSharp.Formats.Png
                 int bytesWritten = PngConstants.XmpKeyword.Length;
 
                 // Write the iTxt header (all zeros in this case).
-                payload[bytesWritten++] = 0;
-                payload[bytesWritten++] = 0;
-                payload[bytesWritten++] = 0;
-                payload[bytesWritten++] = 0;
-                payload[bytesWritten++] = 0;
+                Span<byte> iTxtHeader = payload.Slice(bytesWritten);
+                iTxtHeader[4] = 0;
+                iTxtHeader[3] = 0;
+                iTxtHeader[2] = 0;
+                iTxtHeader[1] = 0;
+                iTxtHeader[0] = 0;
+                bytesWritten += 5;
 
                 // And the XMP data itself.
                 xmpData.CopyTo(payload.Slice(bytesWritten));

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.Chunks.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.Chunks.cs
@@ -302,6 +302,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             {
                 PngChunkType.Header,
                 PngChunkType.Gamma,
+                PngChunkType.EmbeddedColorProfile,
                 PngChunkType.Palette,
                 PngChunkType.InternationalText,
                 PngChunkType.Text,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR changes the PNG encoder to preserve the color profile when encoding an image.

Related issue: #2107 