### PR TITLE
Tiff: Performance improvements for Fax4 decompression

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Compression/BitWriterUtils.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/BitWriterUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.Formats.Tiff.Compression
 {
@@ -44,8 +45,10 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression
             }
         }
 
+        [MethodImpl(InliningOptions.ShortMethod)]
         public static void WriteBit(Span<byte> buffer, int bufferPos, int bitPos) => buffer[bufferPos] |= (byte)(1 << (7 - bitPos));
 
+        [MethodImpl(InliningOptions.ShortMethod)]
         public static void WriteZeroBit(Span<byte> buffer, int bufferPos, int bitPos) => buffer[bufferPos] = (byte)(buffer[bufferPos] & ~(1 << (7 - bitPos)));
     }
 }

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4BitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4BitReader.cs
@@ -52,28 +52,28 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         /// </summary>
         private readonly int maxCodeLength = 13;
 
-        private static readonly Dictionary<uint, uint> WhiteLen4TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen4TermCodes = new()
         {
             { 0x7, 2 }, { 0x8, 3 }, { 0xB, 4 }, { 0xC, 5 }, { 0xE, 6 }, { 0xF, 7 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen5TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen5TermCodes = new()
         {
             { 0x13, 8 }, { 0x14, 9 }, { 0x7, 10 }, { 0x8, 11 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen6TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen6TermCodes = new()
         {
             { 0x7, 1 }, { 0x8, 12 }, { 0x3, 13 }, { 0x34, 14 }, { 0x35, 15 }, { 0x2A, 16 }, { 0x2B, 17 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen7TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen7TermCodes = new()
         {
             { 0x27, 18 }, { 0xC, 19 }, { 0x8, 20 }, { 0x17, 21 }, { 0x3, 22 }, { 0x4, 23 }, { 0x28, 24 }, { 0x2B, 25 }, { 0x13, 26 },
             { 0x24, 27 }, { 0x18, 28 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen8TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen8TermCodes = new()
         {
             { 0x35, 0 }, { 0x2, 29 }, { 0x3, 30 }, { 0x1A, 31 }, { 0x1B, 32 }, { 0x12, 33 }, { 0x13, 34 }, { 0x14, 35 }, { 0x15, 36 },
             { 0x16, 37 }, { 0x17, 38 }, { 0x28, 39 }, { 0x29, 40 }, { 0x2A, 41 }, { 0x2B, 42 }, { 0x2C, 43 }, { 0x2D, 44 }, { 0x4, 45 },
@@ -81,57 +81,57 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
             { 0x58, 55 }, { 0x59, 56 }, { 0x5A, 57 }, { 0x5B, 58 }, { 0x4A, 59 }, { 0x4B, 60 }, { 0x32, 61 }, { 0x33, 62 }, { 0x34, 63 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen2TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen2TermCodes = new()
         {
             { 0x3, 2 }, { 0x2, 3 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen3TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen3TermCodes = new()
         {
             { 0x2, 1 }, { 0x3, 4 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen4TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen4TermCodes = new()
         {
             { 0x3, 5 }, { 0x2, 6 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen5TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen5TermCodes = new()
         {
             { 0x3, 7 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen6TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen6TermCodes = new()
         {
             { 0x5, 8 }, { 0x4, 9 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen7TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen7TermCodes = new()
         {
             { 0x4, 10 }, { 0x5, 11 }, { 0x7, 12 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen8TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen8TermCodes = new()
         {
             { 0x4, 13 }, { 0x7, 14 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen9TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen9TermCodes = new()
         {
             { 0x18, 15 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen10TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen10TermCodes = new()
         {
             { 0x37, 0 }, { 0x17, 16 }, { 0x18, 17 }, { 0x8, 18 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen11TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen11TermCodes = new()
         {
             { 0x67, 19 }, { 0x68, 20 }, { 0x6C, 21 }, { 0x37, 22 }, { 0x28, 23 }, { 0x17, 24 }, { 0x18, 25 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen12TermCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen12TermCodes = new()
         {
             { 0xCA, 26 }, { 0xCB, 27 }, { 0xCC, 28 }, { 0xCD, 29 }, { 0x68, 30 }, { 0x69, 31 }, { 0x6A, 32 }, { 0x6B, 33 }, { 0xD2, 34 },
             { 0xD3, 35 }, { 0xD4, 36 }, { 0xD5, 37 }, { 0xD6, 38 }, { 0xD7, 39 }, { 0x6C, 40 }, { 0x6D, 41 }, { 0xDA, 42 }, { 0xDB, 43 },
@@ -140,62 +140,62 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
             { 0x66, 62 }, { 0x67, 63 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen5MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen5MakeupCodes = new()
         {
             { 0x1B, 64 }, { 0x12, 128 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen6MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen6MakeupCodes = new()
         {
             { 0x17, 192 }, { 0x18, 1664 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen8MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen8MakeupCodes = new()
         {
             { 0x36, 320 }, { 0x37, 384 }, { 0x64, 448 }, { 0x65, 512 }, { 0x68, 576 }, { 0x67, 640 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen7MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen7MakeupCodes = new()
         {
             { 0x37, 256 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen9MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen9MakeupCodes = new()
         {
             { 0xCC, 704 }, { 0xCD, 768 }, { 0xD2, 832 }, { 0xD3, 896 }, { 0xD4, 960 }, { 0xD5, 1024 }, { 0xD6, 1088 },
             { 0xD7, 1152 }, { 0xD8, 1216 }, { 0xD9, 1280 }, { 0xDA, 1344 }, { 0xDB, 1408 }, { 0x98, 1472 }, { 0x99, 1536 },
             { 0x9A, 1600 }, { 0x9B, 1728 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen11MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen11MakeupCodes = new()
         {
             { 0x8, 1792 }, { 0xC, 1856 }, { 0xD, 1920 }
         };
 
-        private static readonly Dictionary<uint, uint> WhiteLen12MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> WhiteLen12MakeupCodes = new()
         {
             { 0x12, 1984 }, { 0x13, 2048 }, { 0x14, 2112 }, { 0x15, 2176 }, { 0x16, 2240 }, { 0x17, 2304 }, { 0x1C, 2368 },
             { 0x1D, 2432 }, { 0x1E, 2496 }, { 0x1F, 2560 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen10MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen10MakeupCodes = new()
         {
             { 0xF, 64 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen11MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen11MakeupCodes = new()
         {
             { 0x8, 1792 }, { 0xC, 1856 }, { 0xD, 1920 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen12MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen12MakeupCodes = new()
         {
             { 0xC8, 128 }, { 0xC9, 192 }, { 0x5B, 256 }, { 0x33, 320 }, { 0x34, 384 }, { 0x35, 448 },
             { 0x12, 1984 }, { 0x13, 2048 }, { 0x14, 2112 }, { 0x15, 2176 }, { 0x16, 2240 }, { 0x17, 2304 }, { 0x1C, 2368 },
             { 0x1D, 2432 }, { 0x1E, 2496 }, { 0x1F, 2560 }
         };
 
-        private static readonly Dictionary<uint, uint> BlackLen13MakeupCodes = new Dictionary<uint, uint>()
+        private static readonly Dictionary<uint, uint> BlackLen13MakeupCodes = new()
         {
             { 0x6C, 512 }, { 0x6D, 576 }, { 0x4A, 640 }, { 0x4B, 704 }, { 0x4C, 768 }, { 0x4D, 832 }, { 0x72, 896 },
             { 0x73, 960 }, { 0x74, 1024 }, { 0x75, 1088 }, { 0x76, 1152 }, { 0x77, 1216 }, { 0x52, 1280 }, { 0x53, 1344 },

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -77,10 +77,27 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         private uint WriteScanLine(Span<byte> buffer, Span<byte> scanLine, uint bitsWritten)
         {
             byte white = (byte)(this.isWhiteZero ? 0 : 255);
+            int bitPos = (int)(bitsWritten % 8);
+            int bufferPos = (int)(bitsWritten / 8);
             for (int i = 0; i < scanLine.Length; i++)
             {
-                BitWriterUtils.WriteBits(buffer, (int)bitsWritten, 1, scanLine[i] == white ? this.whiteValue : this.blackValue);
+                if (scanLine[i] == white)
+                {
+                    BitWriterUtils.WriteZeroBit(buffer, bufferPos, bitPos);
+                }
+                else
+                {
+                    BitWriterUtils.WriteBit(buffer, bufferPos, bitPos);
+                }
+
+                bitPos++;
                 bitsWritten++;
+
+                if (bitPos >= 8)
+                {
+                    bitPos = 0;
+                    bufferPos++;
+                }
             }
 
             // Write padding bytes, if necessary.
@@ -122,7 +139,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
                     }
                     else
                     {
-                        scanline.Fill((byte)255);
+                        scanline.Fill(255);
                     }
 
                     break;

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero1TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero1TiffColor{TPixel}.cs
@@ -17,14 +17,15 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         /// <inheritdoc/>
         public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
         {
-            var color = default(TPixel);
-
             int offset = 0;
+            var colorBlack = default(TPixel);
+            var colorWhite = default(TPixel);
 
-            Color black = Color.Black;
-            Color white = Color.White;
+            colorBlack.FromRgba32(Color.Black);
+            colorWhite.FromRgba32(Color.White);
             for (int y = top; y < top + height; y++)
             {
+                Span<TPixel> pixelRowSpan = pixels.DangerousGetRowSpan(y);
                 for (int x = left; x < left + width; x += 8)
                 {
                     byte b = data[offset++];
@@ -34,9 +35,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     {
                         int bit = (b >> (7 - shift)) & 1;
 
-                        color.FromRgba32(bit == 0 ? black : white);
-
-                        pixels[x + shift, y] = color;
+                        pixelRowSpan[x + shift] = bit == 0 ? colorBlack : colorWhite;
                     }
                 }
             }

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/WhiteIsZero1TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/WhiteIsZero1TiffColor{TPixel}.cs
@@ -16,14 +16,15 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
         /// <inheritdoc/>
         public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
         {
-            var color = default(TPixel);
-
             int offset = 0;
+            var colorBlack = default(TPixel);
+            var colorWhite = default(TPixel);
 
-            Color black = Color.Black;
-            Color white = Color.White;
+            colorBlack.FromRgba32(Color.Black);
+            colorWhite.FromRgba32(Color.White);
             for (int y = top; y < top + height; y++)
             {
+                Span<TPixel> pixelRowSpan = pixels.DangerousGetRowSpan(y);
                 for (int x = left; x < left + width; x += 8)
                 {
                     byte b = data[offset++];
@@ -33,9 +34,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.PhotometricInterpretation
                     {
                         int bit = (b >> (7 - shift)) & 1;
 
-                        color.FromRgba32(bit == 0 ? white : black);
-
-                        pixels[x + shift, y] = color;
+                        pixelRowSpan[x + shift] = bit == 0 ? colorWhite : colorBlack;
                     }
                 }
             }

--- a/tests/ImageSharp.Benchmarks/Codecs/Tiff/DecodeTiff.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Tiff/DecodeTiff.cs
@@ -46,6 +46,7 @@ namespace SixLabors.ImageSharp.Benchmarks.Codecs
 
         [Params(
             TestImages.Tiff.CcittFax3AllTermCodes,
+            TestImages.Tiff.Fax4Compressed2,
             TestImages.Tiff.HuffmanRleAllMakeupCodes,
             TestImages.Tiff.Calliphora_GrayscaleUncompressed,
             TestImages.Tiff.Calliphora_RgbPaletteLzw_Predictor,

--- a/tests/ImageSharp.Benchmarks/Config.cs
+++ b/tests/ImageSharp.Benchmarks/Config.cs
@@ -32,17 +32,13 @@ namespace SixLabors.ImageSharp.Benchmarks
         public class MultiFramework : Config
         {
             public MultiFramework() => this.AddJob(
-                    Job.Default.WithRuntime(ClrRuntime.Net472),
-                    Job.Default.WithRuntime(CoreRuntime.Core31),
-                    Job.Default.WithRuntime(CoreRuntime.Core50).WithArguments(new Argument[] { new MsBuildArgument("/p:DebugType=portable") }));
+                    Job.Default.WithRuntime(CoreRuntime.Core60).WithArguments(new Argument[] { new MsBuildArgument("/p:DebugType=portable") }));
         }
 
         public class ShortMultiFramework : Config
         {
             public ShortMultiFramework() => this.AddJob(
-                    Job.Default.WithRuntime(ClrRuntime.Net472).WithLaunchCount(1).WithWarmupCount(3).WithIterationCount(3),
-                    Job.Default.WithRuntime(CoreRuntime.Core31).WithLaunchCount(1).WithWarmupCount(3).WithIterationCount(3),
-                    Job.Default.WithRuntime(CoreRuntime.Core50).WithLaunchCount(1).WithWarmupCount(3).WithIterationCount(3).WithArguments(new Argument[] { new MsBuildArgument("/p:DebugType=portable") }));
+                    Job.Default.WithRuntime(CoreRuntime.Core60).WithLaunchCount(1).WithWarmupCount(3).WithIterationCount(3).WithArguments(new Argument[] { new MsBuildArgument("/p:DebugType=portable") }));
         }
 
         public class ShortCore31 : Config

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -759,6 +759,7 @@ namespace SixLabors.ImageSharp.Tests
             public const string Calliphora_HuffmanCompressed = "Tiff/Calliphora_huffman_rle.tiff";
             public const string Calliphora_BiColorUncompressed = "Tiff/Calliphora_bicolor_uncompressed.tiff";
             public const string Fax4Compressed = "Tiff/basi3p02_fax4.tiff";
+            public const string Fax4Compressed2 = "Tiff/CCITTGroup4.tiff";
             public const string Fax4CompressedLowerOrderBitsFirst = "Tiff/basi3p02_fax4_lowerOrderBitsFirst.tiff";
 
             public const string CcittFax3AllTermCodes = "Tiff/ccitt_fax3_all_terminating_codes.tiff";

--- a/tests/Images/Input/Tiff/CCITTGroup4.tiff
+++ b/tests/Images/Input/Tiff/CCITTGroup4.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:120ad0814f207c45d968b05f7435034ecfee8ac1a0958cd984a070dad31f66f3
+size 11082


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR brings performance improvements for Tiff Fax4 decompression.

Related to #2132 

Benchmarks:

```
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1706 (21H1/May2021Update)
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.100-preview.4.22252.9
  [Host]     : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
  Job-NMOCEA : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT

Runtime=.NET 6.0  Arguments=/p:DebugType=portable  InvocationCount=1
IterationCount=3  LaunchCount=1  UnrollFactor=1
WarmupCount=3
```

main 

```
|                Method |                                      TestImage |         Mean |       Error |    StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 | Gen 2 |    Allocated |
|---------------------- |----------------------------------------------- |-------------:|------------:|----------:|------:|--------:|----------:|----------:|------:|-------------:|
| 'System.Drawing Tiff' |                          Tiff/CCITTGroup4.tiff |   1,529.8 us |   568.26 us |  31.15 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |                          Tiff/CCITTGroup4.tiff | 117,745.8 us | 4,076.57 us | 223.45 us | 76.99 |    1.64 |         - |         - |     - |     20,872 B |
|                       |                                                |              |             |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |    Tiff/Calliphora_grayscale_uncompressed.tiff |     196.0 us |   774.67 us |  42.46 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |    Tiff/Calliphora_grayscale_uncompressed.tiff |     176.2 us |   175.31 us |   9.61 us |  0.94 |    0.26 |         - |         - |     - |     22,688 B |
|                       |                                                |              |             |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |     Tiff/Calliphora_rgb_deflate_predictor.tiff |   1,195.0 us |   551.90 us |  30.25 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |     Tiff/Calliphora_rgb_deflate_predictor.tiff |   1,082.5 us |   424.99 us |  23.30 us |  0.91 |    0.03 |         - |         - |     - |     23,856 B |
|                       |                                                |              |             |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |         Tiff/Calliphora_rgb_lzw_predictor.tiff |   1,212.8 us |   663.35 us |  36.36 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |         Tiff/Calliphora_rgb_lzw_predictor.tiff |   5,099.8 us | 3,391.88 us | 185.92 us |  4.20 |    0.03 |         - |         - |     - |  2,935,984 B |
|                       |                                                |              |             |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |              Tiff/Calliphora_rgb_packbits.tiff |     472.1 us |   209.06 us |  11.46 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |              Tiff/Calliphora_rgb_packbits.tiff |     206.3 us |   364.32 us |  19.97 us |  0.44 |    0.04 |         - |         - |     - |     22,840 B |
|                       |                                                |              |             |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' | Tiff/Calliphora_rgb_palette_lzw_predictor.tiff |  34,671.3 us | 8,561.18 us | 469.27 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' | Tiff/Calliphora_rgb_palette_lzw_predictor.tiff |  43,881.6 us | 1,559.07 us |  85.46 us |  1.27 |    0.02 | 4000.0000 | 1000.0000 |     - | 18,032,064 B |
|                       |                                                |              |             |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |          Tiff/Calliphora_rgb_uncompressed.tiff |     269.9 us |   114.12 us |   6.26 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |          Tiff/Calliphora_rgb_uncompressed.tiff |     170.5 us |   247.64 us |  13.57 us |  0.63 |    0.04 |         - |         - |     - |     22,736 B |
|                       |                                                |              |             |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |     Tiff/ccitt_fax3_all_terminating_codes.tiff |     138.0 us |   881.60 us |  48.32 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |     Tiff/ccitt_fax3_all_terminating_codes.tiff |     493.3 us |   407.67 us |  22.35 us |  3.80 |    0.98 |         - |         - |     - |     19,320 B |
|                       |                                                |              |             |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |         Tiff/huffman_rle_all_makeup_codes.tiff |     118.6 us |   219.62 us |  12.04 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |         Tiff/huffman_rle_all_makeup_codes.tiff |   2,893.1 us |    46.58 us |   2.55 us | 24.56 |    2.41 |         - |         - |     - |     19,472 B |
```

PR

```
|                Method |                                      TestImage |        Mean |      Error |    StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 | Gen 2 |    Allocated |
|---------------------- |----------------------------------------------- |------------:|-----------:|----------:|------:|--------:|----------:|----------:|------:|-------------:|
| 'System.Drawing Tiff' |                          Tiff/CCITTGroup4.tiff |  1,557.2 us |   521.1 us |  28.56 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |                          Tiff/CCITTGroup4.tiff | 26,244.3 us | 1,184.6 us |  64.93 us | 16.86 |    0.35 |         - |         - |     - |     20,872 B |
|                       |                                                |             |            |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |    Tiff/Calliphora_grayscale_uncompressed.tiff |    156.7 us |   302.2 us |  16.56 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |    Tiff/Calliphora_grayscale_uncompressed.tiff |    184.0 us |   290.1 us |  15.90 us |  1.19 |    0.22 |         - |         - |     - |     22,688 B |
|                       |                                                |             |            |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |     Tiff/Calliphora_rgb_deflate_predictor.tiff |  1,194.3 us |   769.5 us |  42.18 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |     Tiff/Calliphora_rgb_deflate_predictor.tiff |  1,113.0 us |   989.2 us |  54.22 us |  0.93 |    0.07 |         - |         - |     - |     23,856 B |
|                       |                                                |             |            |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |         Tiff/Calliphora_rgb_lzw_predictor.tiff |  1,269.0 us |   892.3 us |  48.91 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |         Tiff/Calliphora_rgb_lzw_predictor.tiff |  4,957.7 us | 1,098.1 us |  60.19 us |  3.91 |    0.14 |         - |         - |     - |  2,935,984 B |
|                       |                                                |             |            |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |              Tiff/Calliphora_rgb_packbits.tiff |    488.5 us |   673.0 us |  36.89 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |              Tiff/Calliphora_rgb_packbits.tiff |    193.9 us |   303.3 us |  16.62 us |  0.40 |    0.00 |         - |         - |     - |     22,840 B |
|                       |                                                |             |            |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' | Tiff/Calliphora_rgb_palette_lzw_predictor.tiff | 35,581.1 us | 5,135.7 us | 281.50 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' | Tiff/Calliphora_rgb_palette_lzw_predictor.tiff | 44,538.7 us | 2,855.5 us | 156.52 us |  1.25 |    0.01 | 4000.0000 | 1000.0000 |     - | 18,032,064 B |
|                       |                                                |             |            |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |          Tiff/Calliphora_rgb_uncompressed.tiff |    288.1 us |   139.6 us |   7.65 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |          Tiff/Calliphora_rgb_uncompressed.tiff |    173.3 us |   467.9 us |  25.65 us |  0.60 |    0.07 |         - |         - |     - |     22,736 B |
|                       |                                                |             |            |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |     Tiff/ccitt_fax3_all_terminating_codes.tiff |    119.2 us |   236.1 us |  12.94 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |     Tiff/ccitt_fax3_all_terminating_codes.tiff |    454.9 us |   580.4 us |  31.81 us |  3.83 |    0.14 |         - |         - |     - |     19,320 B |
|                       |                                                |             |            |           |       |         |           |           |       |              |
| 'System.Drawing Tiff' |         Tiff/huffman_rle_all_makeup_codes.tiff |    121.1 us |   145.5 us |   7.98 us |  1.00 |    0.00 |         - |         - |     - |        648 B |
|     'ImageSharp Tiff' |         Tiff/huffman_rle_all_makeup_codes.tiff |  1,050.5 us |   850.1 us |  46.60 us |  8.69 |    0.54 |         - |         - |     - |     19,472 B |
```

note: `Tiff/CCITTGroup4.tiff` is the image from #2132 