### PR TITLE
Fix regression in TIF image loading

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -52,6 +52,7 @@ namespace SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors
         protected override void Decompress(BufferedReadStream stream, int byteCount, int stripHeight, Span<byte> buffer)
         {
             int height = stripHeight;
+            buffer.Clear();
 
             using System.Buffers.IMemoryOwner<byte> scanLineBuffer = this.Allocator.Allocate<byte>(this.width * 2);
             Span<byte> scanLine = scanLineBuffer.GetSpan().Slice(0, this.width);

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -665,6 +665,12 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tiff
                     }
                 });
 
+        // https://github.com/SixLabors/ImageSharp/issues/2149
+        [Theory]
+        [WithFile(Issues2149, PixelTypes.Rgba32)]
+        public void TiffDecoder_CanDecode_Fax4CompressedWithStrips<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
         [Theory]
         [WithFileCollection(nameof(MultiframeTestImages), PixelTypes.Rgba32)]
         public void DecodeMultiframe<TPixel>(TestImageProvider<TPixel> provider)

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -917,6 +917,7 @@ namespace SixLabors.ImageSharp.Tests
             public const string Issues1716Rgb161616BitLittleEndian = "Tiff/Issues/Issue1716.tiff";
             public const string Issues1891 = "Tiff/Issues/Issue1891.tiff";
             public const string Issues2123 = "Tiff/Issues/Issue2123.tiff";
+            public const string Issues2149 = "Tiff/Issues/Group4CompressionWithStrips.tiff";
 
             public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
             public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/Images/Input/Tiff/Issues/Group4CompressionWithStrips.tiff
+++ b/tests/Images/Input/Tiff/Issues/Group4CompressionWithStrips.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:141320615d58b2971aedfeba8d408c38c0b4ab43024678254cecaebf0ed7edb0
+size 4440


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR fixes an issue with Fax4 compressed tiff images introduced in #2134.

Closes #2149 