### PR TITLE
Print environment info on tests start

### DIFF
--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" />
     <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />

--- a/tests/ImageSharp.Tests/TestUtilities/SixLaborsXunitTestFramework.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/SixLaborsXunitTestFramework.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using BenchmarkDotNet.Environments;
+using SixLabors.ImageSharp.Tests.TestUtilities;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: Xunit.TestFramework(SixLaborsXunitTestFramework.Type, SixLaborsXunitTestFramework.Assembly)]
+
+namespace SixLabors.ImageSharp.Tests.TestUtilities
+{
+    public class SixLaborsXunitTestFramework : XunitTestFramework
+    {
+        public const string Type = "SixLabors.ImageSharp.Tests.TestUtilities.SixLaborsXunitTestFramework";
+        public const string Assembly = "SixLabors.ImageSharp.Tests";
+
+        public SixLaborsXunitTestFramework(IMessageSink messageSink)
+            : base(messageSink)
+        {
+            var message = new DiagnosticMessage(HostEnvironmentInfo.GetInformation());
+            messageSink.OnMessage(message);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Uses the BenchMarkDotNet tooling to print out environment information before running any tests.

Should be helpful figuring out what is happening with #2117 and https://github.com/SixLabors/ImageSharp/pull/2173#issuecomment-1183293799

<img  alt="environment diagnostic output" src="https://user-images.githubusercontent.com/385879/179008570-ff9e24c8-0b5a-4604-9717-42c974690373.png">


<!-- Thanks for contributing to ImageSharp! -->
