### PR TITLE
TGA Encoder/Decoder Improvements

### DIFF
--- a/src/ImageSharp/Formats/Tga/TgaEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tga/TgaEncoderCore.cs
@@ -301,7 +301,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
                 TPixel nextPixel = pixelRow[x];
                 if (currentPixel.Equals(nextPixel))
                 {
-                    return (byte)Math.Max(0, unEqualPixelCount - 1);
+                    return unEqualPixelCount;
                 }
 
                 unEqualPixelCount++;
@@ -314,7 +314,7 @@ namespace SixLabors.ImageSharp.Formats.Tga
                 currentPixel = nextPixel;
             }
 
-            return (byte)Math.Max(0, unEqualPixelCount - 1);
+            return unEqualPixelCount;
         }
 
         private IMemoryOwner<byte> AllocateRow(int width, int bytesPerPixel)

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaDecoderTests.cs
@@ -733,6 +733,20 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
             }
         }
 
+        // Test case for legacy format, when RLE crosses multiple lines:
+        // https://github.com/SixLabors/ImageSharp/pull/2172
+        [Theory]
+        [WithFile(Github_RLE_legacy, PixelTypes.Rgba32)]
+        public void TgaDecoder_CanDecode_LegacyFormat<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage(TgaDecoder))
+            {
+                image.DebugSave(provider);
+                ImageComparingUtils.CompareWithReferenceDecoder(provider, image);
+            }
+        }
+
         [Theory]
         [WithFile(Bit16BottomLeft, PixelTypes.Rgba32)]
         [WithFile(Bit24BottomLeft, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/Formats/Tga/TgaEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tga/TgaEncoderTests.cs
@@ -135,6 +135,24 @@ namespace SixLabors.ImageSharp.Tests.Formats.Tga
             }
         }
 
+        // Run length encoded pixels should not exceed row boundaries.
+        // https://github.com/SixLabors/ImageSharp/pull/2172
+        [Fact]
+        public void TgaEncoder_RunLengthDoesNotCrossRowBoundaries()
+        {
+            var options = new TgaEncoder() { Compression = TgaCompression.RunLength };
+
+            using (var input = new Image<Rgba32>(30, 30))
+            {
+                using (var memStream = new MemoryStream())
+                {
+                    input.Save(memStream, options);
+                    byte[] imageBytes = memStream.ToArray();
+                    Assert.Equal(138, imageBytes.Length);
+                }
+            }
+        }
+
         [Theory]
         [WithFile(Bit32BottomLeft, PixelTypes.Rgba32, TgaBitsPerPixel.Pixel32)]
         [WithFile(Bit24BottomLeft, PixelTypes.Rgba32, TgaBitsPerPixel.Pixel24)]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -544,6 +544,8 @@ namespace SixLabors.ImageSharp.Tests
             public const string NoAlphaBits16BitRle = "Tga/16bit_rle_noalphabits.tga";
             public const string NoAlphaBits32Bit = "Tga/32bit_no_alphabits.tga";
             public const string NoAlphaBits32BitRle = "Tga/32bit_rle_no_alphabits.tga";
+
+            public const string Github_RLE_legacy = "Tga/Github_RLE_legacy.tga";
         }
 
         public static class Webp

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -546,6 +546,7 @@ namespace SixLabors.ImageSharp.Tests
             public const string NoAlphaBits32BitRle = "Tga/32bit_rle_no_alphabits.tga";
 
             public const string Github_RLE_legacy = "Tga/Github_RLE_legacy.tga";
+            public const string WhiteStripesPattern = "Tga/whitestripes.png";
         }
 
         public static class Webp

--- a/tests/Images/Input/Tga/Github_RLE_legacy.tga
+++ b/tests/Images/Input/Tga/Github_RLE_legacy.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3570d2883a10a764577dd5174a9168320e8653b220800714da8e3880f752ab5e
+size 51253

--- a/tests/Images/Input/Tga/whitestripes.png
+++ b/tests/Images/Input/Tga/whitestripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bc5d67ce368d2a40fb99df994c6973287fca2d8c8cff78227996f9acb5c6e1e
+size 127


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This is a follow up PR for #2172. It does a few things:
- Add tests for #2172
- Add checks to make sure enough data is available when decoding
- Change run length encoding to not always write RLE packets. This can be ineffective (add overhead) if there are no equal pixels.