### PR TITLE
Refactor `EnumUtils` and make it AOT-friendly.

### DIFF
--- a/src/ImageSharp/Common/Helpers/EnumUtils.cs
+++ b/src/ImageSharp/Common/Helpers/EnumUtils.cs
@@ -19,15 +19,14 @@ namespace SixLabors.ImageSharp
         /// <param name="defaultValue">The default value to return.</param>
         /// <returns>The <typeparamref name="TEnum"/>.</returns>
         public static TEnum Parse<TEnum>(int value, TEnum defaultValue)
-            where TEnum : Enum
+            where TEnum : struct, Enum
         {
-            foreach (TEnum enumValue in Enum.GetValues(typeof(TEnum)))
+            DebugGuard.IsTrue(Unsafe.SizeOf<TEnum>() == sizeof(int), "Only int-sized enums are supported.");
+
+            TEnum valueEnum = Unsafe.As<int, TEnum>(ref value);
+            if (Enum.IsDefined(valueEnum))
             {
-                TEnum current = enumValue;
-                if (value == Unsafe.As<TEnum, int>(ref current))
-                {
-                    return enumValue;
-                }
+                return valueEnum;
             }
 
             return defaultValue;
@@ -41,8 +40,10 @@ namespace SixLabors.ImageSharp
         /// <param name="flag">The flag.</param>
         /// <returns>The <see cref="bool"/>.</returns>
         public static bool HasFlag<TEnum>(TEnum value, TEnum flag)
-          where TEnum : Enum
+          where TEnum : struct, Enum
         {
+            DebugGuard.IsTrue(Unsafe.SizeOf<TEnum>() == sizeof(int), "Only int-sized enums are supported.");
+
             uint flagValue = Unsafe.As<TEnum, uint>(ref flag);
             return (Unsafe.As<TEnum, uint>(ref value) & flagValue) == flagValue;
         }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] ~~I have provided test coverage for my change (where applicable)~~

### Description

The `EnumUtils.Parse` method used to use the non-generic `Enum.GetValues` method to do its job, which is unsafe and produces AOT warnings.
This PR refactors it to use `Enum.IsDefined` instead, which does not allocate.
I also added asserts to methods in `EnumUtils` that ensure we use them with int-sized enums.