### PR TITLE
Tiff: Make sure 1 Bit compression is only used with 1 bit pixel type

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -417,6 +417,13 @@ namespace SixLabors.ImageSharp.Formats.Tiff
                     return;
 
                 case TiffPhotometricInterpretation.Rgb:
+                    // Make sure 1 Bit compression is only used with 1 bit pixel type.
+                    if (IsOneBitCompression(this.CompressionType))
+                    {
+                        // Invalid compression / bits per pixel combination, fallback to no compression.
+                        compression = DefaultCompression;
+                    }
+
                     this.SetEncoderOptions(TiffBitsPerPixel.Bit24, photometricInterpretation, compression, predictor);
                     return;
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable) (note: tests are there, but only fail in Debug mode)

### Description

Fixes issue #2179: It was possible to choose a invalid encoder option combination with `TiffPhotometricInterpretation.Rgb` and one of the 1D compressions. This was caught by a `Debug.Guard`, but well only in Debug mode. This PR fixes Encoder Options sanitization by not allowing this and fallback to RGB/No-Compression.
