### PR TITLE
WIP: Fix issue capping xmp data at 65KB

### DIFF
--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -274,6 +274,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string ValidExifArgumentNullExceptionOnEncode = "Jpg/issues/Issue2087-exif-null-reference-on-encode.jpg";
                 public const string Issue2133_DeduceColorSpace = "Jpg/issues/Issue2133.jpg";
                 public const string Issue2136_ScanMarkerExtraneousBytes = "Jpg/issues/Issue2136-scan-segment-extraneous-bytes.jpg";
+                public const string Issue2022_LargeXmp = "Jpg/issues/Issue2202LargeXmp.png";
 
                 public static class Fuzz
                 {

--- a/tests/Images/Input/Jpg/issues/Issue2202LargeXmp.png
+++ b/tests/Images/Input/Jpg/issues/Issue2202LargeXmp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e081c82d31bf1d30eaf638d159bbb0a4919aa21c739165dd9b1972c361c1248
+size 5353733


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR fixes an issue capping the XMP data at 65KB.
Closes #2202