### PR TITLE
Fix Image.Identify/IdentifyAsync byte array/file overloads still referring to a stream argument in documentation

### DIFF
--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given encoded byte array without fully decoding it.
         /// </summary>
         /// <param name="data">The byte array containing encoded image data to read the header from.</param>
         /// <exception cref="ArgumentNullException">The data is null.</exception>
@@ -52,7 +52,7 @@ namespace SixLabors.ImageSharp
         public static IImageInfo Identify(byte[] data) => Identify(data, out IImageFormat _);
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given encoded byte array without fully decoding it.
         /// </summary>
         /// <param name="data">The byte array containing encoded image data to read the header from.</param>
         /// <param name="format">The format type of the decoded image.</param>
@@ -64,7 +64,7 @@ namespace SixLabors.ImageSharp
         public static IImageInfo Identify(byte[] data, out IImageFormat format) => Identify(Configuration.Default, data, out format);
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given encoded byte array without fully decoding it.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="data">The byte array containing encoded image data to read the header from.</param>

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given file without fully decoding it.
         /// </summary>
         /// <param name="filePath">The image file to open and to read the header from.</param>
         /// <returns>
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp
             => Identify(filePath, out IImageFormat _);
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given file without fully decoding it.
         /// </summary>
         /// <param name="filePath">The image file to open and to read the header from.</param>
         /// <param name="format">The format type of the decoded image.</param>
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp
             => Identify(Configuration.Default, filePath, out format);
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given file without fully decoding it.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="filePath">The image file to open and to read the header from.</param>
@@ -81,7 +81,7 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given file without fully decoding it.
         /// </summary>
         /// <param name="filePath">The image file to open and to read the header from.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
@@ -94,7 +94,7 @@ namespace SixLabors.ImageSharp
             => IdentifyAsync(Configuration.Default, filePath, cancellationToken);
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given file without fully decoding it.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="filePath">The image file to open and to read the header from.</param>
@@ -115,7 +115,7 @@ namespace SixLabors.ImageSharp
         }
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given file without fully decoding it.
         /// </summary>
         /// <param name="filePath">The image file to open and to read the header from.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
@@ -130,7 +130,7 @@ namespace SixLabors.ImageSharp
             => IdentifyWithFormatAsync(Configuration.Default, filePath, cancellationToken);
 
         /// <summary>
-        /// Reads the raw image information from the specified stream without fully decoding it.
+        /// Reads the raw image information from the given file without fully decoding it.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="filePath">The image file to open and to read the header from.</param>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

The `Image.Identify/IdentifyAsync` overloads that took byte arrays or file paths as the input argument still referred to them as a stream in their documentation

<!-- Thanks for contributing to ImageSharp! -->
