### PR TITLE
Fix IPTC tags written on jpg files that contains non-English characters can't be correctly displayed on external apps #2212

### DIFF
--- a/src/ImageSharp/Metadata/Profiles/IPTC/IptcProfile.cs
+++ b/src/ImageSharp/Metadata/Profiles/IPTC/IptcProfile.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
+using SixLabors.ImageSharp.Metadata.Profiles.IPTC;
 
 namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
 {
@@ -265,7 +266,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
             {
                 // Envelope Record.
                 this.Data[i++] = IptcTagMarkerByte;
-                this.Data[i++] = 1; // Envelope
+                this.Data[i++] = (byte)IptcRecordNumber.Envelope;
                 this.Data[i++] = IptcEnvelopeCodedCharacterSet;
                 this.Data[i++] = (byte)(CodedCharacterSetUtf8Value.Length >> 8);
                 this.Data[i++] = (byte)CodedCharacterSetUtf8Value.Length;
@@ -293,7 +294,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
                 // |           |                | octet 4(most significant bit) always will be 0.                                 |
                 // +-----------+----------------+---------------------------------------------------------------------------------+
                 this.Data[i++] = IptcTagMarkerByte;
-                this.Data[i++] = 2; // Application
+                this.Data[i++] = (byte)IptcRecordNumber.Application;
                 this.Data[i++] = (byte)value.Tag;
                 this.Data[i++] = (byte)(value.Length >> 8);
                 this.Data[i++] = (byte)value.Length;
@@ -327,7 +328,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
                 bool isValidRecordNumber = recordNumber is >= 1 and <= 9;
                 var tag = (IptcTag)this.Data[offset++];
                 bool isValidEntry = isValidTagMarker && isValidRecordNumber;
-                bool isApplicationRecord = recordNumber == 0x02;
+                bool isApplicationRecord = recordNumber == (byte)IptcRecordNumber.Application;
 
                 uint byteCount = BinaryPrimitives.ReadUInt16BigEndian(this.Data.AsSpan(offset, 2));
                 offset += 2;

--- a/src/ImageSharp/Metadata/Profiles/IPTC/IptcProfile.cs
+++ b/src/ImageSharp/Metadata/Profiles/IPTC/IptcProfile.cs
@@ -21,12 +21,12 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
         private const uint MaxStandardDataTagSize = 0x7FFF;
 
         /// <summary>
-        /// 1:90 Coded Character Set
+        /// 1:90 Coded Character Set.
         /// </summary>
         private const byte IptcEnvelopeCodedCharacterSet = 0x5A;
 
         /// <summary>
-        /// This value marks that UTF-8 encoding is used in application records
+        /// This value marks that UTF-8 encoding is used in application records.
         /// </summary>
         private static readonly byte[] CodedCharacterSetUtf8Value = { 0x1B, 0x25, 0x47 };
 
@@ -255,7 +255,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
 
             if (hasValuesInUtf8)
             {
-                length += 5 + CodedCharacterSetUtf8Value.Length; // additional length for UTF-8 Tag
+                length += 5 + CodedCharacterSetUtf8Value.Length; // Additional length for UTF-8 Tag.
             }
 
             this.Data = new byte[length];
@@ -263,7 +263,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
 
             if (hasValuesInUtf8)
             {
-                // Standard DataSet Tag
+                // Envelope Record.
                 this.Data[i++] = IptcTagMarkerByte;
                 this.Data[i++] = 1; // Envelope
                 this.Data[i++] = IptcEnvelopeCodedCharacterSet;
@@ -275,7 +275,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
 
             foreach (IptcValue value in this.Values)
             {
-                // Standard DataSet Tag
+                // Application Record.
                 // +-----------+----------------+---------------------------------------------------------------------------------+
                 // | Octet Pos | Name           | Description                                                                     |
                 // +==========-+================+=================================================================================+
@@ -327,6 +327,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
                 bool isValidRecordNumber = recordNumber is >= 1 and <= 9;
                 var tag = (IptcTag)this.Data[offset++];
                 bool isValidEntry = isValidTagMarker && isValidRecordNumber;
+                bool isApplicationRecord = recordNumber == 0x02;
 
                 uint byteCount = BinaryPrimitives.ReadUInt16BigEndian(this.Data.AsSpan(offset, 2));
                 offset += 2;
@@ -336,7 +337,7 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
                     break;
                 }
 
-                if (isValidEntry && byteCount > 0 && (offset <= this.Data.Length - byteCount))
+                if (isValidEntry && isApplicationRecord && byteCount > 0 && (offset <= this.Data.Length - byteCount))
                 {
                     byte[] iptcData = new byte[byteCount];
                     Buffer.BlockCopy(this.Data, offset, iptcData, 0, (int)byteCount);
@@ -348,9 +349,9 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Iptc
         }
 
         /// <summary>
-        /// Gets if any value has UTF-8 encoding
+        /// Gets if any value has UTF-8 encoding.
         /// </summary>
-        /// <returns>true if any value has UTF-8 encoding</returns>
+        /// <returns>true if any value has UTF-8 encoding.</returns>
         private bool HasValuesInUtf8()
         {
             foreach (IptcValue value in this.values)

--- a/src/ImageSharp/Metadata/Profiles/IPTC/IptcRecordNumber.cs
+++ b/src/ImageSharp/Metadata/Profiles/IPTC/IptcRecordNumber.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.ImageSharp.Metadata.Profiles.IPTC
+{
+    /// <summary>
+    /// Enum for the different record types of a IPTC value.
+    /// </summary>
+    internal enum IptcRecordNumber : byte
+    {
+        /// <summary>
+        /// A Envelope Record.
+        /// </summary>
+        Envelope = 0x01,
+
+        /// <summary>
+        /// A Application Record.
+        /// </summary>
+        Application = 0x02
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.Metadata.cs
@@ -38,8 +38,10 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
         {
             // arrange
             using var input = new Image<Rgba32>(1, 1);
-            input.Metadata.IptcProfile = new IptcProfile();
-            input.Metadata.IptcProfile.SetValue(IptcTag.Byline, "unit_test");
+            var expectedProfile = new IptcProfile();
+            expectedProfile.SetValue(IptcTag.Country, "ESPAÑA");
+            expectedProfile.SetValue(IptcTag.City, "unit-test-city");
+            input.Metadata.IptcProfile = expectedProfile;
 
             // act
             using var memStream = new MemoryStream();
@@ -50,7 +52,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             using var output = Image.Load<Rgba32>(memStream);
             IptcProfile actual = output.Metadata.IptcProfile;
             Assert.NotNull(actual);
-            IEnumerable<IptcValue> values = input.Metadata.IptcProfile.Values;
+            IEnumerable<IptcValue> values = expectedProfile.Values;
             Assert.Equal(values, actual.Values);
         }
 

--- a/tests/ImageSharp.Tests/Metadata/Profiles/IPTC/IptcProfileTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/IPTC/IptcProfileTests.cs
@@ -15,9 +15,9 @@ namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.IPTC
 {
     public class IptcProfileTests
     {
-        private static JpegDecoder JpegDecoder => new JpegDecoder() { IgnoreMetadata = false };
+        private static JpegDecoder JpegDecoder => new() { IgnoreMetadata = false };
 
-        private static TiffDecoder TiffDecoder => new TiffDecoder() { IgnoreMetadata = false };
+        private static TiffDecoder TiffDecoder => new() { IgnoreMetadata = false };
 
         public static IEnumerable<object[]> AllIptcTags()
         {
@@ -25,6 +25,22 @@ namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.IPTC
             {
                 yield return new object[] { tag };
             }
+        }
+
+        [Fact]
+        public void IptcProfile_WithUtf8Data_WritesEnvelopeRecord_Works()
+        {
+            // arrange
+            var profile = new IptcProfile();
+            profile.SetValue(IptcTag.City, "ESPAÑA");
+            profile.UpdateData();
+            byte[] expectedEnvelopeData = { 28, 1, 90, 0, 3, 27, 37, 71 };
+
+            // act
+            byte[] profileBytes = profile.Data;
+
+            // assert
+            Assert.True(profileBytes.AsSpan(0, 8).SequenceEqual(expectedEnvelopeData));
         }
 
         [Theory]


### PR DESCRIPTION

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This fixes the issue of incorrect characters showed on IPTC tags that contains non-English characters.
