### PR TITLE
Identify transparency for indexed PNG correctly

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
@@ -188,6 +187,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 chunk.Data.GetSpan().CopyTo(alpha);
                                 this.paletteAlpha = alpha;
                                 this.AssignTransparentMarkers(alpha, pngMetadata);
+                                pngMetadata.HasTransparency = true;
                                 break;
                             case PngChunkType.Text:
                                 this.ReadTextChunk(metadata, pngMetadata, chunk.Data.GetSpan());
@@ -295,6 +295,7 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 chunk.Data.GetSpan().CopyTo(alpha);
                                 this.paletteAlpha = alpha;
                                 this.AssignTransparentMarkers(alpha, pngMetadata);
+                                pngMetadata.HasTransparency = true;
 
                                 if (this.colorMetadataOnly)
                                 {
@@ -380,8 +381,8 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// <summary>
         /// Reads the least significant bits from the byte pair with the others set to 0.
         /// </summary>
-        /// <param name="buffer">The source buffer</param>
-        /// <param name="offset">THe offset</param>
+        /// <param name="buffer">The source buffer.</param>
+        /// <param name="offset">THe offset.</param>
         /// <returns>The <see cref="int"/></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static byte ReadByteLittleEndian(ReadOnlySpan<byte> buffer, int offset)
@@ -392,7 +393,7 @@ namespace SixLabors.ImageSharp.Formats.Png
         /// specified number of bits.
         /// </summary>
         /// <param name="source">The bytes to convert from. Cannot be empty.</param>
-        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
+        /// <param name="bytesPerScanline">The number of bytes per scanline.</param>
         /// <param name="bits">The number of bits per value.</param>
         /// <param name="buffer">The new array.</param>
         /// <returns>The resulting <see cref="ReadOnlySpan{Byte}"/> array.</returns>

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -187,7 +187,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 chunk.Data.GetSpan().CopyTo(alpha);
                                 this.paletteAlpha = alpha;
                                 this.AssignTransparentMarkers(alpha, pngMetadata);
-                                pngMetadata.HasTransparency = true;
                                 break;
                             case PngChunkType.Text:
                                 this.ReadTextChunk(metadata, pngMetadata, chunk.Data.GetSpan());
@@ -295,7 +294,6 @@ namespace SixLabors.ImageSharp.Formats.Png
                                 chunk.Data.GetSpan().CopyTo(alpha);
                                 this.paletteAlpha = alpha;
                                 this.AssignTransparentMarkers(alpha, pngMetadata);
-                                pngMetadata.HasTransparency = true;
 
                                 if (this.colorMetadataOnly)
                                 {
@@ -973,6 +971,10 @@ namespace SixLabors.ImageSharp.Formats.Png
 
                     pngMetadata.HasTransparency = true;
                 }
+            }
+            else if (this.pngColorType == PngColorType.Palette && alpha.Length > 0)
+            {
+                pngMetadata.HasTransparency = true;
             }
         }
 

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -470,6 +470,30 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             Assert.Null(ex);
         }
 
+        // https://github.com/SixLabors/ImageSharp/issues/2209
+        [Theory]
+        [WithFile(TestImages.Png.Issue2209IndexedWithTransparency, PixelTypes.Rgba32)]
+        public void Issue2209_Decode_HasTransparencyIsTrue<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage(PngDecoder);
+            image.DebugSave(provider);
+            PngMetadata metadata = image.Metadata.GetPngMetadata();
+            Assert.True(metadata.HasTransparency);
+        }
+
+        // https://github.com/SixLabors/ImageSharp/issues/2209
+        [Theory]
+        [InlineData(TestImages.Png.Issue2209IndexedWithTransparency)]
+        public void Issue2209_Identify_HasTransparencyIsTrue(string imagePath)
+        {
+            var testFile = TestFile.Create(imagePath);
+            using var stream = new MemoryStream(testFile.Bytes, false);
+            IImageInfo imageInfo = Image.Identify(stream);
+            PngMetadata metadata = imageInfo.Metadata.GetPngMetadata();
+            Assert.True(metadata.HasTransparency);
+        }
+
         // https://github.com/SixLabors/ImageSharp/issues/410
         [Theory]
         [WithFile(TestImages.Png.Bad.Issue410_MalformedApplePng, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -125,6 +125,9 @@ namespace SixLabors.ImageSharp.Tests
             // Discussion 1875: https://github.com/SixLabors/ImageSharp/discussions/1875
             public const string Issue1875 = "Png/raw-profile-type-exif.png";
 
+            // Issue 2209: https://github.com/SixLabors/ImageSharp/issues/2209
+            public const string Issue2209IndexedWithTransparency = "Png/issues/Issue_2209.png";
+
             public static class Bad
             {
                 public const string MissingDataChunk = "Png/xdtn0g01.png";

--- a/tests/Images/Input/Png/issues/Issue_2209.png
+++ b/tests/Images/Input/Png/issues/Issue_2209.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58eae3863a2107bf3359a87492bc95524b54dd091683e333ac73d76f229a1f71
+size 621275


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR fixes an issue that `HasTransparency` is not set for index PNG's.
This fixes #2209