### PR TITLE
PNG filter improvements

### DIFF
--- a/src/ImageSharp/Formats/Png/Filters/NoneFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/NoneFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 using System;
@@ -21,8 +21,8 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Encode(ReadOnlySpan<byte> scanline, Span<byte> result)
         {
-            // Insert a byte before the data.
-            result[0] = 0;
+            // Insert row filter byte before the data.
+            result[0] = (byte)FilterType.None;
             result = result[1..];
             scanline[..Math.Min(scanline.Length, result.Length)].CopyTo(result);
         }

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -91,9 +91,9 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             sum = 0;
 
             // Sub(x) = Raw(x) - Raw(x-bpp)
-            resultBaseRef = 1;
+            resultBaseRef = (byte)FilterType.Sub;
 
-            int x = 0;
+            nint x = 0;
             for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
             {
                 byte scan = Unsafe.Add(ref scanBaseRef, x);
@@ -108,7 +108,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
                 Vector256<byte> zero = Vector256<byte>.Zero;
                 Vector256<int> sumAccumulator = Vector256<int>.Zero;
 
-                for (int xLeft = x - bytesPerPixel; x + Vector256<byte>.Count <= scanline.Length; xLeft += Vector256<byte>.Count)
+                for (nint xLeft = x - bytesPerPixel; x <= scanline.Length - Vector256<byte>.Count; xLeft += Vector256<byte>.Count)
                 {
                     Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                     Vector256<byte> prev = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -126,7 +126,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
             {
                 Vector<uint> sumAccumulator = Vector<uint>.Zero;
 
-                for (int xLeft = x - bytesPerPixel; x + Vector<byte>.Count <= scanline.Length; xLeft += Vector<byte>.Count)
+                for (nint xLeft = x - bytesPerPixel; x <= scanline.Length - Vector<byte>.Count; xLeft += Vector<byte>.Count)
                 {
                     Vector<byte> scan = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                     Vector<byte> prev = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -144,7 +144,7 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
                 }
             }
 
-            for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+            for (nint xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
             {
                 byte scan = Unsafe.Add(ref scanBaseRef, x);
                 byte prev = Unsafe.Add(ref scanBaseRef, xLeft);
@@ -153,8 +153,6 @@ namespace SixLabors.ImageSharp.Formats.Png.Filters
                 res = (byte)(scan - prev);
                 sum += Numerics.Abs(unchecked((sbyte)res));
             }
-
-            sum--;
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Png/ReferenceImplementations.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/ReferenceImplementations.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void EncodePaethFilter(ReadOnlySpan<byte> scanline, Span<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
         {
-            DebugGuard.MustBeSameSized<byte>(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
             DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
 
             ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
@@ -57,8 +57,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 res = (byte)(scan - PaethPredictor(left, above, upperLeft));
                 sum += Numerics.Abs(unchecked((sbyte)res));
             }
-
-            sum -= 4;
         }
 
         /// <summary>
@@ -99,8 +97,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 res = (byte)(scan - prev);
                 sum += Numerics.Abs(unchecked((sbyte)res));
             }
-
-            sum -= 1;
         }
 
         /// <summary>
@@ -135,8 +131,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 res = (byte)(scan - above);
                 sum += Numerics.Abs(unchecked((sbyte)res));
             }
-
-            sum -= 2;
         }
 
         /// <summary>
@@ -182,8 +176,6 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                 res = (byte)(scan - Average(left, above));
                 sum += Numerics.Abs(unchecked((sbyte)res));
             }
-
-            sum -= 3;
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Fixes a bug in the sums calculation for adaptive filtering:

https://github.com/SixLabors/ImageSharp/blob/ea97bac681f325e3ca4e1ecb87eb53d0048c1d25/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs#L217

I can only guess this adjustment was compensating for a bug that existed in an earlier version of the code where it counted the row filter byte in the sum.  In any case, that is not happening now, so the adjustment at the end is taking away from a valid sum value.  Although this is generally harmless, it does mean that in the event of a tie for sum values (e.g. 0 in a solid color image), Paeth will win by virtue of its larger row filter number (-4 adjustment), making the resulting image needlessly expensive to decode.

Also tidies up the code and codegen for PNG filters in a few ways:
* Inlines the SIMD Paeth predictors for encoding, which were previously emitted as method calls for each input vector
* Simplifies fallback code for SSE2-only configs
* Eliminates some sign-extensions and extra arithmetic on row ref offsets
* Uses FilterTypes enum values for row filter byte instead of magic numbers.

I will follow up another time with some improvements to the SIMD decode filter implementations.  I have ideas 😉