### PR TITLE
Extend row operation interfaces with buffer length method

### DIFF
--- a/src/ImageSharp/Advanced/IRowIntervalOperation{TBuffer}.cs
+++ b/src/ImageSharp/Advanced/IRowIntervalOperation{TBuffer}.cs
@@ -13,6 +13,13 @@ public interface IRowIntervalOperation<TBuffer>
     where TBuffer : unmanaged
 {
     /// <summary>
+    /// Return the minimal required number of items in the buffer passed on <see cref="Invoke" />.
+    /// </summary>
+    /// <param name="bounds">The bounds of the operation.</param>
+    /// <returns>The required buffer length.</returns>
+    int GetRequiredBufferLength(Rectangle bounds);
+
+    /// <summary>
     /// Invokes the method passing the row interval and a buffer.
     /// </summary>
     /// <param name="rows">The row interval.</param>

--- a/src/ImageSharp/Advanced/IRowOperation{TBuffer}.cs
+++ b/src/ImageSharp/Advanced/IRowOperation{TBuffer}.cs
@@ -11,6 +11,13 @@ public interface IRowOperation<TBuffer>
     where TBuffer : unmanaged
 {
     /// <summary>
+    /// Return the minimal required number of items in the buffer passed on <see cref="Invoke" />.
+    /// </summary>
+    /// <param name="bounds">The bounds of the operation.</param>
+    /// <returns>The required buffer length.</returns>
+    int GetRequiredBufferLength(Rectangle bounds);
+
+    /// <summary>
     /// Invokes the method passing the row and a buffer.
     /// </summary>
     /// <param name="y">The row y coordinate.</param>

--- a/src/ImageSharp/Advanced/ParallelRowIterator.Wrappers.cs
+++ b/src/ImageSharp/Advanced/ParallelRowIterator.Wrappers.cs
@@ -63,7 +63,7 @@ public static partial class ParallelRowIterator
         private readonly int minY;
         private readonly int maxY;
         private readonly int stepY;
-        private readonly int width;
+        private readonly int bufferLength;
         private readonly MemoryAllocator allocator;
         private readonly T action;
 
@@ -72,14 +72,14 @@ public static partial class ParallelRowIterator
             int minY,
             int maxY,
             int stepY,
-            int width,
+            int bufferLength,
             MemoryAllocator allocator,
             in T action)
         {
             this.minY = minY;
             this.maxY = maxY;
             this.stepY = stepY;
-            this.width = width;
+            this.bufferLength = bufferLength;
             this.allocator = allocator;
             this.action = action;
         }
@@ -96,7 +96,7 @@ public static partial class ParallelRowIterator
 
             int yMax = Math.Min(yMin + this.stepY, this.maxY);
 
-            using IMemoryOwner<TBuffer> buffer = this.allocator.Allocate<TBuffer>(this.width);
+            using IMemoryOwner<TBuffer> buffer = this.allocator.Allocate<TBuffer>(this.bufferLength);
 
             Span<TBuffer> span = buffer.Memory.Span;
 
@@ -153,7 +153,7 @@ public static partial class ParallelRowIterator
         private readonly int minY;
         private readonly int maxY;
         private readonly int stepY;
-        private readonly int width;
+        private readonly int bufferLength;
         private readonly MemoryAllocator allocator;
         private readonly T operation;
 
@@ -162,14 +162,14 @@ public static partial class ParallelRowIterator
             int minY,
             int maxY,
             int stepY,
-            int width,
+            int bufferLength,
             MemoryAllocator allocator,
             in T operation)
         {
             this.minY = minY;
             this.maxY = maxY;
             this.stepY = stepY;
-            this.width = width;
+            this.bufferLength = bufferLength;
             this.allocator = allocator;
             this.operation = operation;
         }
@@ -187,7 +187,7 @@ public static partial class ParallelRowIterator
             int yMax = Math.Min(yMin + this.stepY, this.maxY);
             var rows = new RowInterval(yMin, yMax);
 
-            using IMemoryOwner<TBuffer> buffer = this.allocator.Allocate<TBuffer>(this.width);
+            using IMemoryOwner<TBuffer> buffer = this.allocator.Allocate<TBuffer>(this.bufferLength);
 
             Unsafe.AsRef(in this.operation).Invoke(in rows, buffer.Memory.Span);
         }

--- a/src/ImageSharp/Processing/Processors/Binarization/AdaptiveThresholdProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/AdaptiveThresholdProcessor{TPixel}.cs
@@ -87,6 +87,11 @@ internal class AdaptiveThresholdProcessor<TPixel> : ImageProcessor<TPixel>
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(int y, Span<L8> span)
         {
             Span<TPixel> rowSpan = this.source.DangerousGetRowSpan(y).Slice(this.startX, span.Length);

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor{TPixel}.cs
@@ -87,6 +87,11 @@ internal class BinaryThresholdProcessor<TPixel> : ImageProcessor<TPixel>
         }
 
         /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Invoke(int y, Span<Rgb24> span)
         {

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
@@ -222,6 +222,11 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(int y, Span<Vector4> span)
         {
             int boundsX = this.bounds.X;
@@ -291,6 +296,11 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(int y, Span<Vector4> span)
         {
             Span<TPixel> targetRowSpan = this.targetPixels.DangerousGetRowSpan(y)[this.bounds.X..];
@@ -327,6 +337,13 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
             this.bounds = bounds;
             this.targetPixels = targetPixels;
             this.configuration = configuration;
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+        {
+            return bounds.Width;
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor{TPixel}.cs
@@ -64,10 +64,6 @@ internal class Convolution2DProcessor<TPixel> : ImageProcessor<TPixel>
 
         var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
 
-        // We use a rectangle 3x the interest width to allocate a buffer big enough
-        // for source and target bulk pixel conversion.
-        var operationBounds = new Rectangle(interest.X, interest.Y, interest.Width * 3, interest.Height);
-
         using (var map = new KernelSamplingMap(allocator))
         {
             // Since the kernel sizes are identical we can use a single map.
@@ -85,7 +81,7 @@ internal class Convolution2DProcessor<TPixel> : ImageProcessor<TPixel>
 
             ParallelRowIterator.IterateRows<Convolution2DRowOperation<TPixel>, Vector4>(
                 this.Configuration,
-                operationBounds,
+                interest,
                 in operation);
         }
 

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DRowOperation{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DRowOperation{TPixel}.cs
@@ -49,7 +49,7 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
     /// <inheritdoc/>
     [MethodImpl(InliningOptions.ShortMethod)]
     public int GetRequiredBufferLength(Rectangle bounds)
-        => bounds.Width;
+        => 3 * bounds.Width;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DRowOperation{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DRowOperation{TPixel}.cs
@@ -47,6 +47,11 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
     }
 
     /// <inheritdoc/>
+    [MethodImpl(InliningOptions.ShortMethod)]
+    public int GetRequiredBufferLength(Rectangle bounds)
+        => bounds.Width;
+
+    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Invoke(int y, Span<Vector4> span)
     {

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
@@ -70,10 +70,6 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
 
         var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
 
-        // We use a rectangle 2x the interest width to allocate a buffer big enough
-        // for source and target bulk pixel conversion.
-        var operationBounds = new Rectangle(interest.X, interest.Y, interest.Width * 2, interest.Height);
-
         // We can create a single sampling map with the size as if we were using the non separated 2D kernel
         // the two 1D kernels represent, and reuse it across both convolution steps, like in the bokeh blur.
         using var mapXY = new KernelSamplingMap(this.Configuration.MemoryAllocator);
@@ -92,7 +88,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
 
         ParallelRowIterator.IterateRows<HorizontalConvolutionRowOperation, Vector4>(
             this.Configuration,
-            operationBounds,
+            interest,
             in horizontalOperation);
 
         // Vertical convolution
@@ -107,7 +103,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
 
         ParallelRowIterator.IterateRows<VerticalConvolutionRowOperation, Vector4>(
             this.Configuration,
-            operationBounds,
+            interest,
             in verticalOperation);
     }
 
@@ -146,7 +142,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
         public int GetRequiredBufferLength(Rectangle bounds)
-            => bounds.Width;
+            => 2 * bounds.Width;
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -312,7 +308,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
         public int GetRequiredBufferLength(Rectangle bounds)
-            => bounds.Width;
+            => 2 * bounds.Width;
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
@@ -144,6 +144,11 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
         }
 
         /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Invoke(int y, Span<Vector4> span)
         {
@@ -303,6 +308,11 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
             this.configuration = configuration;
             this.preserveAlpha = preserveAlpha;
         }
+
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
@@ -108,6 +108,11 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(int y, Span<Vector4> span)
         {
             // Span is 2x bounds.

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
@@ -57,9 +57,6 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
 
         var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
 
-        // We use a rectangle 2x the interest width to allocate a buffer big enough
-        // for source and target bulk pixel conversion.
-        var operationBounds = new Rectangle(interest.X, interest.Y, interest.Width * 2, interest.Height);
         using (var map = new KernelSamplingMap(allocator))
         {
             map.BuildSamplingOffsetMap(this.KernelXY, interest);
@@ -67,7 +64,7 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
             var operation = new RowOperation(interest, targetPixels, source.PixelBuffer, map, this.KernelXY, this.Configuration, this.PreserveAlpha);
             ParallelRowIterator.IterateRows<RowOperation, Vector4>(
                this.Configuration,
-               operationBounds,
+               interest,
                in operation);
         }
 
@@ -109,7 +106,7 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
         public int GetRequiredBufferLength(Rectangle bounds)
-            => bounds.Width;
+            => 2 * bounds.Width;
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]

--- a/src/ImageSharp/Processing/Processors/Convolution/MedianBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/MedianBlurProcessor{TPixel}.cs
@@ -31,11 +31,6 @@ internal sealed class MedianBlurProcessor<TPixel> : ImageProcessor<TPixel>
 
         Rectangle interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
 
-        // We use a rectangle with width set wider, to allocate a buffer big enough
-        // for kernel source, channel buffers, source rows and target bulk pixel conversion.
-        int operationWidth = (2 * kernelSize * kernelSize) + interest.Width + (kernelSize * interest.Width);
-        Rectangle operationBounds = new(interest.X, interest.Y, operationWidth, interest.Height);
-
         using KernelSamplingMap map = new(this.Configuration.MemoryAllocator);
         map.BuildSamplingOffsetMap(kernelSize, kernelSize, interest, this.definition.BorderWrapModeX, this.definition.BorderWrapModeY);
 
@@ -50,7 +45,7 @@ internal sealed class MedianBlurProcessor<TPixel> : ImageProcessor<TPixel>
 
         ParallelRowIterator.IterateRows<MedianRowOperation<TPixel>, Vector4>(
             this.Configuration,
-            operationBounds,
+            interest,
             in operation);
 
         Buffer2D<TPixel>.SwapOrCopyContent(source.PixelBuffer, targetPixels);

--- a/src/ImageSharp/Processing/Processors/Convolution/MedianRowOperation{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/MedianRowOperation{TPixel}.cs
@@ -46,7 +46,7 @@ internal readonly struct MedianRowOperation<TPixel> : IRowOperation<Vector4>
     /// <inheritdoc/>
     [MethodImpl(InliningOptions.ShortMethod)]
     public int GetRequiredBufferLength(Rectangle bounds)
-        => (2 * this.kernelSize * this.kernelSize) + bounds.Width + (kernelSize * bounds.Width);
+        => (2 * this.kernelSize * this.kernelSize) + bounds.Width + (this.kernelSize * bounds.Width);
 
     public void Invoke(int y, Span<Vector4> span)
     {

--- a/src/ImageSharp/Processing/Processors/Convolution/MedianRowOperation{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/MedianRowOperation{TPixel}.cs
@@ -46,11 +46,11 @@ internal readonly struct MedianRowOperation<TPixel> : IRowOperation<Vector4>
     /// <inheritdoc/>
     [MethodImpl(InliningOptions.ShortMethod)]
     public int GetRequiredBufferLength(Rectangle bounds)
-        => bounds.Width;
+        => (2 * this.kernelSize * this.kernelSize) + bounds.Width + (kernelSize * bounds.Width);
 
     public void Invoke(int y, Span<Vector4> span)
     {
-        // Span has kernelSize^2 followed by bound width.
+        // Span has kernelSize^2 twice, then bound width followed by kernelsize * bounds width.
         int boundsX = this.bounds.X;
         int boundsWidth = this.bounds.Width;
         int kernelCount = this.kernelSize * this.kernelSize;

--- a/src/ImageSharp/Processing/Processors/Convolution/MedianRowOperation{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/MedianRowOperation{TPixel}.cs
@@ -43,6 +43,11 @@ internal readonly struct MedianRowOperation<TPixel> : IRowOperation<Vector4>
         this.wChannelStart = this.zChannelStart + kernelCount;
     }
 
+    /// <inheritdoc/>
+    [MethodImpl(InliningOptions.ShortMethod)]
+    public int GetRequiredBufferLength(Rectangle bounds)
+        => bounds.Width;
+
     public void Invoke(int y, Span<Vector4> span)
     {
         // Span has kernelSize^2 followed by bound width.

--- a/src/ImageSharp/Processing/Processors/Effects/PixelRowDelegateProcessor{TPixel,TDelegate}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/PixelRowDelegateProcessor{TPixel,TDelegate}.cs
@@ -85,6 +85,11 @@ internal sealed class PixelRowDelegateProcessor<TPixel, TDelegate> : ImageProces
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(int y, Span<Vector4> span)
         {
             Span<TPixel> rowSpan = this.source.DangerousGetRowSpan(y).Slice(this.startX, span.Length);

--- a/src/ImageSharp/Processing/Processors/Filters/FilterProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/FilterProcessor{TPixel}.cs
@@ -68,6 +68,11 @@ internal class FilterProcessor<TPixel> : ImageProcessor<TPixel>
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(int y, Span<Vector4> span)
         {
             Span<TPixel> rowSpan = this.source.DangerousGetRowSpan(y).Slice(this.startX, span.Length);

--- a/src/ImageSharp/Processing/Processors/Filters/OpaqueProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/OpaqueProcessor{TPixel}.cs
@@ -48,6 +48,11 @@ internal sealed class OpaqueProcessor<TPixel> : ImageProcessor<TPixel>
 
         /// <inheritdoc/>
         [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(int y, Span<Vector4> span)
         {
             Span<TPixel> targetRowSpan = this.target.DangerousGetRowSpan(y)[this.bounds.X..];

--- a/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor{TPixel}.cs
@@ -93,6 +93,11 @@ internal class GlowProcessor<TPixel> : ImageProcessor<TPixel>
             this.source = source;
         }
 
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
         [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(int y, Span<float> span)
         {

--- a/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor{TPixel}.cs
@@ -101,6 +101,11 @@ internal class VignetteProcessor<TPixel> : ImageProcessor<TPixel>
             this.source = source;
         }
 
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
         [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(int y, Span<float> span)
         {

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
@@ -176,6 +176,11 @@ internal class AffineTransformProcessor<TPixel> : TransformProcessor<TPixel>, IR
             this.xRadius = LinearTransformUtility.GetSamplingRadius(in sampler, source.Width, destination.Width);
         }
 
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
         [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(in RowInterval rows, Span<Vector4> span)
         {

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
@@ -176,6 +176,11 @@ internal class ProjectiveTransformProcessor<TPixel> : TransformProcessor<TPixel>
             this.xRadius = LinearTransformUtility.GetSamplingRadius(in sampler, bounds.Width, destination.Width);
         }
 
+        /// <inheritdoc/>
+        [MethodImpl(InliningOptions.ShortMethod)]
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
         [MethodImpl(InliningOptions.ShortMethod)]
         public void Invoke(in RowInterval rows, Span<Vector4> span)
         {

--- a/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
+++ b/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
@@ -413,6 +413,9 @@ public class ParallelRowIteratorTests
         public TestRowIntervalOperation(Action<RowInterval> action)
             => this.action = action;
 
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
         public void Invoke(in RowInterval rows) => this.action(rows);
     }
 
@@ -423,6 +426,9 @@ public class ParallelRowIteratorTests
 
         public TestRowIntervalOperation(RowIntervalAction<TBuffer> action)
             => this.action = action;
+
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
 
         public void Invoke(in RowInterval rows, Span<TBuffer> span)
             => this.action(rows, span);

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -755,6 +755,9 @@ public static class TestImageExtensions
                 this.source = source;
             }
 
+            public int GetRequiredBufferLength(Rectangle bounds)
+                => bounds.Width;
+
             public void Invoke(in RowInterval rows, Span<Vector4> span)
             {
                 for (int y = rows.Min; y < rows.Max; y++)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Some implementation of `IRowOperation{T}` and `IRowIntervalOperation{T}` interfaces use buffer length other than the width of the bounds. Examples are most convolution processors.
This PR makes the required buffer length an explicit method in these interfaces. This introduces some boiler plate code when the `IRowOperation{T}` is using the default, but I think the readability of the code improves even there. When re-using `IRowOperation{T}` implementations in other processors, the _internal_ knowledge of the buffer length is no longer required. Last but not least, my personal trigger to start this PR: It eliminates contributors going back and forth between the RowOperation and the Processor when the buffer length is changed in the code.

Also, implemented buffered pixel conversions in Normalization processors using these extended interfaces.

I feel the existing test cover the changes in this PR already. Let me know if you feel otherwise.
