### PR TITLE
Tiff: Make sure bits per pixel is set to 1 for bilevel compression

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -384,6 +384,13 @@ internal sealed class TiffEncoderCore : IImageEncoderInternals
         // If no photometric interpretation was chosen, the input image bit per pixel should be preserved.
         if (!photometricInterpretation.HasValue)
         {
+            if (IsOneBitCompression(this.CompressionType))
+            {
+                // We need to make sure bits per pixel is set to Bit1 now. WhiteIsZero is set because its the default for bilevel compressed data.
+                this.SetEncoderOptions(TiffBitsPerPixel.Bit1, TiffPhotometricInterpretation.WhiteIsZero, compression, TiffPredictor.None);
+                return;
+            }
+
             // At the moment only 8 and 32 bits per pixel can be preserved by the tiff encoder.
             if (inputBitsPerPixel == 8)
             {

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderBaseTester.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderBaseTester.cs
@@ -80,7 +80,7 @@ public abstract class TiffEncoderBaseTester
     protected static void TestTiffEncoderCore<TPixel>(
         TestImageProvider<TPixel> provider,
         TiffBitsPerPixel? bitsPerPixel,
-        TiffPhotometricInterpretation photometricInterpretation,
+        TiffPhotometricInterpretation? photometricInterpretation,
         TiffCompression compression = TiffCompression.None,
         TiffPredictor predictor = TiffPredictor.None,
         bool useExactComparer = true,

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -428,6 +428,11 @@ public class TiffEncoderTests : TiffEncoderBaseTester
         where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit1, TiffPhotometricInterpretation.BlackIsZero, TiffCompression.CcittGroup3Fax);
 
     [Theory]
+    [WithFile(Issues2255, PixelTypes.Rgba32)]
+    public void TiffEncoder_EncodeBiColor_WithCcittGroup3FaxCompression_WithoutSpecifyingBitPerPixel_Works<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, null, null, TiffCompression.CcittGroup3Fax, useExactComparer: false, compareTolerance: 0.025f);
+
+    [Theory]
     [WithFile(Calliphora_BiColorUncompressed, PixelTypes.Rgba32)]
     public void TiffEncoder_EncodeBiColor_WithCcittGroup4FaxCompression_WhiteIsZero_Works<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit1, TiffPhotometricInterpretation.WhiteIsZero, TiffCompression.CcittGroup4Fax);

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -934,6 +934,7 @@ public static class TestImages
         public const string Issues1891 = "Tiff/Issues/Issue1891.tiff";
         public const string Issues2123 = "Tiff/Issues/Issue2123.tiff";
         public const string Issues2149 = "Tiff/Issues/Group4CompressionWithStrips.tiff";
+        public const string Issues2255 = "Tiff/Issues/Issue2255.png";
 
         public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
         public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/Images/Input/Tiff/Issues/Issue2255.png
+++ b/tests/Images/Input/Tiff/Issues/Issue2255.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff555fb2478406a1f3b2202c2ae3b0a691a16bfe2a5b586f38b348c9f4a858e6
+size 3635


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Make sure bits per pixel is set to 1 for bilevel compression when encoding tiff's, fixes #2255.