### PR TITLE
Fix various Gif Decoder/Encoder behaviors. 

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -479,7 +479,7 @@ internal sealed class GifDecoderCore : IImageDecoderInternals
                 prevFrame = previousFrame;
             }
 
-            currentFrame = image.Frames.AddFrame(new ImageFrame<TPixel>(this.configuration, previousFrame.Width, previousFrame.Height));
+            currentFrame = image.Frames.CreateFrame();
 
             this.SetFrameMetadata(currentFrame.Metadata, false);
 

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -548,7 +548,7 @@ internal sealed class GifDecoderCore : IImageDecoderInternals
                 // #403 The left + width value can be larger than the image width
                 for (int x = descriptorLeft; x < descriptorRight && x < imageWidth; x++)
                 {
-                    int index = Numerics.Clamp(Unsafe.Add(ref indicesRowRef, x - descriptorLeft), 0, Math.Max(transIndex, colorTableMaxIdx));
+                    int index = Numerics.Clamp(Unsafe.Add(ref indicesRowRef, x - descriptorLeft), 0, colorTableMaxIdx);
                     ref TPixel pixel = ref Unsafe.Add(ref rowRef, x);
                     Rgb24 rgb = colorTable[index];
                     pixel.FromRgb24(rgb);

--- a/src/ImageSharp/Formats/Gif/GifFrameMetadata.cs
+++ b/src/ImageSharp/Formats/Gif/GifFrameMetadata.cs
@@ -21,13 +21,19 @@ public class GifFrameMetadata : IDeepCloneable
     /// <param name="other">The metadata to create an instance from.</param>
     private GifFrameMetadata(GifFrameMetadata other)
     {
+        this.ColorTableMode = other.ColorTableMode;
         this.ColorTableLength = other.ColorTableLength;
         this.FrameDelay = other.FrameDelay;
         this.DisposalMethod = other.DisposalMethod;
     }
 
     /// <summary>
-    /// Gets or sets the length of the color table for paletted images.
+    /// Gets or sets the color table mode.
+    /// </summary>
+    public GifColorTableMode ColorTableMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the length of the color table.
     /// If not 0, then this field indicates the maximum number of colors to use when quantizing the
     /// image frame.
     /// </summary>

--- a/src/ImageSharp/Formats/Gif/GifMetadata.cs
+++ b/src/ImageSharp/Formats/Gif/GifMetadata.cs
@@ -50,7 +50,7 @@ public class GifMetadata : IDeepCloneable
     public int GlobalColorTableLength { get; set; }
 
     /// <summary>
-    /// Gets or sets the the collection of comments about the graphics, credits, descriptions or any
+    /// Gets or sets the collection of comments about the graphics, credits, descriptions or any
     /// other type of non-control and non-graphic data.
     /// </summary>
     public IList<string> Comments { get; set; } = new List<string>();

--- a/src/ImageSharp/Formats/Gif/GifThrowHelper.cs
+++ b/src/ImageSharp/Formats/Gif/GifThrowHelper.cs
@@ -1,12 +1,19 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace SixLabors.ImageSharp.Formats.Gif;
 
 internal static class GifThrowHelper
 {
+    [DoesNotReturn]
     public static void ThrowInvalidImageContentException(string errorMessage)
         => throw new InvalidImageContentException(errorMessage);
 
-    public static void ThrowInvalidImageContentException(string errorMessage, Exception innerException) => throw new InvalidImageContentException(errorMessage, innerException);
+    [DoesNotReturn]
+    public static void ThrowNoHeader() => throw new InvalidImageContentException("Gif image does not contain a Logical Screen Descriptor.");
+
+    [DoesNotReturn]
+    public static void ThrowNoData() => throw new InvalidImageContentException("Unable to read Gif image data");
 }

--- a/src/ImageSharp/Formats/Gif/MetadataExtensions.cs
+++ b/src/ImageSharp/Formats/Gif/MetadataExtensions.cs
@@ -14,14 +14,28 @@ public static partial class MetadataExtensions
     /// <summary>
     /// Gets the gif format specific metadata for the image.
     /// </summary>
-    /// <param name="metadata">The metadata this method extends.</param>
+    /// <param name="source">The metadata this method extends.</param>
     /// <returns>The <see cref="GifMetadata"/>.</returns>
-    public static GifMetadata GetGifMetadata(this ImageMetadata metadata) => metadata.GetFormatMetadata(GifFormat.Instance);
+    public static GifMetadata GetGifMetadata(this ImageMetadata source) => source.GetFormatMetadata(GifFormat.Instance);
 
     /// <summary>
     /// Gets the gif format specific metadata for the image frame.
     /// </summary>
-    /// <param name="metadata">The metadata this method extends.</param>
+    /// <param name="source">The metadata this method extends.</param>
     /// <returns>The <see cref="GifFrameMetadata"/>.</returns>
-    public static GifFrameMetadata GetGifMetadata(this ImageFrameMetadata metadata) => metadata.GetFormatMetadata(GifFormat.Instance);
+    public static GifFrameMetadata GetGifMetadata(this ImageFrameMetadata source) => source.GetFormatMetadata(GifFormat.Instance);
+
+    /// <summary>
+    /// Gets the gif format specific metadata for the image frame.
+    /// </summary>
+    /// <param name="source">The metadata this method extends.</param>
+    /// <param name="metadata">
+    /// When this method returns, contains the metadata associated with the specified frame,
+    /// if found; otherwise, the default value for the type of the metadata parameter.
+    /// This parameter is passed uninitialized.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the gif frame metadata exists; otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool TryGetGifMetadata(this ImageFrameMetadata source, out GifFrameMetadata metadata) => source.TryGetFormatMetadata(GifFormat.Instance, out metadata);
 }

--- a/src/ImageSharp/Formats/Gif/Sections/GifGraphicControlExtension.cs
+++ b/src/ImageSharp/Formats/Gif/Sections/GifGraphicControlExtension.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Formats.Gif;
 /// processing a graphic rendering block.
 /// </summary>
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-internal readonly struct GifGraphicControlExtension : IGifExtension
+internal readonly struct GifGraphicControlExtension : IGifExtension, IEquatable<GifGraphicControlExtension>
 {
     public GifGraphicControlExtension(
         byte packed,
@@ -64,6 +64,10 @@ internal readonly struct GifGraphicControlExtension : IGifExtension
 
     int IGifExtension.ContentLength => 5;
 
+    public static bool operator ==(GifGraphicControlExtension left, GifGraphicControlExtension right) => left.Equals(right);
+
+    public static bool operator !=(GifGraphicControlExtension left, GifGraphicControlExtension right) => !(left == right);
+
     public int WriteTo(Span<byte> buffer)
     {
         ref GifGraphicControlExtension dest = ref Unsafe.As<byte, GifGraphicControlExtension>(ref MemoryMarshal.GetReference(buffer));
@@ -101,4 +105,27 @@ internal readonly struct GifGraphicControlExtension : IGifExtension
 
         return value;
     }
+
+    public override bool Equals(object obj) => obj is GifGraphicControlExtension extension && this.Equals(extension);
+
+    public bool Equals(GifGraphicControlExtension other)
+        => this.BlockSize == other.BlockSize
+        && this.Packed == other.Packed
+        && this.DelayTime == other.DelayTime
+        && this.TransparencyIndex == other.TransparencyIndex
+        && this.DisposalMethod == other.DisposalMethod
+        && this.TransparencyFlag == other.TransparencyFlag
+        && ((IGifExtension)this).Label == ((IGifExtension)other).Label
+        && ((IGifExtension)this).ContentLength == ((IGifExtension)other).ContentLength;
+
+    public override int GetHashCode()
+        => HashCode.Combine(
+            this.BlockSize,
+            this.Packed,
+            this.DelayTime,
+            this.TransparencyIndex,
+            this.DisposalMethod,
+            this.TransparencyFlag,
+            ((IGifExtension)this).Label,
+            ((IGifExtension)this).ContentLength);
 }

--- a/src/ImageSharp/Formats/Gif/Sections/GifXmpApplicationExtension.cs
+++ b/src/ImageSharp/Formats/Gif/Sections/GifXmpApplicationExtension.cs
@@ -28,7 +28,6 @@ internal readonly struct GifXmpApplicationExtension : IGifExtension
     /// <param name="stream">The stream to read from.</param>
     /// <param name="allocator">The memory allocator.</param>
     /// <returns>The XMP metadata</returns>
-    /// <exception cref="ImageFormatException">Thrown if the XMP block is not properly terminated.</exception>
     public static GifXmpApplicationExtension Read(Stream stream, MemoryAllocator allocator)
     {
         byte[] xmpBytes = ReadXmpData(stream, allocator);

--- a/src/ImageSharp/Formats/ImageDecoderUtilities.cs
+++ b/src/ImageSharp/Formats/ImageDecoderUtilities.cs
@@ -68,6 +68,10 @@ internal static class ImageDecoderUtilities
         {
             throw new InvalidImageContentException(decoder.Dimensions, ex);
         }
+        catch (Exception)
+        {
+            throw;
+        }
     }
 
     internal static Image<TPixel> Decode<TPixel>(
@@ -95,6 +99,10 @@ internal static class ImageDecoderUtilities
         catch (InvalidMemoryOperationException ex)
         {
             throw largeImageExceptionFactory(ex, decoder.Dimensions);
+        }
+        catch (Exception)
+        {
+            throw;
         }
     }
 

--- a/src/ImageSharp/Metadata/ImageFrameMetadata.cs
+++ b/src/ImageSharp/Metadata/ImageFrameMetadata.cs
@@ -69,7 +69,8 @@ public sealed class ImageFrameMetadata : IDeepCloneable<ImageFrameMetadata>
     public ImageFrameMetadata DeepClone() => new(this);
 
     /// <summary>
-    /// Gets the metadata value associated with the specified key.
+    /// Gets the metadata value associated with the specified key. This method will always return a result creating
+    /// a new instance and binding it to the frame metadata if none is found.
     /// </summary>
     /// <typeparam name="TFormatMetadata">The type of format metadata.</typeparam>
     /// <typeparam name="TFormatFrameMetadata">The type of format frame metadata.</typeparam>
@@ -89,5 +90,33 @@ public sealed class ImageFrameMetadata : IDeepCloneable<ImageFrameMetadata>
         TFormatFrameMetadata newMeta = key.CreateDefaultFormatFrameMetadata();
         this.formatMetadata[key] = newMeta;
         return newMeta;
+    }
+
+    /// <summary>
+    /// Gets the metadata value associated with the specified key.
+    /// </summary>
+    /// <typeparam name="TFormatMetadata">The type of format metadata.</typeparam>
+    /// <typeparam name="TFormatFrameMetadata">The type of format frame metadata.</typeparam>
+    /// <param name="key">The key of the value to get.</param>
+    /// <param name="metadata">
+    /// When this method returns, contains the metadata associated with the specified key,
+    /// if the key is found; otherwise, the default value for the type of the metadata parameter.
+    /// This parameter is passed uninitialized.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the frame metadata exists for the specified key; otherwise, <see langword="false"/>.
+    /// </returns>
+    public bool TryGetFormatMetadata<TFormatMetadata, TFormatFrameMetadata>(IImageFormat<TFormatMetadata, TFormatFrameMetadata> key, out TFormatFrameMetadata metadata)
+        where TFormatMetadata : class
+        where TFormatFrameMetadata : class, IDeepCloneable
+    {
+        if (this.formatMetadata.TryGetValue(key, out IDeepCloneable meta))
+        {
+            metadata = (TFormatFrameMetadata)meta;
+            return true;
+        }
+
+        metadata = default;
+        return false;
     }
 }

--- a/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer{TPixel}.cs
@@ -106,7 +106,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
         // for higher bit depths. Lower bit depths will correctly reduce the palette.
         // TODO: Investigate more evenly reduced palette reduction.
         int max = this.maxColors;
-        if (this.bitDepth == 8)
+        if (this.bitDepth >= 4)
         {
             max--;
         }

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer.cs
@@ -49,12 +49,8 @@ public class PaletteQuantizer : IQuantizer
     {
         Guard.NotNull(options, nameof(options));
 
-        // The palette quantizer can reuse the same pixel map across multiple frames
-        // since the palette is unchanging. This allows a reduction of memory usage across
-        // multi frame gifs using a global palette.
-        int length = Math.Min(this.colorPalette.Length, options.MaxColors);
-        TPixel[] palette = new TPixel[length];
-
+        // Always use the palette length over options since the palette cannot be reduced.
+        TPixel[] palette = new TPixel[this.colorPalette.Length];
         Color.ToPixel(configuration, this.colorPalette.Span, palette.AsSpan());
         return new PaletteQuantizer<TPixel>(configuration, options, palette);
     }

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -203,8 +203,10 @@ public class GifEncoderTests
     }
 
     [Theory]
-    [WithFile(TestImages.Gif.Issues.Issue2288OptionalExtension, PixelTypes.Rgba32)]
-    [WithFile(TestImages.Gif.Issues.Issue2288OptionalExtension2, PixelTypes.Rgba32)]
+    [WithFile(TestImages.Gif.Issues.Issue2288_A, PixelTypes.Rgba32)]
+    [WithFile(TestImages.Gif.Issues.Issue2288_B, PixelTypes.Rgba32)]
+    [WithFile(TestImages.Gif.Issues.Issue2288_C, PixelTypes.Rgba32)]
+    [WithFile(TestImages.Gif.Issues.Issue2288_D, PixelTypes.Rgba32)]
     public void OptionalExtensionsShouldBeHandledProperly<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
     {

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -204,6 +204,7 @@ public class GifEncoderTests
 
     [Theory]
     [WithFile(TestImages.Gif.Issues.Issue2288OptionalExtension, PixelTypes.Rgba32)]
+    [WithFile(TestImages.Gif.Issues.Issue2288OptionalExtension2, PixelTypes.Rgba32)]
     public void OptionalExtensionsShouldBeHandledProperly<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
     {

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -201,4 +201,39 @@ public class GifEncoderTests
         image.Dispose();
         clone.Dispose();
     }
+
+    [Theory]
+    [WithFile(TestImages.Gif.Issues.Issue2288OptionalExtension, PixelTypes.Rgba32)]
+    public void OptionalExtensionsShouldBeHandledProperly<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage();
+
+        int count = 0;
+        foreach (ImageFrame<TPixel> frame in image.Frames)
+        {
+            if (frame.Metadata.TryGetGifMetadata(out GifFrameMetadata _))
+            {
+                count++;
+            }
+        }
+
+        provider.Utility.SaveTestOutputFile(image, extension: "gif");
+
+        using FileStream fs = File.OpenRead(provider.Utility.GetTestOutputFileName("gif"));
+        using Image<TPixel> image2 = Image.Load<TPixel>(fs);
+
+        Assert.Equal(image.Frames.Count, image2.Frames.Count);
+
+        count = 0;
+        foreach (ImageFrame<TPixel> frame in image2.Frames)
+        {
+            if (frame.Metadata.TryGetGifMetadata(out GifFrameMetadata _))
+            {
+                count++;
+            }
+        }
+
+        Assert.Equal(image2.Frames.Count, count);
+    }
 }

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderMultiframeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderMultiframeTests.cs
@@ -30,7 +30,9 @@ public class TiffEncoderMultiframeTests : TiffEncoderBaseTester
 
     [Theory]
     [WithFile(TestImages.Gif.Receipt, PixelTypes.Rgb24)]
-    [WithFile(TestImages.Gif.Issues.BadDescriptorWidth, PixelTypes.Rgba32)]
+
+    // MAGICK decoder makes the same mistake we did and clones the proceeding frame overwriting the differences.
+    // [WithFile(TestImages.Gif.Issues.BadDescriptorWidth, PixelTypes.Rgba32)]
     public void TiffEncoder_EncodeMultiframe_Convert<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit48, TiffPhotometricInterpretation.Rgb);
 

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -476,6 +476,7 @@ public static class TestImages
             public const string Issue1962NoColorTable = "Gif/issues/issue1962_tiniest_gif_1st.gif";
             public const string Issue2012EmptyXmp = "Gif/issues/issue2012_Stronghold-Crusader-Extreme-Cover.gif";
             public const string Issue2012BadMinCode = "Gif/issues/issue2012_drona1.gif";
+            public const string Issue2288OptionalExtension = "Gif/issues/issue_2288.gif";
         }
 
         public static readonly string[] All = { Rings, Giphy, Cheers, Trans, Kumin, Leo, Ratio4x1, Ratio1x4 };

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -477,6 +477,7 @@ public static class TestImages
             public const string Issue2012EmptyXmp = "Gif/issues/issue2012_Stronghold-Crusader-Extreme-Cover.gif";
             public const string Issue2012BadMinCode = "Gif/issues/issue2012_drona1.gif";
             public const string Issue2288OptionalExtension = "Gif/issues/issue_2288.gif";
+            public const string Issue2288OptionalExtension2 = "Gif/issues/issue_2288_2.gif";
         }
 
         public static readonly string[] All = { Rings, Giphy, Cheers, Trans, Kumin, Leo, Ratio4x1, Ratio1x4 };

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -476,8 +476,10 @@ public static class TestImages
             public const string Issue1962NoColorTable = "Gif/issues/issue1962_tiniest_gif_1st.gif";
             public const string Issue2012EmptyXmp = "Gif/issues/issue2012_Stronghold-Crusader-Extreme-Cover.gif";
             public const string Issue2012BadMinCode = "Gif/issues/issue2012_drona1.gif";
-            public const string Issue2288OptionalExtension = "Gif/issues/issue_2288.gif";
-            public const string Issue2288OptionalExtension2 = "Gif/issues/issue_2288_2.gif";
+            public const string Issue2288_A = "Gif/issues/issue_2288.gif";
+            public const string Issue2288_B = "Gif/issues/issue_2288_2.gif";
+            public const string Issue2288_C = "Gif/issues/issue_2288_3.gif";
+            public const string Issue2288_D = "Gif/issues/issue_2288_4.gif";
         }
 
         public static readonly string[] All = { Rings, Giphy, Cheers, Trans, Kumin, Leo, Ratio4x1, Ratio1x4 };

--- a/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ExactImageComparer.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ExactImageComparer.cs
@@ -12,6 +12,7 @@ public class ExactImageComparer : ImageComparer
     public static ExactImageComparer Instance { get; } = new ExactImageComparer();
 
     public override ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(
+        int index,
         ImageFrame<TPixelA> expected,
         ImageFrame<TPixelB> actual)
     {
@@ -52,6 +53,6 @@ public class ExactImageComparer : ImageComparer
             }
         }
 
-        return new ImageSimilarityReport<TPixelA, TPixelB>(expected, actual, differences);
+        return new ImageSimilarityReport<TPixelA, TPixelB>(index, expected, actual, differences);
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/ImageComparison/Exceptions/ImageDifferenceIsOverThresholdException.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageComparison/Exceptions/ImageDifferenceIsOverThresholdException.cs
@@ -36,7 +36,7 @@ public class ImageDifferenceIsOverThresholdException : ImagesSimilarityException
         int i = 0;
         foreach (ImageSimilarityReport r in reports)
         {
-            sb.Append("Report ImageFrame {i}: ");
+            sb.Append($"Report ImageFrame {i}: ");
             sb.Append(r);
             sb.Append(Environment.NewLine);
             i++;

--- a/tests/ImageSharp.Tests/TestUtilities/ImageComparison/Exceptions/ImageDifferenceIsOverThresholdException.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageComparison/Exceptions/ImageDifferenceIsOverThresholdException.cs
@@ -33,13 +33,11 @@ public class ImageDifferenceIsOverThresholdException : ImagesSimilarityException
         sb.AppendFormat("Test Environment is Mono : {0}", TestEnvironment.IsMono);
         sb.Append(Environment.NewLine);
 
-        int i = 0;
         foreach (ImageSimilarityReport r in reports)
         {
-            sb.Append($"Report ImageFrame {i}: ");
+            sb.AppendFormat("Report ImageFrame {0}: ", r.Index);
             sb.Append(r);
             sb.Append(Environment.NewLine);
-            i++;
         }
 
         return sb.ToString();

--- a/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageComparer.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageComparer.cs
@@ -27,6 +27,7 @@ public abstract class ImageComparer
         => Tolerant(imageThresholdInPercents / 100F, perPixelManhattanThreshold);
 
     public abstract ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(
+        int index,
         ImageFrame<TPixelA> expected,
         ImageFrame<TPixelB> actual)
         where TPixelA : unmanaged, IPixel<TPixelA>
@@ -40,7 +41,7 @@ public static class ImageComparerExtensions
         Image<TPixelA> expected,
         Image<TPixelB> actual)
         where TPixelA : unmanaged, IPixel<TPixelA>
-        where TPixelB : unmanaged, IPixel<TPixelB> => comparer.CompareImagesOrFrames(expected.Frames.RootFrame, actual.Frames.RootFrame);
+        where TPixelB : unmanaged, IPixel<TPixelB> => comparer.CompareImagesOrFrames(0, expected.Frames.RootFrame, actual.Frames.RootFrame);
 
     public static IEnumerable<ImageSimilarityReport<TPixelA, TPixelB>> CompareImages<TPixelA, TPixelB>(
         this ImageComparer comparer,
@@ -58,7 +59,7 @@ public static class ImageComparerExtensions
 
         for (int i = 0; i < expected.Frames.Count; i++)
         {
-            ImageSimilarityReport<TPixelA, TPixelB> report = comparer.CompareImagesOrFrames(expected.Frames[i], actual.Frames[i]);
+            ImageSimilarityReport<TPixelA, TPixelB> report = comparer.CompareImagesOrFrames(i, expected.Frames[i], actual.Frames[i]);
             if (!report.IsEmpty)
             {
                 result.Add(report);
@@ -125,7 +126,7 @@ public static class ImageComparerExtensions
 
                 if (outsideChanges.Any())
                 {
-                    cleanedReports.Add(new ImageSimilarityReport<TPixelA, TPixelB>(r.ExpectedImage, r.ActualImage, outsideChanges, null));
+                    cleanedReports.Add(new ImageSimilarityReport<TPixelA, TPixelB>(r.Index, r.ExpectedImage, r.ActualImage, outsideChanges, null));
                 }
             }
 

--- a/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageSimilarityReport.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageComparison/ImageSimilarityReport.cs
@@ -9,16 +9,20 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 public class ImageSimilarityReport
 {
     protected ImageSimilarityReport(
+        int index,
         object expectedImage,
         object actualImage,
         IEnumerable<PixelDifference> differences,
         float? totalNormalizedDifference = null)
     {
+        this.Index = index;
         this.ExpectedImage = expectedImage;
         this.ActualImage = actualImage;
         this.TotalNormalizedDifference = totalNormalizedDifference;
         this.Differences = differences.ToArray();
     }
+
+    public int Index { get; }
 
     public object ExpectedImage { get; }
 
@@ -89,16 +93,17 @@ public class ImageSimilarityReport<TPixelA, TPixelB> : ImageSimilarityReport
     where TPixelB : unmanaged, IPixel<TPixelB>
 {
     public ImageSimilarityReport(
+        int index,
         ImageFrame<TPixelA> expectedImage,
         ImageFrame<TPixelB> actualImage,
         IEnumerable<PixelDifference> differences,
         float? totalNormalizedDifference = null)
-        : base(expectedImage, actualImage, differences, totalNormalizedDifference)
+        : base(index, expectedImage, actualImage, differences, totalNormalizedDifference)
     {
     }
 
     public static ImageSimilarityReport<TPixelA, TPixelB> Empty =>
-        new ImageSimilarityReport<TPixelA, TPixelB>(null, null, Enumerable.Empty<PixelDifference>(), 0f);
+        new ImageSimilarityReport<TPixelA, TPixelB>(0, null, null, Enumerable.Empty<PixelDifference>(), 0f);
 
     public new ImageFrame<TPixelA> ExpectedImage => (ImageFrame<TPixelA>)base.ExpectedImage;
 

--- a/tests/ImageSharp.Tests/TestUtilities/ImageComparison/TolerantImageComparer.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageComparison/TolerantImageComparer.cs
@@ -56,7 +56,7 @@ public class TolerantImageComparer : ImageComparer
     /// </summary>
     public int PerPixelManhattanThreshold { get; }
 
-    public override ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(ImageFrame<TPixelA> expected, ImageFrame<TPixelB> actual)
+    public override ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(int index, ImageFrame<TPixelA> expected, ImageFrame<TPixelB> actual)
     {
         if (expected.Size() != actual.Size())
         {
@@ -103,7 +103,7 @@ public class TolerantImageComparer : ImageComparer
 
         if (normalizedDifference > this.ImageThreshold)
         {
-            return new ImageSimilarityReport<TPixelA, TPixelB>(expected, actual, differences, normalizedDifference);
+            return new ImageSimilarityReport<TPixelA, TPixelB>(index, expected, actual, differences, normalizedDifference);
         }
         else
         {

--- a/tests/Images/Input/Gif/issues/issue_2288.gif
+++ b/tests/Images/Input/Gif/issues/issue_2288.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d38bc98de425322bc0d435b7ff538c170897bfc728ea77ee26dd172106dcf99a
+size 1223216

--- a/tests/Images/Input/Gif/issues/issue_2288_2.gif
+++ b/tests/Images/Input/Gif/issues/issue_2288_2.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8919e83c8a19502b3217c75e0a7c98be46732c2126816f8882e9bed19478ded7
+size 811449

--- a/tests/Images/Input/Gif/issues/issue_2288_3.gif
+++ b/tests/Images/Input/Gif/issues/issue_2288_3.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3f0fd68a03e9c1c896e021828f470d9ceeb8f10e1aead230e42e55670520840
+size 958995

--- a/tests/Images/Input/Gif/issues/issue_2288_4.gif
+++ b/tests/Images/Input/Gif/issues/issue_2288_4.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ac8bc8677a1eb4e26161e5255a5c651321ff063892f3caec3f95264aee38057
+size 1971226


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Fixes #2288 

This PR does a few things
- Ensures that Graphics Control Extension blocks are read and written correctly
- No longer clones the entire previous frame on decode and only write what we need. This was causing some gif sizes to explode.
- Fixes decode transparency flag handling.
- Ensures palette quantizer enables the whole palette
- Changes lower bit threshold for octree hack to ensure a transparent palette entry is maintained
- Allows mixing of global and local color tables per frame as per specification.
- Fixes the comparer to output the correct frames index.
- Fixes bad XMP handling

![OptionalExtensionsShouldBeHandledProperly_Rgba32_issue_2288](https://user-images.githubusercontent.com/385879/200540334-4e410191-6a5b-4e62-a7e0-5e7f8ca247cb.gif)
![OptionalExtensionsShouldBeHandledProperly_Rgba32_issue_2288_2](https://user-images.githubusercontent.com/385879/200540344-6009dc68-2d44-4c5d-800a-e8f806c49ad2.gif)


<!-- Thanks for contributing to ImageSharp! -->
