### PR TITLE
Fix small deviation to the spec when encoding tiff images

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -244,6 +244,12 @@ internal sealed class TiffEncoderCore : IImageEncoderInternals
         entriesCollector.ProcessFrameInfo(frame, imageMetadata);
         entriesCollector.ProcessImageFormat(this);
 
+        if (writer.Position % 2 != 0)
+        {
+            // Write padding byte, because the tiff spec requires ifd offset to begin on a word boundary.
+            writer.Write(0);
+        }
+
         this.frameMarkers.Add((ifdOffset, (uint)writer.Position));
 
         return this.WriteIfd(writer, entriesCollector.Entries);

--- a/src/ImageSharp/Formats/Tiff/TiffEncoderEntriesCollector.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderEntriesCollector.cs
@@ -278,7 +278,7 @@ internal class TiffEncoderEntriesCollector
                 Value = (ushort)TiffPlanarConfiguration.Chunky
             };
 
-            ExifLong samplesPerPixel = new(ExifTagValue.SamplesPerPixel)
+            ExifShort samplesPerPixel = new(ExifTagValue.SamplesPerPixel)
             {
                 Value = GetSamplesPerPixel(encoder)
             };
@@ -317,7 +317,7 @@ internal class TiffEncoderEntriesCollector
             }
         }
 
-        private static uint GetSamplesPerPixel(TiffEncoderCore encoder)
+        private static ushort GetSamplesPerPixel(TiffEncoderCore encoder)
             => encoder.PhotometricInterpretation switch
             {
                 TiffPhotometricInterpretation.PaletteColor or

--- a/src/ImageSharp/Formats/Tiff/TiffEncoderEntriesCollector.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderEntriesCollector.cs
@@ -178,7 +178,7 @@ internal class TiffEncoderEntriesCollector
                     Value = imageMetadata.IptcProfile.Data
                 };
 
-                this.Collector.Add(iptc);
+                this.Collector.AddOrReplace(iptc);
             }
             else
             {
@@ -192,7 +192,7 @@ internal class TiffEncoderEntriesCollector
                     Value = imageMetadata.IccProfile.ToByteArray()
                 };
 
-                this.Collector.Add(icc);
+                this.Collector.AddOrReplace(icc);
             }
             else
             {
@@ -206,7 +206,7 @@ internal class TiffEncoderEntriesCollector
                     Value = xmpProfile.Data
                 };
 
-                this.Collector.Add(xmp);
+                this.Collector.AddOrReplace(xmp);
             }
             else
             {

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -246,6 +246,25 @@ public class TiffEncoderTests : TiffEncoderBaseTester
         Assert.Equal(expectedPredictor, frameMetadata.Predictor);
     }
 
+    // https://github.com/SixLabors/ImageSharp/issues/2297
+    [Fact]
+    public void TiffEncoder_WritesIfdOffsetAtWordBoundary()
+    {
+        // arrange
+        var tiffEncoder = new TiffEncoder();
+        using var memStream = new MemoryStream();
+        using Image<Rgba32> image = new(1, 1);
+        byte[] expectedIfdOffsetBytes = { 12, 0 };
+
+        // act
+        image.Save(memStream, tiffEncoder);
+
+        // assert
+        byte[] imageBytes = memStream.ToArray();
+        Assert.Equal(imageBytes[4], expectedIfdOffsetBytes[0]);
+        Assert.Equal(imageBytes[5], expectedIfdOffsetBytes[1]);
+    }
+
     [Theory]
     [WithFile(RgbUncompressed, PixelTypes.Rgba32, TiffCompression.CcittGroup3Fax, TiffCompression.CcittGroup3Fax)]
     [WithFile(RgbUncompressed, PixelTypes.Rgba32, TiffCompression.CcittGroup4Fax, TiffCompression.CcittGroup4Fax)]

--- a/tests/Images/Input/Tiff/metadata_sample.tiff
+++ b/tests/Images/Input/Tiff/metadata_sample.tiff
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72a1c8022d699e0e7248940f0734d01d6ab9bf4a71022e8b5626b64d66a5f39d
-size 8107
+oid sha256:c2f20e3ebb51b743b635377b93e78a6dc91c07ca97be38f500c4d6d3c465d9c1
+size 3472


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR fixes the following issues when encoding tiff images:
- Write padding byte, because the tiff spec requires ifd offset to begin on a word boundary.
- Change samples per pixel to ushort

Closes #2297