### PR TITLE
Remove #nullable disable from ExifProfile

### DIFF
--- a/src/ImageSharp/Common/Helpers/UnitConverter.cs
+++ b/src/ImageSharp/Common/Helpers/UnitConverter.cs
@@ -91,10 +91,13 @@ internal static class UnitConverter
     [MethodImpl(InliningOptions.ShortMethod)]
     public static PixelResolutionUnit ExifProfileToResolutionUnit(ExifProfile profile)
     {
-        IExifValue<ushort>? resolution = profile.GetValue(ExifTag.ResolutionUnit);
+        if (profile.TryGetValue(ExifTag.ResolutionUnit, out IExifValue<ushort>? resolution))
+        {
+            // EXIF is 1, 2, 3 so we minus "1" off the result.
+            return (PixelResolutionUnit)(byte)(resolution.Value - 1);
+        }
 
-        // EXIF is 1, 2, 3 so we minus "1" off the result.
-        return resolution is null ? DefaultResolutionUnit : (PixelResolutionUnit)(byte)(resolution.Value - 1);
+        return DefaultResolutionUnit;
     }
 
     /// <summary>

--- a/src/ImageSharp/Common/Helpers/UnitConverter.cs
+++ b/src/ImageSharp/Common/Helpers/UnitConverter.cs
@@ -91,7 +91,7 @@ internal static class UnitConverter
     [MethodImpl(InliningOptions.ShortMethod)]
     public static PixelResolutionUnit ExifProfileToResolutionUnit(ExifProfile profile)
     {
-        IExifValue<ushort> resolution = profile.GetValue(ExifTag.ResolutionUnit);
+        IExifValue<ushort>? resolution = profile.GetValue(ExifTag.ResolutionUnit);
 
         // EXIF is 1, 2, 3 so we minus "1" off the result.
         return resolution is null ? DefaultResolutionUnit : (PixelResolutionUnit)(byte)(resolution.Value - 1);

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -705,9 +705,12 @@ internal sealed class JpegDecoderCore : IRawJpegData, IImageDecoderInternals
 
     private double GetExifResolutionValue(ExifTag<Rational> tag)
     {
-        IExifValue<Rational> resolution = this.Metadata.ExifProfile.GetValue(tag);
+        if (this.Metadata.ExifProfile.TryGetValue(tag, out IExifValue<Rational> resolution))
+        {
+            return resolution.Value.ToDouble();
+        }
 
-        return resolution is null ? 0 : resolution.Value.ToDouble();
+        return 0;
     }
 
     /// <summary>

--- a/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffBitsPerSample.cs
@@ -82,7 +82,7 @@ public readonly struct TiffBitsPerSample : IEquatable<TiffBitsPerSample>
     /// <param name="value">The value to parse.</param>
     /// <param name="sample">The tiff bits per sample.</param>
     /// <returns>True, if the value could be parsed.</returns>
-    public static bool TryParse(ushort[] value, out TiffBitsPerSample sample)
+    public static bool TryParse(ushort[]? value, out TiffBitsPerSample sample)
     {
         if (value is null || value.Length == 0)
         {

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -793,7 +793,7 @@ internal class TiffDecoderCore : IImageDecoderInternals
     {
         if (!exifProfile.TryGetValue(ExifTag.ImageWidth, out IExifValue<Number> width))
         {
-            TiffThrowHelper.ThrowImageFormatException("The TIFF image frame is missing the ImageWidth");
+            TiffThrowHelper.ThrowInvalidImageContentException("The TIFF image frame is missing the ImageWidth");
         }
 
         DebugGuard.MustBeLessThanOrEqualTo((ulong)width.Value, (ulong)int.MaxValue, nameof(ExifTag.ImageWidth));

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderMetadataCreator.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderMetadataCreator.cs
@@ -38,14 +38,12 @@ internal static class TiffDecoderMetadataCreator
                     frameMetaData.IptcProfile = new IptcProfile(iptcBytes);
                 }
 
-                IExifValue<byte[]> xmpProfileBytes = frameMetaData.ExifProfile.GetValue(ExifTag.XMP);
-                if (xmpProfileBytes != null)
+                if (frameMetaData.ExifProfile.TryGetValue(ExifTag.XMP, out IExifValue<byte[]> xmpProfileBytes))
                 {
                     frameMetaData.XmpProfile = new XmpProfile(xmpProfileBytes.Value);
                 }
 
-                IExifValue<byte[]> iccProfileBytes = frameMetaData.ExifProfile.GetValue(ExifTag.IccProfile);
-                if (iccProfileBytes != null)
+                if (frameMetaData.ExifProfile.TryGetValue(ExifTag.IccProfile, out IExifValue<byte[]> iccProfileBytes))
                 {
                     frameMetaData.IccProfile = new IccProfile(iccProfileBytes.Value);
                 }
@@ -70,16 +68,20 @@ internal static class TiffDecoderMetadataCreator
     private static void SetResolution(ImageMetadata imageMetaData, ExifProfile exifProfile)
     {
         imageMetaData.ResolutionUnits = exifProfile != null ? UnitConverter.ExifProfileToResolutionUnit(exifProfile) : PixelResolutionUnit.PixelsPerInch;
-        double? horizontalResolution = exifProfile?.GetValue(ExifTag.XResolution)?.Value.ToDouble();
-        if (horizontalResolution != null)
+
+        if (exifProfile is null)
         {
-            imageMetaData.HorizontalResolution = horizontalResolution.Value;
+            return;
         }
 
-        double? verticalResolution = exifProfile?.GetValue(ExifTag.YResolution)?.Value.ToDouble();
-        if (verticalResolution != null)
+        if (exifProfile.TryGetValue(ExifTag.XResolution, out IExifValue<Rational> horizontalResolution))
         {
-            imageMetaData.VerticalResolution = verticalResolution.Value;
+            imageMetaData.HorizontalResolution = horizontalResolution.Value.ToDouble();
+        }
+
+        if (exifProfile.TryGetValue(ExifTag.YResolution, out IExifValue<Rational> verticalResolution))
+        {
+            imageMetaData.VerticalResolution = verticalResolution.Value.ToDouble();
         }
     }
 

--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -164,8 +164,6 @@ internal sealed class TiffEncoderCore : IImageEncoderInternals
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            TiffNewSubfileType subfileType = (TiffNewSubfileType)(frame.Metadata.ExifProfile?.GetValue(ExifTag.SubfileType)?.Value ?? (int)TiffNewSubfileType.FullImage);
-
             ifdMarker = this.WriteFrame(writer, frame, image.Metadata, metadataImage, ifdMarker);
             metadataImage = null;
         }

--- a/src/ImageSharp/Formats/Tiff/TiffFrameMetadata.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffFrameMetadata.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using SixLabors.ImageSharp.Formats.Tiff.Constants;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
@@ -78,15 +77,30 @@ public class TiffFrameMetadata : IDeepCloneable
     {
         if (profile != null)
         {
-            if (TiffBitsPerSample.TryParse(profile.GetValue(ExifTag.BitsPerSample)?.Value, out TiffBitsPerSample bitsPerSample))
+            if (profile.TryGetValue(ExifTag.BitsPerSample, out IExifValue<ushort[]>? bitsPerSampleValue))
             {
-                meta.BitsPerSample = bitsPerSample;
+                if (TiffBitsPerSample.TryParse(bitsPerSampleValue.Value, out TiffBitsPerSample bitsPerSample))
+                {
+                    meta.BitsPerSample = bitsPerSample;
+                }
             }
 
             meta.BitsPerPixel = meta.BitsPerSample?.BitsPerPixel();
-            meta.Compression = (TiffCompression?)profile.GetValue(ExifTag.Compression)?.Value;
-            meta.PhotometricInterpretation = (TiffPhotometricInterpretation?)profile.GetValue(ExifTag.PhotometricInterpretation)?.Value;
-            meta.Predictor = (TiffPredictor?)profile.GetValue(ExifTag.Predictor)?.Value;
+
+            if (profile.TryGetValue(ExifTag.Compression, out IExifValue<ushort>? compressionValue))
+            {
+                meta.Compression = (TiffCompression)compressionValue.Value;
+            }
+
+            if (profile.TryGetValue(ExifTag.PhotometricInterpretation, out IExifValue<ushort>? photometricInterpretationValue))
+            {
+                meta.PhotometricInterpretation = (TiffPhotometricInterpretation)photometricInterpretationValue.Value;
+            }
+
+            if (profile.TryGetValue(ExifTag.Predictor, out IExifValue<ushort>? predictorValue))
+            {
+                meta.Predictor = (TiffPredictor)predictorValue.Value;
+            }
 
             profile.RemoveValue(ExifTag.BitsPerSample);
             profile.RemoveValue(ExifTag.Compression);

--- a/src/ImageSharp/Formats/Tiff/TiffThrowHelper.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffThrowHelper.cs
@@ -11,6 +11,9 @@ internal static class TiffThrowHelper
     public static Exception ThrowImageFormatException(string errorMessage) => throw new ImageFormatException(errorMessage);
 
     [DoesNotReturn]
+    public static Exception ThrowInvalidImageContentException(string errorMessage) => throw new InvalidImageContentException(errorMessage);
+
+    [DoesNotReturn]
     public static Exception NotSupportedDecompressor(string compressionType) => throw new NotSupportedException($"Not supported decoder compression method: {compressionType}");
 
     [DoesNotReturn]

--- a/src/ImageSharp/Formats/Tiff/TiffThrowHelper.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffThrowHelper.cs
@@ -1,21 +1,30 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace SixLabors.ImageSharp.Formats.Tiff;
 
 internal static class TiffThrowHelper
 {
+    [DoesNotReturn]
     public static Exception ThrowImageFormatException(string errorMessage) => throw new ImageFormatException(errorMessage);
 
+    [DoesNotReturn]
     public static Exception NotSupportedDecompressor(string compressionType) => throw new NotSupportedException($"Not supported decoder compression method: {compressionType}");
 
+    [DoesNotReturn]
     public static Exception NotSupportedCompressor(string compressionType) => throw new NotSupportedException($"Not supported encoder compression method: {compressionType}");
 
+    [DoesNotReturn]
     public static Exception InvalidColorType(string colorType) => throw new NotSupportedException($"Invalid color type: {colorType}");
 
+    [DoesNotReturn]
     public static Exception ThrowInvalidHeader() => throw new ImageFormatException("Invalid TIFF file header.");
 
+    [DoesNotReturn]
     public static void ThrowNotSupported(string message) => throw new NotSupportedException(message);
 
+    [DoesNotReturn]
     public static void ThrowArgumentException(string message) => throw new ArgumentException(message);
 }

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Buffers.Binary;
 using System.Text;
@@ -27,7 +26,8 @@ internal static class ExifEncodedStringHelpers
 
     // 20932 EUC-JP Japanese (JIS 0208-1990 and 0212-1990)
     // https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding?view=net-6.0
-    private static Encoding JIS0208Encoding => CodePagesEncodingProvider.Instance.GetEncoding(20932);
+    private static Encoding JIS0208Encoding => CodePagesEncodingProvider.Instance.GetEncoding(20932) ??
+                                               throw new InvalidOperationException();
 
     public static bool IsEncodedString(ExifTagValue tag) => tag switch
     {

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
@@ -26,8 +26,7 @@ internal static class ExifEncodedStringHelpers
 
     // 20932 EUC-JP Japanese (JIS 0208-1990 and 0212-1990)
     // https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding?view=net-6.0
-    private static Encoding JIS0208Encoding => CodePagesEncodingProvider.Instance.GetEncoding(20932) ??
-                                               throw new InvalidOperationException();
+    private static Encoding JIS0208Encoding => Encoding.GetEncoding(20932);
 
     public static bool IsEncodedString(ExifTagValue tag) => tag switch
     {

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifEncodedStringHelpers.cs
@@ -26,7 +26,14 @@ internal static class ExifEncodedStringHelpers
 
     // 20932 EUC-JP Japanese (JIS 0208-1990 and 0212-1990)
     // https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding?view=net-6.0
-    private static Encoding JIS0208Encoding => Encoding.GetEncoding(20932);
+    private static Encoding JIS0208Encoding
+    {
+        get
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            return Encoding.GetEncoding(20932);
+        }
+    }
 
     public static bool IsEncodedString(ExifTagValue tag) => tag switch
     {

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Metadata.Profiles.Exif;
@@ -14,12 +15,12 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// <summary>
     /// The byte array to read the EXIF profile from.
     /// </summary>
-    private readonly byte[] data;
+    private readonly byte[]? data;
 
     /// <summary>
     /// The collection of EXIF values
     /// </summary>
-    private List<IExifValue> values;
+    private List<IExifValue>? values;
 
     /// <summary>
     /// The thumbnail offset position in the byte stream
@@ -35,7 +36,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// Initializes a new instance of the <see cref="ExifProfile"/> class.
     /// </summary>
     public ExifProfile()
-        : this((byte[])null)
+        : this((byte[]?)null)
     {
     }
 
@@ -43,7 +44,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// Initializes a new instance of the <see cref="ExifProfile"/> class.
     /// </summary>
     /// <param name="data">The byte array to read the EXIF profile from.</param>
-    public ExifProfile(byte[] data)
+    public ExifProfile(byte[]? data)
     {
         this.Parts = ExifParts.All;
         this.data = data;
@@ -110,6 +111,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// <summary>
     /// Gets the values of this EXIF profile.
     /// </summary>
+    [MemberNotNull(nameof(values))]
     public IReadOnlyList<IExifValue> Values
     {
         get
@@ -125,7 +127,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// <returns>
     /// The <see cref="Image"/>.
     /// </returns>
-    public Image CreateThumbnail() => this.CreateThumbnail<Rgba32>();
+    public Image? CreateThumbnail() => this.CreateThumbnail<Rgba32>();
 
     /// <summary>
     /// Returns the thumbnail in the EXIF profile when available.
@@ -134,7 +136,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// <returns>
     /// The <see cref="Image{TPixel}"/>.
     /// </returns>
-    public Image<TPixel> CreateThumbnail<TPixel>()
+    public Image<TPixel>? CreateThumbnail<TPixel>()
         where TPixel : unmanaged, IPixel<TPixel>
     {
         this.InitializeValues();
@@ -161,9 +163,9 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// <param name="tag">The tag of the exif value.</param>
     /// <returns>The value with the specified tag.</returns>
     /// <typeparam name="TValueType">The data type of the tag.</typeparam>
-    public IExifValue<TValueType> GetValue<TValueType>(ExifTag<TValueType> tag)
+    public IExifValue<TValueType>? GetValue<TValueType>(ExifTag<TValueType> tag)
     {
-        IExifValue value = this.GetValueInternal(tag);
+        IExifValue? value = this.GetValueInternal(tag);
         return value is null ? null : (IExifValue<TValueType>)value;
     }
 
@@ -203,7 +205,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// Converts this instance to a byte array.
     /// </summary>
     /// <returns>The <see cref="T:byte[]"/></returns>
-    public byte[] ToByteArray()
+    public byte[]? ToByteArray()
     {
         if (this.values is null)
         {
@@ -227,7 +229,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// </summary>
     /// <param name="tag">The tag of the exif value.</param>
     /// <returns>The value with the specified tag.</returns>
-    internal IExifValue GetValueInternal(ExifTag tag)
+    internal IExifValue? GetValueInternal(ExifTag tag)
     {
         foreach (IExifValue exifValue in this.Values)
         {
@@ -245,7 +247,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// </summary>
     /// <param name="tag">The tag of the exif value.</param>
     /// <param name="value">The value.</param>
-    internal void SetValueInternal(ExifTag tag, object value)
+    internal void SetValueInternal(ExifTag tag, object? value)
     {
         foreach (IExifValue exifValue in this.Values)
         {
@@ -256,7 +258,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
             }
         }
 
-        ExifValue newExifValue = ExifValues.Create(tag);
+        ExifValue? newExifValue = ExifValues.Create(tag);
         if (newExifValue is null)
         {
             throw new NotSupportedException();
@@ -278,7 +280,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
 
     private void SyncResolution(ExifTag<Rational> tag, double resolution)
     {
-        IExifValue<Rational> value = this.GetValue(tag);
+        IExifValue<Rational>? value = this.GetValue(tag);
 
         if (value is null)
         {
@@ -294,6 +296,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
         this.SetValue(tag, newResolution);
     }
 
+    [MemberNotNull(nameof(values))]
     private void InitializeValues()
     {
         if (this.values != null)

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
@@ -124,36 +124,47 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// <summary>
     /// Returns the thumbnail in the EXIF profile when available.
     /// </summary>
+    /// <param name="image">The thumbnail</param>
     /// <returns>
-    /// The <see cref="Image"/>.
+    /// True, if there is a thumbnail otherwise false.
     /// </returns>
-    public Image? CreateThumbnail() => this.CreateThumbnail<Rgba32>();
+    public bool TryCreateThumbnail([NotNullWhen(true)] out Image? image)
+    {
+        if (this.TryCreateThumbnail(out Image<Rgba32>? innerimage))
+        {
+            image = innerimage;
+            return true;
+        }
+
+        image = null;
+        return false;
+    }
 
     /// <summary>
     /// Returns the thumbnail in the EXIF profile when available.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    /// <returns>
-    /// The <see cref="Image{TPixel}"/>.
-    /// </returns>
-    public Image<TPixel>? CreateThumbnail<TPixel>()
+    /// <param name="image">The thumbnail.</param>
+    /// <returns>True, if there is a thumbnail otherwise false.</returns>
+    public bool TryCreateThumbnail<TPixel>([NotNullWhen(true)] out Image<TPixel>? image)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         this.InitializeValues();
-
+        image = null;
         if (this.thumbnailOffset == 0 || this.thumbnailLength == 0)
         {
-            return null;
+            return false;
         }
 
         if (this.data is null || this.data.Length < (this.thumbnailOffset + this.thumbnailLength))
         {
-            return null;
+            return false;
         }
 
         using (var memStream = new MemoryStream(this.data, this.thumbnailOffset, this.thumbnailLength))
         {
-            return Image.Load<TPixel>(memStream);
+            image = Image.Load<TPixel>(memStream);
+            return true;
         }
     }
 

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifProfile.cs
@@ -172,12 +172,21 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
     /// Returns the value with the specified tag.
     /// </summary>
     /// <param name="tag">The tag of the exif value.</param>
-    /// <returns>The value with the specified tag.</returns>
+    /// <param name="exifValue">The value with the specified tag.</param>
+    /// <returns>True when found, otherwise false</returns>
     /// <typeparam name="TValueType">The data type of the tag.</typeparam>
-    public IExifValue<TValueType>? GetValue<TValueType>(ExifTag<TValueType> tag)
+    public bool TryGetValue<TValueType>(ExifTag<TValueType> tag, [NotNullWhen(true)] out IExifValue<TValueType>? exifValue)
     {
         IExifValue? value = this.GetValueInternal(tag);
-        return value is null ? null : (IExifValue<TValueType>)value;
+
+        if (value is null)
+        {
+            exifValue = null;
+            return false;
+        }
+
+        exifValue = (IExifValue<TValueType>)value;
+        return true;
     }
 
     /// <summary>
@@ -291,9 +300,7 @@ public sealed class ExifProfile : IDeepCloneable<ExifProfile>
 
     private void SyncResolution(ExifTag<Rational> tag, double resolution)
     {
-        IExifValue<Rational>? value = this.GetValue(tag);
-
-        if (value is null)
+        if (!this.TryGetValue(tag, out IExifValue<Rational>? value))
         {
             return;
         }

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifReader.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifReader.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Buffers;
 using System.Buffers.Binary;
@@ -20,7 +19,7 @@ internal class ExifReader : BaseExifReader
     {
     }
 
-    public ExifReader(byte[] exifData, MemoryAllocator allocator)
+    public ExifReader(byte[] exifData, MemoryAllocator? allocator)
         : base(new MemoryStream(exifData ?? throw new ArgumentNullException(nameof(exifData))), allocator)
     {
     }
@@ -90,13 +89,13 @@ internal abstract class BaseExifReader
     private readonly byte[] buf4 = new byte[4];
     private readonly byte[] buf2 = new byte[2];
 
-    private readonly MemoryAllocator allocator;
+    private readonly MemoryAllocator? allocator;
     private readonly Stream data;
-    private List<ExifTag> invalidTags;
+    private List<ExifTag>? invalidTags;
 
-    private List<ulong> subIfds;
+    private List<ulong>? subIfds;
 
-    protected BaseExifReader(Stream stream, MemoryAllocator allocator)
+    protected BaseExifReader(Stream stream, MemoryAllocator? allocator)
     {
         this.data = stream ?? throw new ArgumentNullException(nameof(stream));
         this.allocator = allocator;
@@ -219,7 +218,7 @@ internal abstract class BaseExifReader
         this.Seek(tag.Offset);
         if (this.TryReadSpan(buffer))
         {
-            object value = this.ConvertValue(tag.DataType, buffer, tag.NumberOfComponents > 1 || tag.Exif.IsArray);
+            object? value = this.ConvertValue(tag.DataType, buffer, tag.NumberOfComponents > 1 || tag.Exif.IsArray);
             this.Add(values, tag.Exif, value);
         }
     }
@@ -255,7 +254,7 @@ internal abstract class BaseExifReader
 
     private static byte ConvertToByte(ReadOnlySpan<byte> buffer) => buffer[0];
 
-    private object ConvertValue(ExifDataType dataType, ReadOnlySpan<byte> buffer, bool isArray)
+    private object? ConvertValue(ExifDataType dataType, ReadOnlySpan<byte> buffer, bool isArray)
     {
         if (buffer.Length == 0)
         {
@@ -390,7 +389,7 @@ internal abstract class BaseExifReader
             numberOfComponents = 4 / ExifDataTypes.GetSize(dataType);
         }
 
-        ExifValue exifValue = ExifValues.Create(tag) ?? ExifValues.Create(tag, dataType, numberOfComponents);
+        ExifValue? exifValue = ExifValues.Create(tag) ?? ExifValues.Create(tag, dataType, numberOfComponents);
 
         if (exifValue is null)
         {
@@ -414,7 +413,7 @@ internal abstract class BaseExifReader
         }
         else
         {
-            object value = this.ConvertValue(dataType, offsetBuffer[..(int)size], numberOfComponents > 1 || exifValue.IsArray);
+            object? value = this.ConvertValue(dataType, offsetBuffer[..(int)size], numberOfComponents > 1 || exifValue.IsArray);
             this.Add(values, exifValue, value);
         }
     }
@@ -443,7 +442,7 @@ internal abstract class BaseExifReader
             numberOfComponents = 8 / ExifDataTypes.GetSize(dataType);
         }
 
-        ExifValue exifValue = tag switch
+        ExifValue? exifValue = tag switch
         {
             ExifTagValue.StripOffsets => new ExifLong8Array(ExifTagValue.StripOffsets),
             ExifTagValue.StripByteCounts => new ExifLong8Array(ExifTagValue.StripByteCounts),
@@ -471,12 +470,12 @@ internal abstract class BaseExifReader
         }
         else
         {
-            object value = this.ConvertValue(dataType, offsetBuffer[..(int)size], numberOfComponents > 1 || exifValue.IsArray);
+            object? value = this.ConvertValue(dataType, offsetBuffer[..(int)size], numberOfComponents > 1 || exifValue.IsArray);
             this.Add(values, exifValue, value);
         }
     }
 
-    private void Add(IList<IExifValue> values, IExifValue exif, object value)
+    private void Add(IList<IExifValue> values, IExifValue exif, object? value)
     {
         if (!exif.TrySetValue(value))
         {
@@ -510,7 +509,7 @@ internal abstract class BaseExifReader
     private void AddInvalidTag(ExifTag tag)
         => (this.invalidTags ??= new List<ExifTag>()).Add(tag);
 
-    private void AddSubIfd(object val)
+    private void AddSubIfd(object? val)
         => (this.subIfds ??= new List<ulong>()).Add(Convert.ToUInt64(val, CultureInfo.InvariantCulture));
 
     private void Seek(ulong pos)

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifReader.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifReader.cs
@@ -22,6 +22,7 @@ internal class ExifReader : BaseExifReader
     public ExifReader(byte[] exifData, MemoryAllocator? allocator)
         : base(new MemoryStream(exifData ?? throw new ArgumentNullException(nameof(exifData))), allocator)
     {
+        // TODO: We never call this constructor passing a non-null allocator.
     }
 
     /// <summary>

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifTagDescriptionAttribute.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifTagDescriptionAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace SixLabors.ImageSharp.Metadata.Profiles.Exif;
@@ -25,17 +26,20 @@ internal sealed class ExifTagDescriptionAttribute : Attribute
     /// </summary>
     /// <param name="tag">The tag.</param>
     /// <param name="value">The value.</param>
+    /// <param name="description">The description.</param>
     /// <returns>
-    /// The <see cref="string"/>.
+    /// True when description was found
     /// </returns>
-    public static string? GetDescription(ExifTag tag, object? value)
+    public static bool TryGetDescription(ExifTag tag, object? value, [NotNullWhen(true)] out string? description)
     {
-        var tagValue = (ExifTagValue)(ushort)tag;
+        ExifTagValue tagValue = (ExifTagValue)(ushort)tag;
         FieldInfo? field = typeof(ExifTagValue).GetField(tagValue.ToString(), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        description = null;
 
         if (field is null)
         {
-            return null;
+            return false;
         }
 
         foreach (CustomAttributeData customAttribute in field.CustomAttributes)
@@ -44,10 +48,12 @@ internal sealed class ExifTagDescriptionAttribute : Attribute
 
             if (Equals(attributeValue, value))
             {
-                return (string?)customAttribute.ConstructorArguments[1].Value;
+                description = (string?)customAttribute.ConstructorArguments[1].Value;
+
+                return description is not null;
             }
         }
 
-        return null;
+        return false;
     }
 }

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifTagDescriptionAttribute.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifTagDescriptionAttribute.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Reflection;
 
@@ -29,10 +28,10 @@ internal sealed class ExifTagDescriptionAttribute : Attribute
     /// <returns>
     /// The <see cref="string"/>.
     /// </returns>
-    public static string GetDescription(ExifTag tag, object value)
+    public static string? GetDescription(ExifTag tag, object? value)
     {
         var tagValue = (ExifTagValue)(ushort)tag;
-        FieldInfo field = typeof(ExifTagValue).GetField(tagValue.ToString(), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        FieldInfo? field = typeof(ExifTagValue).GetField(tagValue.ToString(), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
 
         if (field is null)
         {
@@ -41,11 +40,11 @@ internal sealed class ExifTagDescriptionAttribute : Attribute
 
         foreach (CustomAttributeData customAttribute in field.CustomAttributes)
         {
-            object attributeValue = customAttribute.ConstructorArguments[0].Value;
+            object? attributeValue = customAttribute.ConstructorArguments[0].Value;
 
             if (Equals(attributeValue, value))
             {
-                return (string)customAttribute.ConstructorArguments[1].Value;
+                return (string?)customAttribute.ConstructorArguments[1].Value;
             }
         }
 

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifWriter.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifWriter.cs
@@ -179,9 +179,11 @@ internal sealed class ExifWriter
             }
 
             ExifValue? result = ExifValues.Create(offset);
-            Guard.NotNull(result);
 
-            ifdValues.Add(result);
+            if (result is not null)
+            {
+                ifdValues.Add(result);
+            }
 
             return result;
         }

--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifWriter.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifWriter.cs
@@ -90,7 +90,7 @@ internal sealed class ExifWriter
         if (gpsLength > 0)
         {
             i = this.WriteHeaders(this.gpsValues, result, i);
-            i = this.WriteData(startIndex, this.gpsValues, result, i);
+            this.WriteData(startIndex, this.gpsValues, result, i);
         }
 
         return result;
@@ -228,9 +228,8 @@ internal sealed class ExifWriter
             return false;
         }
 
-        if (exifValue.DataType == ExifDataType.Ascii)
+        if (exifValue.DataType == ExifDataType.Ascii && value is string stringValue)
         {
-            string stringValue = (string)value;
             return stringValue.Length > 0;
         }
 

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifArrayValue{TValueType}.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifArrayValue{TValueType}.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 namespace SixLabors.ImageSharp.Metadata.Profiles.Exif;
 
@@ -23,11 +22,11 @@ internal abstract class ExifArrayValue<TValueType> : ExifValue, IExifValue<TValu
 
     public override bool IsArray => true;
 
-    public TValueType[] Value { get; set; }
+    public TValueType[]? Value { get; set; }
 
-    public override object GetValue() => this.Value;
+    public override object? GetValue() => this.Value;
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (value is null)
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifByte.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifByte.cs
@@ -20,7 +20,7 @@ internal sealed class ExifByte : ExifValue<byte>
 
     protected override string StringValue => this.Value.ToString("X2", CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifByteArray.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifByteArray.cs
@@ -16,7 +16,7 @@ internal sealed class ExifByteArray : ExifArrayValue<byte>
 
     public override ExifDataType DataType { get; }
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifDouble.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifDouble.cs
@@ -26,7 +26,7 @@ internal sealed class ExifDouble : ExifValue<double>
 
     protected override string StringValue => this.Value.ToString(CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifEncodedString.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifEncodedString.cs
@@ -24,7 +24,7 @@ internal sealed class ExifEncodedString : ExifValue<EncodedString>
 
     protected override string StringValue => this.Value.Text;
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifFloat.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifFloat.cs
@@ -21,7 +21,7 @@ internal sealed class ExifFloat : ExifValue<float>
 
     protected override string StringValue => this.Value.ToString(CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifLong.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifLong.cs
@@ -26,7 +26,7 @@ internal sealed class ExifLong : ExifValue<uint>
 
     protected override string StringValue => this.Value.ToString(CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifLong8.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifLong8.cs
@@ -26,7 +26,7 @@ internal sealed class ExifLong8 : ExifValue<ulong>
 
     protected override string StringValue => this.Value.ToString(CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifLong8Array.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifLong8Array.cs
@@ -34,7 +34,7 @@ internal sealed class ExifLong8Array : ExifArrayValue<ulong>
         }
     }
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifNumber.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifNumber.cs
@@ -32,7 +32,7 @@ internal sealed class ExifNumber : ExifValue<Number>
 
     protected override string StringValue => this.Value.ToString(CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifNumberArray.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifNumberArray.cs
@@ -34,7 +34,7 @@ internal sealed class ExifNumberArray : ExifArrayValue<Number>
         }
     }
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifRational.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifRational.cs
@@ -26,7 +26,7 @@ internal sealed class ExifRational : ExifValue<Rational>
 
     protected override string StringValue => this.Value.ToString(CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifRationalArray.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifRationalArray.cs
@@ -22,7 +22,7 @@ internal sealed class ExifRationalArray : ExifArrayValue<Rational>
 
     public override ExifDataType DataType => ExifDataType.Rational;
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifShort.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifShort.cs
@@ -26,7 +26,7 @@ internal sealed class ExifShort : ExifValue<ushort>
 
     protected override string StringValue => this.Value.ToString(CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifShortArray.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifShortArray.cs
@@ -22,7 +22,7 @@ internal sealed class ExifShortArray : ExifArrayValue<ushort>
 
     public override ExifDataType DataType => ExifDataType.Short;
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifSignedByte.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifSignedByte.cs
@@ -21,7 +21,7 @@ internal sealed class ExifSignedByte : ExifValue<sbyte>
 
     protected override string StringValue => this.Value.ToString("X2", CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifSignedShort.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifSignedShort.cs
@@ -21,7 +21,7 @@ internal sealed class ExifSignedShort : ExifValue<short>
 
     protected override string StringValue => this.Value.ToString(CultureInfo.InvariantCulture);
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifSignedShortArray.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifSignedShortArray.cs
@@ -17,7 +17,7 @@ internal sealed class ExifSignedShortArray : ExifArrayValue<short>
 
     public override ExifDataType DataType => ExifDataType.SignedShort;
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifString.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifString.cs
@@ -24,9 +24,9 @@ internal sealed class ExifString : ExifValue<string>
 
     public override ExifDataType DataType => ExifDataType.Ascii;
 
-    protected override string StringValue => this.Value;
+    protected override string? StringValue => this.Value;
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifUcs2String.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifUcs2String.cs
@@ -22,11 +22,11 @@ internal sealed class ExifUcs2String : ExifValue<string>
 
     public override ExifDataType DataType => ExifDataType.Byte;
 
-    protected override string StringValue => this.Value;
+    protected override string? StringValue => this.Value;
 
-    public override object GetValue() => this.Value;
+    public override object? GetValue() => this.Value;
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (base.TrySetValue(value))
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValue.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValue.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Runtime.CompilerServices;
 
@@ -28,7 +27,7 @@ internal abstract class ExifValue : IExifValue, IEquatable<ExifTag>
         else
         {
             // All array types are value types so Clone() is sufficient here.
-            var array = (Array)other.GetValue();
+            Array? array = (Array?)other.GetValue();
             this.TrySetValue(array?.Clone());
         }
     }
@@ -43,7 +42,7 @@ internal abstract class ExifValue : IExifValue, IEquatable<ExifTag>
 
     public static bool operator !=(ExifValue left, ExifTag right) => !Equals(left, right);
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj is null)
         {
@@ -69,14 +68,14 @@ internal abstract class ExifValue : IExifValue, IEquatable<ExifTag>
     }
 
     [MethodImpl(InliningOptions.ShortMethod)]
-    public bool Equals(ExifTag other) => this.Tag.Equals(other);
+    public bool Equals(ExifTag? other) => this.Tag.Equals(other);
 
     [MethodImpl(InliningOptions.ShortMethod)]
     public override int GetHashCode() => HashCode.Combine(this.Tag, this.GetValue());
 
-    public abstract object GetValue();
+    public abstract object? GetValue();
 
-    public abstract bool TrySetValue(object value);
+    public abstract bool TrySetValue(object? value);
 
     public abstract IExifValue DeepClone();
 }

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValues.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValues.cs
@@ -1,18 +1,17 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 namespace SixLabors.ImageSharp.Metadata.Profiles.Exif;
 
 internal static partial class ExifValues
 {
-    public static ExifValue Create(ExifTagValue tag) => (ExifValue)CreateValue(tag);
+    public static ExifValue? Create(ExifTagValue tag) => (ExifValue?)CreateValue(tag);
 
-    public static ExifValue Create(ExifTag tag) => (ExifValue)CreateValue((ExifTagValue)(ushort)tag);
+    public static ExifValue? Create(ExifTag tag) => (ExifValue?)CreateValue((ExifTagValue)(ushort)tag);
 
-    public static ExifValue Create(ExifTagValue tag, ExifDataType dataType, ulong numberOfComponents) => Create(tag, dataType, numberOfComponents != 1);
+    public static ExifValue? Create(ExifTagValue tag, ExifDataType dataType, ulong numberOfComponents) => Create(tag, dataType, numberOfComponents != 1);
 
-    public static ExifValue Create(ExifTagValue tag, ExifDataType dataType, bool isArray)
+    public static ExifValue? Create(ExifTagValue tag, ExifDataType dataType, bool isArray)
     {
         switch (dataType)
         {
@@ -49,7 +48,7 @@ internal static partial class ExifValues
         }
     }
 
-    private static object CreateValue(ExifTagValue tag)
+    private static object? CreateValue(ExifTagValue tag)
     {
         switch (tag)
         {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValue{TValueType}.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValue{TValueType}.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 namespace SixLabors.ImageSharp.Metadata.Profiles.Exif;
 
@@ -21,16 +20,16 @@ internal abstract class ExifValue<TValueType> : ExifValue, IExifValue<TValueType
     {
     }
 
-    public TValueType Value { get; set; }
+    public TValueType? Value { get; set; }
 
     /// <summary>
     /// Gets the value of the current instance as a string.
     /// </summary>
-    protected abstract string StringValue { get; }
+    protected abstract string? StringValue { get; }
 
-    public override object GetValue() => this.Value;
+    public override object? GetValue() => this.Value;
 
-    public override bool TrySetValue(object value)
+    public override bool TrySetValue(object? value)
     {
         if (value is null)
         {
@@ -49,14 +48,9 @@ internal abstract class ExifValue<TValueType> : ExifValue, IExifValue<TValueType
         return false;
     }
 
-    public override string ToString()
+    public override string? ToString()
     {
-        if (this.Value == null)
-        {
-            return null;
-        }
-
-        string description = ExifTagDescriptionAttribute.GetDescription(this.Tag, this.Value);
+        string? description = ExifTagDescriptionAttribute.GetDescription(this.Tag, this.Value);
         return description ?? this.StringValue;
     }
 }

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValue{TValueType}.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValue{TValueType}.cs
@@ -48,9 +48,5 @@ internal abstract class ExifValue<TValueType> : ExifValue, IExifValue<TValueType
         return false;
     }
 
-    public override string? ToString()
-    {
-        string? description = ExifTagDescriptionAttribute.GetDescription(this.Tag, this.Value);
-        return description ?? this.StringValue;
-    }
+    public override string? ToString() => ExifTagDescriptionAttribute.TryGetDescription(this.Tag, this.Value, out string? description) ? description : this.StringValue;
 }

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/IExifValue.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/IExifValue.cs
@@ -27,12 +27,12 @@ public interface IExifValue : IDeepCloneable<IExifValue>
     /// Gets the value of this exif value.
     /// </summary>
     /// <returns>The value of this exif value.</returns>
-    object GetValue();
+    object? GetValue();
 
     /// <summary>
     /// Sets the value of this exif value.
     /// </summary>
     /// <param name="value">The value of this exif value.</param>
     /// <returns>A value indicating whether the value could be set.</returns>
-    bool TrySetValue(object value);
+    bool TrySetValue(object? value);
 }

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/IExifValue{TValueType}.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/IExifValue{TValueType}.cs
@@ -12,5 +12,5 @@ public interface IExifValue<TValueType> : IExifValue
     /// <summary>
     /// Gets or sets the value.
     /// </summary>
-    TValueType Value { get; set; }
+    TValueType? Value { get; set; }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AutoOrientProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AutoOrientProcessor{TPixel}.cs
@@ -88,7 +88,7 @@ internal class AutoOrientProcessor<TPixel> : ImageProcessor<TPixel>
             return ExifOrientationMode.Unknown;
         }
 
-        IExifValue<ushort> value = source.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
+        IExifValue<ushort>? value = source.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
         if (value is null)
         {
             return ExifOrientationMode.Unknown;

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AutoOrientProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AutoOrientProcessor{TPixel}.cs
@@ -88,8 +88,7 @@ internal class AutoOrientProcessor<TPixel> : ImageProcessor<TPixel>
             return ExifOrientationMode.Unknown;
         }
 
-        IExifValue<ushort>? value = source.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
-        if (value is null)
+        if (!source.Metadata.ExifProfile.TryGetValue(ExifTag.Orientation, out IExifValue<ushort>? value))
         {
             return ExifOrientationMode.Unknown;
         }

--- a/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorHelpers.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformProcessorHelpers.cs
@@ -26,12 +26,12 @@ internal static class TransformProcessorHelpers
         }
 
         // Only set the value if it already exists.
-        if (profile.GetValue(ExifTag.PixelXDimension) != null)
+        if (profile.TryGetValue(ExifTag.PixelXDimension, out _))
         {
             profile.SetValue(ExifTag.PixelXDimension, image.Width);
         }
 
-        if (profile.GetValue(ExifTag.PixelYDimension) != null)
+        if (profile.TryGetValue(ExifTag.PixelYDimension, out _))
         {
             profile.SetValue(ExifTag.PixelYDimension, image.Height);
         }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
@@ -8,6 +8,7 @@ using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Jpg;

--- a/tests/ImageSharp.Tests/Formats/Png/PngMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngMetadataTests.cs
@@ -6,6 +6,7 @@ using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Png;
 

--- a/tests/ImageSharp.Tests/Formats/Tiff/BigTiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/BigTiffDecoderTests.cs
@@ -6,6 +6,7 @@ using SixLabors.ImageSharp.Formats.Tiff;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 using static SixLabors.ImageSharp.Tests.TestImages.BigTiff;
 

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderBaseTester.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderBaseTester.cs
@@ -6,6 +6,7 @@ using SixLabors.ImageSharp.Formats.Tiff;
 using SixLabors.ImageSharp.Formats.Tiff.Constants;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 using SixLabors.ImageSharp.Tests.TestUtilities.ReferenceCodecs;
 

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
@@ -10,6 +10,7 @@ using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.Metadata.Profiles.Iptc;
 using SixLabors.ImageSharp.Metadata.Profiles.Xmp;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 using static SixLabors.ImageSharp.Tests.TestImages.Tiff;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Tiff;
@@ -167,9 +168,9 @@ public class TiffMetadataTests
         Assert.Equal("Make", exifProfile.GetValue(ExifTag.Make).Value);
         Assert.Equal("Model", exifProfile.GetValue(ExifTag.Model).Value);
         Assert.Equal("ImageSharp", exifProfile.GetValue(ExifTag.Software).Value);
-        Assert.Null(exifProfile.GetValue(ExifTag.DateTime)?.Value);
+        Assert.Null(exifProfile.GetValue(ExifTag.DateTime, false)?.Value);
         Assert.Equal("Artist", exifProfile.GetValue(ExifTag.Artist).Value);
-        Assert.Null(exifProfile.GetValue(ExifTag.HostComputer)?.Value);
+        Assert.Null(exifProfile.GetValue(ExifTag.HostComputer, false)?.Value);
         Assert.Equal("Copyright", exifProfile.GetValue(ExifTag.Copyright).Value);
         Assert.Equal(4, exifProfile.GetValue(ExifTag.Rating).Value);
         Assert.Equal(75, exifProfile.GetValue(ExifTag.RatingPercent).Value);
@@ -178,9 +179,9 @@ public class TiffMetadataTests
         Assert.Equal(expectedResolution, exifProfile.GetValue(ExifTag.YResolution).Value);
         Assert.Equal(new Number[] { 8u }, exifProfile.GetValue(ExifTag.StripOffsets)?.Value, new NumberComparer());
         Assert.Equal(new Number[] { 285u }, exifProfile.GetValue(ExifTag.StripByteCounts)?.Value, new NumberComparer());
-        Assert.Null(exifProfile.GetValue(ExifTag.ExtraSamples)?.Value);
+        Assert.Null(exifProfile.GetValue(ExifTag.ExtraSamples, false)?.Value);
         Assert.Equal(32u, exifProfile.GetValue(ExifTag.RowsPerStrip).Value);
-        Assert.Null(exifProfile.GetValue(ExifTag.SampleFormat));
+        Assert.Null(exifProfile.GetValue(ExifTag.SampleFormat, false));
         Assert.Equal(PixelResolutionUnit.PixelsPerInch, UnitConverter.ExifProfileToResolutionUnit(exifProfile));
         ushort[] colorMap = exifProfile.GetValue(ExifTag.ColorMap)?.Value;
         Assert.NotNull(colorMap);

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpMetaDataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpMetaDataTests.cs
@@ -5,6 +5,7 @@ using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Formats.Webp;

--- a/tests/ImageSharp.Tests/Metadata/ImageMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/ImageMetadataTests.cs
@@ -4,6 +4,7 @@
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 
 namespace SixLabors.ImageSharp.Tests.Metadata;
 

--- a/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifProfileTests.cs
@@ -345,13 +345,14 @@ public class ExifProfileTests
         ExifProfile profile = GetExifProfile();
 
         TestProfile(profile);
-
-        using Image thumbnail = profile.CreateThumbnail();
+        bool retVal = profile.TryCreateThumbnail(out Image thumbnail);
+        Assert.True(retVal);
         Assert.NotNull(thumbnail);
         Assert.Equal(256, thumbnail.Width);
         Assert.Equal(170, thumbnail.Height);
 
-        using Image<Rgba32> genericThumbnail = profile.CreateThumbnail<Rgba32>();
+        retVal = profile.TryCreateThumbnail<Rgba32>(out Image<Rgba32> genericThumbnail);
+        Assert.True(retVal);
         Assert.NotNull(genericThumbnail);
         Assert.Equal(256, genericThumbnail.Width);
         Assert.Equal(170, genericThumbnail.Height);

--- a/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifProfileTests.cs
@@ -7,6 +7,7 @@ using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 
 namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.Exif;
 
@@ -255,7 +256,7 @@ public class ExifProfileTests
         xResolution = image.Metadata.ExifProfile.GetValue(ExifTag.XResolution);
         Assert.Equal(new Rational(150.0), xResolution.Value);
 
-        referenceBlackWhite = image.Metadata.ExifProfile.GetValue(ExifTag.ReferenceBlackWhite);
+        referenceBlackWhite = image.Metadata.ExifProfile.GetValue(ExifTag.ReferenceBlackWhite, false);
         Assert.Null(referenceBlackWhite);
 
         latitude = image.Metadata.ExifProfile.GetValue(ExifTag.GPSLatitude);
@@ -300,7 +301,7 @@ public class ExifProfileTests
         Assert.NotNull(image.Metadata.ExifProfile.GetValue(ExifTag.ColorSpace));
         Assert.True(image.Metadata.ExifProfile.RemoveValue(ExifTag.ColorSpace));
         Assert.False(image.Metadata.ExifProfile.RemoveValue(ExifTag.ColorSpace));
-        Assert.Null(image.Metadata.ExifProfile.GetValue(ExifTag.ColorSpace));
+        Assert.Null(image.Metadata.ExifProfile.GetValue(ExifTag.ColorSpace, false));
         Assert.Equal(profileCount - 1, image.Metadata.ExifProfile.Values.Count);
     }
 

--- a/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifTagDescriptionAttributeTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifTagDescriptionAttributeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Six Labors Split License.
 
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 
 namespace SixLabors.ImageSharp.Tests.Metadata.Profiles.Exif;
 

--- a/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifValueTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/Exif/ExifValueTests.cs
@@ -23,7 +23,9 @@ public class ExifValueTests
     {
         Assert.NotNull(this.profile);
 
-        return this.profile.GetValue(ExifTag.Software);
+        this.profile.TryGetValue(ExifTag.Software, out IExifValue<string> value);
+
+        return value;
     }
 
     [Fact]

--- a/tests/ImageSharp.Tests/Processing/Transforms/TransformsHelpersTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/TransformsHelpersTest.cs
@@ -4,6 +4,7 @@
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 
 namespace SixLabors.ImageSharp.Tests.Processing.Transforms;
 

--- a/tests/ImageSharp.Tests/TestUtilities/ExifProfileExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ExifProfileExtensions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+
+namespace SixLabors.ImageSharp.Tests.TestUtilities;
+
+public static class ExifProfileExtensions
+{
+    public static IExifValue<T> GetValue<T>(this ExifProfile exifProfileInput, ExifTag<T> tag, bool assertTrue = true)
+    {
+        bool boolValue = exifProfileInput.TryGetValue(tag, out IExifValue<T> value);
+
+        Assert.Equal(assertTrue, boolValue);
+
+        return value;
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Resolves the nullable issues in the ExifProfile space #2231

@JimBobSquarePants Do you think we can tackle it like that, or do you have other opinions how we could/should do it?

I had a bit of a struggle with the Generic TValueType. I tried to introduce `were TValueType : struct`. But there are cases where `TValueType = string` --> zonk


I added an InvalidOperationException to 'private static Encoding JIS0208Encoding' to not expose Encoding? because that will never happen. What do you think about this? Wanna go this way or should I add an ! here to dismiss the warning