### PR TITLE
Allow zero DPI and only throw at EOF when not enough data

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
@@ -26,16 +26,6 @@ internal readonly struct JFifMarker : IEquatable<JFifMarker>
     /// <param name="yDensity">The vertical pixel density.</param>
     private JFifMarker(byte majorVersion, byte minorVersion, byte densityUnits, short xDensity, short yDensity)
     {
-        if (xDensity <= 0)
-        {
-            JpegThrowHelper.ThrowInvalidImageContentException($"X-Density {xDensity} must be greater than 0.");
-        }
-
-        if (yDensity <= 0)
-        {
-            JpegThrowHelper.ThrowInvalidImageContentException($"Y-Density {yDensity} must be greater than 0.");
-        }
-
         this.MajorVersion = majorVersion;
         this.MinorVersion = minorVersion;
 
@@ -64,12 +54,12 @@ internal readonly struct JFifMarker : IEquatable<JFifMarker>
     public PixelResolutionUnit DensityUnits { get; }
 
     /// <summary>
-    /// Gets the horizontal pixel density. Must not be zero.
+    /// Gets the horizontal pixel density.
     /// </summary>
     public short XDensity { get; }
 
     /// <summary>
-    /// Gets the vertical pixel density. Must not be zero.
+    /// Gets the vertical pixel density.
     /// </summary>
     public short YDensity { get; }
 
@@ -88,12 +78,8 @@ internal readonly struct JFifMarker : IEquatable<JFifMarker>
             byte densityUnits = bytes[7];
             short xDensity = (short)((bytes[8] << 8) | bytes[9]);
             short yDensity = (short)((bytes[10] << 8) | bytes[11]);
-
-            if (xDensity > 0 && yDensity > 0)
-            {
-                marker = new JFifMarker(majorVersion, minorVersion, densityUnits, xDensity, yDensity);
-                return true;
-            }
+            marker = new JFifMarker(majorVersion, minorVersion, densityUnits, xDensity, yDensity);
+            return true;
         }
 
         marker = default;

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter.cs
@@ -121,4 +121,10 @@ internal abstract class SpectralConverter
 
         return size;
     }
+
+    /// <summary>
+    /// Gets a value indicating whether the converter has a pixel buffer.
+    /// </summary>
+    /// <returns><see langword="true"/> if the converter has a pixel buffer; otherwise, <see langword="false"/>.</returns>
+    public abstract bool HasPixelBuffer();
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
@@ -86,6 +86,12 @@ internal class SpectralConverter<TPixel> : SpectralConverter, IDisposable
     public Configuration Configuration { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the converter has a pixel buffer.
+    /// </summary>
+    /// <returns><see langword="true"/> if the converter has a pixel buffer; otherwise, <see langword="false"/>.</returns>
+    public override bool HasPixelBuffer() => this.pixelBuffer is not null;
+
+    /// <summary>
     /// Gets converted pixel buffer.
     /// </summary>
     /// <remarks>

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -356,6 +356,18 @@ internal sealed class JpegDecoderCore : IRawJpegData, IImageDecoderInternals
                 // to uint to avoid sign extension.
                 if (stream.RemainingBytes < (uint)markerContentByteSize)
                 {
+                    if (metadataOnly && this.Metadata != null && this.Frame != null)
+                    {
+                        // We have enough data to decode the image, so we can stop parsing.
+                        return;
+                    }
+
+                    if (this.Metadata != null && this.Frame != null && spectralConverter.HasPixelBuffer())
+                    {
+                        // We have enough data to decode the image, so we can stop parsing.
+                        return;
+                    }
+
                     JpegThrowHelper.ThrowNotEnoughBytesForMarker(fileMarker.Marker);
                 }
 

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/DecodeJpegParseStreamOnly.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/DecodeJpegParseStreamOnly.cs
@@ -54,6 +54,8 @@ public class DecodeJpegParseStreamOnly
         {
         }
 
+        public override bool HasPixelBuffer() => throw new NotImplementedException();
+
         public override void InjectFrameData(JpegFrame frame, IRawJpegData jpegData)
         {
         }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JFifMarkerTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JFifMarkerTests.cs
@@ -47,15 +47,6 @@ public class JFifMarkerTests
     }
 
     [Fact]
-    public void MarkerIgnoresCorrectHeaderButInvalidDensities()
-    {
-        bool isJFif = JFifMarker.TryParse(this.bytes3, out JFifMarker marker);
-
-        Assert.False(isJFif);
-        Assert.Equal(default, marker);
-    }
-
-    [Fact]
     public void MarkerEqualityIsCorrect()
     {
         JFifMarker.TryParse(this.bytes, out JFifMarker marker);

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -300,4 +300,15 @@ public partial class JpegDecoderTests
         image.DebugSave(provider);
         image.CompareToOriginal(provider);
     }
+
+    // https://github.com/SixLabors/ImageSharp/issues/2315
+    [Theory]
+    [WithFile(TestImages.Jpeg.Issues.Issue2315_NotEnoughBytes, PixelTypes.Rgba32)]
+    public void Issue2315_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
+        image.DebugSave(provider);
+        image.CompareToOriginal(provider);
+    }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
@@ -187,6 +187,8 @@ public class SpectralJpegTests
             }
         }
 
+        public override bool HasPixelBuffer() => throw new NotImplementedException();
+
         public override void InjectFrameData(JpegFrame frame, IRawJpegData jpegData)
         {
             this.frame = frame;

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -281,6 +281,7 @@ public static class TestImages
             public const string ValidExifArgumentNullExceptionOnEncode = "Jpg/issues/Issue2087-exif-null-reference-on-encode.jpg";
             public const string Issue2133_DeduceColorSpace = "Jpg/issues/Issue2133.jpg";
             public const string Issue2136_ScanMarkerExtraneousBytes = "Jpg/issues/Issue2136-scan-segment-extraneous-bytes.jpg";
+            public const string Issue2315_NotEnoughBytes = "Jpg/issues/issue-2315.jpg";
 
             public static class Fuzz
             {

--- a/tests/Images/Input/Jpg/issues/issue-2315.jpg
+++ b/tests/Images/Input/Jpg/issues/issue-2315.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f129b057efb499d492e9afcffdd98de62aac1e04b97a09a75b4799ba498cd3c1
+size 319056


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #2315 

The image has two issues. 

1. Zero density unit values in the JFIF header.
2. Erroneous marker data at the end of the stream following the image data.

I've relaxed the decoder to cater for these cases.

 cc\ @br3aker 

<!-- Thanks for contributing to ImageSharp! -->
