### PR TITLE
Remove nullable disable from ColorSpace and Color

### DIFF
--- a/src/ImageSharp/Color/Color.cs
+++ b/src/ImageSharp/Color/Color.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -20,7 +19,7 @@ namespace SixLabors.ImageSharp;
 public readonly partial struct Color : IEquatable<Color>
 {
     private readonly Rgba64 data;
-    private readonly IPixel boxedHighPrecisionPixel;
+    private readonly IPixel? boxedHighPrecisionPixel;
 
     [MethodImpl(InliningOptions.ShortMethod)]
     private Color(byte r, byte g, byte b, byte a)
@@ -317,7 +316,7 @@ public readonly partial struct Color : IEquatable<Color>
     }
 
     /// <inheritdoc />
-    public override bool Equals(object obj) => obj is Color other && this.Equals(other);
+    public override bool Equals(object? obj) => obj is Color other && this.Equals(other);
 
     /// <inheritdoc />
     [MethodImpl(InliningOptions.ShortMethod)]

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Adapt.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Adapt.cs
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         }
 
         // Conversion to XYZ
-        LinearRgbToCieXyzConverter converterToXYZ = this.GetLinearRgbToCieXyzConverter(color.WorkingSpace);
+        LinearRgbToCieXyzConverter converterToXYZ = GetLinearRgbToCieXyzConverter(color.WorkingSpace);
         CieXyz unadapted = converterToXYZ.Convert(color);
 
         // Adaptation

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Adapt.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Adapt.cs
@@ -32,7 +32,8 @@ public partial class ColorSpaceConverter
             return color;
         }
 
-        return this.chromaticAdaptation.Transform(color, sourceWhitePoint, targetWhitePoint);
+        // We know that chromaticAdaption is not null because performChromaticAdaption is checked
+        return this.chromaticAdaptation!.Transform(color, sourceWhitePoint, targetWhitePoint);
     }
 
     /// <summary>
@@ -132,7 +133,8 @@ public partial class ColorSpaceConverter
         CieXyz unadapted = converterToXYZ.Convert(color);
 
         // Adaptation
-        CieXyz adapted = this.chromaticAdaptation.Transform(unadapted, color.WorkingSpace.WhitePoint, this.targetRgbWorkingSpace.WhitePoint);
+        // We know that chromaticAdaption is not null because performChromaticAdaption is checked
+        CieXyz adapted = this.chromaticAdaptation!.Transform(unadapted, color.WorkingSpace.WhitePoint, this.targetRgbWorkingSpace.WhitePoint);
 
         // Conversion back to RGB
         return this.cieXyzToLinearRgbConverter.Convert(adapted);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyz.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyz.cs
@@ -13,7 +13,7 @@ public partial class ColorSpaceConverter
 {
     private static readonly HunterLabToCieXyzConverter HunterLabToCieXyzConverter = new();
 
-    private LinearRgbToCieXyzConverter linearRgbToCieXyzConverter;
+    private LinearRgbToCieXyzConverter? linearRgbToCieXyzConverter;
 
     /// <summary>
     /// Converts a <see cref="CieLab"/> into a <see cref="CieXyz"/>.

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyz.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyz.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -11,9 +12,7 @@ namespace SixLabors.ImageSharp.ColorSpaces.Conversion;
 /// </content>
 public partial class ColorSpaceConverter
 {
-    private static readonly HunterLabToCieXyzConverter HunterLabToCieXyzConverter = new();
-
-    private LinearRgbToCieXyzConverter? linearRgbToCieXyzConverter;
+    private static readonly ConcurrentDictionary<RgbWorkingSpace, LinearRgbToCieXyzConverter> ConverterCache = new();
 
     /// <summary>
     /// Converts a <see cref="CieLab"/> into a <see cref="CieXyz"/>.
@@ -327,7 +326,7 @@ public partial class ColorSpaceConverter
     public CieXyz ToCieXyz(in LinearRgb color)
     {
         // Conversion
-        LinearRgbToCieXyzConverter converter = this.GetLinearRgbToCieXyzConverter(color.WorkingSpace);
+        LinearRgbToCieXyzConverter converter = GetLinearRgbToCieXyzConverter(color.WorkingSpace);
         CieXyz unadapted = converter.Convert(color);
 
         return this.Adapt(unadapted, color.WorkingSpace.WhitePoint);
@@ -454,13 +453,6 @@ public partial class ColorSpaceConverter
     /// </summary>
     /// <param name="workingSpace">The source working space</param>
     /// <returns>The <see cref="LinearRgbToCieXyzConverter"/></returns>
-    private LinearRgbToCieXyzConverter GetLinearRgbToCieXyzConverter(RgbWorkingSpace workingSpace)
-    {
-        if (this.linearRgbToCieXyzConverter?.SourceWorkingSpace.Equals(workingSpace) == true)
-        {
-            return this.linearRgbToCieXyzConverter;
-        }
-
-        return this.linearRgbToCieXyzConverter = new LinearRgbToCieXyzConverter(workingSpace);
-    }
+    private static LinearRgbToCieXyzConverter GetLinearRgbToCieXyzConverter(RgbWorkingSpace workingSpace)
+        => ConverterCache.GetOrAdd(workingSpace, (key) => new LinearRgbToCieXyzConverter(key));
 }

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 namespace SixLabors.ImageSharp.ColorSpaces.Conversion;
@@ -12,7 +11,7 @@ namespace SixLabors.ImageSharp.ColorSpaces.Conversion;
 public partial class ColorSpaceConverter
 {
     // Options.
-    private static readonly ColorSpaceConverterOptions DefaultOptions = new ColorSpaceConverterOptions();
+    private static readonly ColorSpaceConverterOptions DefaultOptions = new();
     private readonly Matrix4x4 lmsAdaptationMatrix;
     private readonly CieXyz whitePoint;
     private readonly CieXyz targetLuvWhitePoint;

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 namespace SixLabors.ImageSharp.ColorSpaces.Conversion;
@@ -19,7 +19,7 @@ public partial class ColorSpaceConverter
     private readonly CieXyz targetLabWhitePoint;
     private readonly CieXyz targetHunterLabWhitePoint;
     private readonly RgbWorkingSpace targetRgbWorkingSpace;
-    private readonly IChromaticAdaptation chromaticAdaptation;
+    private readonly IChromaticAdaptation? chromaticAdaptation;
     private readonly bool performChromaticAdaptation;
     private readonly CieXyzAndLmsConverter cieXyzAndLmsConverter;
     private readonly CieXyzToCieLabConverter cieXyzToCieLabConverter;

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverterOptions.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverterOptions.cs
@@ -44,7 +44,7 @@ public class ColorSpaceConverterOptions
     /// <summary>
     /// Gets or sets the chromatic adaptation method used. When <value>null</value>, no adaptation will be performed.
     /// </summary>
-    public IChromaticAdaptation ChromaticAdaptation { get; set; } = new VonKriesChromaticAdaptation();
+    public IChromaticAdaptation? ChromaticAdaptation { get; set; } = new VonKriesChromaticAdaptation();
 
     /// <summary>
     /// Gets or sets transformation matrix used in conversion to and from <see cref="Lms"/>.

--- a/src/ImageSharp/ColorSpaces/Conversion/Implementation/WorkingSpaces/RgbWorkingSpace.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/Implementation/WorkingSpaces/RgbWorkingSpace.cs
@@ -75,7 +75,5 @@ public abstract class RgbWorkingSpace
 
     /// <inheritdoc/>
     public override int GetHashCode()
-    {
-        return HashCode.Combine(this.WhitePoint, this.ChromaticityCoordinates);
-    }
+        => HashCode.Combine(this.WhitePoint, this.ChromaticityCoordinates);
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Remove nullable disable from ColorSpace and Color
