### PR TITLE
Add test images for 2334

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -302,8 +302,11 @@ public partial class JpegDecoderTests
     }
 
     // https://github.com/SixLabors/ImageSharp/issues/2315
+    // https://github.com/SixLabors/ImageSharp/issues/2334
     [Theory]
     [WithFile(TestImages.Jpeg.Issues.Issue2315_NotEnoughBytes, PixelTypes.Rgba32)]
+    [WithFile(TestImages.Jpeg.Issues.Issue2334_NotEnoughBytesA, PixelTypes.Rgba32)]
+    [WithFile(TestImages.Jpeg.Issues.Issue2334_NotEnoughBytesB, PixelTypes.Rgba32)]
     public void Issue2315_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
     {

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -282,6 +282,8 @@ public static class TestImages
             public const string Issue2133_DeduceColorSpace = "Jpg/issues/Issue2133.jpg";
             public const string Issue2136_ScanMarkerExtraneousBytes = "Jpg/issues/Issue2136-scan-segment-extraneous-bytes.jpg";
             public const string Issue2315_NotEnoughBytes = "Jpg/issues/issue-2315.jpg";
+            public const string Issue2334_NotEnoughBytesA = "Jpg/issues/issue-2334-a.jpg";
+            public const string Issue2334_NotEnoughBytesB = "Jpg/issues/issue-2334-b.jpg";
 
             public static class Fuzz
             {

--- a/tests/Images/Input/Jpg/issues/issue-2334-a.jpg
+++ b/tests/Images/Input/Jpg/issues/issue-2334-a.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75d7e645cc359340a0a77f13c842551dce8f82773d2eba18bf18b149dcf9a2ff
+size 411155

--- a/tests/Images/Input/Jpg/issues/issue-2334-b.jpg
+++ b/tests/Images/Input/Jpg/issues/issue-2334-b.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad6725bfa405454f6fb524dd632a53367f8853fd4a68705c773f0aeef068f7b3
+size 159229


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
The issue was already fixed with #2324. This just adds test images from #2334 

<!-- Thanks for contributing to ImageSharp! -->
