### PR TITLE
Remove nullable disable from Processing.Processors

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -171,7 +171,10 @@ internal sealed class GifEncoderCore : IImageEncoderInternals
             quantized = null;
         }
 
-        paletteQuantizer.Dispose();
+        if (hasPaletteQuantizer)
+        {
+            paletteQuantizer.Dispose();
+        }
     }
 
     private void EncodeFrame<TPixel>(

--- a/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
+++ b/src/ImageSharp/Processing/DefaultImageProcessorContext{TPixel}.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Collections.Concurrent;
 using SixLabors.ImageSharp.PixelFormats;
@@ -17,7 +16,7 @@ internal class DefaultImageProcessorContext<TPixel> : IInternalImageProcessingCo
 {
     private readonly bool mutate;
     private readonly Image<TPixel> source;
-    private Image<TPixel> destination;
+    private Image<TPixel>? destination;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultImageProcessorContext{TPixel}"/> class.
@@ -54,7 +53,7 @@ internal class DefaultImageProcessorContext<TPixel> : IInternalImageProcessingCo
             this.destination = this.source.Clone();
         }
 
-        return this.destination;
+        return this.destination!;
     }
 
     /// <inheritdoc/>
@@ -87,7 +86,7 @@ internal class DefaultImageProcessorContext<TPixel> : IInternalImageProcessingCo
         }
 
         // Standard processing pipeline.
-        using (IImageProcessor<TPixel> specificProcessor = processor.CreatePixelSpecificProcessor(this.Configuration, this.destination, rectangle))
+        using (IImageProcessor<TPixel> specificProcessor = processor.CreatePixelSpecificProcessor(this.Configuration, this.destination!, rectangle))
         {
             specificProcessor.Execute();
         }

--- a/src/ImageSharp/Processing/Processors/Convolution/KernelSamplingMap.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KernelSamplingMap.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Buffers;
 using System.Runtime.CompilerServices;
@@ -16,8 +15,8 @@ internal sealed class KernelSamplingMap : IDisposable
 {
     private readonly MemoryAllocator allocator;
     private bool isDisposed;
-    private IMemoryOwner<int> yOffsets;
-    private IMemoryOwner<int> xOffsets;
+    private IMemoryOwner<int>? yOffsets;
+    private IMemoryOwner<int>? xOffsets;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="KernelSamplingMap"/> class.
@@ -65,10 +64,10 @@ internal sealed class KernelSamplingMap : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Span<int> GetRowOffsetSpan() => this.yOffsets.GetSpan();
+    public Span<int> GetRowOffsetSpan() => this.yOffsets!.GetSpan();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Span<int> GetColumnOffsetSpan() => this.xOffsets.GetSpan();
+    public Span<int> GetColumnOffsetSpan() => this.xOffsets!.GetSpan();
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
@@ -65,7 +64,7 @@ public class DrawImageProcessor : IImageProcessor
     {
         ProcessorFactoryVisitor<TPixelBg> visitor = new(configuration, this, source, sourceRectangle);
         this.Image.AcceptVisitor(visitor);
-        return visitor.Result;
+        return visitor.Result!;
     }
 
     private class ProcessorFactoryVisitor<TPixelBg> : IImageVisitor
@@ -84,7 +83,7 @@ public class DrawImageProcessor : IImageProcessor
             this.sourceRectangle = sourceRectangle;
         }
 
-        public IImageProcessor<TPixelBg> Result { get; private set; }
+        public IImageProcessor<TPixelBg>? Result { get; private set; }
 
         public void Visit<TPixelFg>(Image<TPixelFg> image)
             where TPixelFg : unmanaged, IPixel<TPixelFg>

--- a/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer{TPixel}.cs
@@ -26,7 +26,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
     private readonly int maxColors;
     private readonly int bitDepth;
     private readonly Octree octree;
-    private IMemoryOwner<TPixel>? paletteOwner;
+    private IMemoryOwner<TPixel> paletteOwner;
     private ReadOnlyMemory<TPixel> palette;
     private EuclideanPixelMap<TPixel>? pixelMap;
     private readonly bool isDithering;
@@ -98,7 +98,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
         }
 
         int paletteIndex = 0;
-        Span<TPixel> paletteSpan = this.paletteOwner!.GetSpan();
+        Span<TPixel> paletteSpan = this.paletteOwner.GetSpan();
 
         // On very rare occasions, (blur.png), the quantizer does not preserve a
         // transparent entry when palletizing the captured colors.
@@ -112,7 +112,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
         }
 
         this.octree.Palletize(paletteSpan, max, ref paletteIndex);
-        ReadOnlyMemory<TPixel> result = this.paletteOwner!.Memory[..paletteSpan.Length];
+        ReadOnlyMemory<TPixel> result = this.paletteOwner.Memory[..paletteSpan.Length];
 
         // When called multiple times by QuantizerUtilities.BuildPalette
         // this prevents memory churn caused by reallocation.
@@ -157,8 +157,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
         if (!this.isDisposed)
         {
             this.isDisposed = true;
-            this.paletteOwner?.Dispose();
-            this.paletteOwner = null;
+            this.paletteOwner.Dispose();
             this.pixelMap?.Dispose();
             this.pixelMap = null;
         }

--- a/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer{TPixel}.cs
@@ -26,7 +26,6 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
     private readonly int maxColors;
     private readonly int bitDepth;
     private readonly Octree octree;
-    [NotNull]
     private IMemoryOwner<TPixel>? paletteOwner;
     private ReadOnlyMemory<TPixel> palette;
     private EuclideanPixelMap<TPixel>? pixelMap;
@@ -99,7 +98,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
         }
 
         int paletteIndex = 0;
-        Span<TPixel> paletteSpan = this.paletteOwner.GetSpan();
+        Span<TPixel> paletteSpan = this.paletteOwner!.GetSpan();
 
         // On very rare occasions, (blur.png), the quantizer does not preserve a
         // transparent entry when palletizing the captured colors.
@@ -113,7 +112,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
         }
 
         this.octree.Palletize(paletteSpan, max, ref paletteIndex);
-        ReadOnlyMemory<TPixel> result = this.paletteOwner.Memory[..paletteSpan.Length];
+        ReadOnlyMemory<TPixel> result = this.paletteOwner!.Memory[..paletteSpan.Length];
 
         // When called multiple times by QuantizerUtilities.BuildPalette
         // this prevents memory churn caused by reallocation.

--- a/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/OctreeQuantizer{TPixel}.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
@@ -27,9 +26,10 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
     private readonly int maxColors;
     private readonly int bitDepth;
     private readonly Octree octree;
-    private IMemoryOwner<TPixel> paletteOwner;
+    [NotNull]
+    private IMemoryOwner<TPixel>? paletteOwner;
     private ReadOnlyMemory<TPixel> palette;
-    private EuclideanPixelMap<TPixel> pixelMap;
+    private EuclideanPixelMap<TPixel>? pixelMap;
     private readonly bool isDithering;
     private bool isDisposed;
 
@@ -143,7 +143,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
         // pixel and a black one.
         if (this.isDithering || color.Equals(default))
         {
-            return (byte)this.pixelMap.GetClosestColor(color, out match);
+            return (byte)this.pixelMap!.GetClosestColor(color, out match);
         }
 
         ref TPixel paletteRef = ref MemoryMarshal.GetReference(this.palette.Span);
@@ -183,7 +183,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
         /// <summary>
         /// Store the last node quantized
         /// </summary>
-        private OctreeNode previousNode;
+        private OctreeNode? previousNode;
 
         /// <summary>
         /// Cache the previous color quantized
@@ -221,7 +221,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
         /// <summary>
         /// Gets the array of reducible nodes
         /// </summary>
-        private OctreeNode[] ReducibleNodes
+        private OctreeNode?[] ReducibleNodes
         {
             [MethodImpl(InliningOptions.ShortMethod)]
             get;
@@ -311,7 +311,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
             }
 
             // Reduce the node most recently added to the list at level 'index'
-            OctreeNode node = this.ReducibleNodes[index];
+            OctreeNode node = this.ReducibleNodes[index]!;
             this.ReducibleNodes[index] = node.NextReducible;
 
             // Decrement the leaf count after reducing the node
@@ -330,7 +330,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
             /// <summary>
             /// Pointers to any child nodes
             /// </summary>
-            private readonly OctreeNode[] children;
+            private readonly OctreeNode?[]? children;
 
             /// <summary>
             /// Flag indicating that this is a leaf node
@@ -395,7 +395,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
             /// <summary>
             /// Gets the next reducible node
             /// </summary>
-            public OctreeNode NextReducible
+            public OctreeNode? NextReducible
             {
                 [MethodImpl(InliningOptions.ShortMethod)]
                 get;
@@ -423,7 +423,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
                     // Go to the next level down in the tree
                     int index = GetColorIndex(ref color, level);
 
-                    OctreeNode child = this.children[index];
+                    OctreeNode? child = this.children![index];
                     if (child is null)
                     {
                         // Create a new child node and store it in the array
@@ -448,7 +448,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
                 // Loop through all children and add their information to this node
                 for (int index = 0; index < 8; index++)
                 {
-                    OctreeNode child = this.children[index];
+                    OctreeNode? child = this.children![index];
                     if (child != null)
                     {
                         this.red += child.red;
@@ -495,7 +495,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
                     // Loop through children looking for leaves
                     for (int i = 0; i < 8; i++)
                     {
-                        this.children[i]?.ConstructPalette(palette, ref index);
+                        this.children![i]?.ConstructPalette(palette, ref index);
                     }
                 }
             }
@@ -517,7 +517,7 @@ public struct OctreeQuantizer<TPixel> : IQuantizer<TPixel>
                 }
 
                 int colorIndex = GetColorIndex(ref pixel, level);
-                OctreeNode child = this.children[colorIndex];
+                OctreeNode? child = this.children![colorIndex];
 
                 int index = 0;
                 if (child != null)

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer{TPixel}.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization;
 internal struct PaletteQuantizer<TPixel> : IQuantizer<TPixel>
     where TPixel : unmanaged, IPixel<TPixel>
 {
-    private EuclideanPixelMap<TPixel>? pixelMap;
+    private EuclideanPixelMap<TPixel> pixelMap;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteQuantizer{TPixel}"/> struct.
@@ -46,7 +46,7 @@ internal struct PaletteQuantizer<TPixel> : IQuantizer<TPixel>
     public QuantizerOptions Options { get; }
 
     /// <inheritdoc/>
-    public ReadOnlyMemory<TPixel> Palette => this.pixelMap!.Palette;
+    public ReadOnlyMemory<TPixel> Palette => this.pixelMap.Palette;
 
     /// <inheritdoc/>
     [MethodImpl(InliningOptions.ShortMethod)]
@@ -62,12 +62,11 @@ internal struct PaletteQuantizer<TPixel> : IQuantizer<TPixel>
     /// <inheritdoc/>
     [MethodImpl(InliningOptions.ShortMethod)]
     public readonly byte GetQuantizedColor(TPixel color, out TPixel match)
-        => (byte)this.pixelMap!.GetClosestColor(color, out match);
+        => (byte)this.pixelMap.GetClosestColor(color, out match);
 
     /// <inheritdoc/>
     public void Dispose()
     {
-        this.pixelMap?.Dispose();
-        this.pixelMap = null;
+        this.pixelMap.Dispose();
     }
 }

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer{TPixel}.cs
@@ -20,7 +20,6 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization;
 internal struct PaletteQuantizer<TPixel> : IQuantizer<TPixel>
     where TPixel : unmanaged, IPixel<TPixel>
 {
-    [NotNull]
     private EuclideanPixelMap<TPixel>? pixelMap;
 
     /// <summary>
@@ -47,7 +46,7 @@ internal struct PaletteQuantizer<TPixel> : IQuantizer<TPixel>
     public QuantizerOptions Options { get; }
 
     /// <inheritdoc/>
-    public ReadOnlyMemory<TPixel> Palette => this.pixelMap.Palette;
+    public ReadOnlyMemory<TPixel> Palette => this.pixelMap!.Palette;
 
     /// <inheritdoc/>
     [MethodImpl(InliningOptions.ShortMethod)]
@@ -63,7 +62,7 @@ internal struct PaletteQuantizer<TPixel> : IQuantizer<TPixel>
     /// <inheritdoc/>
     [MethodImpl(InliningOptions.ShortMethod)]
     public readonly byte GetQuantizedColor(TPixel color, out TPixel match)
-        => (byte)this.pixelMap.GetClosestColor(color, out match);
+        => (byte)this.pixelMap!.GetClosestColor(color, out match);
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/PaletteQuantizer{TPixel}.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -21,7 +20,8 @@ namespace SixLabors.ImageSharp.Processing.Processors.Quantization;
 internal struct PaletteQuantizer<TPixel> : IQuantizer<TPixel>
     where TPixel : unmanaged, IPixel<TPixel>
 {
-    private EuclideanPixelMap<TPixel> pixelMap;
+    [NotNull]
+    private EuclideanPixelMap<TPixel>? pixelMap;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteQuantizer{TPixel}"/> struct.

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizerOptions.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizerOptions.cs
@@ -17,7 +17,7 @@ public class QuantizerOptions
     /// Gets or sets the  algorithm to apply to the output image.
     /// Defaults to <see cref="QuantizerConstants.DefaultDither"/>; set to <see langword="null"/> for no dithering.
     /// </summary>
-    public IDither Dither { get; set; } = QuantizerConstants.DefaultDither;
+    public IDither? Dither { get; set; } = QuantizerConstants.DefaultDither;
 
     /// <summary>
     /// Gets or sets the dithering scale used to adjust the amount of dither. Range 0..1.

--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizerUtilities.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizerUtilities.cs
@@ -146,7 +146,7 @@ public static class QuantizerUtilities
         where TFrameQuantizer : struct, IQuantizer<TPixel>
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        IDither dither = quantizer.Options.Dither;
+        IDither? dither = quantizer.Options.Dither;
         Buffer2D<TPixel> sourceBuffer = source.PixelBuffer;
 
         if (dither is null)

--- a/src/ImageSharp/Processing/Processors/Quantization/WuQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/WuQuantizer{TPixel}.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
@@ -76,7 +75,7 @@ internal struct WuQuantizer<TPixel> : IQuantizer<TPixel>
     private ReadOnlyMemory<TPixel> palette;
     private int maxColors;
     private readonly Box[] colorCube;
-    private EuclideanPixelMap<TPixel> pixelMap;
+    private EuclideanPixelMap<TPixel>? pixelMap;
     private readonly bool isDithering;
     private bool isDisposed;
 
@@ -175,7 +174,7 @@ internal struct WuQuantizer<TPixel> : IQuantizer<TPixel>
     {
         if (this.isDithering)
         {
-            return (byte)this.pixelMap.GetClosestColor(color, out match);
+            return (byte)this.pixelMap!.GetClosestColor(color, out match);
         }
 
         Rgba32 rgba = default;
@@ -203,9 +202,6 @@ internal struct WuQuantizer<TPixel> : IQuantizer<TPixel>
             this.momentsOwner?.Dispose();
             this.tagsOwner?.Dispose();
             this.paletteOwner?.Dispose();
-            this.momentsOwner = null;
-            this.tagsOwner = null;
-            this.paletteOwner = null;
             this.pixelMap?.Dispose();
             this.pixelMap = null;
         }
@@ -869,7 +865,7 @@ internal struct WuQuantizer<TPixel> : IQuantizer<TPixel>
         public int Volume;
 
         /// <inheritdoc/>
-        public override readonly bool Equals(object obj)
+        public override readonly bool Equals(object? obj)
             => obj is Box box
             && this.Equals(box);
 

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/AffineTransformProcessor{TPixel}.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -20,8 +19,8 @@ internal class AffineTransformProcessor<TPixel> : TransformProcessor<TPixel>, IR
     private readonly Size destinationSize;
     private readonly Matrix3x2 transformMatrix;
     private readonly IResampler resampler;
-    private ImageFrame<TPixel> source;
-    private ImageFrame<TPixel> destination;
+    private ImageFrame<TPixel>? source;
+    private ImageFrame<TPixel>? destination;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AffineTransformProcessor{TPixel}"/> class.
@@ -53,8 +52,8 @@ internal class AffineTransformProcessor<TPixel> : TransformProcessor<TPixel>, IR
         where TResampler : struct, IResampler
     {
         Configuration configuration = this.Configuration;
-        ImageFrame<TPixel> source = this.source;
-        ImageFrame<TPixel> destination = this.destination;
+        ImageFrame<TPixel> source = this.source!;
+        ImageFrame<TPixel> destination = this.destination!;
         Matrix3x2 matrix = this.transformMatrix;
 
         // Handle transforms that result in output identical to the original.

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/ProjectiveTransformProcessor{TPixel}.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -20,8 +19,8 @@ internal class ProjectiveTransformProcessor<TPixel> : TransformProcessor<TPixel>
     private readonly Size destinationSize;
     private readonly IResampler resampler;
     private readonly Matrix4x4 transformMatrix;
-    private ImageFrame<TPixel> source;
-    private ImageFrame<TPixel> destination;
+    private ImageFrame<TPixel>? source;
+    private ImageFrame<TPixel>? destination;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProjectiveTransformProcessor{TPixel}"/> class.
@@ -53,8 +52,8 @@ internal class ProjectiveTransformProcessor<TPixel> : TransformProcessor<TPixel>
         where TResampler : struct, IResampler
     {
         Configuration configuration = this.Configuration;
-        ImageFrame<TPixel> source = this.source;
-        ImageFrame<TPixel> destination = this.destination;
+        ImageFrame<TPixel> source = this.source!;
+        ImageFrame<TPixel> destination = this.destination!;
         Matrix4x4 matrix = this.transformMatrix;
 
         // Handle transforms that result in output identical to the original.

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeProcessor{TPixel}.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
-#nullable disable
 
 using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.Advanced;
@@ -21,7 +20,7 @@ internal class ResizeProcessor<TPixel> : TransformProcessor<TPixel>, IResampling
     private readonly int destinationHeight;
     private readonly IResampler resampler;
     private readonly Rectangle destinationRectangle;
-    private Image<TPixel> destination;
+    private Image<TPixel>? destination;
 
     public ResizeProcessor(Configuration configuration, ResizeProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
         : base(configuration, source, sourceRectangle)
@@ -56,7 +55,7 @@ internal class ResizeProcessor<TPixel> : TransformProcessor<TPixel>, IResampling
     {
         Configuration configuration = this.Configuration;
         Image<TPixel> source = this.Source;
-        Image<TPixel> destination = this.destination;
+        Image<TPixel> destination = this.destination!;
         Rectangle sourceRectangle = this.SourceRectangle;
         Rectangle destinationRectangle = this.destinationRectangle;
         bool compand = this.options.Compand;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
#2231


Here I went the easy way and introduced some bangs!.

It is not easy to not use it, for example using the visitor pattern, I can not tell the compiler that the value is not null so I had to use the !
