### PR TITLE
Add ARM Intrinsics for PNG filters

### DIFF
--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace SixLabors.ImageSharp.Formats.Png.Filters;
@@ -37,6 +38,10 @@ internal static class PaethFilter
         if (Sse41.IsSupported && bytesPerPixel is 4)
         {
             DecodeSse41(scanline, previousScanline);
+        }
+        else if (AdvSimd.Arm64.IsSupported && bytesPerPixel is 4)
+        {
+            DecodeArm(scanline, previousScanline);
         }
         else
         {
@@ -97,6 +102,80 @@ internal static class PaethFilter
             rb -= 4;
             offset += 4;
         }
+    }
+
+    public static void DecodeArm(Span<byte> scanline, Span<byte> previousScanline)
+    {
+        ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
+        ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
+
+        Vector128<byte> b = Vector128<byte>.Zero;
+        Vector128<byte> d = Vector128<byte>.Zero;
+
+        int rb = scanline.Length;
+        nint offset = 1;
+        const int bytesPerBatch = 4;
+        while (rb >= bytesPerBatch)
+        {
+            ref byte scanRef = ref Unsafe.Add(ref scanBaseRef, offset);
+            Vector128<byte> c = b;
+            Vector128<byte> a = d;
+            b = AdvSimd.Arm64.ZipLow(
+                Vector128.CreateScalar(Unsafe.As<byte, int>(ref Unsafe.Add(ref prevBaseRef, offset))).AsByte(),
+                Vector128<byte>.Zero).AsByte();
+            d = AdvSimd.Arm64.ZipLow(
+                Vector128.CreateScalar(Unsafe.As<byte, int>(ref scanRef)).AsByte(),
+                Vector128<byte>.Zero).AsByte();
+
+            // (p-a) == (a+b-c - a) == (b-c)
+            Vector128<short> pa = AdvSimd.Subtract(b.AsInt16(), c.AsInt16());
+
+            // (p-b) == (a+b-c - b) == (a-c)
+            Vector128<short> pb = AdvSimd.Subtract(a.AsInt16(), c.AsInt16());
+
+            // (p-c) == (a+b-c - c) == (a+b-c-c) == (b-c)+(a-c)
+            Vector128<short> pc = AdvSimd.Add(pa.AsInt16(), pb.AsInt16());
+
+            pa = AdvSimd.Abs(pa.AsInt16()).AsInt16(); /* |p-a| */
+            pb = AdvSimd.Abs(pb.AsInt16()).AsInt16(); /* |p-b| */
+            pc = AdvSimd.Abs(pc.AsInt16()).AsInt16(); /* |p-c| */
+
+            Vector128<short> smallest = AdvSimd.Min(pc, AdvSimd.Min(pa, pb));
+
+            // Paeth breaks ties favoring a over b over c.
+            Vector128<byte> mask = BlendVariable(c, b, AdvSimd.CompareEqual(smallest, pb).AsByte());
+            Vector128<byte> nearest = BlendVariable(mask, a, AdvSimd.CompareEqual(smallest, pa).AsByte());
+
+            d = AdvSimd.Add(d, nearest);
+
+            Vector64<byte> e = AdvSimd.ExtractNarrowingSaturateUnsignedLower(d.AsInt16());
+
+            Unsafe.As<byte, int>(ref scanRef) = Vector128.Create(e, e).AsInt32().ToScalar();
+
+            rb -= bytesPerBatch;
+            offset += bytesPerBatch;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<byte> BlendVariable(Vector128<byte> a, Vector128<byte> b, Vector128<byte> c)
+    {
+        // Equivalent of Sse41.BlendVariable:
+        // Blend packed 8-bit integers from a and b using mask, and store the results in
+        // dst.
+        //
+        //   FOR j := 0 to 15
+        //       i := j*8
+        //       IF mask[i+7]
+        //           dst[i+7:i] := b[i+7:i]
+        //       ELSE
+        //           dst[i+7:i] := a[i+7:i]
+        //       FI
+        //   ENDFOR
+        //
+        // Use a signed shift right to create a mask with the sign bit.
+        Vector128<short> mask = AdvSimd.ShiftRightArithmetic(c.AsInt16(), 7);
+        return AdvSimd.BitwiseSelect(mask, b.AsInt16(), a.AsInt16()).AsByte();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Tests.TestUtilities;
 /// </summary>
 public static class FeatureTestRunner
 {
-    private static readonly char[] SplitChars = new[] { ',', ' ' };
+    private static readonly char[] SplitChars = { ',', ' ' };
 
     /// <summary>
     /// Allows the deserialization of parameters passed to the feature test.
@@ -35,6 +35,7 @@ public static class FeatureTestRunner
     /// Allows the deserialization of types implementing <see cref="IConvertible"/>
     /// passed to the feature test.
     /// </summary>
+    /// <typeparam name="T">The type of object to deserialize.</typeparam>
     /// <param name="value">The string value to deserialize.</param>
     /// <returns>The <typeparamref name="T"/> value.</returns>
     public static T Deserialize<T>(string value)
@@ -58,7 +59,7 @@ public static class FeatureTestRunner
 
         foreach (KeyValuePair<HwIntrinsics, string> intrinsic in intrinsics.ToFeatureKeyValueCollection())
         {
-            var processStartInfo = new ProcessStartInfo();
+            ProcessStartInfo processStartInfo = new();
             if (intrinsic.Key != HwIntrinsics.AllowAll)
             {
                 processStartInfo.Environment[$"COMPlus_{intrinsic.Value}"] = "0";
@@ -99,7 +100,7 @@ public static class FeatureTestRunner
 
         foreach (KeyValuePair<HwIntrinsics, string> intrinsic in intrinsics.ToFeatureKeyValueCollection())
         {
-            var processStartInfo = new ProcessStartInfo();
+            ProcessStartInfo processStartInfo = new();
             if (intrinsic.Key != HwIntrinsics.AllowAll)
             {
                 processStartInfo.Environment[$"COMPlus_{intrinsic.Value}"] = "0";
@@ -142,7 +143,7 @@ public static class FeatureTestRunner
 
         foreach (KeyValuePair<HwIntrinsics, string> intrinsic in intrinsics.ToFeatureKeyValueCollection())
         {
-            var processStartInfo = new ProcessStartInfo();
+            ProcessStartInfo processStartInfo = new();
             if (intrinsic.Key != HwIntrinsics.AllowAll)
             {
                 processStartInfo.Environment[$"COMPlus_{intrinsic.Value}"] = "0";
@@ -185,7 +186,7 @@ public static class FeatureTestRunner
 
         foreach (KeyValuePair<HwIntrinsics, string> intrinsic in intrinsics.ToFeatureKeyValueCollection())
         {
-            var processStartInfo = new ProcessStartInfo();
+            ProcessStartInfo processStartInfo = new();
             if (intrinsic.Key != HwIntrinsics.AllowAll)
             {
                 processStartInfo.Environment[$"COMPlus_{intrinsic.Value}"] = "0";
@@ -232,7 +233,7 @@ public static class FeatureTestRunner
 
         foreach (KeyValuePair<HwIntrinsics, string> intrinsic in intrinsics.ToFeatureKeyValueCollection())
         {
-            var processStartInfo = new ProcessStartInfo();
+            ProcessStartInfo processStartInfo = new();
             if (intrinsic.Key != HwIntrinsics.AllowAll)
             {
                 processStartInfo.Environment[$"COMPlus_{intrinsic.Value}"] = "0";
@@ -276,7 +277,7 @@ public static class FeatureTestRunner
 
         foreach (KeyValuePair<HwIntrinsics, string> intrinsic in intrinsics.ToFeatureKeyValueCollection())
         {
-            var processStartInfo = new ProcessStartInfo();
+            ProcessStartInfo processStartInfo = new();
             if (intrinsic.Key != HwIntrinsics.AllowAll)
             {
                 processStartInfo.Environment[$"COMPlus_{intrinsic.Value}"] = "0";
@@ -321,7 +322,7 @@ public static class FeatureTestRunner
 
         foreach (KeyValuePair<HwIntrinsics, string> intrinsic in intrinsics.ToFeatureKeyValueCollection())
         {
-            var processStartInfo = new ProcessStartInfo();
+            ProcessStartInfo processStartInfo = new();
             if (intrinsic.Key != HwIntrinsics.AllowAll)
             {
                 processStartInfo.Environment[$"COMPlus_{intrinsic.Value}"] = "0";
@@ -347,11 +348,11 @@ public static class FeatureTestRunner
 
     internal static Dictionary<HwIntrinsics, string> ToFeatureKeyValueCollection(this HwIntrinsics intrinsics)
     {
-        // Loop through and translate the given values into COMPlus equivaluents
-        var features = new Dictionary<HwIntrinsics, string>();
+        // Loop through and translate the given values into COMPlus equivalents
+        Dictionary<HwIntrinsics, string> features = new();
         foreach (string intrinsic in intrinsics.ToString("G").Split(SplitChars, StringSplitOptions.RemoveEmptyEntries))
         {
-            var key = (HwIntrinsics)Enum.Parse(typeof(HwIntrinsics), intrinsic);
+            HwIntrinsics key = (HwIntrinsics)Enum.Parse(typeof(HwIntrinsics), intrinsic);
             switch (intrinsic)
             {
                 case nameof(HwIntrinsics.AllowAll):
@@ -400,5 +401,11 @@ public enum HwIntrinsics
     DisableBMI1 = 1 << 13,
     DisableBMI2 = 1 << 14,
     DisableLZCNT = 1 << 15,
-    AllowAll = 1 << 16
+    DisableArm64AdvSimd = 1 << 16,
+    DisableArm64Crc32 = 1 << 17,
+    DisableArm64Dp = 1 << 18,
+    DisableArm64Aes = 1 << 19,
+    DisableArm64Sha1 = 1 << 20,
+    DisableArm64Sha256 = 1 << 21,
+    AllowAll = 1 << 22
 }

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/FeatureTestRunnerTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the Six Labors Split License.
 
 using System.Numerics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 using Xunit.Abstractions;
+using Aes = System.Runtime.Intrinsics.X86.Aes;
 
 namespace SixLabors.ImageSharp.Tests.TestUtilities.Tests;
 
@@ -12,9 +14,9 @@ public class FeatureTestRunnerTests
     public static TheoryData<HwIntrinsics, string[]> Intrinsics =>
         new()
         {
-            { HwIntrinsics.DisableAES | HwIntrinsics.AllowAll, new string[] { "EnableAES", "AllowAll" } },
-            { HwIntrinsics.DisableHWIntrinsic, new string[] { "EnableHWIntrinsic" } },
-            { HwIntrinsics.DisableSSE42 | HwIntrinsics.DisableAVX, new string[] { "EnableSSE42", "EnableAVX" } }
+            { HwIntrinsics.DisableAES | HwIntrinsics.AllowAll, new[] { "EnableAES", "AllowAll" } },
+            { HwIntrinsics.DisableHWIntrinsic, new[] { "EnableHWIntrinsic" } },
+            { HwIntrinsics.DisableSSE42 | HwIntrinsics.DisableAVX, new[] { "EnableSSE42", "EnableAVX" } }
         };
 
     [Theory]
@@ -101,6 +103,12 @@ public class FeatureTestRunnerTests
                     Assert.False(Bmi1.IsSupported);
                     Assert.False(Bmi2.IsSupported);
                     Assert.False(Lzcnt.IsSupported);
+                    Assert.False(AdvSimd.IsSupported);
+                    Assert.False(System.Runtime.Intrinsics.Arm.Aes.IsSupported);
+                    Assert.False(Crc32.IsSupported);
+                    Assert.False(Dp.IsSupported);
+                    Assert.False(Sha1.IsSupported);
+                    Assert.False(Sha256.IsSupported);
                     break;
                 case HwIntrinsics.DisableSSE:
                     Assert.False(Sse.IsSupported);
@@ -146,6 +154,24 @@ public class FeatureTestRunnerTests
                     break;
                 case HwIntrinsics.DisableLZCNT:
                     Assert.False(Lzcnt.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64AdvSimd:
+                    Assert.False(AdvSimd.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Aes:
+                    Assert.False(System.Runtime.Intrinsics.Arm.Aes.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Crc32:
+                    Assert.False(Crc32.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Dp:
+                    Assert.False(Dp.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Sha1:
+                    Assert.False(Sha1.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Sha256:
+                    Assert.False(Sha256.IsSupported);
                     break;
             }
         }
@@ -198,6 +224,12 @@ public class FeatureTestRunnerTests
                     Assert.False(Bmi1.IsSupported);
                     Assert.False(Bmi2.IsSupported);
                     Assert.False(Lzcnt.IsSupported);
+                    Assert.False(AdvSimd.IsSupported);
+                    Assert.False(System.Runtime.Intrinsics.Arm.Aes.IsSupported);
+                    Assert.False(Crc32.IsSupported);
+                    Assert.False(Dp.IsSupported);
+                    Assert.False(Sha1.IsSupported);
+                    Assert.False(Sha256.IsSupported);
                     break;
                 case HwIntrinsics.DisableSSE:
                     Assert.False(Sse.IsSupported);
@@ -243,6 +275,24 @@ public class FeatureTestRunnerTests
                     break;
                 case HwIntrinsics.DisableLZCNT:
                     Assert.False(Lzcnt.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64AdvSimd:
+                    Assert.False(AdvSimd.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Aes:
+                    Assert.False(System.Runtime.Intrinsics.Arm.Aes.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Crc32:
+                    Assert.False(Crc32.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Dp:
+                    Assert.False(Dp.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Sha1:
+                    Assert.False(Sha1.IsSupported);
+                    break;
+                case HwIntrinsics.DisableArm64Sha256:
+                    Assert.False(Sha256.IsSupported);
                     break;
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
All credit goes to @brianpopow here. Merging main into his arm branch containing these optimizations proved too difficult after a 10 month gap so I simply recreated them in a new branch.

<!-- Thanks for contributing to ImageSharp! -->
