### PR TITLE
Actually call arm methods, if arm is supported

### DIFF
--- a/src/ImageSharp/Compression/Zlib/Adler32.cs
+++ b/src/ImageSharp/Compression/Zlib/Adler32.cs
@@ -71,6 +71,11 @@ internal static class Adler32
             return CalculateSse(adler, buffer);
         }
 
+        if (AdvSimd.IsSupported)
+        {
+            return CalculateArm(adler, buffer);
+        }
+
         return CalculateScalar(adler, buffer);
     }
 

--- a/src/ImageSharp/Compression/Zlib/Crc32.cs
+++ b/src/ImageSharp/Compression/Zlib/Crc32.cs
@@ -61,6 +61,16 @@ internal static partial class Crc32
             return ~CalculateSse(~crc, buffer);
         }
 
+        if (ArmCrc32.Arm64.IsSupported)
+        {
+            return ~CalculateArm64(~crc, buffer);
+        }
+
+        if (ArmCrc32.IsSupported)
+        {
+            return ~CalculateArm(~crc, buffer);
+        }
+
         return ~CalculateScalar(~crc, buffer);
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This is a follow up PR for #2344: There was a mistake that the arm methods for Adler and CRC32 were not called. It was not catched by tests, because it did fallback to the scalar version.