### PR TITLE
Allow setting configuration property

### DIFF
--- a/src/ImageSharp/Formats/DecoderOptions.cs
+++ b/src/ImageSharp/Formats/DecoderOptions.cs
@@ -15,6 +15,11 @@ public sealed class DecoderOptions
 
     private uint maxFrames = int.MaxValue;
 
+    // Used by the FileProvider in the unit tests to set the configuration on the fly.
+#pragma warning disable SA1401 // Fields should be private
+    internal Configuration BackingConfiguration = Configuration.Default;
+#pragma warning restore SA1401 // Fields should be private
+
     /// <summary>
     /// Gets the shared default general decoder options instance.
     /// Used internally to reduce allocations for default decoding operations.
@@ -24,7 +29,7 @@ public sealed class DecoderOptions
     /// <summary>
     /// Gets a custom configuration instance to be used by the image processing pipeline.
     /// </summary>
-    public Configuration Configuration { get; init; } = Configuration.Default;
+    public Configuration Configuration { get => this.BackingConfiguration; init => this.BackingConfiguration = value; }
 
     /// <summary>
     /// Gets the target size to decode the image into. Scaling should use an operation equivalent to <see cref="ResizeMode.Max"/>.
@@ -45,4 +50,10 @@ public sealed class DecoderOptions
     /// Gets the maximum number of image frames to decode, inclusive.
     /// </summary>
     public uint MaxFrames { get => this.maxFrames; init => this.maxFrames = Math.Clamp(value, 1, int.MaxValue); }
+}
+
+internal static class DecoderOptionsExtensions
+{
+    public static void SetConfiguration(this DecoderOptions options, Configuration configuration)
+        => options.BackingConfiguration = configuration;
 }

--- a/src/ImageSharp/Formats/DecoderOptions.cs
+++ b/src/ImageSharp/Formats/DecoderOptions.cs
@@ -17,13 +17,14 @@ public sealed class DecoderOptions
 
     /// <summary>
     /// Gets the shared default general decoder options instance.
+    /// Used internally to reduce allocations for default decoding operations.
     /// </summary>
     internal static DecoderOptions Default { get; } = LazyOptions.Value;
 
     /// <summary>
     /// Gets a custom configuration instance to be used by the image processing pipeline.
     /// </summary>
-    public Configuration Configuration { get; internal set; } = Configuration.Default;
+    public Configuration Configuration { get; init; } = Configuration.Default;
 
     /// <summary>
     /// Gets the target size to decode the image into. Scaling should use an operation equivalent to <see cref="ResizeMode.Max"/>.

--- a/src/ImageSharp/Formats/DecoderOptions.cs
+++ b/src/ImageSharp/Formats/DecoderOptions.cs
@@ -16,9 +16,9 @@ public sealed class DecoderOptions
     private uint maxFrames = int.MaxValue;
 
     // Used by the FileProvider in the unit tests to set the configuration on the fly.
-#pragma warning disable SA1401 // Fields should be private
-    internal Configuration BackingConfiguration = Configuration.Default;
-#pragma warning restore SA1401 // Fields should be private
+#pragma warning disable IDE0032 // Use auto property
+    private Configuration configuration = Configuration.Default;
+#pragma warning restore IDE0032 // Use auto property
 
     /// <summary>
     /// Gets the shared default general decoder options instance.
@@ -29,7 +29,11 @@ public sealed class DecoderOptions
     /// <summary>
     /// Gets a custom configuration instance to be used by the image processing pipeline.
     /// </summary>
-    public Configuration Configuration { get => this.BackingConfiguration; init => this.BackingConfiguration = value; }
+#pragma warning disable IDE0032 // Use auto property
+#pragma warning disable RCS1085 // Use auto-implemented property.
+    public Configuration Configuration { get => this.configuration; init => this.configuration = value; }
+#pragma warning restore RCS1085 // Use auto-implemented property.
+#pragma warning restore IDE0032 // Use auto property
 
     /// <summary>
     /// Gets the target size to decode the image into. Scaling should use an operation equivalent to <see cref="ResizeMode.Max"/>.
@@ -50,10 +54,6 @@ public sealed class DecoderOptions
     /// Gets the maximum number of image frames to decode, inclusive.
     /// </summary>
     public uint MaxFrames { get => this.maxFrames; init => this.maxFrames = Math.Clamp(value, 1, int.MaxValue); }
-}
 
-internal static class DecoderOptionsExtensions
-{
-    public static void SetConfiguration(this DecoderOptions options, Configuration configuration)
-        => options.BackingConfiguration = configuration;
+    internal void SetConfiguration(Configuration configuration) => this.configuration = configuration;
 }

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
@@ -207,7 +207,7 @@ public abstract partial class TestImageProvider<TPixel> : IXunitSerializable
             Guard.NotNull(decoder, nameof(decoder));
             Guard.NotNull(options, nameof(options));
 
-            options.Configuration = this.Configuration;
+            options.SetConfiguration(this.Configuration);
 
             // Used in small subset of decoder tests, no caching.
             // TODO: Check Path here. Why combined?
@@ -244,7 +244,7 @@ public abstract partial class TestImageProvider<TPixel> : IXunitSerializable
             Guard.NotNull(decoder, nameof(decoder));
             Guard.NotNull(options, nameof(options));
 
-            options.GeneralOptions.Configuration = this.Configuration;
+            options.GeneralOptions.SetConfiguration(this.Configuration);
 
             // Used in small subset of decoder tests, no caching.
             // TODO: Check Path here. Why combined?
@@ -268,7 +268,7 @@ public abstract partial class TestImageProvider<TPixel> : IXunitSerializable
 
         private Image<TPixel> DecodeImage(IImageDecoder decoder, DecoderOptions options)
         {
-            options.Configuration = this.Configuration;
+            options.SetConfiguration(this.Configuration);
 
             var testFile = TestFile.Create(this.FilePath);
             using Stream stream = new MemoryStream(testFile.Bytes);
@@ -278,7 +278,7 @@ public abstract partial class TestImageProvider<TPixel> : IXunitSerializable
         private Image<TPixel> DecodeImage<T>(ISpecializedImageDecoder<T> decoder, T options)
             where T : class, ISpecializedDecoderOptions, new()
         {
-            options.GeneralOptions.Configuration = this.Configuration;
+            options.GeneralOptions.SetConfiguration(this.Configuration);
 
             var testFile = TestFile.Create(this.FilePath);
             using Stream stream = new MemoryStream(testFile.Bytes);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
The property was internal when it shouldn't be. 

<!-- Thanks for contributing to ImageSharp! -->
