### PR TITLE
Disable preEnumerateTheories for running tests

### DIFF
--- a/tests/ImageSharp.Tests/xunit.runner.json
+++ b/tests/ImageSharp.Tests/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "shadowCopy": false,
   "methodDisplay": "method",
-  "diagnosticMessages": true
+  "diagnosticMessages": true,
+  "preEnumerateTheories": false
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Added `"preEnumerateTheories": false` to the xunit config, to avoid many useless warnings during tests.
