### PR TITLE
Replace MyGet with Feedz as our nightly package repository.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -196,9 +196,9 @@ jobs:
         shell: pwsh
         run: ./ci-pack.ps1
 
-      - name: MyGet Publish
+      - name: Feedz Publish
         shell: pwsh
         run: |
-          dotnet nuget push .\artifacts\*.nupkg -k ${{secrets.MYGET_TOKEN}} -s https://www.myget.org/F/sixlabors/api/v2/package
-          dotnet nuget push .\artifacts\*.snupkg -k ${{secrets.MYGET_TOKEN}} -s https://www.myget.org/F/sixlabors/api/v3/index.json
+          dotnet nuget push .\artifacts\*.nupkg -k ${{secrets.FEEDZ_TOKEN}} -s https://f.feedz.io/sixlabors/sixlabors/nuget/index.json
+          dotnet nuget push .\artifacts\*.snupkg -k ${{secrets.FEEDZ_TOKEN}} -s https://f.feedz.io/sixlabors/sixlabors/symbols
         # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ For more information, see the [.NET Foundation Code of Conduct](https://dotnetfo
 
 Install stable releases via Nuget; development releases are available via MyGet.
 
-| Package Name                   | Release (NuGet) | Nightly (MyGet) |
+| Package Name                   | Release (NuGet) | Nightly (Feedz.io) |
 |--------------------------------|-----------------|-----------------|
-| `SixLabors.ImageSharp`         | [![NuGet](https://img.shields.io/nuget/v/SixLabors.ImageSharp.svg)](https://www.nuget.org/packages/SixLabors.ImageSharp/) | [![MyGet](https://img.shields.io/myget/sixlabors/vpre/SixLabors.ImageSharp.svg)](https://www.myget.org/feed/sixlabors/package/nuget/SixLabors.ImageSharp) |
+| `SixLabors.ImageSharp`         | [![NuGet](https://img.shields.io/nuget/v/SixLabors.ImageSharp.svg)](https://www.nuget.org/packages/SixLabors.ImageSharp/) | [![feedz.io](https://img.shields.io/badge/endpoint.svg?url=https%3A%2F%2Ff.feedz.io%2Fsixlabors%2Fsixlabors%2Fshield%2FSixLabors.ImageSharp%2Flatest)](https://f.feedz.io/sixlabors/sixlabors/nuget/index.json) |
 
 ## Manual build
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
MyGet is refusing to upload our binaries reporting the following error

>Pushing SixLabors.ImageSharp.3.0.0-alpha.0.101.nupkg to 'https://www.myget.org/F/sixlabors/api/v2/package'...
  PUT https://www.myget.org/F/sixlabors/api/v2/package/
  RequestEntityTooLarge https://www.myget.org/F/sixlabors/api/v2/package/ 1312ms
error: Response status code does not indicate success: 413 (The total packages size for the pending uploads is too large. The feed owner may have to upgrade the MyGet subscription to resolve this issue.).

We've only used 6MB of 100MB so I'm switching our as I cannot afford time wasted. 

Feedz give us 2GB of storage and 2GB of package traffic per month plus has a limit of 3.5GB for individual package sizes so should never cause issues. 

<!-- Thanks for contributing to ImageSharp! -->
