### PR TITLE
ISSUE #2385 - Implementing try get pattern to TryFindFormatByFileExtension(string extension, [NotNullWhen(true)] out IImageFormat? format)

### DIFF
--- a/src/ImageSharp/Formats/ImageFormatManager.cs
+++ b/src/ImageSharp/Formats/ImageFormatManager.cs
@@ -102,9 +102,12 @@ public class ImageFormatManager
     /// <returns><see langword="true"/> if a match is found; otherwise, <see langword="false"/></returns>
     public bool TryFindFormatByFileExtension(string extension, [NotNullWhen(true)] out IImageFormat? format)
     {
-        if (extension[0] == '.')
+        if (!string.IsNullOrWhiteSpace(extension))
         {
-            extension = extension[1..];
+            if (extension[0] == '.')
+            {
+                extension = extension[1..];
+            }
         }
 
         format = this.imageFormats.FirstOrDefault(x =>

--- a/src/ImageSharp/Formats/ImageFormatManager.cs
+++ b/src/ImageSharp/Formats/ImageFormatManager.cs
@@ -102,12 +102,9 @@ public class ImageFormatManager
     /// <returns><see langword="true"/> if a match is found; otherwise, <see langword="false"/></returns>
     public bool TryFindFormatByFileExtension(string extension, [NotNullWhen(true)] out IImageFormat? format)
     {
-        if (!string.IsNullOrWhiteSpace(extension))
+        if (!string.IsNullOrWhiteSpace(extension) && extension[0] == '.')
         {
-            if (extension[0] == '.')
-            {
-                extension = extension[1..];
-            }
+            extension = extension[1..];
         }
 
         format = this.imageFormats.FirstOrDefault(x =>

--- a/src/ImageSharp/Formats/ImageFormatManager.cs
+++ b/src/ImageSharp/Formats/ImageFormatManager.cs
@@ -102,8 +102,6 @@ public class ImageFormatManager
     /// <returns><see langword="true"/> if a match is found; otherwise, <see langword="false"/></returns>
     public bool TryFindFormatByFileExtension(string extension, [NotNullWhen(true)] out IImageFormat? format)
     {
-        Guard.NotNullOrWhiteSpace(extension, nameof(extension));
-
         if (extension[0] == '.')
         {
             extension = extension[1..];


### PR DESCRIPTION
### Prerequisites

- [*] I have written a descriptive pull-request title
- [*] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [*] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [*] I have provided test coverage for my change (where applicable)

### Description
An issue was raised recently (#2385) Implementing try get pattern to `public bool TryFindFormatByFileExtension(string extension, [NotNullWhen(true)] out IImageFormat? format)`. This PR simply removes `Guard.NotNullOrWhiteSpace(extension, nameof(extension));` on line `105` in amendment to this.

I have also added a check for null or whitespace before the check for the presence of a `'.'` character to prevent out of range exceptions. 
``` csharp  
if (!string.IsNullOrWhiteSpace(extension) && extension[0] == '.')
{
    extension = extension[1..];
}
```
I have not edited any other code and there were no extra Unit Test failures after this change was made (1 unit test was failing before any changes were made to the branch)