### PR TITLE
Add Microsoft.CodeAnalysis.PublicApiAnalyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -204,6 +204,7 @@ dotnet_separate_import_directive_groups = false
 # Dotnet namespace options
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_diagnostic.IDE0130.severity = suggestion
+dotnet_diagnostic.RS0041.severity = none
 
 # C# formatting rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#c-formatting-rules

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -228,5 +228,12 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />
 </Project>

--- a/src/ImageSharp/PublicAPI.Shipped.txt
+++ b/src/ImageSharp/PublicAPI.Shipped.txt
@@ -1,0 +1,5352 @@
+#nullable enable
+abstract SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace.Compress(float channel) -> float
+abstract SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace.Expand(float channel) -> float
+abstract SixLabors.ImageSharp.Formats.ImageDecoder.Decode(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> SixLabors.ImageSharp.Image!
+abstract SixLabors.ImageSharp.Formats.ImageDecoder.Decode<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> SixLabors.ImageSharp.Image<TPixel>!
+abstract SixLabors.ImageSharp.Formats.ImageDecoder.Identify(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> SixLabors.ImageSharp.ImageInfo!
+abstract SixLabors.ImageSharp.Formats.ImageEncoder.Encode<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> void
+abstract SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.CreateDefaultSpecializedOptions(SixLabors.ImageSharp.Formats.DecoderOptions! options) -> T
+abstract SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.Decode(T options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> SixLabors.ImageSharp.Image!
+abstract SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.Decode<TPixel>(T options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> SixLabors.ImageSharp.Image<TPixel>!
+abstract SixLabors.ImageSharp.Image.CloneAs<TPixel2>(SixLabors.ImageSharp.Configuration! configuration) -> SixLabors.ImageSharp.Image<TPixel2>!
+abstract SixLabors.ImageSharp.Image.Dispose(bool disposing) -> void
+abstract SixLabors.ImageSharp.Image.NonGenericFrameCollection.get -> SixLabors.ImageSharp.ImageFrameCollection!
+abstract SixLabors.ImageSharp.ImageFrame.Dispose(bool disposing) -> void
+abstract SixLabors.ImageSharp.ImageFrameCollection.Contains(SixLabors.ImageSharp.ImageFrame! frame) -> bool
+abstract SixLabors.ImageSharp.ImageFrameCollection.Count.get -> int
+abstract SixLabors.ImageSharp.ImageFrameCollection.Dispose(bool disposing) -> void
+abstract SixLabors.ImageSharp.ImageFrameCollection.IndexOf(SixLabors.ImageSharp.ImageFrame! frame) -> int
+abstract SixLabors.ImageSharp.ImageFrameCollection.MoveFrame(int sourceIndex, int destinationIndex) -> void
+abstract SixLabors.ImageSharp.ImageFrameCollection.NonGenericAddFrame(SixLabors.ImageSharp.ImageFrame! source) -> SixLabors.ImageSharp.ImageFrame!
+abstract SixLabors.ImageSharp.ImageFrameCollection.NonGenericCloneFrame(int index) -> SixLabors.ImageSharp.Image!
+abstract SixLabors.ImageSharp.ImageFrameCollection.NonGenericCreateFrame() -> SixLabors.ImageSharp.ImageFrame!
+abstract SixLabors.ImageSharp.ImageFrameCollection.NonGenericCreateFrame(SixLabors.ImageSharp.Color backgroundColor) -> SixLabors.ImageSharp.ImageFrame!
+abstract SixLabors.ImageSharp.ImageFrameCollection.NonGenericExportFrame(int index) -> SixLabors.ImageSharp.Image!
+abstract SixLabors.ImageSharp.ImageFrameCollection.NonGenericGetEnumerator() -> System.Collections.Generic.IEnumerator<SixLabors.ImageSharp.ImageFrame!>!
+abstract SixLabors.ImageSharp.ImageFrameCollection.NonGenericGetFrame(int index) -> SixLabors.ImageSharp.ImageFrame!
+abstract SixLabors.ImageSharp.ImageFrameCollection.NonGenericInsertFrame(int index, SixLabors.ImageSharp.ImageFrame! source) -> SixLabors.ImageSharp.ImageFrame!
+abstract SixLabors.ImageSharp.ImageFrameCollection.NonGenericRootFrame.get -> SixLabors.ImageSharp.ImageFrame!
+abstract SixLabors.ImageSharp.ImageFrameCollection.RemoveFrame(int index) -> void
+abstract SixLabors.ImageSharp.Memory.MemoryAllocator.Allocate<T>(int length, SixLabors.ImageSharp.Memory.AllocationOptions options = SixLabors.ImageSharp.Memory.AllocationOptions.None) -> System.Buffers.IMemoryOwner<T>!
+abstract SixLabors.ImageSharp.Memory.MemoryAllocator.GetBufferCapacityInBytes() -> int
+abstract SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>.Blend(TPixel background, TPixel source, float amount) -> TPixel
+abstract SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>.BlendFunction(System.Span<System.Numerics.Vector4> destination, System.ReadOnlySpan<System.Numerics.Vector4> background, System.ReadOnlySpan<System.Numerics.Vector4> source, float amount) -> void
+abstract SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>.BlendFunction(System.Span<System.Numerics.Vector4> destination, System.ReadOnlySpan<System.Numerics.Vector4> background, System.ReadOnlySpan<System.Numerics.Vector4> source, System.ReadOnlySpan<float> amount) -> void
+abstract SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor.CreatePixelSpecificCloningProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor<TPixel>!
+abstract SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.GetDestinationSize() -> SixLabors.ImageSharp.Size
+abstract SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.OnFrameApply(SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.ImageFrame<TPixel>! destination) -> void
+abstract SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.OnFrameApply(SixLabors.ImageSharp.ImageFrame<TPixel>! source) -> void
+abstract SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+const SixLabors.ImageSharp.Advanced.ParallelExecutionSettings.DefaultMinimumPixelsProcessedPerTask = 4096 -> int
+const SixLabors.ImageSharp.Metadata.ImageMetadata.DefaultHorizontalResolution = 96 -> double
+const SixLabors.ImageSharp.Metadata.ImageMetadata.DefaultPixelResolutionUnits = SixLabors.ImageSharp.Metadata.PixelResolutionUnit.PixelsPerInch -> SixLabors.ImageSharp.Metadata.PixelResolutionUnit
+const SixLabors.ImageSharp.Metadata.ImageMetadata.DefaultVerticalResolution = 96 -> double
+const SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode.BottomLeft = 4 -> ushort
+const SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode.BottomRight = 3 -> ushort
+const SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode.LeftBottom = 8 -> ushort
+const SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode.LeftTop = 5 -> ushort
+const SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode.RightBottom = 7 -> ushort
+const SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode.RightTop = 6 -> ushort
+const SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode.TopLeft = 1 -> ushort
+const SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode.TopRight = 2 -> ushort
+const SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode.Unknown = 0 -> ushort
+const SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor.DefaultComponents = 2 -> int
+const SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor.DefaultGamma = 3 -> float
+const SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor.DefaultRadius = 32 -> int
+const SixLabors.ImageSharp.Processing.Processors.Convolution.BoxBlurProcessor.DefaultRadius = 7 -> int
+const SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.DefaultSigma = 3 -> float
+const SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.DefaultSigma = 3 -> float
+const SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerConstants.MaxColors = 256 -> int
+const SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerConstants.MaxDitherScale = 1 -> float
+const SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerConstants.MinColors = 1 -> int
+const SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerConstants.MinDitherScale = 0 -> float
+override SixLabors.ImageSharp.Color.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Color.GetHashCode() -> int
+override SixLabors.ImageSharp.Color.ToString() -> string!
+override SixLabors.ImageSharp.ColorMatrix.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorMatrix.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorMatrix.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.CieLab.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.CieLab.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.CieLab.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.CieLch.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.CieLch.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.CieLch.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.CieLchuv.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.CieLchuv.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.CieLchuv.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.CieLuv.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.CieLuv.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.CieLuv.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.CieXyy.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.CieXyy.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.CieXyy.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.CieXyz.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.CieXyz.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.CieXyz.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.Cmyk.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.Cmyk.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.Cmyk.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.Conversion.GammaWorkingSpace.Compress(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Conversion.GammaWorkingSpace.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.Conversion.GammaWorkingSpace.Expand(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Conversion.GammaWorkingSpace.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.Conversion.LWorkingSpace.Compress(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Conversion.LWorkingSpace.Expand(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Conversion.Rec2020WorkingSpace.Compress(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Conversion.Rec2020WorkingSpace.Expand(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Conversion.Rec709WorkingSpace.Compress(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Conversion.Rec709WorkingSpace.Expand(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.Conversion.SRgbWorkingSpace.Compress(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Conversion.SRgbWorkingSpace.Expand(float channel) -> float
+override SixLabors.ImageSharp.ColorSpaces.Hsl.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.Hsl.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.Hsl.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.Hsv.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.Hsv.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.Hsv.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.HunterLab.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.HunterLab.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.HunterLab.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.LinearRgb.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.LinearRgb.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.LinearRgb.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.Lms.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.Lms.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.Lms.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.Rgb.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.Rgb.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.Rgb.ToString() -> string!
+override SixLabors.ImageSharp.ColorSpaces.YCbCr.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.ColorSpaces.YCbCr.GetHashCode() -> int
+override SixLabors.ImageSharp.ColorSpaces.YCbCr.ToString() -> string!
+override SixLabors.ImageSharp.DenseMatrix<T>.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.DenseMatrix<T>.GetHashCode() -> int
+override SixLabors.ImageSharp.Formats.Png.PngTextData.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Formats.Png.PngTextData.GetHashCode() -> int
+override SixLabors.ImageSharp.Formats.Png.PngTextData.ToString() -> string!
+override SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.Decode(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> SixLabors.ImageSharp.Image!
+override SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.Decode<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> SixLabors.ImageSharp.Image<TPixel>!
+override SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.GetHashCode() -> int
+override SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.ToString() -> string!
+override SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.Encode<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> void
+override SixLabors.ImageSharp.Image<TPixel>.CloneAs<TPixel2>(SixLabors.ImageSharp.Configuration! configuration) -> SixLabors.ImageSharp.Image<TPixel2>!
+override SixLabors.ImageSharp.Image<TPixel>.ToString() -> string!
+override SixLabors.ImageSharp.ImageFrame<TPixel>.ToString() -> string!
+override SixLabors.ImageSharp.ImageFrameCollection<TPixel>.Contains(SixLabors.ImageSharp.ImageFrame! frame) -> bool
+override SixLabors.ImageSharp.ImageFrameCollection<TPixel>.Count.get -> int
+override SixLabors.ImageSharp.ImageFrameCollection<TPixel>.IndexOf(SixLabors.ImageSharp.ImageFrame! frame) -> int
+override SixLabors.ImageSharp.ImageFrameCollection<TPixel>.MoveFrame(int sourceIndex, int destinationIndex) -> void
+override SixLabors.ImageSharp.ImageFrameCollection<TPixel>.RemoveFrame(int index) -> void
+override SixLabors.ImageSharp.Memory.RowInterval.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Memory.RowInterval.GetHashCode() -> int
+override SixLabors.ImageSharp.Memory.RowInterval.ToString() -> string!
+override SixLabors.ImageSharp.Memory.SimpleGcMemoryAllocator.Allocate<T>(int length, SixLabors.ImageSharp.Memory.AllocationOptions options = SixLabors.ImageSharp.Memory.AllocationOptions.None) -> System.Buffers.IMemoryOwner<T>!
+override SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.GetHashCode() -> int
+override SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.ToString() -> string!
+override SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GetHashCode() -> int
+override SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ToString() -> string!
+override SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.GetHashCode() -> int
+override SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.ToString() -> string!
+override SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry.GetHashCode() -> int
+override SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.GetHashCode() -> int
+override SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.ToString() -> string!
+override SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.GetHashCode() -> int
+override SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.ToString() -> string!
+override SixLabors.ImageSharp.Number.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Number.GetHashCode() -> int
+override SixLabors.ImageSharp.Number.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.A8.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.A8.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.A8.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Abgr32.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Abgr32.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Abgr32.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Argb32.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Argb32.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Argb32.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Bgr24.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Bgr24.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Bgr24.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Bgr565.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Bgr565.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Bgr565.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Bgra32.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Bgra32.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Bgra32.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Bgra4444.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Bgra4444.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Bgra4444.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Bgra5551.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Bgra5551.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Bgra5551.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Byte4.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Byte4.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Byte4.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.HalfSingle.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.HalfSingle.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.HalfSingle.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.HalfVector2.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.HalfVector2.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.HalfVector2.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.HalfVector4.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.HalfVector4.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.HalfVector4.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.L16.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.L16.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.L16.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.L8.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.L8.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.L8.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.La16.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.La16.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.La16.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.La32.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.La32.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.La32.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.NormalizedByte2.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.NormalizedByte2.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.NormalizedByte2.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.NormalizedByte4.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.NormalizedByte4.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.NormalizedByte4.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.NormalizedShort2.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.NormalizedShort2.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.NormalizedShort2.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.NormalizedShort4.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.NormalizedShort4.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.NormalizedShort4.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Rg32.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Rg32.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Rg32.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Rgb24.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Rgb24.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Rgb24.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Rgb48.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Rgb48.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Rgb48.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Rgba1010102.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Rgba1010102.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Rgba1010102.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Rgba32.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Rgba32.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Rgba32.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Rgba64.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Rgba64.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Rgba64.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.RgbaVector.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.RgbaVector.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.RgbaVector.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Short2.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Short2.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Short2.ToString() -> string!
+override SixLabors.ImageSharp.PixelFormats.Short4.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PixelFormats.Short4.GetHashCode() -> int
+override SixLabors.ImageSharp.PixelFormats.Short4.ToString() -> string!
+override SixLabors.ImageSharp.Point.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Point.GetHashCode() -> int
+override SixLabors.ImageSharp.Point.ToString() -> string!
+override SixLabors.ImageSharp.PointF.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.PointF.GetHashCode() -> int
+override SixLabors.ImageSharp.PointF.ToString() -> string!
+override SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.GetHashCode() -> int
+override SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.GetHashCode() -> int
+override SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.GetHashCode() -> int
+override SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.GetHashCode() -> int
+override SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.GetHashCode() -> int
+override SixLabors.ImageSharp.Processing.Processors.Filters.LomographProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Filters.PolaroidProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Normalization.AdaptiveHistogramEqualizationProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Normalization.AdaptiveHistogramEqualizationSlidingWindowProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Normalization.AutoLevelProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Normalization.GlobalHistogramEqualizationProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Transforms.AffineTransformProcessor.CreatePixelSpecificCloningProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Transforms.CropProcessor.CreatePixelSpecificCloningProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Transforms.ProjectiveTransformProcessor.CreatePixelSpecificCloningProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Transforms.ResizeProcessor.CreatePixelSpecificCloningProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Processing.Processors.Transforms.RotateProcessor.CreatePixelSpecificCloningProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor<TPixel>!
+override SixLabors.ImageSharp.Rational.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Rational.GetHashCode() -> int
+override SixLabors.ImageSharp.Rational.ToString() -> string!
+override SixLabors.ImageSharp.Rectangle.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Rectangle.GetHashCode() -> int
+override SixLabors.ImageSharp.Rectangle.ToString() -> string!
+override SixLabors.ImageSharp.RectangleF.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.RectangleF.GetHashCode() -> int
+override SixLabors.ImageSharp.RectangleF.ToString() -> string!
+override SixLabors.ImageSharp.SignedRational.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.SignedRational.GetHashCode() -> int
+override SixLabors.ImageSharp.SignedRational.ToString() -> string!
+override SixLabors.ImageSharp.Size.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.Size.GetHashCode() -> int
+override SixLabors.ImageSharp.Size.ToString() -> string!
+override SixLabors.ImageSharp.SizeF.Equals(object? obj) -> bool
+override SixLabors.ImageSharp.SizeF.GetHashCode() -> int
+override SixLabors.ImageSharp.SizeF.ToString() -> string!
+SixLabors.ImageSharp.Advanced.AdvancedImageExtensions
+SixLabors.ImageSharp.Advanced.IImageVisitor
+SixLabors.ImageSharp.Advanced.IImageVisitor.Visit<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image) -> void
+SixLabors.ImageSharp.Advanced.IImageVisitorAsync
+SixLabors.ImageSharp.Advanced.IImageVisitorAsync.VisitAsync<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+SixLabors.ImageSharp.Advanced.IRowIntervalOperation
+SixLabors.ImageSharp.Advanced.IRowIntervalOperation.Invoke(in SixLabors.ImageSharp.Memory.RowInterval rows) -> void
+SixLabors.ImageSharp.Advanced.IRowIntervalOperation<TBuffer>
+SixLabors.ImageSharp.Advanced.IRowIntervalOperation<TBuffer>.GetRequiredBufferLength(SixLabors.ImageSharp.Rectangle bounds) -> int
+SixLabors.ImageSharp.Advanced.IRowIntervalOperation<TBuffer>.Invoke(in SixLabors.ImageSharp.Memory.RowInterval rows, System.Span<TBuffer> span) -> void
+SixLabors.ImageSharp.Advanced.IRowOperation
+SixLabors.ImageSharp.Advanced.IRowOperation.Invoke(int y) -> void
+SixLabors.ImageSharp.Advanced.IRowOperation<TBuffer>
+SixLabors.ImageSharp.Advanced.IRowOperation<TBuffer>.GetRequiredBufferLength(SixLabors.ImageSharp.Rectangle bounds) -> int
+SixLabors.ImageSharp.Advanced.IRowOperation<TBuffer>.Invoke(int y, System.Span<TBuffer> span) -> void
+SixLabors.ImageSharp.Advanced.ParallelExecutionSettings
+SixLabors.ImageSharp.Advanced.ParallelExecutionSettings.MaxDegreeOfParallelism.get -> int
+SixLabors.ImageSharp.Advanced.ParallelExecutionSettings.MemoryAllocator.get -> SixLabors.ImageSharp.Memory.MemoryAllocator!
+SixLabors.ImageSharp.Advanced.ParallelExecutionSettings.MinimumPixelsProcessedPerTask.get -> int
+SixLabors.ImageSharp.Advanced.ParallelExecutionSettings.MultiplyMinimumPixelsPerTask(int multiplier) -> SixLabors.ImageSharp.Advanced.ParallelExecutionSettings
+SixLabors.ImageSharp.Advanced.ParallelExecutionSettings.ParallelExecutionSettings() -> void
+SixLabors.ImageSharp.Advanced.ParallelExecutionSettings.ParallelExecutionSettings(int maxDegreeOfParallelism, int minimumPixelsProcessedPerTask, SixLabors.ImageSharp.Memory.MemoryAllocator! memoryAllocator) -> void
+SixLabors.ImageSharp.Advanced.ParallelExecutionSettings.ParallelExecutionSettings(int maxDegreeOfParallelism, SixLabors.ImageSharp.Memory.MemoryAllocator! memoryAllocator) -> void
+SixLabors.ImageSharp.Advanced.ParallelRowIterator
+SixLabors.ImageSharp.ByteOrder
+SixLabors.ImageSharp.ByteOrder.BigEndian = 0 -> SixLabors.ImageSharp.ByteOrder
+SixLabors.ImageSharp.ByteOrder.LittleEndian = 1 -> SixLabors.ImageSharp.ByteOrder
+SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.Color.Color() -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.Abgr32 pixel) -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.Argb32 pixel) -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.Bgr24 pixel) -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.Bgra32 pixel) -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.L16 pixel) -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.La32 pixel) -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.Rgb24 pixel) -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.Rgb48 pixel) -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.Rgba32 pixel) -> void
+SixLabors.ImageSharp.Color.Color(SixLabors.ImageSharp.PixelFormats.Rgba64 pixel) -> void
+SixLabors.ImageSharp.Color.Color(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.Color.Equals(SixLabors.ImageSharp.Color other) -> bool
+SixLabors.ImageSharp.Color.ToHex() -> string!
+SixLabors.ImageSharp.Color.ToPixel<TPixel>() -> TPixel
+SixLabors.ImageSharp.Color.WithAlpha(float alpha) -> SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.ColorMatrix
+SixLabors.ImageSharp.ColorMatrix.ColorMatrix() -> void
+SixLabors.ImageSharp.ColorMatrix.ColorMatrix(float m11, float m12, float m13, float m14, float m21, float m22, float m23, float m24, float m31, float m32, float m33, float m34, float m41, float m42, float m43, float m44, float m51, float m52, float m53, float m54) -> void
+SixLabors.ImageSharp.ColorMatrix.Equals(SixLabors.ImageSharp.ColorMatrix other) -> bool
+SixLabors.ImageSharp.ColorMatrix.IsIdentity.get -> bool
+SixLabors.ImageSharp.ColorMatrix.M11 -> float
+SixLabors.ImageSharp.ColorMatrix.M12 -> float
+SixLabors.ImageSharp.ColorMatrix.M13 -> float
+SixLabors.ImageSharp.ColorMatrix.M14 -> float
+SixLabors.ImageSharp.ColorMatrix.M21 -> float
+SixLabors.ImageSharp.ColorMatrix.M22 -> float
+SixLabors.ImageSharp.ColorMatrix.M23 -> float
+SixLabors.ImageSharp.ColorMatrix.M24 -> float
+SixLabors.ImageSharp.ColorMatrix.M31 -> float
+SixLabors.ImageSharp.ColorMatrix.M32 -> float
+SixLabors.ImageSharp.ColorMatrix.M33 -> float
+SixLabors.ImageSharp.ColorMatrix.M34 -> float
+SixLabors.ImageSharp.ColorMatrix.M41 -> float
+SixLabors.ImageSharp.ColorMatrix.M42 -> float
+SixLabors.ImageSharp.ColorMatrix.M43 -> float
+SixLabors.ImageSharp.ColorMatrix.M44 -> float
+SixLabors.ImageSharp.ColorMatrix.M51 -> float
+SixLabors.ImageSharp.ColorMatrix.M52 -> float
+SixLabors.ImageSharp.ColorMatrix.M53 -> float
+SixLabors.ImageSharp.ColorMatrix.M54 -> float
+SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.CieLab.A.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLab.B.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLab.CieLab() -> void
+SixLabors.ImageSharp.ColorSpaces.CieLab.CieLab(float l, float a, float b) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLab.CieLab(float l, float a, float b, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLab.CieLab(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLab.CieLab(System.Numerics.Vector3 vector, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLab.Equals(SixLabors.ImageSharp.ColorSpaces.CieLab other) -> bool
+SixLabors.ImageSharp.ColorSpaces.CieLab.L.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLab.WhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.CieLch.C.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLch.CieLch() -> void
+SixLabors.ImageSharp.ColorSpaces.CieLch.CieLch(float l, float c, float h) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLch.CieLch(float l, float c, float h, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLch.CieLch(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLch.CieLch(System.Numerics.Vector3 vector, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLch.Equals(SixLabors.ImageSharp.ColorSpaces.CieLch other) -> bool
+SixLabors.ImageSharp.ColorSpaces.CieLch.H.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLch.L.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLch.Saturation() -> float
+SixLabors.ImageSharp.ColorSpaces.CieLch.WhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.C.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.CieLchuv() -> void
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.CieLchuv(float l, float c, float h) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.CieLchuv(float l, float c, float h, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.CieLchuv(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.CieLchuv(System.Numerics.Vector3 vector, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.Equals(SixLabors.ImageSharp.ColorSpaces.CieLchuv other) -> bool
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.H.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.L.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.Saturation() -> float
+SixLabors.ImageSharp.ColorSpaces.CieLchuv.WhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.CieLuv.CieLuv() -> void
+SixLabors.ImageSharp.ColorSpaces.CieLuv.CieLuv(float l, float u, float v) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLuv.CieLuv(float l, float u, float v, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLuv.CieLuv(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLuv.CieLuv(System.Numerics.Vector3 vector, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.CieLuv.Equals(SixLabors.ImageSharp.ColorSpaces.CieLuv other) -> bool
+SixLabors.ImageSharp.ColorSpaces.CieLuv.L.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLuv.U.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLuv.V.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieLuv.WhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.CieXyy.CieXyy() -> void
+SixLabors.ImageSharp.ColorSpaces.CieXyy.CieXyy(float x, float y, float yl) -> void
+SixLabors.ImageSharp.ColorSpaces.CieXyy.CieXyy(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.CieXyy.Equals(SixLabors.ImageSharp.ColorSpaces.CieXyy other) -> bool
+SixLabors.ImageSharp.ColorSpaces.CieXyy.X.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieXyy.Y.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieXyy.Yl.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.CieXyz.CieXyz() -> void
+SixLabors.ImageSharp.ColorSpaces.CieXyz.CieXyz(float x, float y, float z) -> void
+SixLabors.ImageSharp.ColorSpaces.CieXyz.CieXyz(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.CieXyz.Equals(SixLabors.ImageSharp.ColorSpaces.CieXyz other) -> bool
+SixLabors.ImageSharp.ColorSpaces.CieXyz.ToVector3() -> System.Numerics.Vector3
+SixLabors.ImageSharp.ColorSpaces.CieXyz.X.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieXyz.Y.get -> float
+SixLabors.ImageSharp.ColorSpaces.CieXyz.Z.get -> float
+SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Cmyk.C.get -> float
+SixLabors.ImageSharp.ColorSpaces.Cmyk.Cmyk() -> void
+SixLabors.ImageSharp.ColorSpaces.Cmyk.Cmyk(float c, float m, float y, float k) -> void
+SixLabors.ImageSharp.ColorSpaces.Cmyk.Cmyk(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.Cmyk.Equals(SixLabors.ImageSharp.ColorSpaces.Cmyk other) -> bool
+SixLabors.ImageSharp.ColorSpaces.Cmyk.K.get -> float
+SixLabors.ImageSharp.ColorSpaces.Cmyk.M.get -> float
+SixLabors.ImageSharp.ColorSpaces.Cmyk.Y.get -> float
+SixLabors.ImageSharp.ColorSpaces.Companding.GammaCompanding
+SixLabors.ImageSharp.ColorSpaces.Companding.LCompanding
+SixLabors.ImageSharp.ColorSpaces.Companding.Rec2020Companding
+SixLabors.ImageSharp.ColorSpaces.Companding.Rec709Companding
+SixLabors.ImageSharp.ColorSpaces.Companding.SRgbCompanding
+SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates
+SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.CieXyChromaticityCoordinates() -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.CieXyChromaticityCoordinates(float x, float y) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.Equals(SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates other) -> bool
+SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.X.get -> float
+SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.Y.get -> float
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Adapt(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Adapt(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Adapt(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Adapt(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Adapt(in SixLabors.ImageSharp.ColorSpaces.CieXyz color, in SixLabors.ImageSharp.ColorSpaces.CieXyz sourceWhitePoint) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Adapt(in SixLabors.ImageSharp.ColorSpaces.CieXyz color, in SixLabors.ImageSharp.ColorSpaces.CieXyz sourceWhitePoint, in SixLabors.ImageSharp.ColorSpaces.CieXyz targetWhitePoint) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Adapt(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Adapt(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Adapt(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ColorSpaceConverter() -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ColorSpaceConverter(SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions! options) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLch> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLchuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieLuv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.HunterLab> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Lms> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLch> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLchuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieLuv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.HunterLab> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Lms> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.YCbCr> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLab(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.CieLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLch(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.CieLch
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLchuv(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.CieLchuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieLuv(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.CieLuv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHunterLab(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLms(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.CieLchuv color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.YCbCr color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.CieLab color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.CieLch color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.CieLuv color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.HunterLab color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.Lms color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.ChromaticAdaptation.get -> SixLabors.ImageSharp.ColorSpaces.Conversion.IChromaticAdaptation?
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.ChromaticAdaptation.set -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.ColorSpaceConverterOptions() -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.LmsAdaptationMatrix.get -> System.Numerics.Matrix4x4
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.LmsAdaptationMatrix.set -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.TargetHunterLabWhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.TargetHunterLabWhitePoint.set -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.TargetLabWhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.TargetLabWhitePoint.set -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.TargetLuvWhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.TargetLuvWhitePoint.set -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.TargetRgbWorkingSpace.get -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.TargetRgbWorkingSpace.set -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.WhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverterOptions.WhitePoint.set -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.GammaWorkingSpace
+SixLabors.ImageSharp.ColorSpaces.Conversion.GammaWorkingSpace.Gamma.get -> float
+SixLabors.ImageSharp.ColorSpaces.Conversion.GammaWorkingSpace.GammaWorkingSpace(float gamma, SixLabors.ImageSharp.ColorSpaces.CieXyz referenceWhite, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates chromaticityCoordinates) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.IChromaticAdaptation
+SixLabors.ImageSharp.ColorSpaces.Conversion.IChromaticAdaptation.Transform(in SixLabors.ImageSharp.ColorSpaces.CieXyz source, in SixLabors.ImageSharp.ColorSpaces.CieXyz sourceWhitePoint, in SixLabors.ImageSharp.ColorSpaces.CieXyz destinationWhitePoint) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.IChromaticAdaptation.Transform(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination, SixLabors.ImageSharp.ColorSpaces.CieXyz sourceWhitePoint, in SixLabors.ImageSharp.ColorSpaces.CieXyz destinationWhitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.LmsAdaptationMatrix
+SixLabors.ImageSharp.ColorSpaces.Conversion.LWorkingSpace
+SixLabors.ImageSharp.ColorSpaces.Conversion.LWorkingSpace.LWorkingSpace(SixLabors.ImageSharp.ColorSpaces.CieXyz referenceWhite, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates chromaticityCoordinates) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.Rec2020WorkingSpace
+SixLabors.ImageSharp.ColorSpaces.Conversion.Rec2020WorkingSpace.Rec2020WorkingSpace(SixLabors.ImageSharp.ColorSpaces.CieXyz referenceWhite, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates chromaticityCoordinates) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.Rec709WorkingSpace
+SixLabors.ImageSharp.ColorSpaces.Conversion.Rec709WorkingSpace.Rec709WorkingSpace(SixLabors.ImageSharp.ColorSpaces.CieXyz referenceWhite, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates chromaticityCoordinates) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.B.get -> SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.Equals(SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates other) -> bool
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.G.get -> SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.R.get -> SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.RgbPrimariesChromaticityCoordinates() -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.RgbPrimariesChromaticityCoordinates(SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates r, SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates g, SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates b) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace.ChromaticityCoordinates.get -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace.RgbWorkingSpace(SixLabors.ImageSharp.ColorSpaces.CieXyz referenceWhite, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates chromaticityCoordinates) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace.WhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.SRgbWorkingSpace
+SixLabors.ImageSharp.ColorSpaces.Conversion.SRgbWorkingSpace.SRgbWorkingSpace(SixLabors.ImageSharp.ColorSpaces.CieXyz referenceWhite, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates chromaticityCoordinates) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.VonKriesChromaticAdaptation
+SixLabors.ImageSharp.ColorSpaces.Conversion.VonKriesChromaticAdaptation.Transform(in SixLabors.ImageSharp.ColorSpaces.CieXyz source, in SixLabors.ImageSharp.ColorSpaces.CieXyz sourceWhitePoint, in SixLabors.ImageSharp.ColorSpaces.CieXyz destinationWhitePoint) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Conversion.VonKriesChromaticAdaptation.Transform(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination, SixLabors.ImageSharp.ColorSpaces.CieXyz sourceWhitePoint, in SixLabors.ImageSharp.ColorSpaces.CieXyz destinationWhitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.VonKriesChromaticAdaptation.VonKriesChromaticAdaptation() -> void
+SixLabors.ImageSharp.ColorSpaces.Conversion.VonKriesChromaticAdaptation.VonKriesChromaticAdaptation(System.Numerics.Matrix4x4 transformationMatrix) -> void
+SixLabors.ImageSharp.ColorSpaces.Hsl
+SixLabors.ImageSharp.ColorSpaces.Hsl.Equals(SixLabors.ImageSharp.ColorSpaces.Hsl other) -> bool
+SixLabors.ImageSharp.ColorSpaces.Hsl.H.get -> float
+SixLabors.ImageSharp.ColorSpaces.Hsl.Hsl() -> void
+SixLabors.ImageSharp.ColorSpaces.Hsl.Hsl(float h, float s, float l) -> void
+SixLabors.ImageSharp.ColorSpaces.Hsl.Hsl(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.Hsl.L.get -> float
+SixLabors.ImageSharp.ColorSpaces.Hsl.S.get -> float
+SixLabors.ImageSharp.ColorSpaces.Hsv
+SixLabors.ImageSharp.ColorSpaces.Hsv.Equals(SixLabors.ImageSharp.ColorSpaces.Hsv other) -> bool
+SixLabors.ImageSharp.ColorSpaces.Hsv.H.get -> float
+SixLabors.ImageSharp.ColorSpaces.Hsv.Hsv() -> void
+SixLabors.ImageSharp.ColorSpaces.Hsv.Hsv(float h, float s, float v) -> void
+SixLabors.ImageSharp.ColorSpaces.Hsv.Hsv(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.Hsv.S.get -> float
+SixLabors.ImageSharp.ColorSpaces.Hsv.V.get -> float
+SixLabors.ImageSharp.ColorSpaces.HunterLab
+SixLabors.ImageSharp.ColorSpaces.HunterLab.A.get -> float
+SixLabors.ImageSharp.ColorSpaces.HunterLab.B.get -> float
+SixLabors.ImageSharp.ColorSpaces.HunterLab.Equals(SixLabors.ImageSharp.ColorSpaces.HunterLab other) -> bool
+SixLabors.ImageSharp.ColorSpaces.HunterLab.HunterLab() -> void
+SixLabors.ImageSharp.ColorSpaces.HunterLab.HunterLab(float l, float a, float b) -> void
+SixLabors.ImageSharp.ColorSpaces.HunterLab.HunterLab(float l, float a, float b, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.HunterLab.HunterLab(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.HunterLab.HunterLab(System.Numerics.Vector3 vector, SixLabors.ImageSharp.ColorSpaces.CieXyz whitePoint) -> void
+SixLabors.ImageSharp.ColorSpaces.HunterLab.L.get -> float
+SixLabors.ImageSharp.ColorSpaces.HunterLab.WhitePoint.get -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+SixLabors.ImageSharp.ColorSpaces.Illuminants
+SixLabors.ImageSharp.ColorSpaces.LinearRgb
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.B.get -> float
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.Equals(SixLabors.ImageSharp.ColorSpaces.LinearRgb other) -> bool
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.G.get -> float
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.LinearRgb() -> void
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.LinearRgb(float r, float g, float b) -> void
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.LinearRgb(float r, float g, float b, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace! workingSpace) -> void
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.LinearRgb(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.LinearRgb(System.Numerics.Vector3 vector, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace! workingSpace) -> void
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.R.get -> float
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.ToVector3() -> System.Numerics.Vector3
+SixLabors.ImageSharp.ColorSpaces.LinearRgb.WorkingSpace.get -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+SixLabors.ImageSharp.ColorSpaces.Lms
+SixLabors.ImageSharp.ColorSpaces.Lms.Equals(SixLabors.ImageSharp.ColorSpaces.Lms other) -> bool
+SixLabors.ImageSharp.ColorSpaces.Lms.L.get -> float
+SixLabors.ImageSharp.ColorSpaces.Lms.Lms() -> void
+SixLabors.ImageSharp.ColorSpaces.Lms.Lms(float l, float m, float s) -> void
+SixLabors.ImageSharp.ColorSpaces.Lms.Lms(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.Lms.M.get -> float
+SixLabors.ImageSharp.ColorSpaces.Lms.S.get -> float
+SixLabors.ImageSharp.ColorSpaces.Lms.ToVector3() -> System.Numerics.Vector3
+SixLabors.ImageSharp.ColorSpaces.Rgb
+SixLabors.ImageSharp.ColorSpaces.Rgb.B.get -> float
+SixLabors.ImageSharp.ColorSpaces.Rgb.Equals(SixLabors.ImageSharp.ColorSpaces.Rgb other) -> bool
+SixLabors.ImageSharp.ColorSpaces.Rgb.G.get -> float
+SixLabors.ImageSharp.ColorSpaces.Rgb.R.get -> float
+SixLabors.ImageSharp.ColorSpaces.Rgb.Rgb() -> void
+SixLabors.ImageSharp.ColorSpaces.Rgb.Rgb(float r, float g, float b) -> void
+SixLabors.ImageSharp.ColorSpaces.Rgb.Rgb(float r, float g, float b, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace! workingSpace) -> void
+SixLabors.ImageSharp.ColorSpaces.Rgb.Rgb(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.ColorSpaces.Rgb.Rgb(System.Numerics.Vector3 vector, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace! workingSpace) -> void
+SixLabors.ImageSharp.ColorSpaces.Rgb.ToVector3() -> System.Numerics.Vector3
+SixLabors.ImageSharp.ColorSpaces.Rgb.WorkingSpace.get -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces
+SixLabors.ImageSharp.ColorSpaces.YCbCr
+SixLabors.ImageSharp.ColorSpaces.YCbCr.Cb.get -> float
+SixLabors.ImageSharp.ColorSpaces.YCbCr.Cr.get -> float
+SixLabors.ImageSharp.ColorSpaces.YCbCr.Equals(SixLabors.ImageSharp.ColorSpaces.YCbCr other) -> bool
+SixLabors.ImageSharp.ColorSpaces.YCbCr.Y.get -> float
+SixLabors.ImageSharp.ColorSpaces.YCbCr.YCbCr() -> void
+SixLabors.ImageSharp.ColorSpaces.YCbCr.YCbCr(float y, float cb, float cr) -> void
+SixLabors.ImageSharp.ColorSpaces.YCbCr.YCbCr(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.BestCompression = 9 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.BestSpeed = 1 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.DefaultCompression = 6 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level0 = 0 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level1 = 1 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level2 = 2 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level3 = 3 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level4 = 4 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level5 = 5 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level6 = 6 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level7 = 7 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level8 = 8 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.Level9 = 9 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel.NoCompression = 0 -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel
+SixLabors.ImageSharp.Configuration
+SixLabors.ImageSharp.Configuration.Clone() -> SixLabors.ImageSharp.Configuration!
+SixLabors.ImageSharp.Configuration.Configuration() -> void
+SixLabors.ImageSharp.Configuration.Configuration(params SixLabors.ImageSharp.Formats.IImageFormatConfigurationModule![]! configurationModules) -> void
+SixLabors.ImageSharp.Configuration.Configure(SixLabors.ImageSharp.Formats.IImageFormatConfigurationModule! configuration) -> void
+SixLabors.ImageSharp.Configuration.ImageFormats.get -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.Formats.IImageFormat!>!
+SixLabors.ImageSharp.Configuration.ImageFormatsManager.get -> SixLabors.ImageSharp.Formats.ImageFormatManager!
+SixLabors.ImageSharp.Configuration.MaxDegreeOfParallelism.get -> int
+SixLabors.ImageSharp.Configuration.MaxDegreeOfParallelism.set -> void
+SixLabors.ImageSharp.Configuration.MemoryAllocator.get -> SixLabors.ImageSharp.Memory.MemoryAllocator!
+SixLabors.ImageSharp.Configuration.MemoryAllocator.set -> void
+SixLabors.ImageSharp.Configuration.PreferContiguousImageBuffers.get -> bool
+SixLabors.ImageSharp.Configuration.PreferContiguousImageBuffers.set -> void
+SixLabors.ImageSharp.Configuration.Properties.get -> System.Collections.Generic.IDictionary<object!, object!>!
+SixLabors.ImageSharp.Configuration.ReadOrigin.get -> SixLabors.ImageSharp.ReadOrigin
+SixLabors.ImageSharp.Configuration.ReadOrigin.set -> void
+SixLabors.ImageSharp.Configuration.StreamProcessingBufferSize.get -> int
+SixLabors.ImageSharp.Configuration.StreamProcessingBufferSize.set -> void
+SixLabors.ImageSharp.DenseMatrix<T>
+SixLabors.ImageSharp.DenseMatrix<T>.Clear() -> void
+SixLabors.ImageSharp.DenseMatrix<T>.Columns.get -> int
+SixLabors.ImageSharp.DenseMatrix<T>.Count.get -> int
+SixLabors.ImageSharp.DenseMatrix<T>.Data.get -> T[]!
+SixLabors.ImageSharp.DenseMatrix<T>.DenseMatrix() -> void
+SixLabors.ImageSharp.DenseMatrix<T>.DenseMatrix(int columns, int rows) -> void
+SixLabors.ImageSharp.DenseMatrix<T>.DenseMatrix(int columns, int rows, System.Span<T> data) -> void
+SixLabors.ImageSharp.DenseMatrix<T>.DenseMatrix(int length) -> void
+SixLabors.ImageSharp.DenseMatrix<T>.DenseMatrix(T[,]! data) -> void
+SixLabors.ImageSharp.DenseMatrix<T>.Equals(SixLabors.ImageSharp.DenseMatrix<T> other) -> bool
+SixLabors.ImageSharp.DenseMatrix<T>.Fill(T value) -> void
+SixLabors.ImageSharp.DenseMatrix<T>.Rows.get -> int
+SixLabors.ImageSharp.DenseMatrix<T>.Size.get -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.DenseMatrix<T>.Span.get -> System.Span<T>
+SixLabors.ImageSharp.DenseMatrix<T>.this[int row, int column].get -> T
+SixLabors.ImageSharp.DenseMatrix<T>.Transpose() -> SixLabors.ImageSharp.DenseMatrix<T>
+SixLabors.ImageSharp.Diagnostics.MemoryDiagnostics
+SixLabors.ImageSharp.Diagnostics.UndisposedAllocationDelegate
+SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel
+SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel.Pixel1 = 1 -> SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel
+SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel.Pixel16 = 16 -> SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel
+SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel.Pixel2 = 2 -> SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel
+SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel.Pixel24 = 24 -> SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel
+SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel.Pixel32 = 32 -> SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel
+SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel.Pixel4 = 4 -> SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel
+SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel.Pixel8 = 8 -> SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel
+SixLabors.ImageSharp.Formats.Bmp.BmpConfigurationModule
+SixLabors.ImageSharp.Formats.Bmp.BmpConfigurationModule.BmpConfigurationModule() -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpConfigurationModule.Configure(SixLabors.ImageSharp.Configuration! configuration) -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpDecoder
+SixLabors.ImageSharp.Formats.Bmp.BmpDecoderOptions
+SixLabors.ImageSharp.Formats.Bmp.BmpDecoderOptions.BmpDecoderOptions() -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpDecoderOptions.GeneralOptions.get -> SixLabors.ImageSharp.Formats.DecoderOptions!
+SixLabors.ImageSharp.Formats.Bmp.BmpDecoderOptions.GeneralOptions.init -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpDecoderOptions.RleSkippedPixelHandling.get -> SixLabors.ImageSharp.Formats.Bmp.RleSkippedPixelHandling
+SixLabors.ImageSharp.Formats.Bmp.BmpDecoderOptions.RleSkippedPixelHandling.init -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpEncoder
+SixLabors.ImageSharp.Formats.Bmp.BmpEncoder.BitsPerPixel.get -> SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel?
+SixLabors.ImageSharp.Formats.Bmp.BmpEncoder.BitsPerPixel.init -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpEncoder.BmpEncoder() -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpEncoder.SupportTransparency.get -> bool
+SixLabors.ImageSharp.Formats.Bmp.BmpEncoder.SupportTransparency.init -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType
+SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType.Bitmap = 0 -> SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType
+SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType.BitmapArray = 1 -> SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType
+SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType.ColorIcon = 2 -> SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType
+SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType.ColorPointer = 3 -> SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType
+SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType.Icon = 4 -> SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType
+SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType.Pointer = 5 -> SixLabors.ImageSharp.Formats.Bmp.BmpFileMarkerType
+SixLabors.ImageSharp.Formats.Bmp.BmpFormat
+SixLabors.ImageSharp.Formats.Bmp.BmpFormat.CreateDefaultFormatMetadata() -> SixLabors.ImageSharp.Formats.Bmp.BmpMetadata!
+SixLabors.ImageSharp.Formats.Bmp.BmpFormat.DefaultMimeType.get -> string!
+SixLabors.ImageSharp.Formats.Bmp.BmpFormat.FileExtensions.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Bmp.BmpFormat.MimeTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Bmp.BmpFormat.Name.get -> string!
+SixLabors.ImageSharp.Formats.Bmp.BmpImageFormatDetector
+SixLabors.ImageSharp.Formats.Bmp.BmpImageFormatDetector.BmpImageFormatDetector() -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpImageFormatDetector.HeaderSize.get -> int
+SixLabors.ImageSharp.Formats.Bmp.BmpImageFormatDetector.TryDetectFormat(System.ReadOnlySpan<byte> header, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType.AdobeVersion3 = 52 -> SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType.AdobeVersion3WithAlpha = 56 -> SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType.Os2Version2 = 64 -> SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType.Os2Version2Short = 16 -> SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType.WinVersion2 = 12 -> SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType.WinVersion3 = 40 -> SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType.WinVersion4 = 108 -> SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType.WinVersion5 = 124 -> SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpMetadata
+SixLabors.ImageSharp.Formats.Bmp.BmpMetadata.BitsPerPixel.get -> SixLabors.ImageSharp.Formats.Bmp.BmpBitsPerPixel
+SixLabors.ImageSharp.Formats.Bmp.BmpMetadata.BitsPerPixel.set -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpMetadata.BmpMetadata() -> void
+SixLabors.ImageSharp.Formats.Bmp.BmpMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Bmp.BmpMetadata.InfoHeaderType.get -> SixLabors.ImageSharp.Formats.Bmp.BmpInfoHeaderType
+SixLabors.ImageSharp.Formats.Bmp.BmpMetadata.InfoHeaderType.set -> void
+SixLabors.ImageSharp.Formats.Bmp.RleSkippedPixelHandling
+SixLabors.ImageSharp.Formats.Bmp.RleSkippedPixelHandling.Black = 0 -> SixLabors.ImageSharp.Formats.Bmp.RleSkippedPixelHandling
+SixLabors.ImageSharp.Formats.Bmp.RleSkippedPixelHandling.FirstColorOfPalette = 2 -> SixLabors.ImageSharp.Formats.Bmp.RleSkippedPixelHandling
+SixLabors.ImageSharp.Formats.Bmp.RleSkippedPixelHandling.Transparent = 1 -> SixLabors.ImageSharp.Formats.Bmp.RleSkippedPixelHandling
+SixLabors.ImageSharp.Formats.DecoderOptions
+SixLabors.ImageSharp.Formats.DecoderOptions.Configuration.get -> SixLabors.ImageSharp.Configuration!
+SixLabors.ImageSharp.Formats.DecoderOptions.Configuration.init -> void
+SixLabors.ImageSharp.Formats.DecoderOptions.DecoderOptions() -> void
+SixLabors.ImageSharp.Formats.DecoderOptions.MaxFrames.get -> uint
+SixLabors.ImageSharp.Formats.DecoderOptions.MaxFrames.init -> void
+SixLabors.ImageSharp.Formats.DecoderOptions.Sampler.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+SixLabors.ImageSharp.Formats.DecoderOptions.Sampler.init -> void
+SixLabors.ImageSharp.Formats.DecoderOptions.SkipMetadata.get -> bool
+SixLabors.ImageSharp.Formats.DecoderOptions.SkipMetadata.init -> void
+SixLabors.ImageSharp.Formats.DecoderOptions.TargetSize.get -> SixLabors.ImageSharp.Size?
+SixLabors.ImageSharp.Formats.DecoderOptions.TargetSize.init -> void
+SixLabors.ImageSharp.Formats.Gif.GifColorTableMode
+SixLabors.ImageSharp.Formats.Gif.GifColorTableMode.Global = 0 -> SixLabors.ImageSharp.Formats.Gif.GifColorTableMode
+SixLabors.ImageSharp.Formats.Gif.GifColorTableMode.Local = 1 -> SixLabors.ImageSharp.Formats.Gif.GifColorTableMode
+SixLabors.ImageSharp.Formats.Gif.GifConfigurationModule
+SixLabors.ImageSharp.Formats.Gif.GifConfigurationModule.Configure(SixLabors.ImageSharp.Configuration! configuration) -> void
+SixLabors.ImageSharp.Formats.Gif.GifConfigurationModule.GifConfigurationModule() -> void
+SixLabors.ImageSharp.Formats.Gif.GifDecoder
+SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod
+SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod.NotDispose = 1 -> SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod
+SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod.RestoreToBackground = 2 -> SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod
+SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod.RestoreToPrevious = 3 -> SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod
+SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod.Unspecified = 0 -> SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod
+SixLabors.ImageSharp.Formats.Gif.GifEncoder
+SixLabors.ImageSharp.Formats.Gif.GifEncoder.ColorTableMode.get -> SixLabors.ImageSharp.Formats.Gif.GifColorTableMode?
+SixLabors.ImageSharp.Formats.Gif.GifEncoder.ColorTableMode.init -> void
+SixLabors.ImageSharp.Formats.Gif.GifEncoder.GifEncoder() -> void
+SixLabors.ImageSharp.Formats.Gif.GifFormat
+SixLabors.ImageSharp.Formats.Gif.GifFormat.CreateDefaultFormatFrameMetadata() -> SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata!
+SixLabors.ImageSharp.Formats.Gif.GifFormat.CreateDefaultFormatMetadata() -> SixLabors.ImageSharp.Formats.Gif.GifMetadata!
+SixLabors.ImageSharp.Formats.Gif.GifFormat.DefaultMimeType.get -> string!
+SixLabors.ImageSharp.Formats.Gif.GifFormat.FileExtensions.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Gif.GifFormat.MimeTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Gif.GifFormat.Name.get -> string!
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.ColorTableLength.get -> int
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.ColorTableLength.set -> void
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.ColorTableMode.get -> SixLabors.ImageSharp.Formats.Gif.GifColorTableMode
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.ColorTableMode.set -> void
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.DisposalMethod.get -> SixLabors.ImageSharp.Formats.Gif.GifDisposalMethod
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.DisposalMethod.set -> void
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.FrameDelay.get -> int
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.FrameDelay.set -> void
+SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata.GifFrameMetadata() -> void
+SixLabors.ImageSharp.Formats.Gif.GifImageFormatDetector
+SixLabors.ImageSharp.Formats.Gif.GifImageFormatDetector.GifImageFormatDetector() -> void
+SixLabors.ImageSharp.Formats.Gif.GifImageFormatDetector.HeaderSize.get -> int
+SixLabors.ImageSharp.Formats.Gif.GifImageFormatDetector.TryDetectFormat(System.ReadOnlySpan<byte> header, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.Gif.GifMetadata
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.ColorTableMode.get -> SixLabors.ImageSharp.Formats.Gif.GifColorTableMode
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.ColorTableMode.set -> void
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.Comments.get -> System.Collections.Generic.IList<string!>!
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.Comments.set -> void
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.GifMetadata() -> void
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.GlobalColorTableLength.get -> int
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.GlobalColorTableLength.set -> void
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.RepeatCount.get -> ushort
+SixLabors.ImageSharp.Formats.Gif.GifMetadata.RepeatCount.set -> void
+SixLabors.ImageSharp.Formats.Gif.IGifExtension
+SixLabors.ImageSharp.Formats.Gif.IGifExtension.ContentLength.get -> int
+SixLabors.ImageSharp.Formats.Gif.IGifExtension.Label.get -> byte
+SixLabors.ImageSharp.Formats.Gif.IGifExtension.WriteTo(System.Span<byte> buffer) -> int
+SixLabors.ImageSharp.Formats.IImageDecoder
+SixLabors.ImageSharp.Formats.IImageDecoder.Decode(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image!
+SixLabors.ImageSharp.Formats.IImageDecoder.Decode<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.Formats.IImageDecoder.DecodeAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image!>!
+SixLabors.ImageSharp.Formats.IImageDecoder.DecodeAsync<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image<TPixel>!>!
+SixLabors.ImageSharp.Formats.IImageDecoder.Identify(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.ImageInfo!
+SixLabors.ImageSharp.Formats.IImageDecoder.IdentifyAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.ImageInfo!>!
+SixLabors.ImageSharp.Formats.IImageEncoder
+SixLabors.ImageSharp.Formats.IImageEncoder.Encode<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image, System.IO.Stream! stream) -> void
+SixLabors.ImageSharp.Formats.IImageEncoder.EncodeAsync<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+SixLabors.ImageSharp.Formats.IImageEncoder.SkipMetadata.get -> bool
+SixLabors.ImageSharp.Formats.IImageEncoder.SkipMetadata.init -> void
+SixLabors.ImageSharp.Formats.IImageFormat
+SixLabors.ImageSharp.Formats.IImageFormat.DefaultMimeType.get -> string!
+SixLabors.ImageSharp.Formats.IImageFormat.FileExtensions.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.IImageFormat.MimeTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.IImageFormat.Name.get -> string!
+SixLabors.ImageSharp.Formats.IImageFormat<TFormatMetadata, TFormatFrameMetadata>
+SixLabors.ImageSharp.Formats.IImageFormat<TFormatMetadata, TFormatFrameMetadata>.CreateDefaultFormatFrameMetadata() -> TFormatFrameMetadata!
+SixLabors.ImageSharp.Formats.IImageFormat<TFormatMetadata>
+SixLabors.ImageSharp.Formats.IImageFormat<TFormatMetadata>.CreateDefaultFormatMetadata() -> TFormatMetadata!
+SixLabors.ImageSharp.Formats.IImageFormatConfigurationModule
+SixLabors.ImageSharp.Formats.IImageFormatConfigurationModule.Configure(SixLabors.ImageSharp.Configuration! configuration) -> void
+SixLabors.ImageSharp.Formats.IImageFormatDetector
+SixLabors.ImageSharp.Formats.IImageFormatDetector.HeaderSize.get -> int
+SixLabors.ImageSharp.Formats.IImageFormatDetector.TryDetectFormat(System.ReadOnlySpan<byte> header, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.ImageDecoder
+SixLabors.ImageSharp.Formats.ImageDecoder.Decode(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image!
+SixLabors.ImageSharp.Formats.ImageDecoder.Decode<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.Formats.ImageDecoder.DecodeAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image!>!
+SixLabors.ImageSharp.Formats.ImageDecoder.DecodeAsync<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image<TPixel>!>!
+SixLabors.ImageSharp.Formats.ImageDecoder.Identify(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.ImageInfo!
+SixLabors.ImageSharp.Formats.ImageDecoder.IdentifyAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.ImageInfo!>!
+SixLabors.ImageSharp.Formats.ImageDecoder.ImageDecoder() -> void
+SixLabors.ImageSharp.Formats.ImageEncoder
+SixLabors.ImageSharp.Formats.ImageEncoder.Encode<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image, System.IO.Stream! stream) -> void
+SixLabors.ImageSharp.Formats.ImageEncoder.EncodeAsync<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+SixLabors.ImageSharp.Formats.ImageEncoder.ImageEncoder() -> void
+SixLabors.ImageSharp.Formats.ImageEncoder.SkipMetadata.get -> bool
+SixLabors.ImageSharp.Formats.ImageEncoder.SkipMetadata.init -> void
+SixLabors.ImageSharp.Formats.ImageFormatManager
+SixLabors.ImageSharp.Formats.ImageFormatManager.AddImageFormat(SixLabors.ImageSharp.Formats.IImageFormat! format) -> void
+SixLabors.ImageSharp.Formats.ImageFormatManager.AddImageFormatDetector(SixLabors.ImageSharp.Formats.IImageFormatDetector! detector) -> void
+SixLabors.ImageSharp.Formats.ImageFormatManager.ClearImageFormatDetectors() -> void
+SixLabors.ImageSharp.Formats.ImageFormatManager.GetDecoder(SixLabors.ImageSharp.Formats.IImageFormat! format) -> SixLabors.ImageSharp.Formats.IImageDecoder!
+SixLabors.ImageSharp.Formats.ImageFormatManager.GetEncoder(SixLabors.ImageSharp.Formats.IImageFormat! format) -> SixLabors.ImageSharp.Formats.IImageEncoder!
+SixLabors.ImageSharp.Formats.ImageFormatManager.ImageFormatManager() -> void
+SixLabors.ImageSharp.Formats.ImageFormatManager.ImageFormats.get -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.Formats.IImageFormat!>!
+SixLabors.ImageSharp.Formats.ImageFormatManager.SetDecoder(SixLabors.ImageSharp.Formats.IImageFormat! imageFormat, SixLabors.ImageSharp.Formats.IImageDecoder! decoder) -> void
+SixLabors.ImageSharp.Formats.ImageFormatManager.SetEncoder(SixLabors.ImageSharp.Formats.IImageFormat! imageFormat, SixLabors.ImageSharp.Formats.IImageEncoder! encoder) -> void
+SixLabors.ImageSharp.Formats.ImageFormatManager.TryFindFormatByFileExtension(string! extension, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.ImageFormatManager.TryFindFormatByMimeType(string! mimeType, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.ISpecializedDecoderOptions
+SixLabors.ImageSharp.Formats.ISpecializedDecoderOptions.GeneralOptions.get -> SixLabors.ImageSharp.Formats.DecoderOptions!
+SixLabors.ImageSharp.Formats.ISpecializedDecoderOptions.GeneralOptions.init -> void
+SixLabors.ImageSharp.Formats.ISpecializedImageDecoder<T>
+SixLabors.ImageSharp.Formats.ISpecializedImageDecoder<T>.Decode(T options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image!
+SixLabors.ImageSharp.Formats.ISpecializedImageDecoder<T>.Decode<TPixel>(T options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.Formats.ISpecializedImageDecoder<T>.DecodeAsync(T options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image!>!
+SixLabors.ImageSharp.Formats.ISpecializedImageDecoder<T>.DecodeAsync<TPixel>(T options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image<TPixel>!>!
+SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec
+SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec.Count.get -> byte[]!
+SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec.HuffmanSpec() -> void
+SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec.HuffmanSpec(byte[]! count, byte[]! values) -> void
+SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec.Values.get -> byte[]!
+SixLabors.ImageSharp.Formats.Jpeg.JpegConfigurationModule
+SixLabors.ImageSharp.Formats.Jpeg.JpegConfigurationModule.Configure(SixLabors.ImageSharp.Configuration! configuration) -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegConfigurationModule.JpegConfigurationModule() -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoder
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderOptions
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderOptions.GeneralOptions.get -> SixLabors.ImageSharp.Formats.DecoderOptions!
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderOptions.GeneralOptions.init -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderOptions.JpegDecoderOptions() -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderOptions.ResizeMode.get -> SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderResizeMode
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderOptions.ResizeMode.init -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderResizeMode
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderResizeMode.Combined = 0 -> SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderResizeMode
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderResizeMode.IdctOnly = 1 -> SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderResizeMode
+SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderResizeMode.ScaleOnly = 2 -> SixLabors.ImageSharp.Formats.Jpeg.JpegDecoderResizeMode
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder.ColorType.get -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor?
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder.ColorType.init -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder.Interleaved.get -> bool?
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder.Interleaved.init -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder.JpegEncoder() -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder.Quality.get -> int?
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder.Quality.init -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor.Cmyk = 7 -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor.Luminance = 5 -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor.Rgb = 6 -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor.YCbCrRatio410 = 4 -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor.YCbCrRatio411 = 3 -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor.YCbCrRatio420 = 0 -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor.YCbCrRatio422 = 2 -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor.YCbCrRatio444 = 1 -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor.Ycck = 8 -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor
+SixLabors.ImageSharp.Formats.Jpeg.JpegFormat
+SixLabors.ImageSharp.Formats.Jpeg.JpegFormat.CreateDefaultFormatMetadata() -> SixLabors.ImageSharp.Formats.Jpeg.JpegMetadata!
+SixLabors.ImageSharp.Formats.Jpeg.JpegFormat.DefaultMimeType.get -> string!
+SixLabors.ImageSharp.Formats.Jpeg.JpegFormat.FileExtensions.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Jpeg.JpegFormat.MimeTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Jpeg.JpegFormat.Name.get -> string!
+SixLabors.ImageSharp.Formats.Jpeg.JpegImageFormatDetector
+SixLabors.ImageSharp.Formats.Jpeg.JpegImageFormatDetector.HeaderSize.get -> int
+SixLabors.ImageSharp.Formats.Jpeg.JpegImageFormatDetector.JpegImageFormatDetector() -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegImageFormatDetector.TryDetectFormat(System.ReadOnlySpan<byte> header, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.Jpeg.JpegMetadata
+SixLabors.ImageSharp.Formats.Jpeg.JpegMetadata.ColorType.get -> SixLabors.ImageSharp.Formats.Jpeg.JpegEncodingColor?
+SixLabors.ImageSharp.Formats.Jpeg.JpegMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Jpeg.JpegMetadata.Interleaved.get -> bool?
+SixLabors.ImageSharp.Formats.Jpeg.JpegMetadata.JpegMetadata() -> void
+SixLabors.ImageSharp.Formats.Jpeg.JpegMetadata.Progressive.get -> bool?
+SixLabors.ImageSharp.Formats.Jpeg.JpegMetadata.Quality.get -> int
+SixLabors.ImageSharp.Formats.Pbm.PbmColorType
+SixLabors.ImageSharp.Formats.Pbm.PbmColorType.BlackAndWhite = 0 -> SixLabors.ImageSharp.Formats.Pbm.PbmColorType
+SixLabors.ImageSharp.Formats.Pbm.PbmColorType.Grayscale = 1 -> SixLabors.ImageSharp.Formats.Pbm.PbmColorType
+SixLabors.ImageSharp.Formats.Pbm.PbmColorType.Rgb = 2 -> SixLabors.ImageSharp.Formats.Pbm.PbmColorType
+SixLabors.ImageSharp.Formats.Pbm.PbmComponentType
+SixLabors.ImageSharp.Formats.Pbm.PbmComponentType.Bit = 0 -> SixLabors.ImageSharp.Formats.Pbm.PbmComponentType
+SixLabors.ImageSharp.Formats.Pbm.PbmComponentType.Byte = 1 -> SixLabors.ImageSharp.Formats.Pbm.PbmComponentType
+SixLabors.ImageSharp.Formats.Pbm.PbmComponentType.Short = 2 -> SixLabors.ImageSharp.Formats.Pbm.PbmComponentType
+SixLabors.ImageSharp.Formats.Pbm.PbmConfigurationModule
+SixLabors.ImageSharp.Formats.Pbm.PbmConfigurationModule.Configure(SixLabors.ImageSharp.Configuration! configuration) -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmConfigurationModule.PbmConfigurationModule() -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmDecoder
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoder
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoder.ColorType.get -> SixLabors.ImageSharp.Formats.Pbm.PbmColorType?
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoder.ColorType.init -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoder.ComponentType.get -> SixLabors.ImageSharp.Formats.Pbm.PbmComponentType?
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoder.ComponentType.init -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoder.Encoding.get -> SixLabors.ImageSharp.Formats.Pbm.PbmEncoding?
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoder.Encoding.init -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoder.PbmEncoder() -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoding
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoding.Binary = 1 -> SixLabors.ImageSharp.Formats.Pbm.PbmEncoding
+SixLabors.ImageSharp.Formats.Pbm.PbmEncoding.Plain = 0 -> SixLabors.ImageSharp.Formats.Pbm.PbmEncoding
+SixLabors.ImageSharp.Formats.Pbm.PbmFormat
+SixLabors.ImageSharp.Formats.Pbm.PbmFormat.CreateDefaultFormatMetadata() -> SixLabors.ImageSharp.Formats.Pbm.PbmMetadata!
+SixLabors.ImageSharp.Formats.Pbm.PbmFormat.DefaultMimeType.get -> string!
+SixLabors.ImageSharp.Formats.Pbm.PbmFormat.FileExtensions.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Pbm.PbmFormat.MimeTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Pbm.PbmFormat.Name.get -> string!
+SixLabors.ImageSharp.Formats.Pbm.PbmImageFormatDetector
+SixLabors.ImageSharp.Formats.Pbm.PbmImageFormatDetector.HeaderSize.get -> int
+SixLabors.ImageSharp.Formats.Pbm.PbmImageFormatDetector.PbmImageFormatDetector() -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmImageFormatDetector.TryDetectFormat(System.ReadOnlySpan<byte> header, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.Pbm.PbmMetadata
+SixLabors.ImageSharp.Formats.Pbm.PbmMetadata.ColorType.get -> SixLabors.ImageSharp.Formats.Pbm.PbmColorType
+SixLabors.ImageSharp.Formats.Pbm.PbmMetadata.ColorType.set -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmMetadata.ComponentType.get -> SixLabors.ImageSharp.Formats.Pbm.PbmComponentType
+SixLabors.ImageSharp.Formats.Pbm.PbmMetadata.ComponentType.set -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Pbm.PbmMetadata.Encoding.get -> SixLabors.ImageSharp.Formats.Pbm.PbmEncoding
+SixLabors.ImageSharp.Formats.Pbm.PbmMetadata.Encoding.set -> void
+SixLabors.ImageSharp.Formats.Pbm.PbmMetadata.PbmMetadata() -> void
+SixLabors.ImageSharp.Formats.PixelTypeInfo
+SixLabors.ImageSharp.Formats.PixelTypeInfo.AlphaRepresentation.get -> SixLabors.ImageSharp.PixelFormats.PixelAlphaRepresentation?
+SixLabors.ImageSharp.Formats.PixelTypeInfo.BitsPerPixel.get -> int
+SixLabors.ImageSharp.Formats.PixelTypeInfo.PixelTypeInfo(int bitsPerPixel) -> void
+SixLabors.ImageSharp.Formats.PixelTypeInfo.PixelTypeInfo(int bitsPerPixel, SixLabors.ImageSharp.PixelFormats.PixelAlphaRepresentation alpha) -> void
+SixLabors.ImageSharp.Formats.Png.PngBitDepth
+SixLabors.ImageSharp.Formats.Png.PngBitDepth.Bit1 = 1 -> SixLabors.ImageSharp.Formats.Png.PngBitDepth
+SixLabors.ImageSharp.Formats.Png.PngBitDepth.Bit16 = 16 -> SixLabors.ImageSharp.Formats.Png.PngBitDepth
+SixLabors.ImageSharp.Formats.Png.PngBitDepth.Bit2 = 2 -> SixLabors.ImageSharp.Formats.Png.PngBitDepth
+SixLabors.ImageSharp.Formats.Png.PngBitDepth.Bit4 = 4 -> SixLabors.ImageSharp.Formats.Png.PngBitDepth
+SixLabors.ImageSharp.Formats.Png.PngBitDepth.Bit8 = 8 -> SixLabors.ImageSharp.Formats.Png.PngBitDepth
+SixLabors.ImageSharp.Formats.Png.PngChunkFilter
+SixLabors.ImageSharp.Formats.Png.PngChunkFilter.ExcludeAll = -1 -> SixLabors.ImageSharp.Formats.Png.PngChunkFilter
+SixLabors.ImageSharp.Formats.Png.PngChunkFilter.ExcludeExifChunk = 4 -> SixLabors.ImageSharp.Formats.Png.PngChunkFilter
+SixLabors.ImageSharp.Formats.Png.PngChunkFilter.ExcludeGammaChunk = 2 -> SixLabors.ImageSharp.Formats.Png.PngChunkFilter
+SixLabors.ImageSharp.Formats.Png.PngChunkFilter.ExcludePhysicalChunk = 1 -> SixLabors.ImageSharp.Formats.Png.PngChunkFilter
+SixLabors.ImageSharp.Formats.Png.PngChunkFilter.ExcludeTextChunks = 8 -> SixLabors.ImageSharp.Formats.Png.PngChunkFilter
+SixLabors.ImageSharp.Formats.Png.PngChunkFilter.None = 0 -> SixLabors.ImageSharp.Formats.Png.PngChunkFilter
+SixLabors.ImageSharp.Formats.Png.PngColorType
+SixLabors.ImageSharp.Formats.Png.PngColorType.Grayscale = 0 -> SixLabors.ImageSharp.Formats.Png.PngColorType
+SixLabors.ImageSharp.Formats.Png.PngColorType.GrayscaleWithAlpha = 4 -> SixLabors.ImageSharp.Formats.Png.PngColorType
+SixLabors.ImageSharp.Formats.Png.PngColorType.Palette = 3 -> SixLabors.ImageSharp.Formats.Png.PngColorType
+SixLabors.ImageSharp.Formats.Png.PngColorType.Rgb = 2 -> SixLabors.ImageSharp.Formats.Png.PngColorType
+SixLabors.ImageSharp.Formats.Png.PngColorType.RgbWithAlpha = 6 -> SixLabors.ImageSharp.Formats.Png.PngColorType
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.BestCompression = 9 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.BestSpeed = 1 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.DefaultCompression = 6 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level0 = 0 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level1 = 1 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level2 = 2 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level3 = 3 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level4 = 4 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level5 = 5 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level6 = 6 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level7 = 7 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level8 = 8 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level9 = 9 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.NoCompression = 0 -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngConfigurationModule
+SixLabors.ImageSharp.Formats.Png.PngConfigurationModule.Configure(SixLabors.ImageSharp.Configuration! configuration) -> void
+SixLabors.ImageSharp.Formats.Png.PngConfigurationModule.PngConfigurationModule() -> void
+SixLabors.ImageSharp.Formats.Png.PngDecoder
+SixLabors.ImageSharp.Formats.Png.PngEncoder
+SixLabors.ImageSharp.Formats.Png.PngEncoder.BitDepth.get -> SixLabors.ImageSharp.Formats.Png.PngBitDepth?
+SixLabors.ImageSharp.Formats.Png.PngEncoder.BitDepth.init -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.ChunkFilter.get -> SixLabors.ImageSharp.Formats.Png.PngChunkFilter?
+SixLabors.ImageSharp.Formats.Png.PngEncoder.ChunkFilter.init -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.ColorType.get -> SixLabors.ImageSharp.Formats.Png.PngColorType?
+SixLabors.ImageSharp.Formats.Png.PngEncoder.ColorType.init -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.CompressionLevel.get -> SixLabors.ImageSharp.Formats.Png.PngCompressionLevel
+SixLabors.ImageSharp.Formats.Png.PngEncoder.CompressionLevel.init -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.FilterMethod.get -> SixLabors.ImageSharp.Formats.Png.PngFilterMethod?
+SixLabors.ImageSharp.Formats.Png.PngEncoder.FilterMethod.init -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.Gamma.get -> float?
+SixLabors.ImageSharp.Formats.Png.PngEncoder.Gamma.init -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.InterlaceMethod.get -> SixLabors.ImageSharp.Formats.Png.PngInterlaceMode?
+SixLabors.ImageSharp.Formats.Png.PngEncoder.InterlaceMethod.init -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.PngEncoder() -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.TextCompressionThreshold.get -> int
+SixLabors.ImageSharp.Formats.Png.PngEncoder.TextCompressionThreshold.init -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.Threshold.get -> byte
+SixLabors.ImageSharp.Formats.Png.PngEncoder.Threshold.init -> void
+SixLabors.ImageSharp.Formats.Png.PngEncoder.TransparentColorMode.get -> SixLabors.ImageSharp.Formats.Png.PngTransparentColorMode
+SixLabors.ImageSharp.Formats.Png.PngEncoder.TransparentColorMode.init -> void
+SixLabors.ImageSharp.Formats.Png.PngFilterMethod
+SixLabors.ImageSharp.Formats.Png.PngFilterMethod.Adaptive = 5 -> SixLabors.ImageSharp.Formats.Png.PngFilterMethod
+SixLabors.ImageSharp.Formats.Png.PngFilterMethod.Average = 3 -> SixLabors.ImageSharp.Formats.Png.PngFilterMethod
+SixLabors.ImageSharp.Formats.Png.PngFilterMethod.None = 0 -> SixLabors.ImageSharp.Formats.Png.PngFilterMethod
+SixLabors.ImageSharp.Formats.Png.PngFilterMethod.Paeth = 4 -> SixLabors.ImageSharp.Formats.Png.PngFilterMethod
+SixLabors.ImageSharp.Formats.Png.PngFilterMethod.Sub = 1 -> SixLabors.ImageSharp.Formats.Png.PngFilterMethod
+SixLabors.ImageSharp.Formats.Png.PngFilterMethod.Up = 2 -> SixLabors.ImageSharp.Formats.Png.PngFilterMethod
+SixLabors.ImageSharp.Formats.Png.PngFormat
+SixLabors.ImageSharp.Formats.Png.PngFormat.CreateDefaultFormatMetadata() -> SixLabors.ImageSharp.Formats.Png.PngMetadata!
+SixLabors.ImageSharp.Formats.Png.PngFormat.DefaultMimeType.get -> string!
+SixLabors.ImageSharp.Formats.Png.PngFormat.FileExtensions.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Png.PngFormat.MimeTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Png.PngFormat.Name.get -> string!
+SixLabors.ImageSharp.Formats.Png.PngImageFormatDetector
+SixLabors.ImageSharp.Formats.Png.PngImageFormatDetector.HeaderSize.get -> int
+SixLabors.ImageSharp.Formats.Png.PngImageFormatDetector.PngImageFormatDetector() -> void
+SixLabors.ImageSharp.Formats.Png.PngImageFormatDetector.TryDetectFormat(System.ReadOnlySpan<byte> header, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.Png.PngInterlaceMode
+SixLabors.ImageSharp.Formats.Png.PngInterlaceMode.Adam7 = 1 -> SixLabors.ImageSharp.Formats.Png.PngInterlaceMode
+SixLabors.ImageSharp.Formats.Png.PngInterlaceMode.None = 0 -> SixLabors.ImageSharp.Formats.Png.PngInterlaceMode
+SixLabors.ImageSharp.Formats.Png.PngMetadata
+SixLabors.ImageSharp.Formats.Png.PngMetadata.BitDepth.get -> SixLabors.ImageSharp.Formats.Png.PngBitDepth?
+SixLabors.ImageSharp.Formats.Png.PngMetadata.BitDepth.set -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.ColorType.get -> SixLabors.ImageSharp.Formats.Png.PngColorType?
+SixLabors.ImageSharp.Formats.Png.PngMetadata.ColorType.set -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Png.PngMetadata.Gamma.get -> float
+SixLabors.ImageSharp.Formats.Png.PngMetadata.Gamma.set -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.HasTransparency.get -> bool
+SixLabors.ImageSharp.Formats.Png.PngMetadata.HasTransparency.set -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.InterlaceMethod.get -> SixLabors.ImageSharp.Formats.Png.PngInterlaceMode?
+SixLabors.ImageSharp.Formats.Png.PngMetadata.InterlaceMethod.set -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.PngMetadata() -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TextData.get -> System.Collections.Generic.IList<SixLabors.ImageSharp.Formats.Png.PngTextData>!
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TextData.set -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TransparentL16.get -> SixLabors.ImageSharp.PixelFormats.L16?
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TransparentL16.set -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TransparentL8.get -> SixLabors.ImageSharp.PixelFormats.L8?
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TransparentL8.set -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TransparentRgb24.get -> SixLabors.ImageSharp.PixelFormats.Rgb24?
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TransparentRgb24.set -> void
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TransparentRgb48.get -> SixLabors.ImageSharp.PixelFormats.Rgb48?
+SixLabors.ImageSharp.Formats.Png.PngMetadata.TransparentRgb48.set -> void
+SixLabors.ImageSharp.Formats.Png.PngTextData
+SixLabors.ImageSharp.Formats.Png.PngTextData.Equals(SixLabors.ImageSharp.Formats.Png.PngTextData other) -> bool
+SixLabors.ImageSharp.Formats.Png.PngTextData.Keyword.get -> string!
+SixLabors.ImageSharp.Formats.Png.PngTextData.LanguageTag.get -> string!
+SixLabors.ImageSharp.Formats.Png.PngTextData.PngTextData() -> void
+SixLabors.ImageSharp.Formats.Png.PngTextData.PngTextData(string! keyword, string! value, string! languageTag, string! translatedKeyword) -> void
+SixLabors.ImageSharp.Formats.Png.PngTextData.TranslatedKeyword.get -> string!
+SixLabors.ImageSharp.Formats.Png.PngTextData.Value.get -> string!
+SixLabors.ImageSharp.Formats.Png.PngTransparentColorMode
+SixLabors.ImageSharp.Formats.Png.PngTransparentColorMode.Clear = 1 -> SixLabors.ImageSharp.Formats.Png.PngTransparentColorMode
+SixLabors.ImageSharp.Formats.Png.PngTransparentColorMode.Preserve = 0 -> SixLabors.ImageSharp.Formats.Png.PngTransparentColorMode
+SixLabors.ImageSharp.Formats.QuantizingImageEncoder
+SixLabors.ImageSharp.Formats.QuantizingImageEncoder.PixelSamplingStrategy.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.IPixelSamplingStrategy!
+SixLabors.ImageSharp.Formats.QuantizingImageEncoder.PixelSamplingStrategy.init -> void
+SixLabors.ImageSharp.Formats.QuantizingImageEncoder.Quantizer.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer!
+SixLabors.ImageSharp.Formats.QuantizingImageEncoder.Quantizer.init -> void
+SixLabors.ImageSharp.Formats.QuantizingImageEncoder.QuantizingImageEncoder() -> void
+SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>
+SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.Decode(T options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image!
+SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.Decode<TPixel>(T options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.DecodeAsync(T options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image!>!
+SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.DecodeAsync<TPixel>(T options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image<TPixel>!>!
+SixLabors.ImageSharp.Formats.SpecializedImageDecoder<T>.SpecializedImageDecoder() -> void
+SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel
+SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel.Pixel16 = 16 -> SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel
+SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel.Pixel24 = 24 -> SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel
+SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel.Pixel32 = 32 -> SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel
+SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel.Pixel8 = 8 -> SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel
+SixLabors.ImageSharp.Formats.Tga.TgaCompression
+SixLabors.ImageSharp.Formats.Tga.TgaCompression.None = 0 -> SixLabors.ImageSharp.Formats.Tga.TgaCompression
+SixLabors.ImageSharp.Formats.Tga.TgaCompression.RunLength = 1 -> SixLabors.ImageSharp.Formats.Tga.TgaCompression
+SixLabors.ImageSharp.Formats.Tga.TgaConfigurationModule
+SixLabors.ImageSharp.Formats.Tga.TgaConfigurationModule.Configure(SixLabors.ImageSharp.Configuration! configuration) -> void
+SixLabors.ImageSharp.Formats.Tga.TgaConfigurationModule.TgaConfigurationModule() -> void
+SixLabors.ImageSharp.Formats.Tga.TgaDecoder
+SixLabors.ImageSharp.Formats.Tga.TgaEncoder
+SixLabors.ImageSharp.Formats.Tga.TgaEncoder.BitsPerPixel.get -> SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel?
+SixLabors.ImageSharp.Formats.Tga.TgaEncoder.BitsPerPixel.init -> void
+SixLabors.ImageSharp.Formats.Tga.TgaEncoder.Compression.get -> SixLabors.ImageSharp.Formats.Tga.TgaCompression
+SixLabors.ImageSharp.Formats.Tga.TgaEncoder.Compression.init -> void
+SixLabors.ImageSharp.Formats.Tga.TgaEncoder.TgaEncoder() -> void
+SixLabors.ImageSharp.Formats.Tga.TgaFormat
+SixLabors.ImageSharp.Formats.Tga.TgaFormat.CreateDefaultFormatMetadata() -> SixLabors.ImageSharp.Formats.Tga.TgaMetadata!
+SixLabors.ImageSharp.Formats.Tga.TgaFormat.DefaultMimeType.get -> string!
+SixLabors.ImageSharp.Formats.Tga.TgaFormat.FileExtensions.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Tga.TgaFormat.MimeTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Tga.TgaFormat.Name.get -> string!
+SixLabors.ImageSharp.Formats.Tga.TgaFormat.TgaFormat() -> void
+SixLabors.ImageSharp.Formats.Tga.TgaImageFormatDetector
+SixLabors.ImageSharp.Formats.Tga.TgaImageFormatDetector.HeaderSize.get -> int
+SixLabors.ImageSharp.Formats.Tga.TgaImageFormatDetector.TgaImageFormatDetector() -> void
+SixLabors.ImageSharp.Formats.Tga.TgaImageFormatDetector.TryDetectFormat(System.ReadOnlySpan<byte> header, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.Tga.TgaImageType
+SixLabors.ImageSharp.Formats.Tga.TgaImageType.BlackAndWhite = 3 -> SixLabors.ImageSharp.Formats.Tga.TgaImageType
+SixLabors.ImageSharp.Formats.Tga.TgaImageType.ColorMapped = 1 -> SixLabors.ImageSharp.Formats.Tga.TgaImageType
+SixLabors.ImageSharp.Formats.Tga.TgaImageType.NoImageData = 0 -> SixLabors.ImageSharp.Formats.Tga.TgaImageType
+SixLabors.ImageSharp.Formats.Tga.TgaImageType.RleBlackAndWhite = 11 -> SixLabors.ImageSharp.Formats.Tga.TgaImageType
+SixLabors.ImageSharp.Formats.Tga.TgaImageType.RleColorMapped = 9 -> SixLabors.ImageSharp.Formats.Tga.TgaImageType
+SixLabors.ImageSharp.Formats.Tga.TgaImageType.RleTrueColor = 10 -> SixLabors.ImageSharp.Formats.Tga.TgaImageType
+SixLabors.ImageSharp.Formats.Tga.TgaImageType.TrueColor = 2 -> SixLabors.ImageSharp.Formats.Tga.TgaImageType
+SixLabors.ImageSharp.Formats.Tga.TgaImageTypeExtensions
+SixLabors.ImageSharp.Formats.Tga.TgaMetadata
+SixLabors.ImageSharp.Formats.Tga.TgaMetadata.AlphaChannelBits.get -> byte
+SixLabors.ImageSharp.Formats.Tga.TgaMetadata.AlphaChannelBits.set -> void
+SixLabors.ImageSharp.Formats.Tga.TgaMetadata.BitsPerPixel.get -> SixLabors.ImageSharp.Formats.Tga.TgaBitsPerPixel
+SixLabors.ImageSharp.Formats.Tga.TgaMetadata.BitsPerPixel.set -> void
+SixLabors.ImageSharp.Formats.Tga.TgaMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Tga.TgaMetadata.TgaMetadata() -> void
+SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors.LzwString
+SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors.LzwString.FirstChar.get -> byte
+SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors.LzwString.Length.get -> int
+SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors.LzwString.LzwString(byte code) -> void
+SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors.LzwString.WriteTo(System.Span<byte> buffer, int offset) -> int
+SixLabors.ImageSharp.Formats.Tiff.Compression.FaxCompressionOptions
+SixLabors.ImageSharp.Formats.Tiff.Compression.FaxCompressionOptions.EolPadding = 4 -> SixLabors.ImageSharp.Formats.Tiff.Compression.FaxCompressionOptions
+SixLabors.ImageSharp.Formats.Tiff.Compression.FaxCompressionOptions.None = 0 -> SixLabors.ImageSharp.Formats.Tiff.Compression.FaxCompressionOptions
+SixLabors.ImageSharp.Formats.Tiff.Compression.FaxCompressionOptions.TwoDimensionalCoding = 1 -> SixLabors.ImageSharp.Formats.Tiff.Compression.FaxCompressionOptions
+SixLabors.ImageSharp.Formats.Tiff.Compression.FaxCompressionOptions.UncompressedMode = 2 -> SixLabors.ImageSharp.Formats.Tiff.Compression.FaxCompressionOptions
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.Ccitt1D = 2 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.CcittGroup3Fax = 3 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.CcittGroup4Fax = 4 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.Deflate = 8 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.Invalid = 0 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.ItuTRecT43 = 10 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.ItuTRecT82 = 9 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.Jpeg = 7 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.Lzw = 5 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.NeXT = 32766 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.None = 1 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.OldDeflate = 32946 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.OldJpeg = 6 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.PackBits = 32773 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.ThunderScan = 32809 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression.Webp = 50001 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffInkSet
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffInkSet.Cmyk = 1 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffInkSet
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffInkSet.NotCmyk = 2 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffInkSet
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType.AlternativePreview = 65536 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType.FullImage = 0 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType.MixedRasterContent = 8 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType.Preview = 1 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType.SinglePage = 2 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType.TransparencyMask = 4 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffNewSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.BlackIsZero = 1 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.CieLab = 8 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.ColorFilterArray = 32803 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.IccLab = 9 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.ItuLab = 10 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.LinearRaw = 34892 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.PaletteColor = 3 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.Rgb = 2 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.Separated = 5 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.TransparencyMask = 4 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.WhiteIsZero = 0 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation.YCbCr = 6 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPlanarConfiguration
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPlanarConfiguration.Chunky = 1 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPlanarConfiguration
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPlanarConfiguration.Planar = 2 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPlanarConfiguration
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPredictor
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPredictor.FloatingPoint = 3 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPredictor
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPredictor.Horizontal = 2 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPredictor
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPredictor.None = 1 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPredictor
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat.ComplexFloat = 6 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat.ComplexInt = 5 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat.Float = 3 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat.SignedInteger = 2 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat.Undefined = 4 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat.UnsignedInteger = 1 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSampleFormat
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSubfileType.FullImage = 1 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSubfileType.Preview = 2 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSubfileType
+SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSubfileType.SinglePage = 3 -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffSubfileType
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit1 = 1 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit10 = 10 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit12 = 12 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit14 = 14 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit16 = 16 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit24 = 24 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit30 = 30 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit32 = 32 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit36 = 36 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit4 = 4 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit42 = 42 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit48 = 48 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit6 = 6 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit64 = 64 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel.Bit8 = 8 -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.BitsPerPixel() -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.Channel0.get -> ushort
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.Channel1.get -> ushort
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.Channel2.get -> ushort
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.Channel3.get -> ushort
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.Channels.get -> byte
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.Equals(SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample other) -> bool
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.TiffBitsPerSample() -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.TiffBitsPerSample(ushort channel0, ushort channel1, ushort channel2, ushort channel3 = 0) -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.ToArray() -> ushort[]!
+SixLabors.ImageSharp.Formats.Tiff.TiffConfigurationModule
+SixLabors.ImageSharp.Formats.Tiff.TiffConfigurationModule.Configure(SixLabors.ImageSharp.Configuration! configuration) -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffConfigurationModule.TiffConfigurationModule() -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffDecoder
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.BitsPerPixel.get -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel?
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.BitsPerPixel.init -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.Compression.get -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression?
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.Compression.init -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.CompressionLevel.get -> SixLabors.ImageSharp.Compression.Zlib.DeflateCompressionLevel?
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.CompressionLevel.init -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.HorizontalPredictor.get -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPredictor?
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.HorizontalPredictor.init -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.PhotometricInterpretation.get -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation?
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.PhotometricInterpretation.init -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffEncoder.TiffEncoder() -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffFormat
+SixLabors.ImageSharp.Formats.Tiff.TiffFormat.CreateDefaultFormatFrameMetadata() -> SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata!
+SixLabors.ImageSharp.Formats.Tiff.TiffFormat.CreateDefaultFormatMetadata() -> SixLabors.ImageSharp.Formats.Tiff.TiffMetadata!
+SixLabors.ImageSharp.Formats.Tiff.TiffFormat.DefaultMimeType.get -> string!
+SixLabors.ImageSharp.Formats.Tiff.TiffFormat.FileExtensions.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Tiff.TiffFormat.MimeTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Tiff.TiffFormat.Name.get -> string!
+SixLabors.ImageSharp.Formats.Tiff.TiffFormatType
+SixLabors.ImageSharp.Formats.Tiff.TiffFormatType.BigTIFF = 1 -> SixLabors.ImageSharp.Formats.Tiff.TiffFormatType
+SixLabors.ImageSharp.Formats.Tiff.TiffFormatType.Default = 0 -> SixLabors.ImageSharp.Formats.Tiff.TiffFormatType
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.BitsPerPixel.get -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerPixel?
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.BitsPerPixel.set -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.BitsPerSample.get -> SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample?
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.BitsPerSample.set -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.Compression.get -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffCompression?
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.Compression.set -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.InkSet.get -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffInkSet?
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.InkSet.set -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.PhotometricInterpretation.get -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPhotometricInterpretation?
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.PhotometricInterpretation.set -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.Predictor.get -> SixLabors.ImageSharp.Formats.Tiff.Constants.TiffPredictor?
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.Predictor.set -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata.TiffFrameMetadata() -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffImageFormatDetector
+SixLabors.ImageSharp.Formats.Tiff.TiffImageFormatDetector.HeaderSize.get -> int
+SixLabors.ImageSharp.Formats.Tiff.TiffImageFormatDetector.TiffImageFormatDetector() -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffImageFormatDetector.TryDetectFormat(System.ReadOnlySpan<byte> header, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.Tiff.TiffMetadata
+SixLabors.ImageSharp.Formats.Tiff.TiffMetadata.ByteOrder.get -> SixLabors.ImageSharp.ByteOrder
+SixLabors.ImageSharp.Formats.Tiff.TiffMetadata.ByteOrder.set -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Tiff.TiffMetadata.FormatType.get -> SixLabors.ImageSharp.Formats.Tiff.TiffFormatType
+SixLabors.ImageSharp.Formats.Tiff.TiffMetadata.FormatType.set -> void
+SixLabors.ImageSharp.Formats.Tiff.TiffMetadata.TiffMetadata() -> void
+SixLabors.ImageSharp.Formats.Webp.WebpBitsPerPixel
+SixLabors.ImageSharp.Formats.Webp.WebpBitsPerPixel.Pixel24 = 24 -> SixLabors.ImageSharp.Formats.Webp.WebpBitsPerPixel
+SixLabors.ImageSharp.Formats.Webp.WebpBitsPerPixel.Pixel32 = 32 -> SixLabors.ImageSharp.Formats.Webp.WebpBitsPerPixel
+SixLabors.ImageSharp.Formats.Webp.WebpConfigurationModule
+SixLabors.ImageSharp.Formats.Webp.WebpConfigurationModule.Configure(SixLabors.ImageSharp.Configuration! configuration) -> void
+SixLabors.ImageSharp.Formats.Webp.WebpConfigurationModule.WebpConfigurationModule() -> void
+SixLabors.ImageSharp.Formats.Webp.WebpDecoder
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.EntropyPasses.get -> int
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.EntropyPasses.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.FileFormat.get -> SixLabors.ImageSharp.Formats.Webp.WebpFileFormatType?
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.FileFormat.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.FilterStrength.get -> int
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.FilterStrength.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.Method.get -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.Method.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.NearLossless.get -> bool
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.NearLossless.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.NearLosslessQuality.get -> int
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.NearLosslessQuality.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.Quality.get -> int
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.Quality.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.SpatialNoiseShaping.get -> int
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.SpatialNoiseShaping.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.TransparentColorMode.get -> SixLabors.ImageSharp.Formats.Webp.WebpTransparentColorMode
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.TransparentColorMode.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.UseAlphaCompression.get -> bool
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.UseAlphaCompression.init -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncoder.WebpEncoder() -> void
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.BestQuality = 6 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.Default = 4 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.Fastest = 0 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.Level0 = 0 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.Level1 = 1 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.Level2 = 2 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.Level3 = 3 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.Level4 = 4 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.Level5 = 5 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod.Level6 = 6 -> SixLabors.ImageSharp.Formats.Webp.WebpEncodingMethod
+SixLabors.ImageSharp.Formats.Webp.WebpFileFormatType
+SixLabors.ImageSharp.Formats.Webp.WebpFileFormatType.Lossless = 0 -> SixLabors.ImageSharp.Formats.Webp.WebpFileFormatType
+SixLabors.ImageSharp.Formats.Webp.WebpFileFormatType.Lossy = 1 -> SixLabors.ImageSharp.Formats.Webp.WebpFileFormatType
+SixLabors.ImageSharp.Formats.Webp.WebpFormat
+SixLabors.ImageSharp.Formats.Webp.WebpFormat.CreateDefaultFormatFrameMetadata() -> SixLabors.ImageSharp.Formats.Webp.WebpFrameMetadata!
+SixLabors.ImageSharp.Formats.Webp.WebpFormat.CreateDefaultFormatMetadata() -> SixLabors.ImageSharp.Formats.Webp.WebpMetadata!
+SixLabors.ImageSharp.Formats.Webp.WebpFormat.DefaultMimeType.get -> string!
+SixLabors.ImageSharp.Formats.Webp.WebpFormat.FileExtensions.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Webp.WebpFormat.MimeTypes.get -> System.Collections.Generic.IEnumerable<string!>!
+SixLabors.ImageSharp.Formats.Webp.WebpFormat.Name.get -> string!
+SixLabors.ImageSharp.Formats.Webp.WebpFrameMetadata
+SixLabors.ImageSharp.Formats.Webp.WebpFrameMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Webp.WebpFrameMetadata.FrameDuration.get -> uint
+SixLabors.ImageSharp.Formats.Webp.WebpFrameMetadata.FrameDuration.set -> void
+SixLabors.ImageSharp.Formats.Webp.WebpFrameMetadata.WebpFrameMetadata() -> void
+SixLabors.ImageSharp.Formats.Webp.WebpImageFormatDetector
+SixLabors.ImageSharp.Formats.Webp.WebpImageFormatDetector.HeaderSize.get -> int
+SixLabors.ImageSharp.Formats.Webp.WebpImageFormatDetector.TryDetectFormat(System.ReadOnlySpan<byte> header, out SixLabors.ImageSharp.Formats.IImageFormat? format) -> bool
+SixLabors.ImageSharp.Formats.Webp.WebpImageFormatDetector.WebpImageFormatDetector() -> void
+SixLabors.ImageSharp.Formats.Webp.WebpMetadata
+SixLabors.ImageSharp.Formats.Webp.WebpMetadata.AnimationLoopCount.get -> ushort
+SixLabors.ImageSharp.Formats.Webp.WebpMetadata.AnimationLoopCount.set -> void
+SixLabors.ImageSharp.Formats.Webp.WebpMetadata.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.Formats.Webp.WebpMetadata.FileFormat.get -> SixLabors.ImageSharp.Formats.Webp.WebpFileFormatType?
+SixLabors.ImageSharp.Formats.Webp.WebpMetadata.FileFormat.set -> void
+SixLabors.ImageSharp.Formats.Webp.WebpMetadata.WebpMetadata() -> void
+SixLabors.ImageSharp.Formats.Webp.WebpTransparentColorMode
+SixLabors.ImageSharp.Formats.Webp.WebpTransparentColorMode.Clear = 0 -> SixLabors.ImageSharp.Formats.Webp.WebpTransparentColorMode
+SixLabors.ImageSharp.Formats.Webp.WebpTransparentColorMode.Preserve = 1 -> SixLabors.ImageSharp.Formats.Webp.WebpTransparentColorMode
+SixLabors.ImageSharp.GeometryUtilities
+SixLabors.ImageSharp.GraphicOptionsDefaultsExtensions
+SixLabors.ImageSharp.GraphicsOptions
+SixLabors.ImageSharp.GraphicsOptions.AlphaCompositionMode.get -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.GraphicsOptions.AlphaCompositionMode.set -> void
+SixLabors.ImageSharp.GraphicsOptions.Antialias.get -> bool
+SixLabors.ImageSharp.GraphicsOptions.Antialias.set -> void
+SixLabors.ImageSharp.GraphicsOptions.AntialiasSubpixelDepth.get -> int
+SixLabors.ImageSharp.GraphicsOptions.AntialiasSubpixelDepth.set -> void
+SixLabors.ImageSharp.GraphicsOptions.BlendPercentage.get -> float
+SixLabors.ImageSharp.GraphicsOptions.BlendPercentage.set -> void
+SixLabors.ImageSharp.GraphicsOptions.ColorBlendingMode.get -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.GraphicsOptions.ColorBlendingMode.set -> void
+SixLabors.ImageSharp.GraphicsOptions.DeepClone() -> SixLabors.ImageSharp.GraphicsOptions!
+SixLabors.ImageSharp.GraphicsOptions.GraphicsOptions() -> void
+SixLabors.ImageSharp.IDeepCloneable
+SixLabors.ImageSharp.IDeepCloneable.DeepClone() -> SixLabors.ImageSharp.IDeepCloneable!
+SixLabors.ImageSharp.IDeepCloneable<T>
+SixLabors.ImageSharp.IDeepCloneable<T>.DeepClone() -> T!
+SixLabors.ImageSharp.Image
+SixLabors.ImageSharp.Image.Bounds.get -> SixLabors.ImageSharp.Rectangle
+SixLabors.ImageSharp.Image.CloneAs<TPixel2>() -> SixLabors.ImageSharp.Image<TPixel2>!
+SixLabors.ImageSharp.Image.Dispose() -> void
+SixLabors.ImageSharp.Image.Frames.get -> SixLabors.ImageSharp.ImageFrameCollection!
+SixLabors.ImageSharp.Image.Height.get -> int
+SixLabors.ImageSharp.Image.Image(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Formats.PixelTypeInfo! pixelType, SixLabors.ImageSharp.Metadata.ImageMetadata? metadata, SixLabors.ImageSharp.Size size) -> void
+SixLabors.ImageSharp.Image.Metadata.get -> SixLabors.ImageSharp.Metadata.ImageMetadata!
+SixLabors.ImageSharp.Image.PixelType.get -> SixLabors.ImageSharp.Formats.PixelTypeInfo!
+SixLabors.ImageSharp.Image.Save(System.IO.Stream! stream, SixLabors.ImageSharp.Formats.IImageEncoder! encoder) -> void
+SixLabors.ImageSharp.Image.SaveAsync(System.IO.Stream! stream, SixLabors.ImageSharp.Formats.IImageEncoder! encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+SixLabors.ImageSharp.Image.Size.get -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.Image.UpdateSize(SixLabors.ImageSharp.Size size) -> void
+SixLabors.ImageSharp.Image.Width.get -> int
+SixLabors.ImageSharp.Image<TPixel>
+SixLabors.ImageSharp.Image<TPixel>.Clone() -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.Image<TPixel>.Clone(SixLabors.ImageSharp.Configuration! configuration) -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.Image<TPixel>.CopyPixelDataTo(System.Span<byte> destination) -> void
+SixLabors.ImageSharp.Image<TPixel>.CopyPixelDataTo(System.Span<TPixel> destination) -> void
+SixLabors.ImageSharp.Image<TPixel>.DangerousTryGetSinglePixelMemory(out System.Memory<TPixel> memory) -> bool
+SixLabors.ImageSharp.Image<TPixel>.Frames.get -> SixLabors.ImageSharp.ImageFrameCollection<TPixel>!
+SixLabors.ImageSharp.Image<TPixel>.Image(int width, int height) -> void
+SixLabors.ImageSharp.Image<TPixel>.Image(int width, int height, TPixel backgroundColor) -> void
+SixLabors.ImageSharp.Image<TPixel>.Image(SixLabors.ImageSharp.Configuration! configuration, int width, int height) -> void
+SixLabors.ImageSharp.Image<TPixel>.Image(SixLabors.ImageSharp.Configuration! configuration, int width, int height, TPixel backgroundColor) -> void
+SixLabors.ImageSharp.Image<TPixel>.ProcessPixelRows(SixLabors.ImageSharp.PixelAccessorAction<TPixel>! processPixels) -> void
+SixLabors.ImageSharp.Image<TPixel>.ProcessPixelRows<TPixel2, TPixel3>(SixLabors.ImageSharp.Image<TPixel2>! image2, SixLabors.ImageSharp.Image<TPixel3>! image3, SixLabors.ImageSharp.PixelAccessorAction<TPixel, TPixel2, TPixel3>! processPixels) -> void
+SixLabors.ImageSharp.Image<TPixel>.ProcessPixelRows<TPixel2>(SixLabors.ImageSharp.Image<TPixel2>! image2, SixLabors.ImageSharp.PixelAccessorAction<TPixel, TPixel2>! processPixels) -> void
+SixLabors.ImageSharp.Image<TPixel>.this[int x, int y].get -> TPixel
+SixLabors.ImageSharp.Image<TPixel>.this[int x, int y].set -> void
+SixLabors.ImageSharp.ImageExtensions
+SixLabors.ImageSharp.ImageFormatException
+SixLabors.ImageSharp.ImageFrame
+SixLabors.ImageSharp.ImageFrame.Bounds() -> SixLabors.ImageSharp.Rectangle
+SixLabors.ImageSharp.ImageFrame.Dispose() -> void
+SixLabors.ImageSharp.ImageFrame.Height.get -> int
+SixLabors.ImageSharp.ImageFrame.ImageFrame(SixLabors.ImageSharp.Configuration! configuration, int width, int height, SixLabors.ImageSharp.Metadata.ImageFrameMetadata! metadata) -> void
+SixLabors.ImageSharp.ImageFrame.Metadata.get -> SixLabors.ImageSharp.Metadata.ImageFrameMetadata!
+SixLabors.ImageSharp.ImageFrame.Size() -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.ImageFrame.Width.get -> int
+SixLabors.ImageSharp.ImageFrame<TPixel>
+SixLabors.ImageSharp.ImageFrame<TPixel>.CopyPixelDataTo(System.Span<byte> destination) -> void
+SixLabors.ImageSharp.ImageFrame<TPixel>.CopyPixelDataTo(System.Span<TPixel> destination) -> void
+SixLabors.ImageSharp.ImageFrame<TPixel>.DangerousTryGetSinglePixelMemory(out System.Memory<TPixel> memory) -> bool
+SixLabors.ImageSharp.ImageFrame<TPixel>.PixelBuffer.get -> SixLabors.ImageSharp.Memory.Buffer2D<TPixel>!
+SixLabors.ImageSharp.ImageFrame<TPixel>.ProcessPixelRows(SixLabors.ImageSharp.PixelAccessorAction<TPixel>! processPixels) -> void
+SixLabors.ImageSharp.ImageFrame<TPixel>.ProcessPixelRows<TPixel2, TPixel3>(SixLabors.ImageSharp.ImageFrame<TPixel2>! frame2, SixLabors.ImageSharp.ImageFrame<TPixel3>! frame3, SixLabors.ImageSharp.PixelAccessorAction<TPixel, TPixel2, TPixel3>! processPixels) -> void
+SixLabors.ImageSharp.ImageFrame<TPixel>.ProcessPixelRows<TPixel2>(SixLabors.ImageSharp.ImageFrame<TPixel2>! frame2, SixLabors.ImageSharp.PixelAccessorAction<TPixel, TPixel2>! processPixels) -> void
+SixLabors.ImageSharp.ImageFrame<TPixel>.this[int x, int y].get -> TPixel
+SixLabors.ImageSharp.ImageFrame<TPixel>.this[int x, int y].set -> void
+SixLabors.ImageSharp.ImageFrameCollection
+SixLabors.ImageSharp.ImageFrameCollection.AddFrame(SixLabors.ImageSharp.ImageFrame! source) -> SixLabors.ImageSharp.ImageFrame!
+SixLabors.ImageSharp.ImageFrameCollection.CloneFrame(int index) -> SixLabors.ImageSharp.Image!
+SixLabors.ImageSharp.ImageFrameCollection.CreateFrame() -> SixLabors.ImageSharp.ImageFrame!
+SixLabors.ImageSharp.ImageFrameCollection.CreateFrame(SixLabors.ImageSharp.Color backgroundColor) -> SixLabors.ImageSharp.ImageFrame!
+SixLabors.ImageSharp.ImageFrameCollection.Dispose() -> void
+SixLabors.ImageSharp.ImageFrameCollection.EnsureNotDisposed() -> void
+SixLabors.ImageSharp.ImageFrameCollection.ExportFrame(int index) -> SixLabors.ImageSharp.Image!
+SixLabors.ImageSharp.ImageFrameCollection.ImageFrameCollection() -> void
+SixLabors.ImageSharp.ImageFrameCollection.InsertFrame(int index, SixLabors.ImageSharp.ImageFrame! source) -> SixLabors.ImageSharp.ImageFrame!
+SixLabors.ImageSharp.ImageFrameCollection.RootFrame.get -> SixLabors.ImageSharp.ImageFrame!
+SixLabors.ImageSharp.ImageFrameCollection.this[int index].get -> SixLabors.ImageSharp.ImageFrame!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.AddFrame(SixLabors.ImageSharp.ImageFrame<TPixel>! source) -> SixLabors.ImageSharp.ImageFrame<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.AddFrame(System.ReadOnlySpan<TPixel> source) -> SixLabors.ImageSharp.ImageFrame<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.AddFrame(TPixel[]! source) -> SixLabors.ImageSharp.ImageFrame<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.CloneFrame(int index) -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.Contains(SixLabors.ImageSharp.ImageFrame<TPixel>! frame) -> bool
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.CreateFrame() -> SixLabors.ImageSharp.ImageFrame<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.CreateFrame(TPixel backgroundColor) -> SixLabors.ImageSharp.ImageFrame<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.ExportFrame(int index) -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.GetEnumerator() -> System.Collections.Generic.IEnumerator<SixLabors.ImageSharp.ImageFrame<TPixel>!>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.IndexOf(SixLabors.ImageSharp.ImageFrame<TPixel>! frame) -> int
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.InsertFrame(int index, SixLabors.ImageSharp.ImageFrame<TPixel>! source) -> SixLabors.ImageSharp.ImageFrame<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.RootFrame.get -> SixLabors.ImageSharp.ImageFrame<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollection<TPixel>.this[int index].get -> SixLabors.ImageSharp.ImageFrame<TPixel>!
+SixLabors.ImageSharp.ImageFrameCollectionExtensions
+SixLabors.ImageSharp.ImageInfo
+SixLabors.ImageSharp.ImageInfo.Bounds.get -> SixLabors.ImageSharp.Rectangle
+SixLabors.ImageSharp.ImageInfo.FrameMetadataCollection.get -> System.Collections.Generic.IReadOnlyList<SixLabors.ImageSharp.Metadata.ImageFrameMetadata!>!
+SixLabors.ImageSharp.ImageInfo.Height.get -> int
+SixLabors.ImageSharp.ImageInfo.ImageInfo(SixLabors.ImageSharp.Formats.PixelTypeInfo! pixelType, SixLabors.ImageSharp.Size size, SixLabors.ImageSharp.Metadata.ImageMetadata? metadata) -> void
+SixLabors.ImageSharp.ImageInfo.ImageInfo(SixLabors.ImageSharp.Formats.PixelTypeInfo! pixelType, SixLabors.ImageSharp.Size size, SixLabors.ImageSharp.Metadata.ImageMetadata? metadata, System.Collections.Generic.IReadOnlyList<SixLabors.ImageSharp.Metadata.ImageFrameMetadata!>? frameMetadataCollection) -> void
+SixLabors.ImageSharp.ImageInfo.Metadata.get -> SixLabors.ImageSharp.Metadata.ImageMetadata!
+SixLabors.ImageSharp.ImageInfo.PixelType.get -> SixLabors.ImageSharp.Formats.PixelTypeInfo!
+SixLabors.ImageSharp.ImageInfo.Size.get -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.ImageInfo.Width.get -> int
+SixLabors.ImageSharp.ImageProcessingException
+SixLabors.ImageSharp.ImageProcessingException.ImageProcessingException() -> void
+SixLabors.ImageSharp.ImageProcessingException.ImageProcessingException(string! errorMessage) -> void
+SixLabors.ImageSharp.ImageProcessingException.ImageProcessingException(string! errorMessage, System.Exception! innerException) -> void
+SixLabors.ImageSharp.IndexedImageFrame<TPixel>
+SixLabors.ImageSharp.IndexedImageFrame<TPixel>.Configuration.get -> SixLabors.ImageSharp.Configuration!
+SixLabors.ImageSharp.IndexedImageFrame<TPixel>.DangerousGetRowSpan(int rowIndex) -> System.ReadOnlySpan<byte>
+SixLabors.ImageSharp.IndexedImageFrame<TPixel>.Dispose() -> void
+SixLabors.ImageSharp.IndexedImageFrame<TPixel>.GetWritablePixelRowSpanUnsafe(int rowIndex) -> System.Span<byte>
+SixLabors.ImageSharp.IndexedImageFrame<TPixel>.Height.get -> int
+SixLabors.ImageSharp.IndexedImageFrame<TPixel>.Palette.get -> System.ReadOnlyMemory<TPixel>
+SixLabors.ImageSharp.IndexedImageFrame<TPixel>.Width.get -> int
+SixLabors.ImageSharp.InvalidImageContentException
+SixLabors.ImageSharp.InvalidImageContentException.InvalidImageContentException(string! errorMessage) -> void
+SixLabors.ImageSharp.InvalidImageContentException.InvalidImageContentException(string! errorMessage, System.Exception! innerException) -> void
+SixLabors.ImageSharp.Matrix3x2Extensions
+SixLabors.ImageSharp.Memory.AllocationOptions
+SixLabors.ImageSharp.Memory.AllocationOptions.Clean = 1 -> SixLabors.ImageSharp.Memory.AllocationOptions
+SixLabors.ImageSharp.Memory.AllocationOptions.None = 0 -> SixLabors.ImageSharp.Memory.AllocationOptions
+SixLabors.ImageSharp.Memory.Buffer2D<T>
+SixLabors.ImageSharp.Memory.Buffer2D<T>.DangerousGetRowSpan(int y) -> System.Span<T>
+SixLabors.ImageSharp.Memory.Buffer2D<T>.Dispose() -> void
+SixLabors.ImageSharp.Memory.Buffer2D<T>.Height.get -> int
+SixLabors.ImageSharp.Memory.Buffer2D<T>.MemoryGroup.get -> SixLabors.ImageSharp.Memory.IMemoryGroup<T>!
+SixLabors.ImageSharp.Memory.Buffer2D<T>.this[int x, int y].get -> T
+SixLabors.ImageSharp.Memory.Buffer2D<T>.Width.get -> int
+SixLabors.ImageSharp.Memory.Buffer2DExtensions
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.Buffer.get -> SixLabors.ImageSharp.Memory.Buffer2D<T>!
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.Buffer2DRegion() -> void
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.Buffer2DRegion(SixLabors.ImageSharp.Memory.Buffer2D<T>! buffer) -> void
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.Buffer2DRegion(SixLabors.ImageSharp.Memory.Buffer2D<T>! buffer, SixLabors.ImageSharp.Rectangle rectangle) -> void
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.DangerousGetRowSpan(int y) -> System.Span<T>
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.GetSubRegion(int x, int y, int width, int height) -> SixLabors.ImageSharp.Memory.Buffer2DRegion<T>
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.GetSubRegion(SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Memory.Buffer2DRegion<T>
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.Height.get -> int
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.Rectangle.get -> SixLabors.ImageSharp.Rectangle
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.Stride.get -> int
+SixLabors.ImageSharp.Memory.Buffer2DRegion<T>.Width.get -> int
+SixLabors.ImageSharp.Memory.IMemoryGroup<T>
+SixLabors.ImageSharp.Memory.IMemoryGroup<T>.BufferLength.get -> int
+SixLabors.ImageSharp.Memory.IMemoryGroup<T>.GetEnumerator() -> SixLabors.ImageSharp.Memory.MemoryGroupEnumerator<T>
+SixLabors.ImageSharp.Memory.IMemoryGroup<T>.IsValid.get -> bool
+SixLabors.ImageSharp.Memory.IMemoryGroup<T>.TotalLength.get -> long
+SixLabors.ImageSharp.Memory.InvalidMemoryOperationException
+SixLabors.ImageSharp.Memory.InvalidMemoryOperationException.InvalidMemoryOperationException() -> void
+SixLabors.ImageSharp.Memory.InvalidMemoryOperationException.InvalidMemoryOperationException(string! message) -> void
+SixLabors.ImageSharp.Memory.MemoryAllocator
+SixLabors.ImageSharp.Memory.MemoryAllocator.MemoryAllocator() -> void
+SixLabors.ImageSharp.Memory.MemoryAllocatorExtensions
+SixLabors.ImageSharp.Memory.MemoryAllocatorOptions
+SixLabors.ImageSharp.Memory.MemoryAllocatorOptions.MaximumPoolSizeMegabytes.get -> int?
+SixLabors.ImageSharp.Memory.MemoryAllocatorOptions.MaximumPoolSizeMegabytes.set -> void
+SixLabors.ImageSharp.Memory.MemoryAllocatorOptions.MemoryAllocatorOptions() -> void
+SixLabors.ImageSharp.Memory.MemoryGroupEnumerator<T>
+SixLabors.ImageSharp.Memory.MemoryGroupEnumerator<T>.Current.get -> System.Memory<T>
+SixLabors.ImageSharp.Memory.MemoryGroupEnumerator<T>.MemoryGroupEnumerator() -> void
+SixLabors.ImageSharp.Memory.MemoryGroupEnumerator<T>.MoveNext() -> bool
+SixLabors.ImageSharp.Memory.RowInterval
+SixLabors.ImageSharp.Memory.RowInterval.Equals(SixLabors.ImageSharp.Memory.RowInterval other) -> bool
+SixLabors.ImageSharp.Memory.RowInterval.Height.get -> int
+SixLabors.ImageSharp.Memory.RowInterval.Max.get -> int
+SixLabors.ImageSharp.Memory.RowInterval.Min.get -> int
+SixLabors.ImageSharp.Memory.RowInterval.RowInterval() -> void
+SixLabors.ImageSharp.Memory.RowInterval.RowInterval(int min, int max) -> void
+SixLabors.ImageSharp.Memory.SimpleGcMemoryAllocator
+SixLabors.ImageSharp.Memory.SimpleGcMemoryAllocator.SimpleGcMemoryAllocator() -> void
+SixLabors.ImageSharp.Metadata.FrameDecodingMode
+SixLabors.ImageSharp.Metadata.FrameDecodingMode.All = 0 -> SixLabors.ImageSharp.Metadata.FrameDecodingMode
+SixLabors.ImageSharp.Metadata.FrameDecodingMode.First = 1 -> SixLabors.ImageSharp.Metadata.FrameDecodingMode
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.DeepClone() -> SixLabors.ImageSharp.Metadata.ImageFrameMetadata!
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.ExifProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile?
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.ExifProfile.set -> void
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.GetFormatMetadata<TFormatMetadata, TFormatFrameMetadata>(SixLabors.ImageSharp.Formats.IImageFormat<TFormatMetadata!, TFormatFrameMetadata!>! key) -> TFormatFrameMetadata!
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.IccProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile?
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.IccProfile.set -> void
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.IptcProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile?
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.IptcProfile.set -> void
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.TryGetFormatMetadata<TFormatMetadata, TFormatFrameMetadata>(SixLabors.ImageSharp.Formats.IImageFormat<TFormatMetadata!, TFormatFrameMetadata!>! key, out TFormatFrameMetadata? metadata) -> bool
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.XmpProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Xmp.XmpProfile?
+SixLabors.ImageSharp.Metadata.ImageFrameMetadata.XmpProfile.set -> void
+SixLabors.ImageSharp.Metadata.ImageMetadata
+SixLabors.ImageSharp.Metadata.ImageMetadata.DecodedImageFormat.get -> SixLabors.ImageSharp.Formats.IImageFormat?
+SixLabors.ImageSharp.Metadata.ImageMetadata.DeepClone() -> SixLabors.ImageSharp.Metadata.ImageMetadata!
+SixLabors.ImageSharp.Metadata.ImageMetadata.ExifProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile?
+SixLabors.ImageSharp.Metadata.ImageMetadata.ExifProfile.set -> void
+SixLabors.ImageSharp.Metadata.ImageMetadata.GetFormatMetadata<TFormatMetadata>(SixLabors.ImageSharp.Formats.IImageFormat<TFormatMetadata!>! key) -> TFormatMetadata!
+SixLabors.ImageSharp.Metadata.ImageMetadata.HorizontalResolution.get -> double
+SixLabors.ImageSharp.Metadata.ImageMetadata.HorizontalResolution.set -> void
+SixLabors.ImageSharp.Metadata.ImageMetadata.IccProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile?
+SixLabors.ImageSharp.Metadata.ImageMetadata.IccProfile.set -> void
+SixLabors.ImageSharp.Metadata.ImageMetadata.ImageMetadata() -> void
+SixLabors.ImageSharp.Metadata.ImageMetadata.IptcProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile?
+SixLabors.ImageSharp.Metadata.ImageMetadata.IptcProfile.set -> void
+SixLabors.ImageSharp.Metadata.ImageMetadata.ResolutionUnits.get -> SixLabors.ImageSharp.Metadata.PixelResolutionUnit
+SixLabors.ImageSharp.Metadata.ImageMetadata.ResolutionUnits.set -> void
+SixLabors.ImageSharp.Metadata.ImageMetadata.VerticalResolution.get -> double
+SixLabors.ImageSharp.Metadata.ImageMetadata.VerticalResolution.set -> void
+SixLabors.ImageSharp.Metadata.ImageMetadata.XmpProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Xmp.XmpProfile?
+SixLabors.ImageSharp.Metadata.ImageMetadata.XmpProfile.set -> void
+SixLabors.ImageSharp.Metadata.PixelResolutionUnit
+SixLabors.ImageSharp.Metadata.PixelResolutionUnit.AspectRatio = 0 -> SixLabors.ImageSharp.Metadata.PixelResolutionUnit
+SixLabors.ImageSharp.Metadata.PixelResolutionUnit.PixelsPerCentimeter = 2 -> SixLabors.ImageSharp.Metadata.PixelResolutionUnit
+SixLabors.ImageSharp.Metadata.PixelResolutionUnit.PixelsPerInch = 1 -> SixLabors.ImageSharp.Metadata.PixelResolutionUnit
+SixLabors.ImageSharp.Metadata.PixelResolutionUnit.PixelsPerMeter = 3 -> SixLabors.ImageSharp.Metadata.PixelResolutionUnit
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode.ASCII = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode.JIS = 1 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode.Undefined = 3 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode.Unicode = 2 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.Code.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.EncodedString() -> void
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.EncodedString(SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.CharacterCode code, string! text) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.EncodedString(string! text) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.Equals(SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString other) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.Text.get -> string!
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Ascii = 2 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Byte = 1 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.DoubleFloat = 12 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Ifd = 13 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Ifd8 = 18 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Long = 4 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Long8 = 16 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Rational = 5 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Short = 3 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.SignedByte = 6 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.SignedLong = 9 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.SignedLong8 = 17 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.SignedRational = 10 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.SignedShort = 8 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.SingleFloat = 11 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Undefined = 7 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType.Unknown = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifOrientationMode
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts.All = SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts.IfdTags | SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts.ExifTags | SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts.GpsTags -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts.ExifTags = 2 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts.GpsTags = 4 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts.IfdTags = 1 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts.None = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.DeepClone() -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile!
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.ExifProfile() -> void
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.ExifProfile(byte[]? data) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.InvalidTags.get -> System.Collections.Generic.IReadOnlyList<SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag!>!
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.Parts.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifParts
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.Parts.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.RemoveValue(SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag! tag) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.SetValue<TValueType>(SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<TValueType>! tag, TValueType value) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.ToByteArray() -> byte[]?
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.TryCreateThumbnail(out SixLabors.ImageSharp.Image? image) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.TryCreateThumbnail<TPixel>(out SixLabors.ImageSharp.Image<TPixel>? image) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.TryGetValue<TValueType>(SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<TValueType>! tag, out SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue<TValueType>? exifValue) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifProfile.Values.get -> System.Collections.Generic.IReadOnlyList<SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue!>!
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Equals(SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag? other) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<TValueType>
+SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue
+SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue.DataType.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifDataType
+SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue.GetValue() -> object?
+SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue.IsArray.get -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue.Tag.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag!
+SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue.TrySetValue(object? value) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue<TValueType>
+SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue<TValueType>.Value.get -> TValueType?
+SixLabors.ImageSharp.Metadata.Profiles.Exif.IExifValue<TValueType>.Value.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.CieLab = 1281450528 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.CieLuv = 1282766368 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.CieXyz = 1482250784 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.CieYxy = 1501067552 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Cmy = 1129142560 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Cmyk = 1129142603 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color10 = 1094929490 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color11 = 1111706706 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color12 = 1128483922 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color13 = 1145261138 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color14 = 1162038354 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color15 = 1178815570 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color2 = 843271250 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color3 = 860048466 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color4 = 876825682 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color5 = 893602898 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color6 = 910380114 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color7 = 927157330 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color8 = 943934546 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Color9 = 960711762 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Gray = 1196573017 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Hls = 1212961568 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Hsv = 1213421088 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.Rgb = 1380401696 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType.YCbCr = 1497588338 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute.ChromaBlackWhite = 8 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute.ChromaColor = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute.OpacityReflective = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute.OpacityTransparent = 1 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute.PolarityNegative = 4 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute.PolarityPositive = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute.ReflectivityGlossy = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute.ReflectivityMatte = 2 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType.AppleComputerInc = 1095782476 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType.MicrosoftCorporation = 1297303124 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType.NotIdentified = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType.SiliconGraphicsInc = 1397180704 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType.SunMicrosystemsInc = 1398099543 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile.CheckIsValid() -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile.IccProfile() -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass.Abstract = 1633842036 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass.ColorSpace = 1936744803 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass.DeviceLink = 1818848875 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass.DisplayDevice = 1835955314 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass.InputDevice = 1935896178 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass.NamedColor = 1852662636 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass.OutputDevice = 1886549106 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag.Embedded = 1 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag.Independent = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag.None = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag.NotEmbedded = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag.NotIndependent = 2 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Class.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileClass
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Class.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.CreationDate.get -> System.DateTime
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.CreationDate.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.DataColorSpace.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.DataColorSpace.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.DeviceAttributes.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccDeviceAttribute
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.DeviceAttributes.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.DeviceManufacturer.get -> uint
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.DeviceManufacturer.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.DeviceModel.get -> uint
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.DeviceModel.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Flags.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileFlag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Flags.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.IccProfileHeader() -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Id.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Id.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.PcsIlluminant.get -> System.Numerics.Vector3
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.PcsIlluminant.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.PrimaryPlatformSignature.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccPrimaryPlatformType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.PrimaryPlatformSignature.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.ProfileConnectionSpace.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccColorSpaceType
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.ProfileConnectionSpace.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.RenderingIntent.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.RenderingIntent.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Size.get -> uint
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Size.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Version.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.Version.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.Equals(SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId other) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.IccProfileId() -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.IccProfileId(uint p1, uint p2, uint p3, uint p4) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.IsSet.get -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.Part1.get -> uint
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.Part2.get -> uint
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.Part3.get -> uint
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.Part4.get -> uint
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.AToB0 = 1093812784 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.AToB1 = 1093812785 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.AToB2 = 1093812786 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.BlueMatrixColumn = 1649957210 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.BlueTrc = 1649693251 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.BToA0 = 1110589744 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.BToA1 = 1110589745 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.BToA2 = 1110589746 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.BToD0 = 1110590512 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.BToD1 = 1110590513 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.BToD2 = 1110590514 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.BToD3 = 1110590515 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.CalibrationDateTime = 1667329140 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.CharTarget = 1952543335 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ChromaticAdaptation = 1667785060 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Chromaticity = 1667789421 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ColorantOrder = 1668051567 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ColorantTable = 1668051572 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ColorantTableOut = 1668050804 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ColorimetricIntentImageStat = 1667852659 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Copyright = 1668313716 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.CrdInfo = 1668441193 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Data = 1684108385 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.DateTime = 1685350765 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.DeviceManufacturerDescription = 1684893284 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.DeviceModelDescription = 1684890724 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.DeviceSettings = 1684371059 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.DToB0 = 1144144432 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.DToB1 = 1144144432 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.DToB2 = 1144144432 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.DToB3 = 1144144432 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Gamut = 1734438260 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.GrayTrc = 1800688195 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.GreenMatrixColumn = 1733843290 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.GreenTrc = 1733579331 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Luminance = 1819635049 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Measurement = 1835360627 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.MediaBlackPoint = 1651208308 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.MediaWhitePoint = 2004119668 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.NamedColor = 1852010348 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.NamedColor2 = 1852009522 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.OutputResponse = 1919251312 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.PerceptualRenderingIntentGamut = 1919510320 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.PostScript2Crd0 = 1886610480 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.PostScript2Crd1 = 1886610481 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.PostScript2Crd2 = 1886610482 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.PostScript2Crd3 = 1886610483 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.PostScript2Csa = 1886597747 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.PostScript2RenderingIntent = 1886597737 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Preview0 = 1886545200 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Preview1 = 1886545201 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Preview2 = 1886545202 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ProfileDescription = 1684370275 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ProfileSequenceDescription = 1886610801 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.RedMatrixColumn = 1918392666 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.RedTrc = 1918128707 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.SaturationRenderingIntentGamut = 1919510322 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Screening = 1935897198 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ScreeningDescription = 1935897188 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Technology = 1952801640 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.UcrBgSpecification = 1650877472 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.Unknown = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ViewingCondDescription = 1987405156 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag.ViewingConditions = 1986618743 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent.AbsoluteColorimetric = 3 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent.MediaRelativeColorimetric = 1 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent.Perceptual = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent.Saturation = 2 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccRenderingIntent
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry.IccTagDataEntry(SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature signature) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry.IccTagDataEntry(SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature signature, SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag tagSignature) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry.Signature.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry.TagSignature.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileTag
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry.TagSignature.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Chromaticity = 1667789421 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.ColorantOrder = 1668051567 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.ColorantTable = 1668051572 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.CrdInfo = 1668441193 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Curve = 1668641398 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Data = 1684108385 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.DateTime = 1685350765 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.DeviceSettings = 1684371059 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Lut16 = 1835430962 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Lut8 = 1835430961 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.LutAToB = 1832993312 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.LutBToA = 1833058592 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Measurement = 1835360627 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.MultiLocalizedUnicode = 1835824483 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.MultiProcessElements = 1836082548 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.NamedColor = 1852010348 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.NamedColor2 = 1852009522 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.ParametricCurve = 1885434465 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.ProfileSequenceDesc = 1886610801 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.ProfileSequenceIdentifier = 1886611812 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.ResponseCurveSet16 = 1919120178 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.S15Fixed16Array = 1936077618 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Screening = 1935897198 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Signature = 1936287520 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Text = 1952807028 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.TextDescription = 1684370275 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.U16Fixed16Array = 1969632050 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.UcrBg = 1650877472 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.UInt16Array = 1969828150 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.UInt32Array = 1969828658 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.UInt64Array = 1969829428 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.UInt8Array = 1969827896 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Unknown = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.ViewingConditions = 1986618743 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature.Xyz = 1482250784 -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTypeSignature
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.Equals(SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion other) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.IccVersion() -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.IccVersion(int major, int minor, int patch) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.Major.get -> int
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.Minor.get -> int
+SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.Patch.get -> int
+SixLabors.ImageSharp.Metadata.Profiles.Icc.InvalidIccProfileException
+SixLabors.ImageSharp.Metadata.Profiles.Icc.InvalidIccProfileException.InvalidIccProfileException(string! message) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Icc.InvalidIccProfileException.InvalidIccProfileException(string! message, System.Exception! inner) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.Data.get -> byte[]?
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.DeepClone() -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile!
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.GetValues(SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag) -> System.Collections.Generic.List<SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue!>!
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.IptcProfile() -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.IptcProfile(byte[]? data) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.RemoveValue(SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.RemoveValue(SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag, string! value) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.SetDateTimeValue(SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag, System.DateTimeOffset dateTimeOffset) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.SetEncoding(System.Text.Encoding! encoding) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.SetValue(SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag, string! value, bool strict = true) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.SetValue(SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag, System.Text.Encoding! encoding, string! value, bool strict = true) -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.UpdateData() -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcProfile.Values.get -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue!>!
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ActionAdvised = 42 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Byline = 80 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.BylineTitle = 85 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Caption = 120 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CaptionWriter = 122 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Category = 15 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.City = 90 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Contact = 118 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CopyrightNotice = 116 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Country = 101 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CountryCode = 100 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CreatedDate = 55 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CreatedTime = 60 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Credit = 110 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField1 = 200 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField10 = 209 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField11 = 210 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField12 = 211 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField13 = 212 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField14 = 213 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField15 = 214 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField16 = 215 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField17 = 216 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField18 = 217 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField19 = 218 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField2 = 201 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField20 = 219 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField3 = 202 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField4 = 203 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField5 = 204 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField6 = 205 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField7 = 206 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField8 = 207 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.CustomField9 = 208 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.DigitalCreationDate = 62 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.DigitalCreationTime = 63 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.EditorialUpdate = 8 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.EditStatus = 7 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ExpirationDate = 37 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ExpirationTime = 38 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.FixtureIdentifier = 22 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Headline = 105 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ImageOrientation = 131 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ImageType = 130 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Keywords = 25 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.LocalCaption = 121 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.LocationCode = 26 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.LocationName = 27 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Name = 5 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ObjectAttribute = 4 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ObjectCycle = 75 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ObjectType = 3 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.OriginalTransmissionReference = 103 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.OriginatingProgram = 65 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ProgramVersion = 70 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ProvinceState = 95 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.RecordVersion = 0 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ReferenceDate = 47 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ReferenceNumber = 50 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ReferenceService = 45 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ReleaseDate = 30 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.ReleaseTime = 35 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Source = 115 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.SpecialInstructions = 40 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.SubjectReference = 12 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.SubLocation = 92 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.SupplementalCategories = 20 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Unknown = -1 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag.Urgency = 10 -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTagExtensions
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.DeepClone() -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue!
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Encoding.get -> System.Text.Encoding!
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Encoding.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Equals(SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue? other) -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Length.get -> int
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Strict.get -> bool
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Strict.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Tag.get -> SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.ToByteArray() -> byte[]!
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.ToString(System.Text.Encoding! encoding) -> string!
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Value.get -> string!
+SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcValue.Value.set -> void
+SixLabors.ImageSharp.Metadata.Profiles.Xmp.XmpProfile
+SixLabors.ImageSharp.Metadata.Profiles.Xmp.XmpProfile.DeepClone() -> SixLabors.ImageSharp.Metadata.Profiles.Xmp.XmpProfile!
+SixLabors.ImageSharp.Metadata.Profiles.Xmp.XmpProfile.GetDocument() -> System.Xml.Linq.XDocument?
+SixLabors.ImageSharp.Metadata.Profiles.Xmp.XmpProfile.ToByteArray() -> byte[]!
+SixLabors.ImageSharp.Metadata.Profiles.Xmp.XmpProfile.XmpProfile() -> void
+SixLabors.ImageSharp.Metadata.Profiles.Xmp.XmpProfile.XmpProfile(byte[]? data) -> void
+SixLabors.ImageSharp.MetadataExtensions
+SixLabors.ImageSharp.Number
+SixLabors.ImageSharp.Number.CompareTo(SixLabors.ImageSharp.Number other) -> int
+SixLabors.ImageSharp.Number.Equals(SixLabors.ImageSharp.Number other) -> bool
+SixLabors.ImageSharp.Number.Number() -> void
+SixLabors.ImageSharp.Number.Number(int value) -> void
+SixLabors.ImageSharp.Number.Number(uint value) -> void
+SixLabors.ImageSharp.Number.ToString(System.IFormatProvider! provider) -> string!
+SixLabors.ImageSharp.PixelAccessor<TPixel>
+SixLabors.ImageSharp.PixelAccessor<TPixel>.GetRowSpan(int rowIndex) -> System.Span<TPixel>
+SixLabors.ImageSharp.PixelAccessor<TPixel>.Height.get -> int
+SixLabors.ImageSharp.PixelAccessor<TPixel>.PixelAccessor() -> void
+SixLabors.ImageSharp.PixelAccessor<TPixel>.Width.get -> int
+SixLabors.ImageSharp.PixelAccessorAction<TPixel1, TPixel2, TPixel3>
+SixLabors.ImageSharp.PixelAccessorAction<TPixel1, TPixel2>
+SixLabors.ImageSharp.PixelAccessorAction<TPixel>
+SixLabors.ImageSharp.PixelFormats.A8
+SixLabors.ImageSharp.PixelFormats.A8.A8() -> void
+SixLabors.ImageSharp.PixelFormats.A8.A8(byte alpha) -> void
+SixLabors.ImageSharp.PixelFormats.A8.A8(float alpha) -> void
+SixLabors.ImageSharp.PixelFormats.A8.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.A8>!
+SixLabors.ImageSharp.PixelFormats.A8.Equals(SixLabors.ImageSharp.PixelFormats.A8 other) -> bool
+SixLabors.ImageSharp.PixelFormats.A8.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.A8.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.A8.PackedValue.get -> byte
+SixLabors.ImageSharp.PixelFormats.A8.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.A8.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.A8.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.A8.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Abgr32
+SixLabors.ImageSharp.PixelFormats.Abgr32.A -> byte
+SixLabors.ImageSharp.PixelFormats.Abgr32.Abgr.get -> uint
+SixLabors.ImageSharp.PixelFormats.Abgr32.Abgr.set -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.Abgr32() -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.Abgr32(byte r, byte g, byte b) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.Abgr32(byte r, byte g, byte b, byte a) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.Abgr32(float r, float g, float b, float a = 1) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.Abgr32(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.Abgr32(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.Abgr32(uint packed) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.B -> byte
+SixLabors.ImageSharp.PixelFormats.Abgr32.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Abgr32>!
+SixLabors.ImageSharp.PixelFormats.Abgr32.Equals(SixLabors.ImageSharp.PixelFormats.Abgr32 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.G -> byte
+SixLabors.ImageSharp.PixelFormats.Abgr32.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.Abgr32.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.R -> byte
+SixLabors.ImageSharp.PixelFormats.Abgr32.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Abgr32.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Abgr32.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Argb32
+SixLabors.ImageSharp.PixelFormats.Argb32.A -> byte
+SixLabors.ImageSharp.PixelFormats.Argb32.Argb.get -> uint
+SixLabors.ImageSharp.PixelFormats.Argb32.Argb.set -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.Argb32() -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.Argb32(byte r, byte g, byte b) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.Argb32(byte r, byte g, byte b, byte a) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.Argb32(float r, float g, float b, float a = 1) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.Argb32(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.Argb32(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.Argb32(uint packed) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.B -> byte
+SixLabors.ImageSharp.PixelFormats.Argb32.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Argb32>!
+SixLabors.ImageSharp.PixelFormats.Argb32.Equals(SixLabors.ImageSharp.PixelFormats.Argb32 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Argb32.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.G -> byte
+SixLabors.ImageSharp.PixelFormats.Argb32.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.Argb32.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.R -> byte
+SixLabors.ImageSharp.PixelFormats.Argb32.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Argb32.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Argb32.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgr24
+SixLabors.ImageSharp.PixelFormats.Bgr24.B -> byte
+SixLabors.ImageSharp.PixelFormats.Bgr24.Bgr24() -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.Bgr24(byte r, byte g, byte b) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Bgr24>!
+SixLabors.ImageSharp.PixelFormats.Bgr24.Equals(SixLabors.ImageSharp.PixelFormats.Bgr24 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.G -> byte
+SixLabors.ImageSharp.PixelFormats.Bgr24.R -> byte
+SixLabors.ImageSharp.PixelFormats.Bgr24.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr24.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgr24.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgr565
+SixLabors.ImageSharp.PixelFormats.Bgr565.Bgr565() -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.Bgr565(float x, float y, float z) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.Bgr565(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Bgr565>!
+SixLabors.ImageSharp.PixelFormats.Bgr565.Equals(SixLabors.ImageSharp.PixelFormats.Bgr565 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.PackedValue.get -> ushort
+SixLabors.ImageSharp.PixelFormats.Bgr565.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Bgr565.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgr565.ToVector3() -> System.Numerics.Vector3
+SixLabors.ImageSharp.PixelFormats.Bgr565.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgra32
+SixLabors.ImageSharp.PixelFormats.Bgra32.A -> byte
+SixLabors.ImageSharp.PixelFormats.Bgra32.B -> byte
+SixLabors.ImageSharp.PixelFormats.Bgra32.Bgra.get -> uint
+SixLabors.ImageSharp.PixelFormats.Bgra32.Bgra.set -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.Bgra32() -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.Bgra32(byte r, byte g, byte b) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.Bgra32(byte r, byte g, byte b, byte a) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Bgra32>!
+SixLabors.ImageSharp.PixelFormats.Bgra32.Equals(SixLabors.ImageSharp.PixelFormats.Bgra32 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.G -> byte
+SixLabors.ImageSharp.PixelFormats.Bgra32.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.Bgra32.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.R -> byte
+SixLabors.ImageSharp.PixelFormats.Bgra32.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra32.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgra32.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgra4444
+SixLabors.ImageSharp.PixelFormats.Bgra4444.Bgra4444() -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.Bgra4444(float x, float y, float z, float w) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.Bgra4444(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Bgra4444>!
+SixLabors.ImageSharp.PixelFormats.Bgra4444.Equals(SixLabors.ImageSharp.PixelFormats.Bgra4444 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.PackedValue.get -> ushort
+SixLabors.ImageSharp.PixelFormats.Bgra4444.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra4444.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgra4444.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgra5551
+SixLabors.ImageSharp.PixelFormats.Bgra5551.Bgra5551() -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.Bgra5551(float x, float y, float z, float w) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.Bgra5551(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Bgra5551>!
+SixLabors.ImageSharp.PixelFormats.Bgra5551.Equals(SixLabors.ImageSharp.PixelFormats.Bgra5551 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.PackedValue.get -> ushort
+SixLabors.ImageSharp.PixelFormats.Bgra5551.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Bgra5551.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Bgra5551.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Byte4
+SixLabors.ImageSharp.PixelFormats.Byte4.Byte4() -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.Byte4(float x, float y, float z, float w) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.Byte4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Byte4>!
+SixLabors.ImageSharp.PixelFormats.Byte4.Equals(SixLabors.ImageSharp.PixelFormats.Byte4 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Byte4.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.Byte4.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Byte4.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Byte4.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.HalfSingle
+SixLabors.ImageSharp.PixelFormats.HalfSingle.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.HalfSingle>!
+SixLabors.ImageSharp.PixelFormats.HalfSingle.Equals(SixLabors.ImageSharp.PixelFormats.HalfSingle other) -> bool
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.HalfSingle() -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.HalfSingle(float value) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.PackedValue.get -> ushort
+SixLabors.ImageSharp.PixelFormats.HalfSingle.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.HalfSingle.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.HalfSingle.ToSingle() -> float
+SixLabors.ImageSharp.PixelFormats.HalfSingle.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.HalfVector2
+SixLabors.ImageSharp.PixelFormats.HalfVector2.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.HalfVector2>!
+SixLabors.ImageSharp.PixelFormats.HalfVector2.Equals(SixLabors.ImageSharp.PixelFormats.HalfVector2 other) -> bool
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.HalfVector2() -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.HalfVector2(float x, float y) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.HalfVector2(System.Numerics.Vector2 vector) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.HalfVector2.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector2.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.HalfVector2.ToVector2() -> System.Numerics.Vector2
+SixLabors.ImageSharp.PixelFormats.HalfVector2.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.HalfVector4
+SixLabors.ImageSharp.PixelFormats.HalfVector4.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.HalfVector4>!
+SixLabors.ImageSharp.PixelFormats.HalfVector4.Equals(SixLabors.ImageSharp.PixelFormats.HalfVector4 other) -> bool
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.HalfVector4() -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.HalfVector4(float x, float y, float z, float w) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.HalfVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.PackedValue.get -> ulong
+SixLabors.ImageSharp.PixelFormats.HalfVector4.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.HalfVector4.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.HalfVector4.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.IPackedVector<TPacked>
+SixLabors.ImageSharp.PixelFormats.IPackedVector<TPacked>.PackedValue.get -> TPacked
+SixLabors.ImageSharp.PixelFormats.IPackedVector<TPacked>.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.IPixel
+SixLabors.ImageSharp.PixelFormats.IPixel.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.IPixel.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.IPixel.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.IPixel<TSelf>
+SixLabors.ImageSharp.PixelFormats.IPixel<TSelf>.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<TSelf>!
+SixLabors.ImageSharp.PixelFormats.L16
+SixLabors.ImageSharp.PixelFormats.L16.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.L16>!
+SixLabors.ImageSharp.PixelFormats.L16.Equals(SixLabors.ImageSharp.PixelFormats.L16 other) -> bool
+SixLabors.ImageSharp.PixelFormats.L16.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.L16.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.L16.L16() -> void
+SixLabors.ImageSharp.PixelFormats.L16.L16(ushort luminance) -> void
+SixLabors.ImageSharp.PixelFormats.L16.PackedValue.get -> ushort
+SixLabors.ImageSharp.PixelFormats.L16.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.L16.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.L16.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.L16.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.L8
+SixLabors.ImageSharp.PixelFormats.L8.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.L8>!
+SixLabors.ImageSharp.PixelFormats.L8.Equals(SixLabors.ImageSharp.PixelFormats.L8 other) -> bool
+SixLabors.ImageSharp.PixelFormats.L8.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.L8.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.L8.L8() -> void
+SixLabors.ImageSharp.PixelFormats.L8.L8(byte luminance) -> void
+SixLabors.ImageSharp.PixelFormats.L8.PackedValue.get -> byte
+SixLabors.ImageSharp.PixelFormats.L8.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.L8.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.L8.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.L8.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.La16
+SixLabors.ImageSharp.PixelFormats.La16.A -> byte
+SixLabors.ImageSharp.PixelFormats.La16.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.La16>!
+SixLabors.ImageSharp.PixelFormats.La16.Equals(SixLabors.ImageSharp.PixelFormats.La16 other) -> bool
+SixLabors.ImageSharp.PixelFormats.La16.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.La16.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.La16.L -> byte
+SixLabors.ImageSharp.PixelFormats.La16.La16() -> void
+SixLabors.ImageSharp.PixelFormats.La16.La16(byte l, byte a) -> void
+SixLabors.ImageSharp.PixelFormats.La16.PackedValue.get -> ushort
+SixLabors.ImageSharp.PixelFormats.La16.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.La16.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.La16.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.La16.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.La32
+SixLabors.ImageSharp.PixelFormats.La32.A -> ushort
+SixLabors.ImageSharp.PixelFormats.La32.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.La32>!
+SixLabors.ImageSharp.PixelFormats.La32.Equals(SixLabors.ImageSharp.PixelFormats.La32 other) -> bool
+SixLabors.ImageSharp.PixelFormats.La32.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.La32.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.La32.L -> ushort
+SixLabors.ImageSharp.PixelFormats.La32.La32() -> void
+SixLabors.ImageSharp.PixelFormats.La32.La32(ushort l, ushort a) -> void
+SixLabors.ImageSharp.PixelFormats.La32.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.La32.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.La32.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.La32.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.La32.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.NormalizedByte2>!
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.Equals(SixLabors.ImageSharp.PixelFormats.NormalizedByte2 other) -> bool
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.NormalizedByte2() -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.NormalizedByte2(float x, float y) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.NormalizedByte2(System.Numerics.Vector2 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.PackedValue.get -> ushort
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.ToVector2() -> System.Numerics.Vector2
+SixLabors.ImageSharp.PixelFormats.NormalizedByte2.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.NormalizedByte4>!
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.Equals(SixLabors.ImageSharp.PixelFormats.NormalizedByte4 other) -> bool
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.NormalizedByte4() -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.NormalizedByte4(float x, float y, float z, float w) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.NormalizedByte4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.NormalizedByte4.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.NormalizedShort2>!
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.Equals(SixLabors.ImageSharp.PixelFormats.NormalizedShort2 other) -> bool
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.NormalizedShort2() -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.NormalizedShort2(float x, float y) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.NormalizedShort2(System.Numerics.Vector2 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.ToVector2() -> System.Numerics.Vector2
+SixLabors.ImageSharp.PixelFormats.NormalizedShort2.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.NormalizedShort4>!
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.Equals(SixLabors.ImageSharp.PixelFormats.NormalizedShort4 other) -> bool
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.NormalizedShort4() -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.NormalizedShort4(float x, float y, float z, float w) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.NormalizedShort4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.PackedValue.get -> ulong
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.NormalizedShort4.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.Clear = 10 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.Dest = 5 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.DestAtop = 6 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.DestIn = 8 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.DestOut = 9 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.DestOver = 7 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.Src = 1 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.SrcAtop = 2 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.SrcIn = 3 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.SrcOut = 4 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.SrcOver = 0 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode.Xor = 11 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.PixelFormats.PixelAlphaRepresentation
+SixLabors.ImageSharp.PixelFormats.PixelAlphaRepresentation.Associated = 1 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaRepresentation
+SixLabors.ImageSharp.PixelFormats.PixelAlphaRepresentation.None = 0 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaRepresentation
+SixLabors.ImageSharp.PixelFormats.PixelAlphaRepresentation.Unassociated = 2 -> SixLabors.ImageSharp.PixelFormats.PixelAlphaRepresentation
+SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>
+SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>.Blend(SixLabors.ImageSharp.Configuration! configuration, System.Span<TPixel> destination, System.ReadOnlySpan<TPixel> background, System.ReadOnlySpan<TPixel> source, System.ReadOnlySpan<float> amount) -> void
+SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>.Blend<TPixelSrc>(SixLabors.ImageSharp.Configuration! configuration, System.Span<TPixel> destination, System.ReadOnlySpan<TPixel> background, System.ReadOnlySpan<TPixelSrc> source, float amount) -> void
+SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>.Blend<TPixelSrc>(SixLabors.ImageSharp.Configuration! configuration, System.Span<TPixel> destination, System.ReadOnlySpan<TPixel> background, System.ReadOnlySpan<TPixelSrc> source, System.ReadOnlySpan<float> amount) -> void
+SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>.PixelBlender() -> void
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode.Add = 2 -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode.Darken = 5 -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode.HardLight = 8 -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode.Lighten = 6 -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode.Multiply = 1 -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode.Normal = 0 -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode.Overlay = 7 -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode.Screen = 4 -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode.Subtract = 3 -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers
+SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers.None = 0 -> SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers
+SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers.Premultiply = 2 -> SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers
+SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers.Scale = 1 -> SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers
+SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers.SRgbCompand = 4 -> SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers
+SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>
+SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromVector4Destructive(SixLabors.ImageSharp.Configuration! configuration, System.Span<System.Numerics.Vector4> sourceVectors, System.Span<TPixel> destinationPixels) -> void
+SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.GetPixelBlender(SixLabors.ImageSharp.GraphicsOptions! options) -> SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>!
+SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.PixelOperations() -> void
+SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToVector4(SixLabors.ImageSharp.Configuration! configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<System.Numerics.Vector4> destinationVectors) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32
+SixLabors.ImageSharp.PixelFormats.Rg32.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Rg32>!
+SixLabors.ImageSharp.PixelFormats.Rg32.Equals(SixLabors.ImageSharp.PixelFormats.Rg32 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Rg32.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.Rg32.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.Rg32() -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.Rg32(float x, float y) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.Rg32(System.Numerics.Vector2 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Rg32.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rg32.ToVector2() -> System.Numerics.Vector2
+SixLabors.ImageSharp.PixelFormats.Rg32.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgb24
+SixLabors.ImageSharp.PixelFormats.Rgb24.B -> byte
+SixLabors.ImageSharp.PixelFormats.Rgb24.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Rgb24>!
+SixLabors.ImageSharp.PixelFormats.Rgb24.Equals(SixLabors.ImageSharp.PixelFormats.Rgb24 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.G -> byte
+SixLabors.ImageSharp.PixelFormats.Rgb24.R -> byte
+SixLabors.ImageSharp.PixelFormats.Rgb24.Rgb24() -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.Rgb24(byte r, byte g, byte b) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb24.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgb24.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgb48
+SixLabors.ImageSharp.PixelFormats.Rgb48.B -> ushort
+SixLabors.ImageSharp.PixelFormats.Rgb48.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Rgb48>!
+SixLabors.ImageSharp.PixelFormats.Rgb48.Equals(SixLabors.ImageSharp.PixelFormats.Rgb48 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.G -> ushort
+SixLabors.ImageSharp.PixelFormats.Rgb48.R -> ushort
+SixLabors.ImageSharp.PixelFormats.Rgb48.Rgb48() -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.Rgb48(ushort r, ushort g, ushort b) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Rgb48.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgb48.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgba1010102
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Rgba1010102>!
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.Equals(SixLabors.ImageSharp.PixelFormats.Rgba1010102 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.Rgba1010102() -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.Rgba1010102(float x, float y, float z, float w) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.Rgba1010102(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgba1010102.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgba32
+SixLabors.ImageSharp.PixelFormats.Rgba32.A -> byte
+SixLabors.ImageSharp.PixelFormats.Rgba32.B -> byte
+SixLabors.ImageSharp.PixelFormats.Rgba32.Bgr.get -> SixLabors.ImageSharp.PixelFormats.Bgr24
+SixLabors.ImageSharp.PixelFormats.Rgba32.Bgr.set -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Rgba32>!
+SixLabors.ImageSharp.PixelFormats.Rgba32.Equals(SixLabors.ImageSharp.PixelFormats.Rgba32 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.G -> byte
+SixLabors.ImageSharp.PixelFormats.Rgba32.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.Rgba32.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.R -> byte
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgb.get -> SixLabors.ImageSharp.PixelFormats.Rgb24
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgb.set -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgba.get -> uint
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgba.set -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgba32() -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgba32(byte r, byte g, byte b) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgba32(byte r, byte g, byte b, byte a) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgba32(float r, float g, float b, float a = 1) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgba32(System.Numerics.Vector3 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgba32(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.Rgba32(uint packed) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.ToHex() -> string!
+SixLabors.ImageSharp.PixelFormats.Rgba32.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba32.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgba32.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgba64
+SixLabors.ImageSharp.PixelFormats.Rgba64.A -> ushort
+SixLabors.ImageSharp.PixelFormats.Rgba64.B -> ushort
+SixLabors.ImageSharp.PixelFormats.Rgba64.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Rgba64>!
+SixLabors.ImageSharp.PixelFormats.Rgba64.Equals(SixLabors.ImageSharp.PixelFormats.Rgba64 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.G -> ushort
+SixLabors.ImageSharp.PixelFormats.Rgba64.PackedValue.get -> ulong
+SixLabors.ImageSharp.PixelFormats.Rgba64.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.R -> ushort
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgb.get -> SixLabors.ImageSharp.PixelFormats.Rgb48
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgb.set -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgba64() -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgba64(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgba64(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgba64(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgba64(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgba64(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgba64(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgba64(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.Rgba64(ushort r, ushort g, ushort b, ushort a) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.ToAbgr32() -> SixLabors.ImageSharp.PixelFormats.Abgr32
+SixLabors.ImageSharp.PixelFormats.Rgba64.ToArgb32() -> SixLabors.ImageSharp.PixelFormats.Argb32
+SixLabors.ImageSharp.PixelFormats.Rgba64.ToBgr24() -> SixLabors.ImageSharp.PixelFormats.Bgr24
+SixLabors.ImageSharp.PixelFormats.Rgba64.ToBgra32() -> SixLabors.ImageSharp.PixelFormats.Bgra32
+SixLabors.ImageSharp.PixelFormats.Rgba64.ToRgb24() -> SixLabors.ImageSharp.PixelFormats.Rgb24
+SixLabors.ImageSharp.PixelFormats.Rgba64.ToRgba32() -> SixLabors.ImageSharp.PixelFormats.Rgba32
+SixLabors.ImageSharp.PixelFormats.Rgba64.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Rgba64.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Rgba64.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.RgbaVector
+SixLabors.ImageSharp.PixelFormats.RgbaVector.A -> float
+SixLabors.ImageSharp.PixelFormats.RgbaVector.B -> float
+SixLabors.ImageSharp.PixelFormats.RgbaVector.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.RgbaVector>!
+SixLabors.ImageSharp.PixelFormats.RgbaVector.Equals(SixLabors.ImageSharp.PixelFormats.RgbaVector other) -> bool
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.G -> float
+SixLabors.ImageSharp.PixelFormats.RgbaVector.R -> float
+SixLabors.ImageSharp.PixelFormats.RgbaVector.RgbaVector() -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.RgbaVector(float r, float g, float b, float a = 1) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.ToHex() -> string!
+SixLabors.ImageSharp.PixelFormats.RgbaVector.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.RgbaVector.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.RgbaVector.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Short2
+SixLabors.ImageSharp.PixelFormats.Short2.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Short2>!
+SixLabors.ImageSharp.PixelFormats.Short2.Equals(SixLabors.ImageSharp.PixelFormats.Short2 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Short2.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.PackedValue.get -> uint
+SixLabors.ImageSharp.PixelFormats.Short2.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Short2.Short2() -> void
+SixLabors.ImageSharp.PixelFormats.Short2.Short2(float x, float y) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.Short2(System.Numerics.Vector2 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Short2.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Short2.ToVector2() -> System.Numerics.Vector2
+SixLabors.ImageSharp.PixelFormats.Short2.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Short4
+SixLabors.ImageSharp.PixelFormats.Short4.CreatePixelOperations() -> SixLabors.ImageSharp.PixelFormats.PixelOperations<SixLabors.ImageSharp.PixelFormats.Short4>!
+SixLabors.ImageSharp.PixelFormats.Short4.Equals(SixLabors.ImageSharp.PixelFormats.Short4 other) -> bool
+SixLabors.ImageSharp.PixelFormats.Short4.FromAbgr32(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromArgb32(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromBgr24(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromBgra32(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromBgra5551(SixLabors.ImageSharp.PixelFormats.Bgra5551 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromL16(SixLabors.ImageSharp.PixelFormats.L16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromL8(SixLabors.ImageSharp.PixelFormats.L8 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromLa16(SixLabors.ImageSharp.PixelFormats.La16 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromLa32(SixLabors.ImageSharp.PixelFormats.La32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromRgb24(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromRgb48(SixLabors.ImageSharp.PixelFormats.Rgb48 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromRgba32(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromRgba64(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromScaledVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.FromVector4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.PackedValue.get -> ulong
+SixLabors.ImageSharp.PixelFormats.Short4.PackedValue.set -> void
+SixLabors.ImageSharp.PixelFormats.Short4.Short4() -> void
+SixLabors.ImageSharp.PixelFormats.Short4.Short4(float x, float y, float z, float w) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.Short4(System.Numerics.Vector4 vector) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.ToRgba32(ref SixLabors.ImageSharp.PixelFormats.Rgba32 dest) -> void
+SixLabors.ImageSharp.PixelFormats.Short4.ToScaledVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.PixelFormats.Short4.ToVector4() -> System.Numerics.Vector4
+SixLabors.ImageSharp.Point
+SixLabors.ImageSharp.Point.Deconstruct(out int x, out int y) -> void
+SixLabors.ImageSharp.Point.Equals(SixLabors.ImageSharp.Point other) -> bool
+SixLabors.ImageSharp.Point.IsEmpty.get -> bool
+SixLabors.ImageSharp.Point.Offset(int dx, int dy) -> void
+SixLabors.ImageSharp.Point.Offset(SixLabors.ImageSharp.Point point) -> void
+SixLabors.ImageSharp.Point.Point() -> void
+SixLabors.ImageSharp.Point.Point(int value) -> void
+SixLabors.ImageSharp.Point.Point(int x, int y) -> void
+SixLabors.ImageSharp.Point.Point(SixLabors.ImageSharp.Size size) -> void
+SixLabors.ImageSharp.Point.X.get -> int
+SixLabors.ImageSharp.Point.X.set -> void
+SixLabors.ImageSharp.Point.Y.get -> int
+SixLabors.ImageSharp.Point.Y.set -> void
+SixLabors.ImageSharp.PointF
+SixLabors.ImageSharp.PointF.Deconstruct(out float x, out float y) -> void
+SixLabors.ImageSharp.PointF.Equals(SixLabors.ImageSharp.PointF other) -> bool
+SixLabors.ImageSharp.PointF.IsEmpty.get -> bool
+SixLabors.ImageSharp.PointF.Offset(float dx, float dy) -> void
+SixLabors.ImageSharp.PointF.Offset(SixLabors.ImageSharp.PointF point) -> void
+SixLabors.ImageSharp.PointF.PointF() -> void
+SixLabors.ImageSharp.PointF.PointF(float x, float y) -> void
+SixLabors.ImageSharp.PointF.PointF(SixLabors.ImageSharp.SizeF size) -> void
+SixLabors.ImageSharp.PointF.X.get -> float
+SixLabors.ImageSharp.PointF.X.set -> void
+SixLabors.ImageSharp.PointF.Y.get -> float
+SixLabors.ImageSharp.PointF.Y.set -> void
+SixLabors.ImageSharp.Processing.AdaptiveThresholdExtensions
+SixLabors.ImageSharp.Processing.AffineTransformBuilder
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AffineTransformBuilder() -> void
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendMatrix(System.Numerics.Matrix3x2 matrix) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendRotationDegrees(float degrees) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendRotationDegrees(float degrees, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendRotationRadians(float radians) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendRotationRadians(float radians, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendScale(float scale) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendScale(SixLabors.ImageSharp.SizeF scales) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendScale(System.Numerics.Vector2 scales) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendSkewDegrees(float degreesX, float degreesY) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendSkewDegrees(float degreesX, float degreesY, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendSkewRadians(float radiansX, float radiansY) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendSkewRadians(float radiansX, float radiansY, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendTranslation(SixLabors.ImageSharp.PointF position) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.AppendTranslation(System.Numerics.Vector2 position) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.BuildMatrix(SixLabors.ImageSharp.Rectangle sourceRectangle) -> System.Numerics.Matrix3x2
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.BuildMatrix(SixLabors.ImageSharp.Size sourceSize) -> System.Numerics.Matrix3x2
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependMatrix(System.Numerics.Matrix3x2 matrix) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependRotationDegrees(float degrees) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependRotationDegrees(float degrees, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependRotationRadians(float radians) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependRotationRadians(float radians, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependScale(float scale) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependScale(SixLabors.ImageSharp.SizeF scale) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependScale(System.Numerics.Vector2 scales) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependSkewDegrees(float degreesX, float degreesY) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependSkewDegrees(float degreesX, float degreesY, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependSkewRadians(float radiansX, float radiansY) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependSkewRadians(float radiansX, float radiansY, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependTranslation(SixLabors.ImageSharp.PointF position) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AffineTransformBuilder.PrependTranslation(System.Numerics.Vector2 position) -> SixLabors.ImageSharp.Processing.AffineTransformBuilder!
+SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AnchorPositionMode.Bottom = 2 -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AnchorPositionMode.BottomLeft = 8 -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AnchorPositionMode.BottomRight = 7 -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AnchorPositionMode.Center = 0 -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AnchorPositionMode.Left = 3 -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AnchorPositionMode.Right = 4 -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AnchorPositionMode.Top = 1 -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AnchorPositionMode.TopLeft = 5 -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AnchorPositionMode.TopRight = 6 -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.AutoOrientExtensions
+SixLabors.ImageSharp.Processing.BackgroundColorExtensions
+SixLabors.ImageSharp.Processing.BinaryDitherExtensions
+SixLabors.ImageSharp.Processing.BinaryThresholdExtensions
+SixLabors.ImageSharp.Processing.BinaryThresholdMode
+SixLabors.ImageSharp.Processing.BinaryThresholdMode.Luminance = 0 -> SixLabors.ImageSharp.Processing.BinaryThresholdMode
+SixLabors.ImageSharp.Processing.BinaryThresholdMode.MaxChroma = 2 -> SixLabors.ImageSharp.Processing.BinaryThresholdMode
+SixLabors.ImageSharp.Processing.BinaryThresholdMode.Saturation = 1 -> SixLabors.ImageSharp.Processing.BinaryThresholdMode
+SixLabors.ImageSharp.Processing.BlackWhiteExtensions
+SixLabors.ImageSharp.Processing.BokehBlurExtensions
+SixLabors.ImageSharp.Processing.BoxBlurExtensions
+SixLabors.ImageSharp.Processing.BrightnessExtensions
+SixLabors.ImageSharp.Processing.ColorBlindnessExtensions
+SixLabors.ImageSharp.Processing.ColorBlindnessMode
+SixLabors.ImageSharp.Processing.ColorBlindnessMode.Achromatomaly = 0 -> SixLabors.ImageSharp.Processing.ColorBlindnessMode
+SixLabors.ImageSharp.Processing.ColorBlindnessMode.Achromatopsia = 1 -> SixLabors.ImageSharp.Processing.ColorBlindnessMode
+SixLabors.ImageSharp.Processing.ColorBlindnessMode.Deuteranomaly = 2 -> SixLabors.ImageSharp.Processing.ColorBlindnessMode
+SixLabors.ImageSharp.Processing.ColorBlindnessMode.Deuteranopia = 3 -> SixLabors.ImageSharp.Processing.ColorBlindnessMode
+SixLabors.ImageSharp.Processing.ColorBlindnessMode.Protanomaly = 4 -> SixLabors.ImageSharp.Processing.ColorBlindnessMode
+SixLabors.ImageSharp.Processing.ColorBlindnessMode.Protanopia = 5 -> SixLabors.ImageSharp.Processing.ColorBlindnessMode
+SixLabors.ImageSharp.Processing.ColorBlindnessMode.Tritanomaly = 6 -> SixLabors.ImageSharp.Processing.ColorBlindnessMode
+SixLabors.ImageSharp.Processing.ColorBlindnessMode.Tritanopia = 7 -> SixLabors.ImageSharp.Processing.ColorBlindnessMode
+SixLabors.ImageSharp.Processing.ContrastExtensions
+SixLabors.ImageSharp.Processing.CropExtensions
+SixLabors.ImageSharp.Processing.DetectEdgesExtensions
+SixLabors.ImageSharp.Processing.DitherExtensions
+SixLabors.ImageSharp.Processing.DrawImageExtensions
+SixLabors.ImageSharp.Processing.EntropyCropExtensions
+SixLabors.ImageSharp.Processing.FilterExtensions
+SixLabors.ImageSharp.Processing.FlipExtensions
+SixLabors.ImageSharp.Processing.FlipMode
+SixLabors.ImageSharp.Processing.FlipMode.Horizontal = 1 -> SixLabors.ImageSharp.Processing.FlipMode
+SixLabors.ImageSharp.Processing.FlipMode.None = 0 -> SixLabors.ImageSharp.Processing.FlipMode
+SixLabors.ImageSharp.Processing.FlipMode.Vertical = 2 -> SixLabors.ImageSharp.Processing.FlipMode
+SixLabors.ImageSharp.Processing.GaussianBlurExtensions
+SixLabors.ImageSharp.Processing.GaussianSharpenExtensions
+SixLabors.ImageSharp.Processing.GlowExtensions
+SixLabors.ImageSharp.Processing.GrayscaleExtensions
+SixLabors.ImageSharp.Processing.GrayscaleMode
+SixLabors.ImageSharp.Processing.GrayscaleMode.Bt601 = 1 -> SixLabors.ImageSharp.Processing.GrayscaleMode
+SixLabors.ImageSharp.Processing.GrayscaleMode.Bt709 = 0 -> SixLabors.ImageSharp.Processing.GrayscaleMode
+SixLabors.ImageSharp.Processing.HistogramEqualizationExtensions
+SixLabors.ImageSharp.Processing.HueExtensions
+SixLabors.ImageSharp.Processing.IImageProcessingContext
+SixLabors.ImageSharp.Processing.IImageProcessingContext.ApplyProcessor(SixLabors.ImageSharp.Processing.Processors.IImageProcessor! processor) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+SixLabors.ImageSharp.Processing.IImageProcessingContext.ApplyProcessor(SixLabors.ImageSharp.Processing.Processors.IImageProcessor! processor, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+SixLabors.ImageSharp.Processing.IImageProcessingContext.Configuration.get -> SixLabors.ImageSharp.Configuration!
+SixLabors.ImageSharp.Processing.IImageProcessingContext.GetCurrentSize() -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.Processing.IImageProcessingContext.Properties.get -> System.Collections.Generic.IDictionary<object!, object!>!
+SixLabors.ImageSharp.Processing.InvertExtensions
+SixLabors.ImageSharp.Processing.KnownDitherings
+SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels
+SixLabors.ImageSharp.Processing.KnownFilterMatrices
+SixLabors.ImageSharp.Processing.KnownQuantizers
+SixLabors.ImageSharp.Processing.KnownResamplers
+SixLabors.ImageSharp.Processing.KodachromeExtensions
+SixLabors.ImageSharp.Processing.LightnessExtensions
+SixLabors.ImageSharp.Processing.LomographExtensions
+SixLabors.ImageSharp.Processing.MedianBlurExtensions
+SixLabors.ImageSharp.Processing.OilPaintExtensions
+SixLabors.ImageSharp.Processing.OpacityExtensions
+SixLabors.ImageSharp.Processing.PadExtensions
+SixLabors.ImageSharp.Processing.PixelateExtensions
+SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions
+SixLabors.ImageSharp.Processing.PixelRowOperation
+SixLabors.ImageSharp.Processing.PixelRowOperation<T>
+SixLabors.ImageSharp.Processing.PolaroidExtensions
+SixLabors.ImageSharp.Processing.ProcessingExtensions
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.AdaptiveThresholdProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.AdaptiveThresholdProcessor(float thresholdLimit) -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.AdaptiveThresholdProcessor(SixLabors.ImageSharp.Color upper, SixLabors.ImageSharp.Color lower) -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.AdaptiveThresholdProcessor(SixLabors.ImageSharp.Color upper, SixLabors.ImageSharp.Color lower, float thresholdLimit) -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.Lower.get -> SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.Lower.set -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.ThresholdLimit.get -> float
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.ThresholdLimit.set -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.Upper.get -> SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.Processing.Processors.Binarization.AdaptiveThresholdProcessor.Upper.set -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor.BinaryThresholdProcessor(float threshold) -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor.BinaryThresholdProcessor(float threshold, SixLabors.ImageSharp.Color upperColor, SixLabors.ImageSharp.Color lowerColor) -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor.BinaryThresholdProcessor(float threshold, SixLabors.ImageSharp.Color upperColor, SixLabors.ImageSharp.Color lowerColor, SixLabors.ImageSharp.Processing.BinaryThresholdMode mode) -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor.BinaryThresholdProcessor(float threshold, SixLabors.ImageSharp.Processing.BinaryThresholdMode mode) -> void
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor.LowerColor.get -> SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor.Mode.get -> SixLabors.ImageSharp.Processing.BinaryThresholdMode
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor.Threshold.get -> float
+SixLabors.ImageSharp.Processing.Processors.Binarization.BinaryThresholdProcessor.UpperColor.get -> SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor
+SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor.CloningImageProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>
+SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.CloningImageProcessor(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> void
+SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.Configuration.get -> SixLabors.ImageSharp.Configuration!
+SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.Dispose() -> void
+SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.Source.get -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.SourceRectangle.get -> SixLabors.ImageSharp.Rectangle
+SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor
+SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor.BokehBlurProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor.BokehBlurProcessor(int radius, int components, float gamma) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor.Components.get -> int
+SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor.Gamma.get -> float
+SixLabors.ImageSharp.Processing.Processors.Convolution.BokehBlurProcessor.Radius.get -> int
+SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode.Bounce = 3 -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode.Mirror = 2 -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode.Repeat = 0 -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode.Wrap = 1 -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.BoxBlurProcessor
+SixLabors.ImageSharp.Processing.Processors.Convolution.BoxBlurProcessor.BorderWrapModeX.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.BoxBlurProcessor.BorderWrapModeY.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.BoxBlurProcessor.BoxBlurProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.BoxBlurProcessor.BoxBlurProcessor(int radius) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.BoxBlurProcessor.BoxBlurProcessor(int radius, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeX, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeY) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.BoxBlurProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Convolution.BoxBlurProcessor.Radius.get -> int
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.EdgeDetector2DKernel() -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.EdgeDetector2DKernel(SixLabors.ImageSharp.DenseMatrix<float> kernelX, SixLabors.ImageSharp.DenseMatrix<float> kernelY) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.Equals(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel other) -> bool
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.KernelX.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.KernelY.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DProcessor
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DProcessor.EdgeDetector2DProcessor(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel kernel, bool grayscale) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DProcessor.Grayscale.get -> bool
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DProcessor.Kernel.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.East.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.EdgeDetectorCompassKernel() -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.EdgeDetectorCompassKernel(SixLabors.ImageSharp.DenseMatrix<float> north, SixLabors.ImageSharp.DenseMatrix<float> northWest, SixLabors.ImageSharp.DenseMatrix<float> west, SixLabors.ImageSharp.DenseMatrix<float> southWest, SixLabors.ImageSharp.DenseMatrix<float> south, SixLabors.ImageSharp.DenseMatrix<float> southEast, SixLabors.ImageSharp.DenseMatrix<float> east, SixLabors.ImageSharp.DenseMatrix<float> northEast) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.Equals(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel other) -> bool
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.North.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.NorthEast.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.NorthWest.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.South.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.SouthEast.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.SouthWest.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.West.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassProcessor
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassProcessor.EdgeDetectorCompassProcessor(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel kernel, bool grayscale) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassProcessor.Grayscale.get -> bool
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassProcessor.Kernel.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.EdgeDetectorKernel() -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.EdgeDetectorKernel(SixLabors.ImageSharp.DenseMatrix<float> kernelXY) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.Equals(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel other) -> bool
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.KernelXY.get -> SixLabors.ImageSharp.DenseMatrix<float>
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorProcessor
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorProcessor.EdgeDetectorProcessor(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel kernel, bool grayscale) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorProcessor.Grayscale.get -> bool
+SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorProcessor.Kernel.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.BorderWrapModeX.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.BorderWrapModeY.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.GaussianBlurProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.GaussianBlurProcessor(float sigma) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.GaussianBlurProcessor(float sigma, int radius) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.GaussianBlurProcessor(float sigma, int radius, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeX, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeY) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.GaussianBlurProcessor(float sigma, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeX, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeY) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.GaussianBlurProcessor(int radius) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.Radius.get -> int
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianBlurProcessor.Sigma.get -> float
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.BorderWrapModeX.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.BorderWrapModeY.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.GaussianSharpenProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.GaussianSharpenProcessor(float sigma) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.GaussianSharpenProcessor(float sigma, int radius) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.GaussianSharpenProcessor(float sigma, int radius, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeX, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeY) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.GaussianSharpenProcessor(float sigma, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeX, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeY) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.GaussianSharpenProcessor(int radius) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.Radius.get -> int
+SixLabors.ImageSharp.Processing.Processors.Convolution.GaussianSharpenProcessor.Sigma.get -> float
+SixLabors.ImageSharp.Processing.Processors.Convolution.MedianBlurProcessor
+SixLabors.ImageSharp.Processing.Processors.Convolution.MedianBlurProcessor.BorderWrapModeX.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.MedianBlurProcessor.BorderWrapModeY.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode
+SixLabors.ImageSharp.Processing.Processors.Convolution.MedianBlurProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Convolution.MedianBlurProcessor.MedianBlurProcessor(int radius, bool preserveAlpha) -> void
+SixLabors.ImageSharp.Processing.Processors.Convolution.MedianBlurProcessor.PreserveAlpha.get -> bool
+SixLabors.ImageSharp.Processing.Processors.Convolution.MedianBlurProcessor.Radius.get -> int
+SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.ApplyPaletteDither<TPaletteDitherImageProcessor, TPixel>(in TPaletteDitherImageProcessor processor, SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.Rectangle bounds) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.ApplyQuantizationDither<TFrameQuantizer, TPixel>(ref TFrameQuantizer quantizer, SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.IndexedImageFrame<TPixel>! destination, SixLabors.ImageSharp.Rectangle bounds) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.Equals(SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither other) -> bool
+SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.Equals(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither? other) -> bool
+SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.ErrorDither() -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.ErrorDither(in SixLabors.ImageSharp.DenseMatrix<float> matrix, int offset) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.IDither
+SixLabors.ImageSharp.Processing.Processors.Dithering.IDither.ApplyPaletteDither<TPaletteDitherImageProcessor, TPixel>(in TPaletteDitherImageProcessor processor, SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.Rectangle bounds) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.IDither.ApplyQuantizationDither<TFrameQuantizer, TPixel>(ref TFrameQuantizer quantizer, SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.IndexedImageFrame<TPixel>! destination, SixLabors.ImageSharp.Rectangle bounds) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.IPaletteDitherImageProcessor<TPixel>
+SixLabors.ImageSharp.Processing.Processors.Dithering.IPaletteDitherImageProcessor<TPixel>.Configuration.get -> SixLabors.ImageSharp.Configuration!
+SixLabors.ImageSharp.Processing.Processors.Dithering.IPaletteDitherImageProcessor<TPixel>.DitherScale.get -> float
+SixLabors.ImageSharp.Processing.Processors.Dithering.IPaletteDitherImageProcessor<TPixel>.GetPaletteColor(TPixel color) -> TPixel
+SixLabors.ImageSharp.Processing.Processors.Dithering.IPaletteDitherImageProcessor<TPixel>.Palette.get -> System.ReadOnlyMemory<TPixel>
+SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither
+SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.ApplyPaletteDither<TPaletteDitherImageProcessor, TPixel>(in TPaletteDitherImageProcessor processor, SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.Rectangle bounds) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.ApplyQuantizationDither<TFrameQuantizer, TPixel>(ref TFrameQuantizer quantizer, SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.IndexedImageFrame<TPixel>! destination, SixLabors.ImageSharp.Rectangle bounds) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.Equals(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither? other) -> bool
+SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.Equals(SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither other) -> bool
+SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.OrderedDither() -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.OrderedDither(uint length) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.PaletteDitherProcessor
+SixLabors.ImageSharp.Processing.Processors.Dithering.PaletteDitherProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Dithering.PaletteDitherProcessor.Dither.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+SixLabors.ImageSharp.Processing.Processors.Dithering.PaletteDitherProcessor.DitherScale.get -> float
+SixLabors.ImageSharp.Processing.Processors.Dithering.PaletteDitherProcessor.Palette.get -> System.ReadOnlyMemory<SixLabors.ImageSharp.Color>
+SixLabors.ImageSharp.Processing.Processors.Dithering.PaletteDitherProcessor.PaletteDitherProcessor(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.PaletteDitherProcessor.PaletteDitherProcessor(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, float ditherScale) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.PaletteDitherProcessor.PaletteDitherProcessor(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, float ditherScale, System.ReadOnlyMemory<SixLabors.ImageSharp.Color> palette) -> void
+SixLabors.ImageSharp.Processing.Processors.Dithering.PaletteDitherProcessor.PaletteDitherProcessor(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, System.ReadOnlyMemory<SixLabors.ImageSharp.Color> palette) -> void
+SixLabors.ImageSharp.Processing.Processors.Drawing.DrawImageProcessor
+SixLabors.ImageSharp.Processing.Processors.Drawing.DrawImageProcessor.AlphaCompositionMode.get -> SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode
+SixLabors.ImageSharp.Processing.Processors.Drawing.DrawImageProcessor.ColorBlendingMode.get -> SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode
+SixLabors.ImageSharp.Processing.Processors.Drawing.DrawImageProcessor.CreatePixelSpecificProcessor<TPixelBg>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixelBg>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixelBg>!
+SixLabors.ImageSharp.Processing.Processors.Drawing.DrawImageProcessor.DrawImageProcessor(SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Point location, SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorBlendingMode, SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode alphaCompositionMode, float opacity) -> void
+SixLabors.ImageSharp.Processing.Processors.Drawing.DrawImageProcessor.Image.get -> SixLabors.ImageSharp.Image!
+SixLabors.ImageSharp.Processing.Processors.Drawing.DrawImageProcessor.Location.get -> SixLabors.ImageSharp.Point
+SixLabors.ImageSharp.Processing.Processors.Drawing.DrawImageProcessor.Opacity.get -> float
+SixLabors.ImageSharp.Processing.Processors.Effects.IPixelRowDelegate
+SixLabors.ImageSharp.Processing.Processors.Effects.IPixelRowDelegate.Invoke(System.Span<System.Numerics.Vector4> span, SixLabors.ImageSharp.Point offset) -> void
+SixLabors.ImageSharp.Processing.Processors.Effects.OilPaintingProcessor
+SixLabors.ImageSharp.Processing.Processors.Effects.OilPaintingProcessor.BrushSize.get -> int
+SixLabors.ImageSharp.Processing.Processors.Effects.OilPaintingProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Effects.OilPaintingProcessor.Levels.get -> int
+SixLabors.ImageSharp.Processing.Processors.Effects.OilPaintingProcessor.OilPaintingProcessor(int levels, int brushSize) -> void
+SixLabors.ImageSharp.Processing.Processors.Effects.PixelateProcessor
+SixLabors.ImageSharp.Processing.Processors.Effects.PixelateProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Effects.PixelateProcessor.PixelateProcessor(int size) -> void
+SixLabors.ImageSharp.Processing.Processors.Effects.PixelateProcessor.Size.get -> int
+SixLabors.ImageSharp.Processing.Processors.Filters.AchromatomalyProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.AchromatomalyProcessor.AchromatomalyProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.AchromatopsiaProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.AchromatopsiaProcessor.AchromatopsiaProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.BlackWhiteProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.BlackWhiteProcessor.BlackWhiteProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.BrightnessProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.BrightnessProcessor.Amount.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.BrightnessProcessor.BrightnessProcessor(float amount) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.ContrastProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.ContrastProcessor.Amount.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.ContrastProcessor.ContrastProcessor(float amount) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.DeuteranomalyProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.DeuteranomalyProcessor.DeuteranomalyProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.DeuteranopiaProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.DeuteranopiaProcessor.DeuteranopiaProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.FilterProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.FilterProcessor.FilterProcessor(SixLabors.ImageSharp.ColorMatrix matrix) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.FilterProcessor.Matrix.get -> SixLabors.ImageSharp.ColorMatrix
+SixLabors.ImageSharp.Processing.Processors.Filters.GrayscaleBt601Processor
+SixLabors.ImageSharp.Processing.Processors.Filters.GrayscaleBt601Processor.Amount.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.GrayscaleBt601Processor.GrayscaleBt601Processor(float amount) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.GrayscaleBt709Processor
+SixLabors.ImageSharp.Processing.Processors.Filters.GrayscaleBt709Processor.Amount.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.GrayscaleBt709Processor.GrayscaleBt709Processor(float amount) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.HueProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.HueProcessor.Degrees.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.HueProcessor.HueProcessor(float degrees) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.InvertProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.InvertProcessor.Amount.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.InvertProcessor.InvertProcessor(float amount) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.KodachromeProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.KodachromeProcessor.KodachromeProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.LightnessProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.LightnessProcessor.Amount.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.LightnessProcessor.LightnessProcessor(float amount) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.LomographProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.LomographProcessor.GraphicsOptions.get -> SixLabors.ImageSharp.GraphicsOptions!
+SixLabors.ImageSharp.Processing.Processors.Filters.LomographProcessor.LomographProcessor(SixLabors.ImageSharp.GraphicsOptions! graphicsOptions) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.OpacityProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.OpacityProcessor.Amount.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.OpacityProcessor.OpacityProcessor(float amount) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.PolaroidProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.PolaroidProcessor.GraphicsOptions.get -> SixLabors.ImageSharp.GraphicsOptions!
+SixLabors.ImageSharp.Processing.Processors.Filters.PolaroidProcessor.PolaroidProcessor(SixLabors.ImageSharp.GraphicsOptions! graphicsOptions) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.ProtanomalyProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.ProtanomalyProcessor.ProtanomalyProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.ProtanopiaProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.ProtanopiaProcessor.ProtanopiaProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.SaturateProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.SaturateProcessor.Amount.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.SaturateProcessor.SaturateProcessor(float amount) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.SepiaProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.SepiaProcessor.Amount.get -> float
+SixLabors.ImageSharp.Processing.Processors.Filters.SepiaProcessor.SepiaProcessor(float amount) -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.TritanomalyProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.TritanomalyProcessor.TritanomalyProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Filters.TritanopiaProcessor
+SixLabors.ImageSharp.Processing.Processors.Filters.TritanopiaProcessor.TritanopiaProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor
+SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor.CreatePixelSpecificCloningProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor<TPixel>
+SixLabors.ImageSharp.Processing.Processors.ICloningImageProcessor<TPixel>.CloneAndExecute() -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.IImageProcessor
+SixLabors.ImageSharp.Processing.Processors.IImageProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>
+SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>.Execute() -> void
+SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>
+SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.Apply(SixLabors.ImageSharp.ImageFrame<TPixel>! source) -> void
+SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.Configuration.get -> SixLabors.ImageSharp.Configuration!
+SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.Dispose() -> void
+SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.ImageProcessor(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> void
+SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.Source.get -> SixLabors.ImageSharp.Image<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.SourceRectangle.get -> SixLabors.ImageSharp.Rectangle
+SixLabors.ImageSharp.Processing.Processors.Normalization.AdaptiveHistogramEqualizationProcessor
+SixLabors.ImageSharp.Processing.Processors.Normalization.AdaptiveHistogramEqualizationProcessor.AdaptiveHistogramEqualizationProcessor(int luminanceLevels, bool clipHistogram, int clipLimit, int numberOfTiles) -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.AdaptiveHistogramEqualizationProcessor.NumberOfTiles.get -> int
+SixLabors.ImageSharp.Processing.Processors.Normalization.AdaptiveHistogramEqualizationSlidingWindowProcessor
+SixLabors.ImageSharp.Processing.Processors.Normalization.AdaptiveHistogramEqualizationSlidingWindowProcessor.AdaptiveHistogramEqualizationSlidingWindowProcessor(int luminanceLevels, bool clipHistogram, int clipLimit, int numberOfTiles) -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.AdaptiveHistogramEqualizationSlidingWindowProcessor.NumberOfTiles.get -> int
+SixLabors.ImageSharp.Processing.Processors.Normalization.AutoLevelProcessor
+SixLabors.ImageSharp.Processing.Processors.Normalization.AutoLevelProcessor.AutoLevelProcessor(int luminanceLevels, bool clipHistogram, int clipLimit, bool syncChannels) -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.AutoLevelProcessor.SyncChannels.get -> bool
+SixLabors.ImageSharp.Processing.Processors.Normalization.GlobalHistogramEqualizationProcessor
+SixLabors.ImageSharp.Processing.Processors.Normalization.GlobalHistogramEqualizationProcessor.GlobalHistogramEqualizationProcessor(int luminanceLevels, bool clipHistogram, int clipLimit) -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod.AdaptiveSlidingWindow = 2 -> SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod.AdaptiveTileInterpolation = 1 -> SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod.AutoLevel = 3 -> SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod.Global = 0 -> SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.ClipHistogram.get -> bool
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.ClipHistogram.set -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.ClipLimit.get -> int
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.ClipLimit.set -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.HistogramEqualizationOptions() -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.LuminanceLevels.get -> int
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.LuminanceLevels.set -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.Method.get -> SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationMethod
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.Method.set -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.NumberOfTiles.get -> int
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.NumberOfTiles.set -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.SyncChannels.get -> bool
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions.SyncChannels.set -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationProcessor
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationProcessor.ClipHistogram.get -> bool
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationProcessor.ClipLimit.get -> int
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationProcessor.HistogramEqualizationProcessor(int luminanceLevels, bool clipHistogram, int clipLimit) -> void
+SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationProcessor.LuminanceLevels.get -> int
+SixLabors.ImageSharp.Processing.Processors.Overlays.BackgroundColorProcessor
+SixLabors.ImageSharp.Processing.Processors.Overlays.BackgroundColorProcessor.BackgroundColorProcessor(SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Color color) -> void
+SixLabors.ImageSharp.Processing.Processors.Overlays.BackgroundColorProcessor.Color.get -> SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.Processing.Processors.Overlays.BackgroundColorProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Overlays.BackgroundColorProcessor.GraphicsOptions.get -> SixLabors.ImageSharp.GraphicsOptions!
+SixLabors.ImageSharp.Processing.Processors.Overlays.GlowProcessor
+SixLabors.ImageSharp.Processing.Processors.Overlays.GlowProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Overlays.GlowProcessor.GlowColor.get -> SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.Processing.Processors.Overlays.GlowProcessor.GlowProcessor(SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Color color) -> void
+SixLabors.ImageSharp.Processing.Processors.Overlays.GlowProcessor.GraphicsOptions.get -> SixLabors.ImageSharp.GraphicsOptions!
+SixLabors.ImageSharp.Processing.Processors.Overlays.VignetteProcessor
+SixLabors.ImageSharp.Processing.Processors.Overlays.VignetteProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Overlays.VignetteProcessor.GraphicsOptions.get -> SixLabors.ImageSharp.GraphicsOptions!
+SixLabors.ImageSharp.Processing.Processors.Overlays.VignetteProcessor.VignetteColor.get -> SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.Processing.Processors.Overlays.VignetteProcessor.VignetteProcessor(SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Color color) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.DefaultPixelSamplingStrategy
+SixLabors.ImageSharp.Processing.Processors.Quantization.DefaultPixelSamplingStrategy.DefaultPixelSamplingStrategy() -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.DefaultPixelSamplingStrategy.DefaultPixelSamplingStrategy(int maximumPixels, double minimumScanRatio) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.DefaultPixelSamplingStrategy.EnumeratePixelRegions<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image) -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.Memory.Buffer2DRegion<TPixel>>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.DefaultPixelSamplingStrategy.EnumeratePixelRegions<TPixel>(SixLabors.ImageSharp.ImageFrame<TPixel>! frame) -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.Memory.Buffer2DRegion<TPixel>>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.DefaultPixelSamplingStrategy.MaximumPixels.get -> long
+SixLabors.ImageSharp.Processing.Processors.Quantization.DefaultPixelSamplingStrategy.MinimumScanRatio.get -> double
+SixLabors.ImageSharp.Processing.Processors.Quantization.ExtensivePixelSamplingStrategy
+SixLabors.ImageSharp.Processing.Processors.Quantization.ExtensivePixelSamplingStrategy.EnumeratePixelRegions<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image) -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.Memory.Buffer2DRegion<TPixel>>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.ExtensivePixelSamplingStrategy.EnumeratePixelRegions<TPixel>(SixLabors.ImageSharp.ImageFrame<TPixel>! frame) -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.Memory.Buffer2DRegion<TPixel>>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.ExtensivePixelSamplingStrategy.ExtensivePixelSamplingStrategy() -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.IPixelSamplingStrategy
+SixLabors.ImageSharp.Processing.Processors.Quantization.IPixelSamplingStrategy.EnumeratePixelRegions<TPixel>(SixLabors.ImageSharp.Image<TPixel>! image) -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.Memory.Buffer2DRegion<TPixel>>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.IPixelSamplingStrategy.EnumeratePixelRegions<TPixel>(SixLabors.ImageSharp.ImageFrame<TPixel>! frame) -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.Memory.Buffer2DRegion<TPixel>>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer.CreatePixelSpecificQuantizer<TPixel>(SixLabors.ImageSharp.Configuration! configuration) -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer.CreatePixelSpecificQuantizer<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer.Options.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions!
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>.AddPaletteColors(SixLabors.ImageSharp.Memory.Buffer2DRegion<TPixel> pixelRegion) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>.Configuration.get -> SixLabors.ImageSharp.Configuration!
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>.GetQuantizedColor(TPixel color, out TPixel match) -> byte
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>.Options.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions!
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>.Palette.get -> System.ReadOnlyMemory<TPixel>
+SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>.QuantizeFrame(SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.Rectangle bounds) -> SixLabors.ImageSharp.IndexedImageFrame<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer.CreatePixelSpecificQuantizer<TPixel>(SixLabors.ImageSharp.Configuration! configuration) -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer.CreatePixelSpecificQuantizer<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer.OctreeQuantizer() -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer.OctreeQuantizer(SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer.Options.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions!
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>.AddPaletteColors(SixLabors.ImageSharp.Memory.Buffer2DRegion<TPixel> pixelRegion) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>.Configuration.get -> SixLabors.ImageSharp.Configuration!
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>.Dispose() -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>.GetQuantizedColor(TPixel color, out TPixel match) -> byte
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>.OctreeQuantizer() -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>.OctreeQuantizer(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>.Options.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions!
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>.Palette.get -> System.ReadOnlyMemory<TPixel>
+SixLabors.ImageSharp.Processing.Processors.Quantization.OctreeQuantizer<TPixel>.QuantizeFrame(SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.Rectangle bounds) -> SixLabors.ImageSharp.IndexedImageFrame<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.PaletteQuantizer
+SixLabors.ImageSharp.Processing.Processors.Quantization.PaletteQuantizer.CreatePixelSpecificQuantizer<TPixel>(SixLabors.ImageSharp.Configuration! configuration) -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.PaletteQuantizer.CreatePixelSpecificQuantizer<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.PaletteQuantizer.Options.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions!
+SixLabors.ImageSharp.Processing.Processors.Quantization.PaletteQuantizer.PaletteQuantizer(System.ReadOnlyMemory<SixLabors.ImageSharp.Color> palette) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.PaletteQuantizer.PaletteQuantizer(System.ReadOnlyMemory<SixLabors.ImageSharp.Color> palette, SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizeProcessor
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizeProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizeProcessor.QuantizeProcessor(SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer! quantizer) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizeProcessor.Quantizer.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer!
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerConstants
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions.Dither.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither?
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions.Dither.set -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions.DitherScale.get -> float
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions.DitherScale.set -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions.MaxColors.get -> int
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions.MaxColors.set -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions.QuantizerOptions() -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerUtilities
+SixLabors.ImageSharp.Processing.Processors.Quantization.WebSafePaletteQuantizer
+SixLabors.ImageSharp.Processing.Processors.Quantization.WebSafePaletteQuantizer.WebSafePaletteQuantizer() -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.WebSafePaletteQuantizer.WebSafePaletteQuantizer(SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.WernerPaletteQuantizer
+SixLabors.ImageSharp.Processing.Processors.Quantization.WernerPaletteQuantizer.WernerPaletteQuantizer() -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.WernerPaletteQuantizer.WernerPaletteQuantizer(SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.WuQuantizer
+SixLabors.ImageSharp.Processing.Processors.Quantization.WuQuantizer.CreatePixelSpecificQuantizer<TPixel>(SixLabors.ImageSharp.Configuration! configuration) -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.WuQuantizer.CreatePixelSpecificQuantizer<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Quantization.WuQuantizer.Options.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions!
+SixLabors.ImageSharp.Processing.Processors.Quantization.WuQuantizer.WuQuantizer() -> void
+SixLabors.ImageSharp.Processing.Processors.Quantization.WuQuantizer.WuQuantizer(SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerOptions! options) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.AffineTransformProcessor
+SixLabors.ImageSharp.Processing.Processors.Transforms.AffineTransformProcessor.AffineTransformProcessor(System.Numerics.Matrix3x2 matrix, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler, SixLabors.ImageSharp.Size targetDimensions) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.AffineTransformProcessor.DestinationSize.get -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.Processing.Processors.Transforms.AffineTransformProcessor.Sampler.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+SixLabors.ImageSharp.Processing.Processors.Transforms.AffineTransformProcessor.TransformMatrix.get -> System.Numerics.Matrix3x2
+SixLabors.ImageSharp.Processing.Processors.Transforms.AutoOrientProcessor
+SixLabors.ImageSharp.Processing.Processors.Transforms.AutoOrientProcessor.AutoOrientProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.AutoOrientProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Transforms.BicubicResampler
+SixLabors.ImageSharp.Processing.Processors.Transforms.BicubicResampler.ApplyTransform<TPixel>(SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>! processor) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.BicubicResampler.BicubicResampler() -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.BicubicResampler.GetValue(float x) -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.BicubicResampler.Radius.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.BoxResampler
+SixLabors.ImageSharp.Processing.Processors.Transforms.BoxResampler.ApplyTransform<TPixel>(SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>! processor) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.BoxResampler.BoxResampler() -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.BoxResampler.GetValue(float x) -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.BoxResampler.Radius.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.CropProcessor
+SixLabors.ImageSharp.Processing.Processors.Transforms.CropProcessor.CropProcessor(SixLabors.ImageSharp.Rectangle cropRectangle, SixLabors.ImageSharp.Size sourceSize) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.CropProcessor.CropRectangle.get -> SixLabors.ImageSharp.Rectangle
+SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler
+SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.ApplyTransform<TPixel>(SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>! processor) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.CubicResampler() -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.CubicResampler(float radius, float bspline, float cardinal) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.GetValue(float x) -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.Radius.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.DegenerateTransformException
+SixLabors.ImageSharp.Processing.Processors.Transforms.DegenerateTransformException.DegenerateTransformException() -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.DegenerateTransformException.DegenerateTransformException(string! message) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.DegenerateTransformException.DegenerateTransformException(string! message, System.Exception! innerException) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.EntropyCropProcessor
+SixLabors.ImageSharp.Processing.Processors.Transforms.EntropyCropProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Transforms.EntropyCropProcessor.EntropyCropProcessor() -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.EntropyCropProcessor.EntropyCropProcessor(float threshold) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.EntropyCropProcessor.Threshold.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.FlipProcessor
+SixLabors.ImageSharp.Processing.Processors.Transforms.FlipProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Transforms.FlipProcessor.FlipMode.get -> SixLabors.ImageSharp.Processing.FlipMode
+SixLabors.ImageSharp.Processing.Processors.Transforms.FlipProcessor.FlipProcessor(SixLabors.ImageSharp.Processing.FlipMode flipMode) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler
+SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler.ApplyTransform<TPixel>(SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>! processor) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler.GetValue(float x) -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler.Radius.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>
+SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>.ApplyTransform<TResampler>(in TResampler sampler) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.ISwizzler
+SixLabors.ImageSharp.Processing.Processors.Transforms.ISwizzler.DestinationSize.get -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.Processing.Processors.Transforms.ISwizzler.Transform(SixLabors.ImageSharp.Point point) -> SixLabors.ImageSharp.Point
+SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler
+SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler.ApplyTransform<TPixel>(SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>! processor) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler.GetValue(float x) -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler.LanczosResampler() -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler.LanczosResampler(float radius) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler.Radius.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.NearestNeighborResampler
+SixLabors.ImageSharp.Processing.Processors.Transforms.NearestNeighborResampler.ApplyTransform<TPixel>(SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>! processor) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.NearestNeighborResampler.GetValue(float x) -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.NearestNeighborResampler.NearestNeighborResampler() -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.NearestNeighborResampler.Radius.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.ProjectiveTransformProcessor
+SixLabors.ImageSharp.Processing.Processors.Transforms.ProjectiveTransformProcessor.DestinationSize.get -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.Processing.Processors.Transforms.ProjectiveTransformProcessor.ProjectiveTransformProcessor(System.Numerics.Matrix4x4 matrix, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler, SixLabors.ImageSharp.Size targetDimensions) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.ProjectiveTransformProcessor.Sampler.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+SixLabors.ImageSharp.Processing.Processors.Transforms.ProjectiveTransformProcessor.TransformMatrix.get -> System.Numerics.Matrix4x4
+SixLabors.ImageSharp.Processing.Processors.Transforms.ResizeProcessor
+SixLabors.ImageSharp.Processing.Processors.Transforms.ResizeProcessor.DestinationHeight.get -> int
+SixLabors.ImageSharp.Processing.Processors.Transforms.ResizeProcessor.DestinationRectangle.get -> SixLabors.ImageSharp.Rectangle
+SixLabors.ImageSharp.Processing.Processors.Transforms.ResizeProcessor.DestinationWidth.get -> int
+SixLabors.ImageSharp.Processing.Processors.Transforms.ResizeProcessor.Options.get -> SixLabors.ImageSharp.Processing.ResizeOptions!
+SixLabors.ImageSharp.Processing.Processors.Transforms.ResizeProcessor.ResizeProcessor(SixLabors.ImageSharp.Processing.ResizeOptions! options, SixLabors.ImageSharp.Size sourceSize) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.RotateProcessor
+SixLabors.ImageSharp.Processing.Processors.Transforms.RotateProcessor.Degrees.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.RotateProcessor.RotateProcessor(float degrees, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler, SixLabors.ImageSharp.Size sourceSize) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.RotateProcessor.RotateProcessor(float degrees, SixLabors.ImageSharp.Size sourceSize) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.SkewProcessor
+SixLabors.ImageSharp.Processing.Processors.Transforms.SkewProcessor.DegreesX.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.SkewProcessor.DegreesY.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.SkewProcessor.SkewProcessor(float degreesX, float degreesY, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler, SixLabors.ImageSharp.Size sourceSize) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.SkewProcessor.SkewProcessor(float degreesX, float degreesY, SixLabors.ImageSharp.Size sourceSize) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.SwizzleProcessor<TSwizzler>
+SixLabors.ImageSharp.Processing.Processors.Transforms.SwizzleProcessor<TSwizzler>.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+SixLabors.ImageSharp.Processing.Processors.Transforms.SwizzleProcessor<TSwizzler>.SwizzleProcessor(TSwizzler swizzler) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.SwizzleProcessor<TSwizzler>.Swizzler.get -> TSwizzler
+SixLabors.ImageSharp.Processing.Processors.Transforms.TriangleResampler
+SixLabors.ImageSharp.Processing.Processors.Transforms.TriangleResampler.ApplyTransform<TPixel>(SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>! processor) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.TriangleResampler.GetValue(float x) -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.TriangleResampler.Radius.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.TriangleResampler.TriangleResampler() -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.WelchResampler
+SixLabors.ImageSharp.Processing.Processors.Transforms.WelchResampler.ApplyTransform<TPixel>(SixLabors.ImageSharp.Processing.Processors.Transforms.IResamplingTransformImageProcessor<TPixel>! processor) -> void
+SixLabors.ImageSharp.Processing.Processors.Transforms.WelchResampler.GetValue(float x) -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.WelchResampler.Radius.get -> float
+SixLabors.ImageSharp.Processing.Processors.Transforms.WelchResampler.WelchResampler() -> void
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendMatrix(System.Numerics.Matrix4x4 matrix) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendRotationDegrees(float degrees) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendRotationRadians(float radians) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendScale(float scale) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendScale(SixLabors.ImageSharp.SizeF scales) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendScale(System.Numerics.Vector2 scales) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendSkewDegrees(float degreesX, float degreesY, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendSkewRadians(float radiansX, float radiansY) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendSkewRadians(float radiansX, float radiansY, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendTaper(SixLabors.ImageSharp.Processing.TaperSide side, SixLabors.ImageSharp.Processing.TaperCorner corner, float fraction) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendTranslation(SixLabors.ImageSharp.PointF position) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.AppendTranslation(System.Numerics.Vector2 position) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.BuildMatrix(SixLabors.ImageSharp.Rectangle sourceRectangle) -> System.Numerics.Matrix4x4
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.BuildMatrix(SixLabors.ImageSharp.Size sourceSize) -> System.Numerics.Matrix4x4
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependMatrix(System.Numerics.Matrix4x4 matrix) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependRotationDegrees(float degrees) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependRotationRadians(float radians) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependScale(float scale) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependScale(SixLabors.ImageSharp.SizeF scale) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependScale(System.Numerics.Vector2 scales) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependSkewDegrees(float degreesX, float degreesY, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependSkewRadians(float radiansX, float radiansY) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependSkewRadians(float radiansX, float radiansY, System.Numerics.Vector2 origin) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependTaper(SixLabors.ImageSharp.Processing.TaperSide side, SixLabors.ImageSharp.Processing.TaperCorner corner, float fraction) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependTranslation(SixLabors.ImageSharp.PointF position) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.PrependTranslation(System.Numerics.Vector2 position) -> SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder!
+SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder.ProjectiveTransformBuilder() -> void
+SixLabors.ImageSharp.Processing.QuantizeExtensions
+SixLabors.ImageSharp.Processing.ResizeExtensions
+SixLabors.ImageSharp.Processing.ResizeMode
+SixLabors.ImageSharp.Processing.ResizeMode.BoxPad = 2 -> SixLabors.ImageSharp.Processing.ResizeMode
+SixLabors.ImageSharp.Processing.ResizeMode.Crop = 0 -> SixLabors.ImageSharp.Processing.ResizeMode
+SixLabors.ImageSharp.Processing.ResizeMode.Manual = 6 -> SixLabors.ImageSharp.Processing.ResizeMode
+SixLabors.ImageSharp.Processing.ResizeMode.Max = 3 -> SixLabors.ImageSharp.Processing.ResizeMode
+SixLabors.ImageSharp.Processing.ResizeMode.Min = 4 -> SixLabors.ImageSharp.Processing.ResizeMode
+SixLabors.ImageSharp.Processing.ResizeMode.Pad = 1 -> SixLabors.ImageSharp.Processing.ResizeMode
+SixLabors.ImageSharp.Processing.ResizeMode.Stretch = 5 -> SixLabors.ImageSharp.Processing.ResizeMode
+SixLabors.ImageSharp.Processing.ResizeOptions
+SixLabors.ImageSharp.Processing.ResizeOptions.CenterCoordinates.get -> SixLabors.ImageSharp.PointF?
+SixLabors.ImageSharp.Processing.ResizeOptions.CenterCoordinates.set -> void
+SixLabors.ImageSharp.Processing.ResizeOptions.Compand.get -> bool
+SixLabors.ImageSharp.Processing.ResizeOptions.Compand.set -> void
+SixLabors.ImageSharp.Processing.ResizeOptions.Mode.get -> SixLabors.ImageSharp.Processing.ResizeMode
+SixLabors.ImageSharp.Processing.ResizeOptions.Mode.set -> void
+SixLabors.ImageSharp.Processing.ResizeOptions.PadColor.get -> SixLabors.ImageSharp.Color
+SixLabors.ImageSharp.Processing.ResizeOptions.PadColor.set -> void
+SixLabors.ImageSharp.Processing.ResizeOptions.Position.get -> SixLabors.ImageSharp.Processing.AnchorPositionMode
+SixLabors.ImageSharp.Processing.ResizeOptions.Position.set -> void
+SixLabors.ImageSharp.Processing.ResizeOptions.PremultiplyAlpha.get -> bool
+SixLabors.ImageSharp.Processing.ResizeOptions.PremultiplyAlpha.set -> void
+SixLabors.ImageSharp.Processing.ResizeOptions.ResizeOptions() -> void
+SixLabors.ImageSharp.Processing.ResizeOptions.Sampler.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+SixLabors.ImageSharp.Processing.ResizeOptions.Sampler.set -> void
+SixLabors.ImageSharp.Processing.ResizeOptions.Size.get -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.Processing.ResizeOptions.Size.set -> void
+SixLabors.ImageSharp.Processing.ResizeOptions.TargetRectangle.get -> SixLabors.ImageSharp.Rectangle?
+SixLabors.ImageSharp.Processing.ResizeOptions.TargetRectangle.set -> void
+SixLabors.ImageSharp.Processing.RotateExtensions
+SixLabors.ImageSharp.Processing.RotateFlipExtensions
+SixLabors.ImageSharp.Processing.RotateMode
+SixLabors.ImageSharp.Processing.RotateMode.None = 0 -> SixLabors.ImageSharp.Processing.RotateMode
+SixLabors.ImageSharp.Processing.RotateMode.Rotate180 = 180 -> SixLabors.ImageSharp.Processing.RotateMode
+SixLabors.ImageSharp.Processing.RotateMode.Rotate270 = 270 -> SixLabors.ImageSharp.Processing.RotateMode
+SixLabors.ImageSharp.Processing.RotateMode.Rotate90 = 90 -> SixLabors.ImageSharp.Processing.RotateMode
+SixLabors.ImageSharp.Processing.SaturateExtensions
+SixLabors.ImageSharp.Processing.SepiaExtensions
+SixLabors.ImageSharp.Processing.SkewExtensions
+SixLabors.ImageSharp.Processing.SwizzleExtensions
+SixLabors.ImageSharp.Processing.TaperCorner
+SixLabors.ImageSharp.Processing.TaperCorner.Both = 2 -> SixLabors.ImageSharp.Processing.TaperCorner
+SixLabors.ImageSharp.Processing.TaperCorner.LeftOrTop = 0 -> SixLabors.ImageSharp.Processing.TaperCorner
+SixLabors.ImageSharp.Processing.TaperCorner.RightOrBottom = 1 -> SixLabors.ImageSharp.Processing.TaperCorner
+SixLabors.ImageSharp.Processing.TaperSide
+SixLabors.ImageSharp.Processing.TaperSide.Bottom = 3 -> SixLabors.ImageSharp.Processing.TaperSide
+SixLabors.ImageSharp.Processing.TaperSide.Left = 0 -> SixLabors.ImageSharp.Processing.TaperSide
+SixLabors.ImageSharp.Processing.TaperSide.Right = 2 -> SixLabors.ImageSharp.Processing.TaperSide
+SixLabors.ImageSharp.Processing.TaperSide.Top = 1 -> SixLabors.ImageSharp.Processing.TaperSide
+SixLabors.ImageSharp.Processing.TransformExtensions
+SixLabors.ImageSharp.Processing.VignetteExtensions
+SixLabors.ImageSharp.Rational
+SixLabors.ImageSharp.Rational.Denominator.get -> uint
+SixLabors.ImageSharp.Rational.Equals(SixLabors.ImageSharp.Rational other) -> bool
+SixLabors.ImageSharp.Rational.Numerator.get -> uint
+SixLabors.ImageSharp.Rational.Rational() -> void
+SixLabors.ImageSharp.Rational.Rational(double value) -> void
+SixLabors.ImageSharp.Rational.Rational(double value, bool bestPrecision) -> void
+SixLabors.ImageSharp.Rational.Rational(uint numerator, uint denominator) -> void
+SixLabors.ImageSharp.Rational.Rational(uint numerator, uint denominator, bool simplify) -> void
+SixLabors.ImageSharp.Rational.Rational(uint value) -> void
+SixLabors.ImageSharp.Rational.ToDouble() -> double
+SixLabors.ImageSharp.Rational.ToSingle() -> float
+SixLabors.ImageSharp.Rational.ToString(System.IFormatProvider! provider) -> string!
+SixLabors.ImageSharp.ReadOrigin
+SixLabors.ImageSharp.ReadOrigin.Begin = 0 -> SixLabors.ImageSharp.ReadOrigin
+SixLabors.ImageSharp.ReadOrigin.Current = 1 -> SixLabors.ImageSharp.ReadOrigin
+SixLabors.ImageSharp.Rectangle
+SixLabors.ImageSharp.Rectangle.Bottom.get -> int
+SixLabors.ImageSharp.Rectangle.Contains(int x, int y) -> bool
+SixLabors.ImageSharp.Rectangle.Contains(SixLabors.ImageSharp.Point point) -> bool
+SixLabors.ImageSharp.Rectangle.Contains(SixLabors.ImageSharp.Rectangle rectangle) -> bool
+SixLabors.ImageSharp.Rectangle.Deconstruct(out int x, out int y, out int width, out int height) -> void
+SixLabors.ImageSharp.Rectangle.Equals(SixLabors.ImageSharp.Rectangle other) -> bool
+SixLabors.ImageSharp.Rectangle.Height.get -> int
+SixLabors.ImageSharp.Rectangle.Height.set -> void
+SixLabors.ImageSharp.Rectangle.Inflate(int width, int height) -> void
+SixLabors.ImageSharp.Rectangle.Inflate(SixLabors.ImageSharp.Size size) -> void
+SixLabors.ImageSharp.Rectangle.Intersect(SixLabors.ImageSharp.Rectangle rectangle) -> void
+SixLabors.ImageSharp.Rectangle.IntersectsWith(SixLabors.ImageSharp.Rectangle rectangle) -> bool
+SixLabors.ImageSharp.Rectangle.IsEmpty.get -> bool
+SixLabors.ImageSharp.Rectangle.Left.get -> int
+SixLabors.ImageSharp.Rectangle.Location.get -> SixLabors.ImageSharp.Point
+SixLabors.ImageSharp.Rectangle.Location.set -> void
+SixLabors.ImageSharp.Rectangle.Offset(int dx, int dy) -> void
+SixLabors.ImageSharp.Rectangle.Offset(SixLabors.ImageSharp.Point point) -> void
+SixLabors.ImageSharp.Rectangle.Rectangle() -> void
+SixLabors.ImageSharp.Rectangle.Rectangle(int x, int y, int width, int height) -> void
+SixLabors.ImageSharp.Rectangle.Rectangle(SixLabors.ImageSharp.Point point, SixLabors.ImageSharp.Size size) -> void
+SixLabors.ImageSharp.Rectangle.Right.get -> int
+SixLabors.ImageSharp.Rectangle.Size.get -> SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.Rectangle.Size.set -> void
+SixLabors.ImageSharp.Rectangle.Top.get -> int
+SixLabors.ImageSharp.Rectangle.Width.get -> int
+SixLabors.ImageSharp.Rectangle.Width.set -> void
+SixLabors.ImageSharp.Rectangle.X.get -> int
+SixLabors.ImageSharp.Rectangle.X.set -> void
+SixLabors.ImageSharp.Rectangle.Y.get -> int
+SixLabors.ImageSharp.Rectangle.Y.set -> void
+SixLabors.ImageSharp.RectangleF
+SixLabors.ImageSharp.RectangleF.Bottom.get -> float
+SixLabors.ImageSharp.RectangleF.Contains(float x, float y) -> bool
+SixLabors.ImageSharp.RectangleF.Contains(SixLabors.ImageSharp.PointF point) -> bool
+SixLabors.ImageSharp.RectangleF.Contains(SixLabors.ImageSharp.RectangleF rectangle) -> bool
+SixLabors.ImageSharp.RectangleF.Deconstruct(out float x, out float y, out float width, out float height) -> void
+SixLabors.ImageSharp.RectangleF.Equals(SixLabors.ImageSharp.RectangleF other) -> bool
+SixLabors.ImageSharp.RectangleF.Height.get -> float
+SixLabors.ImageSharp.RectangleF.Height.set -> void
+SixLabors.ImageSharp.RectangleF.Inflate(float width, float height) -> void
+SixLabors.ImageSharp.RectangleF.Inflate(SixLabors.ImageSharp.SizeF size) -> void
+SixLabors.ImageSharp.RectangleF.Intersect(SixLabors.ImageSharp.RectangleF rectangle) -> void
+SixLabors.ImageSharp.RectangleF.IntersectsWith(SixLabors.ImageSharp.RectangleF rectangle) -> bool
+SixLabors.ImageSharp.RectangleF.IsEmpty.get -> bool
+SixLabors.ImageSharp.RectangleF.Left.get -> float
+SixLabors.ImageSharp.RectangleF.Location.get -> SixLabors.ImageSharp.PointF
+SixLabors.ImageSharp.RectangleF.Location.set -> void
+SixLabors.ImageSharp.RectangleF.Offset(float dx, float dy) -> void
+SixLabors.ImageSharp.RectangleF.Offset(SixLabors.ImageSharp.PointF point) -> void
+SixLabors.ImageSharp.RectangleF.RectangleF() -> void
+SixLabors.ImageSharp.RectangleF.RectangleF(float x, float y, float width, float height) -> void
+SixLabors.ImageSharp.RectangleF.RectangleF(SixLabors.ImageSharp.PointF point, SixLabors.ImageSharp.SizeF size) -> void
+SixLabors.ImageSharp.RectangleF.Right.get -> float
+SixLabors.ImageSharp.RectangleF.Size.get -> SixLabors.ImageSharp.SizeF
+SixLabors.ImageSharp.RectangleF.Size.set -> void
+SixLabors.ImageSharp.RectangleF.Top.get -> float
+SixLabors.ImageSharp.RectangleF.Width.get -> float
+SixLabors.ImageSharp.RectangleF.Width.set -> void
+SixLabors.ImageSharp.RectangleF.X.get -> float
+SixLabors.ImageSharp.RectangleF.X.set -> void
+SixLabors.ImageSharp.RectangleF.Y.get -> float
+SixLabors.ImageSharp.RectangleF.Y.set -> void
+SixLabors.ImageSharp.SignedRational
+SixLabors.ImageSharp.SignedRational.Denominator.get -> int
+SixLabors.ImageSharp.SignedRational.Equals(SixLabors.ImageSharp.SignedRational other) -> bool
+SixLabors.ImageSharp.SignedRational.Numerator.get -> int
+SixLabors.ImageSharp.SignedRational.SignedRational() -> void
+SixLabors.ImageSharp.SignedRational.SignedRational(double value) -> void
+SixLabors.ImageSharp.SignedRational.SignedRational(double value, bool bestPrecision) -> void
+SixLabors.ImageSharp.SignedRational.SignedRational(int numerator, int denominator) -> void
+SixLabors.ImageSharp.SignedRational.SignedRational(int numerator, int denominator, bool simplify) -> void
+SixLabors.ImageSharp.SignedRational.SignedRational(int value) -> void
+SixLabors.ImageSharp.SignedRational.ToDouble() -> double
+SixLabors.ImageSharp.SignedRational.ToString(System.IFormatProvider! provider) -> string!
+SixLabors.ImageSharp.Size
+SixLabors.ImageSharp.Size.Deconstruct(out int width, out int height) -> void
+SixLabors.ImageSharp.Size.Equals(SixLabors.ImageSharp.Size other) -> bool
+SixLabors.ImageSharp.Size.Height.get -> int
+SixLabors.ImageSharp.Size.Height.set -> void
+SixLabors.ImageSharp.Size.IsEmpty.get -> bool
+SixLabors.ImageSharp.Size.Size() -> void
+SixLabors.ImageSharp.Size.Size(int value) -> void
+SixLabors.ImageSharp.Size.Size(int width, int height) -> void
+SixLabors.ImageSharp.Size.Size(SixLabors.ImageSharp.Point point) -> void
+SixLabors.ImageSharp.Size.Size(SixLabors.ImageSharp.Size size) -> void
+SixLabors.ImageSharp.Size.Width.get -> int
+SixLabors.ImageSharp.Size.Width.set -> void
+SixLabors.ImageSharp.SizeF
+SixLabors.ImageSharp.SizeF.Deconstruct(out float width, out float height) -> void
+SixLabors.ImageSharp.SizeF.Equals(SixLabors.ImageSharp.SizeF other) -> bool
+SixLabors.ImageSharp.SizeF.Height.get -> float
+SixLabors.ImageSharp.SizeF.Height.set -> void
+SixLabors.ImageSharp.SizeF.IsEmpty.get -> bool
+SixLabors.ImageSharp.SizeF.SizeF() -> void
+SixLabors.ImageSharp.SizeF.SizeF(float width, float height) -> void
+SixLabors.ImageSharp.SizeF.SizeF(SixLabors.ImageSharp.PointF point) -> void
+SixLabors.ImageSharp.SizeF.SizeF(SixLabors.ImageSharp.SizeF size) -> void
+SixLabors.ImageSharp.SizeF.Width.get -> float
+SixLabors.ImageSharp.SizeF.Width.set -> void
+SixLabors.ImageSharp.UnknownImageFormatException
+SixLabors.ImageSharp.UnknownImageFormatException.UnknownImageFormatException(string! errorMessage) -> void
+static readonly SixLabors.ImageSharp.Color.AliceBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.AntiqueWhite -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Aqua -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Aquamarine -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Azure -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Beige -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Bisque -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Black -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.BlanchedAlmond -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Blue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.BlueViolet -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Brown -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.BurlyWood -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.CadetBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Chartreuse -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Chocolate -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Coral -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.CornflowerBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Cornsilk -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Crimson -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Cyan -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkCyan -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkGoldenrod -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkGray -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkGrey -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkKhaki -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkMagenta -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkOliveGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkOrange -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkOrchid -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkRed -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkSalmon -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkSeaGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkSlateBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkSlateGray -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkSlateGrey -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkTurquoise -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DarkViolet -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DeepPink -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DeepSkyBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DimGray -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DimGrey -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.DodgerBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Firebrick -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.FloralWhite -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.ForestGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Fuchsia -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Gainsboro -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.GhostWhite -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Gold -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Goldenrod -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Gray -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Green -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.GreenYellow -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Grey -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Honeydew -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.HotPink -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.IndianRed -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Indigo -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Ivory -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Khaki -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Lavender -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LavenderBlush -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LawnGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LemonChiffon -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightCoral -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightCyan -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightGoldenrodYellow -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightGray -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightGrey -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightPink -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightSalmon -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightSeaGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightSkyBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightSlateGray -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightSlateGrey -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightSteelBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LightYellow -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Lime -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.LimeGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Linen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Magenta -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Maroon -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MediumAquamarine -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MediumBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MediumOrchid -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MediumPurple -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MediumSeaGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MediumSlateBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MediumSpringGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MediumTurquoise -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MediumVioletRed -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MidnightBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MintCream -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.MistyRose -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Moccasin -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.NavajoWhite -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Navy -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.OldLace -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Olive -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.OliveDrab -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Orange -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.OrangeRed -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Orchid -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.PaleGoldenrod -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.PaleGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.PaleTurquoise -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.PaleVioletRed -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.PapayaWhip -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.PeachPuff -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Peru -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Pink -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Plum -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.PowderBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Purple -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.RebeccaPurple -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Red -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.RosyBrown -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.RoyalBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SaddleBrown -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Salmon -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SandyBrown -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SeaGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SeaShell -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Sienna -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Silver -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SkyBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SlateBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SlateGray -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SlateGrey -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Snow -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SpringGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.SteelBlue -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Tan -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Teal -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Thistle -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Tomato -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Transparent -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Turquoise -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Violet -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Wheat -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.White -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.WhiteSmoke -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.Yellow -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.Color.YellowGreen -> SixLabors.ImageSharp.Color
+static readonly SixLabors.ImageSharp.ColorSpaces.CieLab.DefaultWhitePoint -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.CieLch.DefaultWhitePoint -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.CieLchuv.DefaultWhitePoint -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.CieLuv.DefaultWhitePoint -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Conversion.LmsAdaptationMatrix.Bradford -> System.Numerics.Matrix4x4
+static readonly SixLabors.ImageSharp.ColorSpaces.Conversion.LmsAdaptationMatrix.BradfordSharp -> System.Numerics.Matrix4x4
+static readonly SixLabors.ImageSharp.ColorSpaces.Conversion.LmsAdaptationMatrix.CAT02 -> System.Numerics.Matrix4x4
+static readonly SixLabors.ImageSharp.ColorSpaces.Conversion.LmsAdaptationMatrix.CMCCAT2000 -> System.Numerics.Matrix4x4
+static readonly SixLabors.ImageSharp.ColorSpaces.Conversion.LmsAdaptationMatrix.VonKriesHPE -> System.Numerics.Matrix4x4
+static readonly SixLabors.ImageSharp.ColorSpaces.Conversion.LmsAdaptationMatrix.VonKriesHPEAdjusted -> System.Numerics.Matrix4x4
+static readonly SixLabors.ImageSharp.ColorSpaces.Conversion.LmsAdaptationMatrix.XyzScaling -> System.Numerics.Matrix4x4
+static readonly SixLabors.ImageSharp.ColorSpaces.HunterLab.DefaultWhitePoint -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.A -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.B -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.C -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.D50 -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.D55 -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.D65 -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.D75 -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.E -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.F11 -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.F2 -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.Illuminants.F7 -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static readonly SixLabors.ImageSharp.ColorSpaces.LinearRgb.DefaultWorkingSpace -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.Rgb.DefaultWorkingSpace -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.AdobeRgb1998 -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.ApplesRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.BestRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.BetaRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.BruceRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.CIERgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.ColorMatchRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.DonRgb4 -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.ECIRgbv2 -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.EktaSpacePS5 -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.NTSCRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.PALSECAMRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.ProPhotoRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.Rec2020 -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.Rec709 -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.SMPTECRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.SRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.SRgbSimplified -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.ColorSpaces.RgbWorkingSpaces.WideGamutRgb -> SixLabors.ImageSharp.ColorSpaces.Conversion.RgbWorkingSpace!
+static readonly SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec.ChrominanceAC -> SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec
+static readonly SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec.ChrominanceDC -> SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec
+static readonly SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec.LuminanceAC -> SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec
+static readonly SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec.LuminanceDC -> SixLabors.ImageSharp.Formats.Jpeg.Components.Encoder.HuffmanSpec
+static readonly SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.Zero -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId
+static readonly SixLabors.ImageSharp.Point.Empty -> SixLabors.ImageSharp.Point
+static readonly SixLabors.ImageSharp.PointF.Empty -> SixLabors.ImageSharp.PointF
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.KayyaliKernel -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.PrewittKernel -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.RobertsCrossKernel -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.ScharrKernel -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.SobelKernel -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.Kirsch -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.Robinson -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.Laplacian3x3 -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.Laplacian5x5 -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.LaplacianOfGaussian -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.Atkinson -> SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.Burkes -> SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.FloydSteinberg -> SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.JarvisJudiceNinke -> SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.Sierra2 -> SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.Sierra3 -> SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.SierraLite -> SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.StevensonArce -> SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.Stucki -> SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.Bayer16x16 -> SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.Bayer2x2 -> SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.Bayer4x4 -> SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.Bayer8x8 -> SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.Ordered3x3 -> SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.CatmullRom -> SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.Hermite -> SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.MitchellNetravali -> SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.Robidoux -> SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.RobidouxSharp -> SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler.Spline -> SixLabors.ImageSharp.Processing.Processors.Transforms.CubicResampler
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler.Lanczos2 -> SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler.Lanczos3 -> SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler.Lanczos5 -> SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler
+static readonly SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler.Lanczos8 -> SixLabors.ImageSharp.Processing.Processors.Transforms.LanczosResampler
+static readonly SixLabors.ImageSharp.Rectangle.Empty -> SixLabors.ImageSharp.Rectangle
+static readonly SixLabors.ImageSharp.RectangleF.Empty -> SixLabors.ImageSharp.RectangleF
+static readonly SixLabors.ImageSharp.Size.Empty -> SixLabors.ImageSharp.Size
+static readonly SixLabors.ImageSharp.SizeF.Empty -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.Advanced.AdvancedImageExtensions.AcceptVisitor(this SixLabors.ImageSharp.Image! source, SixLabors.ImageSharp.Advanced.IImageVisitor! visitor) -> void
+static SixLabors.ImageSharp.Advanced.AdvancedImageExtensions.AcceptVisitorAsync(this SixLabors.ImageSharp.Image! source, SixLabors.ImageSharp.Advanced.IImageVisitorAsync! visitor, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static SixLabors.ImageSharp.Advanced.AdvancedImageExtensions.DangerousGetPixelRowMemory<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, int rowIndex) -> System.Memory<TPixel>
+static SixLabors.ImageSharp.Advanced.AdvancedImageExtensions.DangerousGetPixelRowMemory<TPixel>(this SixLabors.ImageSharp.ImageFrame<TPixel>! source, int rowIndex) -> System.Memory<TPixel>
+static SixLabors.ImageSharp.Advanced.AdvancedImageExtensions.DetectEncoder(this SixLabors.ImageSharp.Image! source, string! filePath) -> SixLabors.ImageSharp.Formats.IImageEncoder!
+static SixLabors.ImageSharp.Advanced.AdvancedImageExtensions.GetConfiguration(this SixLabors.ImageSharp.Image! source) -> SixLabors.ImageSharp.Configuration!
+static SixLabors.ImageSharp.Advanced.AdvancedImageExtensions.GetConfiguration(this SixLabors.ImageSharp.ImageFrame! source) -> SixLabors.ImageSharp.Configuration!
+static SixLabors.ImageSharp.Advanced.AdvancedImageExtensions.GetPixelMemoryGroup<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source) -> SixLabors.ImageSharp.Memory.IMemoryGroup<TPixel>!
+static SixLabors.ImageSharp.Advanced.AdvancedImageExtensions.GetPixelMemoryGroup<TPixel>(this SixLabors.ImageSharp.ImageFrame<TPixel>! source) -> SixLabors.ImageSharp.Memory.IMemoryGroup<TPixel>!
+static SixLabors.ImageSharp.Advanced.ParallelExecutionSettings.FromConfiguration(SixLabors.ImageSharp.Configuration! configuration) -> SixLabors.ImageSharp.Advanced.ParallelExecutionSettings
+static SixLabors.ImageSharp.Advanced.ParallelRowIterator.IterateRowIntervals<T, TBuffer>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Rectangle rectangle, in T operation) -> void
+static SixLabors.ImageSharp.Advanced.ParallelRowIterator.IterateRowIntervals<T, TBuffer>(SixLabors.ImageSharp.Rectangle rectangle, in SixLabors.ImageSharp.Advanced.ParallelExecutionSettings parallelSettings, in T operation) -> void
+static SixLabors.ImageSharp.Advanced.ParallelRowIterator.IterateRowIntervals<T>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Rectangle rectangle, in T operation) -> void
+static SixLabors.ImageSharp.Advanced.ParallelRowIterator.IterateRowIntervals<T>(SixLabors.ImageSharp.Rectangle rectangle, in SixLabors.ImageSharp.Advanced.ParallelExecutionSettings parallelSettings, in T operation) -> void
+static SixLabors.ImageSharp.Advanced.ParallelRowIterator.IterateRows<T, TBuffer>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Rectangle rectangle, in T operation) -> void
+static SixLabors.ImageSharp.Advanced.ParallelRowIterator.IterateRows<T, TBuffer>(SixLabors.ImageSharp.Rectangle rectangle, in SixLabors.ImageSharp.Advanced.ParallelExecutionSettings parallelSettings, in T operation) -> void
+static SixLabors.ImageSharp.Advanced.ParallelRowIterator.IterateRows<T>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Rectangle rectangle, in T operation) -> void
+static SixLabors.ImageSharp.Advanced.ParallelRowIterator.IterateRows<T>(SixLabors.ImageSharp.Rectangle rectangle, in SixLabors.ImageSharp.Advanced.ParallelExecutionSettings parallelSettings, in T operation) -> void
+static SixLabors.ImageSharp.Color.explicit operator SixLabors.ImageSharp.Color(System.Numerics.Vector4 source) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.Color.explicit operator System.Numerics.Vector4(SixLabors.ImageSharp.Color color) -> System.Numerics.Vector4
+static SixLabors.ImageSharp.Color.FromPixel<TPixel>(TPixel pixel) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.Color.FromRgb(byte r, byte g, byte b) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.Color.FromRgba(byte r, byte g, byte b, byte a) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.Color.operator !=(SixLabors.ImageSharp.Color left, SixLabors.ImageSharp.Color right) -> bool
+static SixLabors.ImageSharp.Color.operator ==(SixLabors.ImageSharp.Color left, SixLabors.ImageSharp.Color right) -> bool
+static SixLabors.ImageSharp.Color.Parse(string! input) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.Color.ParseHex(string! hex) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.Color.ToPixel<TPixel>(System.ReadOnlySpan<SixLabors.ImageSharp.Color> source, System.Span<TPixel> destination) -> void
+static SixLabors.ImageSharp.Color.TryParse(string! input, out SixLabors.ImageSharp.Color result) -> bool
+static SixLabors.ImageSharp.Color.TryParseHex(string! hex, out SixLabors.ImageSharp.Color result) -> bool
+static SixLabors.ImageSharp.Color.WebSafePalette.get -> System.ReadOnlyMemory<SixLabors.ImageSharp.Color>
+static SixLabors.ImageSharp.Color.WernerPalette.get -> System.ReadOnlyMemory<SixLabors.ImageSharp.Color>
+static SixLabors.ImageSharp.ColorMatrix.Identity.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.ColorMatrix.operator !=(SixLabors.ImageSharp.ColorMatrix value1, SixLabors.ImageSharp.ColorMatrix value2) -> bool
+static SixLabors.ImageSharp.ColorMatrix.operator *(SixLabors.ImageSharp.ColorMatrix value1, float value2) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.ColorMatrix.operator *(SixLabors.ImageSharp.ColorMatrix value1, SixLabors.ImageSharp.ColorMatrix value2) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.ColorMatrix.operator +(SixLabors.ImageSharp.ColorMatrix value1, SixLabors.ImageSharp.ColorMatrix value2) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.ColorMatrix.operator -(SixLabors.ImageSharp.ColorMatrix value) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.ColorMatrix.operator -(SixLabors.ImageSharp.ColorMatrix value1, SixLabors.ImageSharp.ColorMatrix value2) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.ColorMatrix.operator ==(SixLabors.ImageSharp.ColorMatrix value1, SixLabors.ImageSharp.ColorMatrix value2) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieLab.operator !=(SixLabors.ImageSharp.ColorSpaces.CieLab left, SixLabors.ImageSharp.ColorSpaces.CieLab right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieLab.operator ==(SixLabors.ImageSharp.ColorSpaces.CieLab left, SixLabors.ImageSharp.ColorSpaces.CieLab right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieLch.operator !=(SixLabors.ImageSharp.ColorSpaces.CieLch left, SixLabors.ImageSharp.ColorSpaces.CieLch right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieLch.operator ==(SixLabors.ImageSharp.ColorSpaces.CieLch left, SixLabors.ImageSharp.ColorSpaces.CieLch right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieLchuv.operator !=(SixLabors.ImageSharp.ColorSpaces.CieLchuv left, SixLabors.ImageSharp.ColorSpaces.CieLchuv right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieLchuv.operator ==(SixLabors.ImageSharp.ColorSpaces.CieLchuv left, SixLabors.ImageSharp.ColorSpaces.CieLchuv right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieLuv.operator !=(SixLabors.ImageSharp.ColorSpaces.CieLuv left, SixLabors.ImageSharp.ColorSpaces.CieLuv right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieLuv.operator ==(SixLabors.ImageSharp.ColorSpaces.CieLuv left, SixLabors.ImageSharp.ColorSpaces.CieLuv right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieXyy.operator !=(SixLabors.ImageSharp.ColorSpaces.CieXyy left, SixLabors.ImageSharp.ColorSpaces.CieXyy right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieXyy.operator ==(SixLabors.ImageSharp.ColorSpaces.CieXyy left, SixLabors.ImageSharp.ColorSpaces.CieXyy right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieXyz.operator !=(SixLabors.ImageSharp.ColorSpaces.CieXyz left, SixLabors.ImageSharp.ColorSpaces.CieXyz right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.CieXyz.operator ==(SixLabors.ImageSharp.ColorSpaces.CieXyz left, SixLabors.ImageSharp.ColorSpaces.CieXyz right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Cmyk.operator !=(SixLabors.ImageSharp.ColorSpaces.Cmyk left, SixLabors.ImageSharp.ColorSpaces.Cmyk right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Cmyk.operator ==(SixLabors.ImageSharp.ColorSpaces.Cmyk left, SixLabors.ImageSharp.ColorSpaces.Cmyk right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Companding.GammaCompanding.Compress(float channel, float gamma) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.GammaCompanding.Expand(float channel, float gamma) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.LCompanding.Compress(float channel) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.LCompanding.Expand(float channel) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.Rec2020Companding.Compress(float channel) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.Rec2020Companding.Expand(float channel) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.Rec709Companding.Compress(float channel) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.Rec709Companding.Expand(float channel) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.SRgbCompanding.Compress(float channel) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.SRgbCompanding.Compress(ref System.Numerics.Vector4 vector) -> void
+static SixLabors.ImageSharp.ColorSpaces.Companding.SRgbCompanding.Compress(System.Span<System.Numerics.Vector4> vectors) -> void
+static SixLabors.ImageSharp.ColorSpaces.Companding.SRgbCompanding.Expand(float channel) -> float
+static SixLabors.ImageSharp.ColorSpaces.Companding.SRgbCompanding.Expand(ref System.Numerics.Vector4 vector) -> void
+static SixLabors.ImageSharp.ColorSpaces.Companding.SRgbCompanding.Expand(System.Span<System.Numerics.Vector4> vectors) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.operator !=(SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates left, SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates.operator ==(SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates left, SixLabors.ImageSharp.ColorSpaces.Conversion.CieXyChromaticityCoordinates right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyy> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyz> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.CieXyz> source, System.Span<SixLabors.ImageSharp.ColorSpaces.CieXyy> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Cmyk> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsl> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Hsv> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Rgb> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.LinearRgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Cmyk> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsl> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.Hsv> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.LinearRgb> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.Convert(System.ReadOnlySpan<SixLabors.ImageSharp.ColorSpaces.Rgb> source, System.Span<SixLabors.ImageSharp.ColorSpaces.YCbCr> destination) -> void
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyy(in SixLabors.ImageSharp.ColorSpaces.CieXyz color) -> SixLabors.ImageSharp.ColorSpaces.CieXyy
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCieXyz(in SixLabors.ImageSharp.ColorSpaces.CieXyy color) -> SixLabors.ImageSharp.ColorSpaces.CieXyz
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToCmyk(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.Cmyk
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsl(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.Hsl
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToHsv(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.Hsv
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToLinearRgb(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.LinearRgb
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToRgb(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.Cmyk color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.Hsl color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.Hsv color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.LinearRgb color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+static SixLabors.ImageSharp.ColorSpaces.Conversion.ColorSpaceConverter.ToYCbCr(in SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.ColorSpaces.YCbCr
+static SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.operator !=(SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates left, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates.operator ==(SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates left, SixLabors.ImageSharp.ColorSpaces.Conversion.RgbPrimariesChromaticityCoordinates right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Hsl.operator !=(SixLabors.ImageSharp.ColorSpaces.Hsl left, SixLabors.ImageSharp.ColorSpaces.Hsl right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Hsl.operator ==(SixLabors.ImageSharp.ColorSpaces.Hsl left, SixLabors.ImageSharp.ColorSpaces.Hsl right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Hsv.operator !=(SixLabors.ImageSharp.ColorSpaces.Hsv left, SixLabors.ImageSharp.ColorSpaces.Hsv right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Hsv.operator ==(SixLabors.ImageSharp.ColorSpaces.Hsv left, SixLabors.ImageSharp.ColorSpaces.Hsv right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.HunterLab.operator !=(SixLabors.ImageSharp.ColorSpaces.HunterLab left, SixLabors.ImageSharp.ColorSpaces.HunterLab right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.HunterLab.operator ==(SixLabors.ImageSharp.ColorSpaces.HunterLab left, SixLabors.ImageSharp.ColorSpaces.HunterLab right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.LinearRgb.operator !=(SixLabors.ImageSharp.ColorSpaces.LinearRgb left, SixLabors.ImageSharp.ColorSpaces.LinearRgb right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.LinearRgb.operator ==(SixLabors.ImageSharp.ColorSpaces.LinearRgb left, SixLabors.ImageSharp.ColorSpaces.LinearRgb right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Lms.operator !=(SixLabors.ImageSharp.ColorSpaces.Lms left, SixLabors.ImageSharp.ColorSpaces.Lms right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Lms.operator ==(SixLabors.ImageSharp.ColorSpaces.Lms left, SixLabors.ImageSharp.ColorSpaces.Lms right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Rgb.implicit operator SixLabors.ImageSharp.ColorSpaces.Rgb(SixLabors.ImageSharp.PixelFormats.Rgb24 color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+static SixLabors.ImageSharp.ColorSpaces.Rgb.implicit operator SixLabors.ImageSharp.ColorSpaces.Rgb(SixLabors.ImageSharp.PixelFormats.Rgba32 color) -> SixLabors.ImageSharp.ColorSpaces.Rgb
+static SixLabors.ImageSharp.ColorSpaces.Rgb.operator !=(SixLabors.ImageSharp.ColorSpaces.Rgb left, SixLabors.ImageSharp.ColorSpaces.Rgb right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.Rgb.operator ==(SixLabors.ImageSharp.ColorSpaces.Rgb left, SixLabors.ImageSharp.ColorSpaces.Rgb right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.YCbCr.operator !=(SixLabors.ImageSharp.ColorSpaces.YCbCr left, SixLabors.ImageSharp.ColorSpaces.YCbCr right) -> bool
+static SixLabors.ImageSharp.ColorSpaces.YCbCr.operator ==(SixLabors.ImageSharp.ColorSpaces.YCbCr left, SixLabors.ImageSharp.ColorSpaces.YCbCr right) -> bool
+static SixLabors.ImageSharp.Configuration.Default.get -> SixLabors.ImageSharp.Configuration!
+static SixLabors.ImageSharp.DenseMatrix<T>.implicit operator SixLabors.ImageSharp.DenseMatrix<T>(T[,]! data) -> SixLabors.ImageSharp.DenseMatrix<T>
+static SixLabors.ImageSharp.DenseMatrix<T>.implicit operator T[,]!(in SixLabors.ImageSharp.DenseMatrix<T> data) -> T[,]!
+static SixLabors.ImageSharp.DenseMatrix<T>.operator !=(SixLabors.ImageSharp.DenseMatrix<T> left, SixLabors.ImageSharp.DenseMatrix<T> right) -> bool
+static SixLabors.ImageSharp.DenseMatrix<T>.operator ==(SixLabors.ImageSharp.DenseMatrix<T> left, SixLabors.ImageSharp.DenseMatrix<T> right) -> bool
+static SixLabors.ImageSharp.Diagnostics.MemoryDiagnostics.TotalUndisposedAllocationCount.get -> int
+static SixLabors.ImageSharp.Diagnostics.MemoryDiagnostics.UndisposedAllocation -> SixLabors.ImageSharp.Diagnostics.UndisposedAllocationDelegate!
+static SixLabors.ImageSharp.Formats.Bmp.BmpDecoder.Instance.get -> SixLabors.ImageSharp.Formats.Bmp.BmpDecoder!
+static SixLabors.ImageSharp.Formats.Bmp.BmpFormat.Instance.get -> SixLabors.ImageSharp.Formats.Bmp.BmpFormat!
+static SixLabors.ImageSharp.Formats.Gif.GifDecoder.Instance.get -> SixLabors.ImageSharp.Formats.Gif.GifDecoder!
+static SixLabors.ImageSharp.Formats.Gif.GifFormat.Instance.get -> SixLabors.ImageSharp.Formats.Gif.GifFormat!
+static SixLabors.ImageSharp.Formats.ImageDecoder.ScaleToTargetSize(SixLabors.ImageSharp.Formats.DecoderOptions! options, SixLabors.ImageSharp.Image! image) -> void
+static SixLabors.ImageSharp.Formats.Jpeg.JpegDecoder.Instance.get -> SixLabors.ImageSharp.Formats.Jpeg.JpegDecoder!
+static SixLabors.ImageSharp.Formats.Jpeg.JpegFormat.Instance.get -> SixLabors.ImageSharp.Formats.Jpeg.JpegFormat!
+static SixLabors.ImageSharp.Formats.Pbm.PbmDecoder.Instance.get -> SixLabors.ImageSharp.Formats.Pbm.PbmDecoder!
+static SixLabors.ImageSharp.Formats.Pbm.PbmFormat.Instance.get -> SixLabors.ImageSharp.Formats.Pbm.PbmFormat!
+static SixLabors.ImageSharp.Formats.Png.PngDecoder.Instance.get -> SixLabors.ImageSharp.Formats.Png.PngDecoder!
+static SixLabors.ImageSharp.Formats.Png.PngFormat.Instance.get -> SixLabors.ImageSharp.Formats.Png.PngFormat!
+static SixLabors.ImageSharp.Formats.Png.PngTextData.operator !=(SixLabors.ImageSharp.Formats.Png.PngTextData left, SixLabors.ImageSharp.Formats.Png.PngTextData right) -> bool
+static SixLabors.ImageSharp.Formats.Png.PngTextData.operator ==(SixLabors.ImageSharp.Formats.Png.PngTextData left, SixLabors.ImageSharp.Formats.Png.PngTextData right) -> bool
+static SixLabors.ImageSharp.Formats.Tga.TgaDecoder.Instance.get -> SixLabors.ImageSharp.Formats.Tga.TgaDecoder!
+static SixLabors.ImageSharp.Formats.Tga.TgaFormat.Instance.get -> SixLabors.ImageSharp.Formats.Tga.TgaFormat!
+static SixLabors.ImageSharp.Formats.Tga.TgaImageTypeExtensions.IsRunLengthEncoded(this SixLabors.ImageSharp.Formats.Tga.TgaImageType imageType) -> bool
+static SixLabors.ImageSharp.Formats.Tga.TgaImageTypeExtensions.IsValid(this SixLabors.ImageSharp.Formats.Tga.TgaImageType imageType) -> bool
+static SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.operator !=(SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample left, SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample right) -> bool
+static SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.operator ==(SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample left, SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample right) -> bool
+static SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample.TryParse(ushort[]? value, out SixLabors.ImageSharp.Formats.Tiff.TiffBitsPerSample sample) -> bool
+static SixLabors.ImageSharp.Formats.Tiff.TiffDecoder.Instance.get -> SixLabors.ImageSharp.Formats.Tiff.TiffDecoder!
+static SixLabors.ImageSharp.Formats.Tiff.TiffFormat.Instance.get -> SixLabors.ImageSharp.Formats.Tiff.TiffFormat!
+static SixLabors.ImageSharp.Formats.Webp.WebpDecoder.Instance.get -> SixLabors.ImageSharp.Formats.Webp.WebpDecoder!
+static SixLabors.ImageSharp.Formats.Webp.WebpFormat.Instance.get -> SixLabors.ImageSharp.Formats.Webp.WebpFormat!
+static SixLabors.ImageSharp.GeometryUtilities.DegreeToRadian(float degree) -> float
+static SixLabors.ImageSharp.GeometryUtilities.RadianToDegree(float radian) -> float
+static SixLabors.ImageSharp.GraphicOptionsDefaultsExtensions.GetGraphicsOptions(this SixLabors.ImageSharp.Configuration! configuration) -> SixLabors.ImageSharp.GraphicsOptions!
+static SixLabors.ImageSharp.GraphicOptionsDefaultsExtensions.GetGraphicsOptions(this SixLabors.ImageSharp.Processing.IImageProcessingContext! context) -> SixLabors.ImageSharp.GraphicsOptions!
+static SixLabors.ImageSharp.GraphicOptionsDefaultsExtensions.SetGraphicsOptions(this SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.GraphicsOptions! options) -> void
+static SixLabors.ImageSharp.GraphicOptionsDefaultsExtensions.SetGraphicsOptions(this SixLabors.ImageSharp.Configuration! configuration, System.Action<SixLabors.ImageSharp.GraphicsOptions!>! optionsBuilder) -> void
+static SixLabors.ImageSharp.GraphicOptionsDefaultsExtensions.SetGraphicsOptions(this SixLabors.ImageSharp.Processing.IImageProcessingContext! context, SixLabors.ImageSharp.GraphicsOptions! options) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.GraphicOptionsDefaultsExtensions.SetGraphicsOptions(this SixLabors.ImageSharp.Processing.IImageProcessingContext! context, System.Action<SixLabors.ImageSharp.GraphicsOptions!>! optionsBuilder) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Image.DetectFormat(SixLabors.ImageSharp.Formats.DecoderOptions! options, string! path) -> SixLabors.ImageSharp.Formats.IImageFormat!
+static SixLabors.ImageSharp.Image.DetectFormat(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Formats.IImageFormat!
+static SixLabors.ImageSharp.Image.DetectFormat(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.ReadOnlySpan<byte> buffer) -> SixLabors.ImageSharp.Formats.IImageFormat!
+static SixLabors.ImageSharp.Image.DetectFormat(string! path) -> SixLabors.ImageSharp.Formats.IImageFormat!
+static SixLabors.ImageSharp.Image.DetectFormat(System.IO.Stream! stream) -> SixLabors.ImageSharp.Formats.IImageFormat!
+static SixLabors.ImageSharp.Image.DetectFormat(System.ReadOnlySpan<byte> buffer) -> SixLabors.ImageSharp.Formats.IImageFormat!
+static SixLabors.ImageSharp.Image.DetectFormatAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Formats.IImageFormat!>!
+static SixLabors.ImageSharp.Image.DetectFormatAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Formats.IImageFormat!>!
+static SixLabors.ImageSharp.Image.DetectFormatAsync(string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Formats.IImageFormat!>!
+static SixLabors.ImageSharp.Image.DetectFormatAsync(System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Formats.IImageFormat!>!
+static SixLabors.ImageSharp.Image.Identify(SixLabors.ImageSharp.Formats.DecoderOptions! options, string! path) -> SixLabors.ImageSharp.ImageInfo!
+static SixLabors.ImageSharp.Image.Identify(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.ImageInfo!
+static SixLabors.ImageSharp.Image.Identify(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.ReadOnlySpan<byte> buffer) -> SixLabors.ImageSharp.ImageInfo!
+static SixLabors.ImageSharp.Image.Identify(string! path) -> SixLabors.ImageSharp.ImageInfo!
+static SixLabors.ImageSharp.Image.Identify(System.IO.Stream! stream) -> SixLabors.ImageSharp.ImageInfo!
+static SixLabors.ImageSharp.Image.Identify(System.ReadOnlySpan<byte> buffer) -> SixLabors.ImageSharp.ImageInfo!
+static SixLabors.ImageSharp.Image.IdentifyAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.ImageInfo!>!
+static SixLabors.ImageSharp.Image.IdentifyAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.ImageInfo!>!
+static SixLabors.ImageSharp.Image.IdentifyAsync(string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.ImageInfo!>!
+static SixLabors.ImageSharp.Image.IdentifyAsync(System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.ImageInfo!>!
+static SixLabors.ImageSharp.Image.Load(SixLabors.ImageSharp.Formats.DecoderOptions! options, string! path) -> SixLabors.ImageSharp.Image!
+static SixLabors.ImageSharp.Image.Load(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image!
+static SixLabors.ImageSharp.Image.Load(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.ReadOnlySpan<byte> buffer) -> SixLabors.ImageSharp.Image!
+static SixLabors.ImageSharp.Image.Load(string! path) -> SixLabors.ImageSharp.Image!
+static SixLabors.ImageSharp.Image.Load(System.IO.Stream! stream) -> SixLabors.ImageSharp.Image!
+static SixLabors.ImageSharp.Image.Load(System.ReadOnlySpan<byte> buffer) -> SixLabors.ImageSharp.Image!
+static SixLabors.ImageSharp.Image.Load<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, string! path) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.Load<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.Load<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.ReadOnlySpan<byte> data) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.Load<TPixel>(string! path) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.Load<TPixel>(System.IO.Stream! stream) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.Load<TPixel>(System.ReadOnlySpan<byte> data) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.LoadAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image!>!
+static SixLabors.ImageSharp.Image.LoadAsync(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image!>!
+static SixLabors.ImageSharp.Image.LoadAsync(string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image!>!
+static SixLabors.ImageSharp.Image.LoadAsync(System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image!>!
+static SixLabors.ImageSharp.Image.LoadAsync<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image<TPixel>!>!
+static SixLabors.ImageSharp.Image.LoadAsync<TPixel>(SixLabors.ImageSharp.Formats.DecoderOptions! options, System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image<TPixel>!>!
+static SixLabors.ImageSharp.Image.LoadAsync<TPixel>(string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image<TPixel>!>!
+static SixLabors.ImageSharp.Image.LoadAsync<TPixel>(System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<SixLabors.ImageSharp.Image<TPixel>!>!
+static SixLabors.ImageSharp.Image.LoadPixelData<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.ReadOnlySpan<byte> data, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.LoadPixelData<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.ReadOnlySpan<TPixel> data, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.LoadPixelData<TPixel>(System.ReadOnlySpan<byte> data, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.LoadPixelData<TPixel>(System.ReadOnlySpan<TPixel> data, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.Buffers.IMemoryOwner<byte>! byteMemoryOwner, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.Buffers.IMemoryOwner<byte>! byteMemoryOwner, int width, int height, SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.Buffers.IMemoryOwner<TPixel>! pixelMemoryOwner, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.Buffers.IMemoryOwner<TPixel>! pixelMemoryOwner, int width, int height, SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.Memory<byte> byteMemory, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.Memory<byte> byteMemory, int width, int height, SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.Memory<TPixel> pixelMemory, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, System.Memory<TPixel> pixelMemory, int width, int height, SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, void* pointer, int bufferSizeInBytes, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(SixLabors.ImageSharp.Configuration! configuration, void* pointer, int bufferSizeInBytes, int width, int height, SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(System.Buffers.IMemoryOwner<byte>! byteMemoryOwner, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(System.Buffers.IMemoryOwner<TPixel>! pixelMemoryOwner, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(System.Memory<byte> byteMemory, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(System.Memory<TPixel> pixelMemory, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Image.WrapMemory<TPixel>(void* pointer, int bufferSizeInBytes, int width, int height) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.ImageExtensions.Save(this SixLabors.ImageSharp.Image! source, string! path) -> void
+static SixLabors.ImageSharp.ImageExtensions.Save(this SixLabors.ImageSharp.Image! source, string! path, SixLabors.ImageSharp.Formats.IImageEncoder! encoder) -> void
+static SixLabors.ImageSharp.ImageExtensions.Save(this SixLabors.ImageSharp.Image! source, System.IO.Stream! stream, SixLabors.ImageSharp.Formats.IImageFormat! format) -> void
+static SixLabors.ImageSharp.ImageExtensions.SaveAsync(this SixLabors.ImageSharp.Image! source, string! path, SixLabors.ImageSharp.Formats.IImageEncoder! encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static SixLabors.ImageSharp.ImageExtensions.SaveAsync(this SixLabors.ImageSharp.Image! source, string! path, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static SixLabors.ImageSharp.ImageExtensions.SaveAsync(this SixLabors.ImageSharp.Image! source, System.IO.Stream! stream, SixLabors.ImageSharp.Formats.IImageFormat! format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static SixLabors.ImageSharp.ImageExtensions.ToBase64String(this SixLabors.ImageSharp.Image! source, SixLabors.ImageSharp.Formats.IImageFormat! format) -> string!
+static SixLabors.ImageSharp.ImageFrameCollectionExtensions.AsEnumerable<TPixel>(this SixLabors.ImageSharp.ImageFrameCollection<TPixel>! source) -> System.Collections.Generic.IEnumerable<SixLabors.ImageSharp.ImageFrame<TPixel>!>!
+static SixLabors.ImageSharp.ImageFrameCollectionExtensions.Select<TPixel, TResult>(this SixLabors.ImageSharp.ImageFrameCollection<TPixel>! source, System.Func<SixLabors.ImageSharp.ImageFrame<TPixel>!, TResult>! selector) -> System.Collections.Generic.IEnumerable<TResult>!
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateRotation(float radians, SixLabors.ImageSharp.PointF centerPoint) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateRotationDegrees(float degrees) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateRotationDegrees(float degrees, SixLabors.ImageSharp.PointF centerPoint) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateScale(float scale, SixLabors.ImageSharp.PointF centerPoint) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateScale(float xScale, float yScale, SixLabors.ImageSharp.PointF centerPoint) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateScale(SixLabors.ImageSharp.SizeF scales) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateScale(SixLabors.ImageSharp.SizeF scales, SixLabors.ImageSharp.PointF centerPoint) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateSkew(float radiansX, float radiansY, SixLabors.ImageSharp.PointF centerPoint) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateSkewDegrees(float degreesX, float degreesY) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateSkewDegrees(float degreesX, float degreesY, SixLabors.ImageSharp.PointF centerPoint) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Matrix3x2Extensions.CreateTranslation(SixLabors.ImageSharp.PointF position) -> System.Numerics.Matrix3x2
+static SixLabors.ImageSharp.Memory.Buffer2DExtensions.GetMemoryGroup<T>(this SixLabors.ImageSharp.Memory.Buffer2D<T>! buffer) -> SixLabors.ImageSharp.Memory.IMemoryGroup<T>!
+static SixLabors.ImageSharp.Memory.MemoryAllocator.Create() -> SixLabors.ImageSharp.Memory.MemoryAllocator!
+static SixLabors.ImageSharp.Memory.MemoryAllocator.Create(SixLabors.ImageSharp.Memory.MemoryAllocatorOptions options) -> SixLabors.ImageSharp.Memory.MemoryAllocator!
+static SixLabors.ImageSharp.Memory.MemoryAllocator.Default.get -> SixLabors.ImageSharp.Memory.MemoryAllocator!
+static SixLabors.ImageSharp.Memory.MemoryAllocatorExtensions.Allocate2D<T>(this SixLabors.ImageSharp.Memory.MemoryAllocator! memoryAllocator, int width, int height, bool preferContiguosImageBuffers, SixLabors.ImageSharp.Memory.AllocationOptions options = SixLabors.ImageSharp.Memory.AllocationOptions.None) -> SixLabors.ImageSharp.Memory.Buffer2D<T>!
+static SixLabors.ImageSharp.Memory.MemoryAllocatorExtensions.Allocate2D<T>(this SixLabors.ImageSharp.Memory.MemoryAllocator! memoryAllocator, int width, int height, SixLabors.ImageSharp.Memory.AllocationOptions options = SixLabors.ImageSharp.Memory.AllocationOptions.None) -> SixLabors.ImageSharp.Memory.Buffer2D<T>!
+static SixLabors.ImageSharp.Memory.MemoryAllocatorExtensions.Allocate2D<T>(this SixLabors.ImageSharp.Memory.MemoryAllocator! memoryAllocator, SixLabors.ImageSharp.Size size, bool preferContiguosImageBuffers, SixLabors.ImageSharp.Memory.AllocationOptions options = SixLabors.ImageSharp.Memory.AllocationOptions.None) -> SixLabors.ImageSharp.Memory.Buffer2D<T>!
+static SixLabors.ImageSharp.Memory.MemoryAllocatorExtensions.Allocate2D<T>(this SixLabors.ImageSharp.Memory.MemoryAllocator! memoryAllocator, SixLabors.ImageSharp.Size size, SixLabors.ImageSharp.Memory.AllocationOptions options = SixLabors.ImageSharp.Memory.AllocationOptions.None) -> SixLabors.ImageSharp.Memory.Buffer2D<T>!
+static SixLabors.ImageSharp.Memory.RowInterval.operator !=(SixLabors.ImageSharp.Memory.RowInterval left, SixLabors.ImageSharp.Memory.RowInterval right) -> bool
+static SixLabors.ImageSharp.Memory.RowInterval.operator ==(SixLabors.ImageSharp.Memory.RowInterval left, SixLabors.ImageSharp.Memory.RowInterval right) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.explicit operator string!(SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString encodedString) -> string!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.implicit operator SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString(string! text) -> SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.operator !=(SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString left, SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString right) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString.operator ==(SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString left, SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString right) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Acceleration.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.AmbientTemperature.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.SignedRational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ApertureValue.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Artist.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.BadFaxLines.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.BatteryLevel.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.BitsPerSample.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.BrightnessValue.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.SignedRational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CameraElevationAngle.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.SignedRational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CellLength.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CellWidth.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CFAPattern.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CFAPattern2.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CFARepeatPatternDim.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CleanFaxData.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ClipPath.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CodingMethods.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ColorMap.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ColorResponseUnit.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ColorSpace.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ComponentsConfiguration.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CompressedBitsPerPixel.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Compression.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ConsecutiveBadFaxLines.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Contrast.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Copyright.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.CustomRendered.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.DateTime.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.DateTimeDigitized.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.DateTimeOriginal.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Decode.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.SignedRational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.DefaultImageColor.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.DeviceSettingDescription.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.DigitalZoomRatio.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.DocumentName.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.DotRange.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ExifVersion.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.explicit operator ushort(SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag! tag) -> ushort
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ExposureBiasValue.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.SignedRational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ExposureIndex.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ExposureIndex2.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ExposureMode.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ExposureProgram.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ExposureTime.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ExtraSamples.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FaxProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FaxRecvParams.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FaxRecvTime.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FaxSubaddress.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FileSource.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FillOrder.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Flash.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FlashEnergy.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FlashEnergy2.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FlashpixVersion.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FNumber.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FocalLength.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FocalLengthIn35mmFilm.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FocalPlaneResolutionUnit.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FocalPlaneResolutionUnit2.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FocalPlaneXResolution.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FocalPlaneXResolution2.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FocalPlaneYResolution.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FocalPlaneYResolution2.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FreeByteCounts.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.FreeOffsets.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GainControl.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GDALMetadata.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GDALNoData.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSAltitude.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSAltitudeRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSAreaInformation.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDateStamp.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDestBearing.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDestBearingRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDestDistance.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDestDistanceRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDestLatitude.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDestLatitudeRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDestLongitude.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDestLongitudeRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDifferential.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSDOP.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSIFDOffset.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSImgDirection.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSImgDirectionRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSLatitude.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSLatitudeRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSLongitude.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSLongitudeRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSMapDatum.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSMeasureMode.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSProcessingMethod.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSSatellites.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSSpeed.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSSpeedRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSStatus.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSTimestamp.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSTrack.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSTrackRef.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GPSVersionID.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GrayResponseCurve.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.GrayResponseUnit.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.HalftoneHints.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.HostComputer.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Humidity.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.IccProfile.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ImageDescription.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ImageHistory.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ImageID.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ImageLayer.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ImageLength.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ImageNumber.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ImageSourceData.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ImageUniqueID.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ImageWidth.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Indexed.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.InkNames.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.InkSet.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.IntergraphMatrix.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<double[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.IntergraphPacketData.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.IntergraphRegisters.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Interlace.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.IPTC.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ISOSpeed.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ISOSpeedLatitudeyyy.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ISOSpeedLatitudezzz.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ISOSpeedRatings.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGACTables.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGDCTables.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGInterchangeFormat.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGInterchangeFormatLength.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGLosslessPredictors.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGPointTransforms.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGProc.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGQTables.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGRestartInterval.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.JPEGTables.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.LensMake.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.LensModel.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.LensSerialNumber.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.LensSpecification.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.LightSource.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Make.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MakerNote.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MaxApertureValue.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MaxSampleValue.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MDFileTag.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MDFileUnits.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MDLabName.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MDPrepDate.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MDPrepTime.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MDSampleInfo.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MDScalePixel.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MeteringMode.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.MinSampleValue.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Model.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ModelTiePoint.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<double[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ModelTransform.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<double[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ModeNumber.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Noise.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.NumberOfInks.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.OECF.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.OffsetTime.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.OffsetTimeDigitized.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.OffsetTimeOriginal.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.OldSubfileType.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.operator !=(SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag! left, SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag! right) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.operator ==(SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag! left, SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag! right) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.OPIProxy.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Orientation.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.OwnerName.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.PageName.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.PageNumber.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.PhotometricInterpretation.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.PixelScale.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<double[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.PixelXDimension.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.PixelYDimension.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.PlanarConfiguration.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Predictor.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Pressure.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.PrimaryChromaticities.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ProfileType.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Rating.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.RatingPercent.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.RecommendedExposureIndex.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ReferenceBlackWhite.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.RelatedSoundFile.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ResolutionUnit.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.RowsPerStrip.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SampleFormat.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SamplesPerPixel.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Saturation.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SceneCaptureType.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SceneType.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SecurityClassification.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SelfTimerMode.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SEMInfo.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SensingMethod.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SensingMethod2.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SensitivityType.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SerialNumber.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Sharpness.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.ShutterSpeedValue.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.SignedRational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SMaxSampleValue.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SMinSampleValue.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Software.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SpatialFrequencyResponse.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SpatialFrequencyResponse2.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SpectralSensitivity.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.StandardOutputSensitivity.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.StripByteCounts.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.StripOffsets.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.StripRowCounts.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubfileType.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubIFDOffset.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubIFDs.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubjectArea.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubjectDistance.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubjectDistanceRange.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubjectLocation.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubsecTime.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubsecTimeDigitized.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.SubsecTimeOriginal.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.T4Options.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.T6Options.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.T82ptions.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.TargetPrinter.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.Thresholding.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.TIFFEPStandardID.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.TileByteCounts.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.TileLength.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.TileOffsets.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.TileWidth.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Number>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.TimeZoneOffset.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.TransferFunction.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.TransferRange.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.UserComment.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Metadata.Profiles.Exif.EncodedString>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.VersionYear.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.WaterDepth.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.SignedRational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.WhiteBalance.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.WhitePoint.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.XClipPathUnits.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.XMP.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<byte[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.XPAuthor.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.XPComment.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.XPKeywords.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.XPosition.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.XPSubject.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.XPTitle.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<string!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.XResolution.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.YCbCrCoefficients.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.YCbCrPositioning.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.YCbCrSubsampling.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<ushort[]!>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.YClipPathUnits.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<uint>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.YPosition.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag.YResolution.get -> SixLabors.ImageSharp.Metadata.Profiles.Exif.ExifTag<SixLabors.ImageSharp.Rational>!
+static SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.operator !=(SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId left, SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId right) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId.operator ==(SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId left, SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId right) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.operator !=(SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion left, SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion right) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion.operator ==(SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion left, SixLabors.ImageSharp.Metadata.Profiles.Icc.IccVersion right) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTagExtensions.IsDate(this SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTagExtensions.IsRepeatable(this SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTagExtensions.IsTime(this SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag) -> bool
+static SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTagExtensions.MaxLength(this SixLabors.ImageSharp.Metadata.Profiles.Iptc.IptcTag tag) -> int
+static SixLabors.ImageSharp.MetadataExtensions.GetBmpMetadata(this SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Formats.Bmp.BmpMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetGifMetadata(this SixLabors.ImageSharp.Metadata.ImageFrameMetadata! source) -> SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetGifMetadata(this SixLabors.ImageSharp.Metadata.ImageMetadata! source) -> SixLabors.ImageSharp.Formats.Gif.GifMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetJpegMetadata(this SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Formats.Jpeg.JpegMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetPbmMetadata(this SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Formats.Pbm.PbmMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetPngMetadata(this SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Formats.Png.PngMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetTgaMetadata(this SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Formats.Tga.TgaMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetTiffMetadata(this SixLabors.ImageSharp.Metadata.ImageFrameMetadata! metadata) -> SixLabors.ImageSharp.Formats.Tiff.TiffFrameMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetTiffMetadata(this SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Formats.Tiff.TiffMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetWebpMetadata(this SixLabors.ImageSharp.Metadata.ImageFrameMetadata! metadata) -> SixLabors.ImageSharp.Formats.Webp.WebpFrameMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.GetWebpMetadata(this SixLabors.ImageSharp.Metadata.ImageMetadata! metadata) -> SixLabors.ImageSharp.Formats.Webp.WebpMetadata!
+static SixLabors.ImageSharp.MetadataExtensions.TryGetGifMetadata(this SixLabors.ImageSharp.Metadata.ImageFrameMetadata! source, out SixLabors.ImageSharp.Formats.Gif.GifFrameMetadata? metadata) -> bool
+static SixLabors.ImageSharp.Number.explicit operator int(SixLabors.ImageSharp.Number number) -> int
+static SixLabors.ImageSharp.Number.explicit operator uint(SixLabors.ImageSharp.Number number) -> uint
+static SixLabors.ImageSharp.Number.explicit operator ushort(SixLabors.ImageSharp.Number number) -> ushort
+static SixLabors.ImageSharp.Number.implicit operator SixLabors.ImageSharp.Number(int value) -> SixLabors.ImageSharp.Number
+static SixLabors.ImageSharp.Number.implicit operator SixLabors.ImageSharp.Number(uint value) -> SixLabors.ImageSharp.Number
+static SixLabors.ImageSharp.Number.implicit operator SixLabors.ImageSharp.Number(ushort value) -> SixLabors.ImageSharp.Number
+static SixLabors.ImageSharp.Number.operator !=(SixLabors.ImageSharp.Number left, SixLabors.ImageSharp.Number right) -> bool
+static SixLabors.ImageSharp.Number.operator <(SixLabors.ImageSharp.Number left, SixLabors.ImageSharp.Number right) -> bool
+static SixLabors.ImageSharp.Number.operator <=(SixLabors.ImageSharp.Number left, SixLabors.ImageSharp.Number right) -> bool
+static SixLabors.ImageSharp.Number.operator ==(SixLabors.ImageSharp.Number left, SixLabors.ImageSharp.Number right) -> bool
+static SixLabors.ImageSharp.Number.operator >(SixLabors.ImageSharp.Number left, SixLabors.ImageSharp.Number right) -> bool
+static SixLabors.ImageSharp.Number.operator >=(SixLabors.ImageSharp.Number left, SixLabors.ImageSharp.Number right) -> bool
+static SixLabors.ImageSharp.PixelFormats.A8.operator !=(SixLabors.ImageSharp.PixelFormats.A8 left, SixLabors.ImageSharp.PixelFormats.A8 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.A8.operator ==(SixLabors.ImageSharp.PixelFormats.A8 left, SixLabors.ImageSharp.PixelFormats.A8 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Abgr32.implicit operator SixLabors.ImageSharp.Color(SixLabors.ImageSharp.PixelFormats.Abgr32 source) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.PixelFormats.Abgr32.implicit operator SixLabors.ImageSharp.PixelFormats.Abgr32(SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.PixelFormats.Abgr32
+static SixLabors.ImageSharp.PixelFormats.Abgr32.operator !=(SixLabors.ImageSharp.PixelFormats.Abgr32 left, SixLabors.ImageSharp.PixelFormats.Abgr32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Abgr32.operator ==(SixLabors.ImageSharp.PixelFormats.Abgr32 left, SixLabors.ImageSharp.PixelFormats.Abgr32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Argb32.implicit operator SixLabors.ImageSharp.Color(SixLabors.ImageSharp.PixelFormats.Argb32 source) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.PixelFormats.Argb32.implicit operator SixLabors.ImageSharp.PixelFormats.Argb32(SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.PixelFormats.Argb32
+static SixLabors.ImageSharp.PixelFormats.Argb32.operator !=(SixLabors.ImageSharp.PixelFormats.Argb32 left, SixLabors.ImageSharp.PixelFormats.Argb32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Argb32.operator ==(SixLabors.ImageSharp.PixelFormats.Argb32 left, SixLabors.ImageSharp.PixelFormats.Argb32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgr24.implicit operator SixLabors.ImageSharp.Color(SixLabors.ImageSharp.PixelFormats.Bgr24 source) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.PixelFormats.Bgr24.implicit operator SixLabors.ImageSharp.PixelFormats.Bgr24(SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.PixelFormats.Bgr24
+static SixLabors.ImageSharp.PixelFormats.Bgr24.operator !=(SixLabors.ImageSharp.PixelFormats.Bgr24 left, SixLabors.ImageSharp.PixelFormats.Bgr24 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgr24.operator ==(SixLabors.ImageSharp.PixelFormats.Bgr24 left, SixLabors.ImageSharp.PixelFormats.Bgr24 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgr565.operator !=(SixLabors.ImageSharp.PixelFormats.Bgr565 left, SixLabors.ImageSharp.PixelFormats.Bgr565 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgr565.operator ==(SixLabors.ImageSharp.PixelFormats.Bgr565 left, SixLabors.ImageSharp.PixelFormats.Bgr565 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgra32.implicit operator SixLabors.ImageSharp.Color(SixLabors.ImageSharp.PixelFormats.Bgra32 source) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.PixelFormats.Bgra32.implicit operator SixLabors.ImageSharp.PixelFormats.Bgra32(SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.PixelFormats.Bgra32
+static SixLabors.ImageSharp.PixelFormats.Bgra32.operator !=(SixLabors.ImageSharp.PixelFormats.Bgra32 left, SixLabors.ImageSharp.PixelFormats.Bgra32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgra32.operator ==(SixLabors.ImageSharp.PixelFormats.Bgra32 left, SixLabors.ImageSharp.PixelFormats.Bgra32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgra4444.operator !=(SixLabors.ImageSharp.PixelFormats.Bgra4444 left, SixLabors.ImageSharp.PixelFormats.Bgra4444 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgra4444.operator ==(SixLabors.ImageSharp.PixelFormats.Bgra4444 left, SixLabors.ImageSharp.PixelFormats.Bgra4444 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgra5551.operator !=(SixLabors.ImageSharp.PixelFormats.Bgra5551 left, SixLabors.ImageSharp.PixelFormats.Bgra5551 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Bgra5551.operator ==(SixLabors.ImageSharp.PixelFormats.Bgra5551 left, SixLabors.ImageSharp.PixelFormats.Bgra5551 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Byte4.operator !=(SixLabors.ImageSharp.PixelFormats.Byte4 left, SixLabors.ImageSharp.PixelFormats.Byte4 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Byte4.operator ==(SixLabors.ImageSharp.PixelFormats.Byte4 left, SixLabors.ImageSharp.PixelFormats.Byte4 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.HalfSingle.operator !=(SixLabors.ImageSharp.PixelFormats.HalfSingle left, SixLabors.ImageSharp.PixelFormats.HalfSingle right) -> bool
+static SixLabors.ImageSharp.PixelFormats.HalfSingle.operator ==(SixLabors.ImageSharp.PixelFormats.HalfSingle left, SixLabors.ImageSharp.PixelFormats.HalfSingle right) -> bool
+static SixLabors.ImageSharp.PixelFormats.HalfVector2.operator !=(SixLabors.ImageSharp.PixelFormats.HalfVector2 left, SixLabors.ImageSharp.PixelFormats.HalfVector2 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.HalfVector2.operator ==(SixLabors.ImageSharp.PixelFormats.HalfVector2 left, SixLabors.ImageSharp.PixelFormats.HalfVector2 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.HalfVector4.operator !=(SixLabors.ImageSharp.PixelFormats.HalfVector4 left, SixLabors.ImageSharp.PixelFormats.HalfVector4 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.HalfVector4.operator ==(SixLabors.ImageSharp.PixelFormats.HalfVector4 left, SixLabors.ImageSharp.PixelFormats.HalfVector4 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.L16.operator !=(SixLabors.ImageSharp.PixelFormats.L16 left, SixLabors.ImageSharp.PixelFormats.L16 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.L16.operator ==(SixLabors.ImageSharp.PixelFormats.L16 left, SixLabors.ImageSharp.PixelFormats.L16 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.L8.operator !=(SixLabors.ImageSharp.PixelFormats.L8 left, SixLabors.ImageSharp.PixelFormats.L8 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.L8.operator ==(SixLabors.ImageSharp.PixelFormats.L8 left, SixLabors.ImageSharp.PixelFormats.L8 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.La16.operator !=(SixLabors.ImageSharp.PixelFormats.La16 left, SixLabors.ImageSharp.PixelFormats.La16 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.La16.operator ==(SixLabors.ImageSharp.PixelFormats.La16 left, SixLabors.ImageSharp.PixelFormats.La16 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.La32.operator !=(SixLabors.ImageSharp.PixelFormats.La32 left, SixLabors.ImageSharp.PixelFormats.La32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.La32.operator ==(SixLabors.ImageSharp.PixelFormats.La32 left, SixLabors.ImageSharp.PixelFormats.La32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.NormalizedByte2.operator !=(SixLabors.ImageSharp.PixelFormats.NormalizedByte2 left, SixLabors.ImageSharp.PixelFormats.NormalizedByte2 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.NormalizedByte2.operator ==(SixLabors.ImageSharp.PixelFormats.NormalizedByte2 left, SixLabors.ImageSharp.PixelFormats.NormalizedByte2 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.NormalizedByte4.operator !=(SixLabors.ImageSharp.PixelFormats.NormalizedByte4 left, SixLabors.ImageSharp.PixelFormats.NormalizedByte4 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.NormalizedByte4.operator ==(SixLabors.ImageSharp.PixelFormats.NormalizedByte4 left, SixLabors.ImageSharp.PixelFormats.NormalizedByte4 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.NormalizedShort2.operator !=(SixLabors.ImageSharp.PixelFormats.NormalizedShort2 left, SixLabors.ImageSharp.PixelFormats.NormalizedShort2 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.NormalizedShort2.operator ==(SixLabors.ImageSharp.PixelFormats.NormalizedShort2 left, SixLabors.ImageSharp.PixelFormats.NormalizedShort2 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.NormalizedShort4.operator !=(SixLabors.ImageSharp.PixelFormats.NormalizedShort4 left, SixLabors.ImageSharp.PixelFormats.NormalizedShort4 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.NormalizedShort4.operator ==(SixLabors.ImageSharp.PixelFormats.NormalizedShort4 left, SixLabors.ImageSharp.PixelFormats.NormalizedShort4 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.Instance.get -> SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>!
+static SixLabors.ImageSharp.PixelFormats.Rg32.operator !=(SixLabors.ImageSharp.PixelFormats.Rg32 left, SixLabors.ImageSharp.PixelFormats.Rg32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rg32.operator ==(SixLabors.ImageSharp.PixelFormats.Rg32 left, SixLabors.ImageSharp.PixelFormats.Rg32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgb24.implicit operator SixLabors.ImageSharp.Color(SixLabors.ImageSharp.PixelFormats.Rgb24 source) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.PixelFormats.Rgb24.implicit operator SixLabors.ImageSharp.PixelFormats.Rgb24(SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.PixelFormats.Rgb24
+static SixLabors.ImageSharp.PixelFormats.Rgb24.implicit operator SixLabors.ImageSharp.PixelFormats.Rgb24(SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.PixelFormats.Rgb24
+static SixLabors.ImageSharp.PixelFormats.Rgb24.operator !=(SixLabors.ImageSharp.PixelFormats.Rgb24 left, SixLabors.ImageSharp.PixelFormats.Rgb24 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgb24.operator ==(SixLabors.ImageSharp.PixelFormats.Rgb24 left, SixLabors.ImageSharp.PixelFormats.Rgb24 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgb48.operator !=(SixLabors.ImageSharp.PixelFormats.Rgb48 left, SixLabors.ImageSharp.PixelFormats.Rgb48 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgb48.operator ==(SixLabors.ImageSharp.PixelFormats.Rgb48 left, SixLabors.ImageSharp.PixelFormats.Rgb48 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgba1010102.operator !=(SixLabors.ImageSharp.PixelFormats.Rgba1010102 left, SixLabors.ImageSharp.PixelFormats.Rgba1010102 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgba1010102.operator ==(SixLabors.ImageSharp.PixelFormats.Rgba1010102 left, SixLabors.ImageSharp.PixelFormats.Rgba1010102 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgba32.implicit operator SixLabors.ImageSharp.Color(SixLabors.ImageSharp.PixelFormats.Rgba32 source) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.PixelFormats.Rgba32.implicit operator SixLabors.ImageSharp.PixelFormats.Rgba32(SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.PixelFormats.Rgba32
+static SixLabors.ImageSharp.PixelFormats.Rgba32.implicit operator SixLabors.ImageSharp.PixelFormats.Rgba32(SixLabors.ImageSharp.ColorSpaces.Rgb color) -> SixLabors.ImageSharp.PixelFormats.Rgba32
+static SixLabors.ImageSharp.PixelFormats.Rgba32.operator !=(SixLabors.ImageSharp.PixelFormats.Rgba32 left, SixLabors.ImageSharp.PixelFormats.Rgba32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgba32.operator ==(SixLabors.ImageSharp.PixelFormats.Rgba32 left, SixLabors.ImageSharp.PixelFormats.Rgba32 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgba32.ParseHex(string! hex) -> SixLabors.ImageSharp.PixelFormats.Rgba32
+static SixLabors.ImageSharp.PixelFormats.Rgba32.TryParseHex(string? hex, out SixLabors.ImageSharp.PixelFormats.Rgba32 result) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgba64.implicit operator SixLabors.ImageSharp.Color(SixLabors.ImageSharp.PixelFormats.Rgba64 source) -> SixLabors.ImageSharp.Color
+static SixLabors.ImageSharp.PixelFormats.Rgba64.implicit operator SixLabors.ImageSharp.PixelFormats.Rgba64(SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.PixelFormats.Rgba64
+static SixLabors.ImageSharp.PixelFormats.Rgba64.operator !=(SixLabors.ImageSharp.PixelFormats.Rgba64 left, SixLabors.ImageSharp.PixelFormats.Rgba64 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Rgba64.operator ==(SixLabors.ImageSharp.PixelFormats.Rgba64 left, SixLabors.ImageSharp.PixelFormats.Rgba64 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.RgbaVector.FromHex(string! hex) -> SixLabors.ImageSharp.PixelFormats.RgbaVector
+static SixLabors.ImageSharp.PixelFormats.RgbaVector.operator !=(SixLabors.ImageSharp.PixelFormats.RgbaVector left, SixLabors.ImageSharp.PixelFormats.RgbaVector right) -> bool
+static SixLabors.ImageSharp.PixelFormats.RgbaVector.operator ==(SixLabors.ImageSharp.PixelFormats.RgbaVector left, SixLabors.ImageSharp.PixelFormats.RgbaVector right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Short2.operator !=(SixLabors.ImageSharp.PixelFormats.Short2 left, SixLabors.ImageSharp.PixelFormats.Short2 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Short2.operator ==(SixLabors.ImageSharp.PixelFormats.Short2 left, SixLabors.ImageSharp.PixelFormats.Short2 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Short4.operator !=(SixLabors.ImageSharp.PixelFormats.Short4 left, SixLabors.ImageSharp.PixelFormats.Short4 right) -> bool
+static SixLabors.ImageSharp.PixelFormats.Short4.operator ==(SixLabors.ImageSharp.PixelFormats.Short4 left, SixLabors.ImageSharp.PixelFormats.Short4 right) -> bool
+static SixLabors.ImageSharp.Point.Add(SixLabors.ImageSharp.Point point, SixLabors.ImageSharp.Size size) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.Ceiling(SixLabors.ImageSharp.PointF point) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.explicit operator SixLabors.ImageSharp.Size(SixLabors.ImageSharp.Point point) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Point.implicit operator SixLabors.ImageSharp.PointF(SixLabors.ImageSharp.Point point) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.Point.implicit operator System.Numerics.Vector2(SixLabors.ImageSharp.Point point) -> System.Numerics.Vector2
+static SixLabors.ImageSharp.Point.Multiply(SixLabors.ImageSharp.Point point, int value) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.operator !=(SixLabors.ImageSharp.Point left, SixLabors.ImageSharp.Point right) -> bool
+static SixLabors.ImageSharp.Point.operator *(int left, SixLabors.ImageSharp.Point right) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.operator *(SixLabors.ImageSharp.Point left, int right) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.operator +(SixLabors.ImageSharp.Point point, SixLabors.ImageSharp.Size size) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.operator -(SixLabors.ImageSharp.Point point, SixLabors.ImageSharp.Size size) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.operator -(SixLabors.ImageSharp.Point value) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.operator /(SixLabors.ImageSharp.Point left, int right) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.operator ==(SixLabors.ImageSharp.Point left, SixLabors.ImageSharp.Point right) -> bool
+static SixLabors.ImageSharp.Point.Round(SixLabors.ImageSharp.PointF point) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.Round(System.Numerics.Vector2 vector) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.Subtract(SixLabors.ImageSharp.Point point, SixLabors.ImageSharp.Size size) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.Transform(SixLabors.ImageSharp.Point point, System.Numerics.Matrix3x2 matrix) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Point.Truncate(SixLabors.ImageSharp.PointF point) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.PointF.Add(SixLabors.ImageSharp.PointF point, SixLabors.ImageSharp.PointF pointb) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.Add(SixLabors.ImageSharp.PointF point, SixLabors.ImageSharp.SizeF size) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.explicit operator SixLabors.ImageSharp.Point(SixLabors.ImageSharp.PointF point) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.PointF.implicit operator SixLabors.ImageSharp.PointF(System.Numerics.Vector2 vector) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.implicit operator System.Numerics.Vector2(SixLabors.ImageSharp.PointF point) -> System.Numerics.Vector2
+static SixLabors.ImageSharp.PointF.Multiply(SixLabors.ImageSharp.PointF point, float right) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.operator !=(SixLabors.ImageSharp.PointF left, SixLabors.ImageSharp.PointF right) -> bool
+static SixLabors.ImageSharp.PointF.operator *(float left, SixLabors.ImageSharp.PointF right) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.operator *(SixLabors.ImageSharp.PointF left, float right) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.operator +(SixLabors.ImageSharp.PointF point, SixLabors.ImageSharp.PointF size) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.operator +(SixLabors.ImageSharp.PointF point, SixLabors.ImageSharp.SizeF size) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.operator -(SixLabors.ImageSharp.PointF point, SixLabors.ImageSharp.PointF size) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.operator -(SixLabors.ImageSharp.PointF point, SixLabors.ImageSharp.SizeF size) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.operator -(SixLabors.ImageSharp.PointF value) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.operator /(SixLabors.ImageSharp.PointF left, float right) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.operator ==(SixLabors.ImageSharp.PointF left, SixLabors.ImageSharp.PointF right) -> bool
+static SixLabors.ImageSharp.PointF.Subtract(SixLabors.ImageSharp.PointF point, SixLabors.ImageSharp.PointF pointb) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.Subtract(SixLabors.ImageSharp.PointF point, SixLabors.ImageSharp.SizeF size) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.PointF.Transform(SixLabors.ImageSharp.PointF point, System.Numerics.Matrix3x2 matrix) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.Processing.AdaptiveThresholdExtensions.AdaptiveThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.AdaptiveThresholdExtensions.AdaptiveThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float thresholdLimit) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.AdaptiveThresholdExtensions.AdaptiveThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color upper, SixLabors.ImageSharp.Color lower) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.AdaptiveThresholdExtensions.AdaptiveThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color upper, SixLabors.ImageSharp.Color lower, float thresholdLimit) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.AdaptiveThresholdExtensions.AdaptiveThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color upper, SixLabors.ImageSharp.Color lower, float thresholdLimit, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.AdaptiveThresholdExtensions.AdaptiveThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color upper, SixLabors.ImageSharp.Color lower, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.AutoOrientExtensions.AutoOrient(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BackgroundColorExtensions.BackgroundColor(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BackgroundColorExtensions.BackgroundColor(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color color, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BackgroundColorExtensions.BackgroundColor(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BackgroundColorExtensions.BackgroundColor(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Color color, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryDitherExtensions.BinaryDither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryDitherExtensions.BinaryDither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, SixLabors.ImageSharp.Color upperColor, SixLabors.ImageSharp.Color lowerColor) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryDitherExtensions.BinaryDither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, SixLabors.ImageSharp.Color upperColor, SixLabors.ImageSharp.Color lowerColor, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryDitherExtensions.BinaryDither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryThresholdExtensions.BinaryThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float threshold) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryThresholdExtensions.BinaryThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float threshold, SixLabors.ImageSharp.Color upperColor, SixLabors.ImageSharp.Color lowerColor) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryThresholdExtensions.BinaryThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float threshold, SixLabors.ImageSharp.Color upperColor, SixLabors.ImageSharp.Color lowerColor, SixLabors.ImageSharp.Processing.BinaryThresholdMode mode) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryThresholdExtensions.BinaryThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float threshold, SixLabors.ImageSharp.Color upperColor, SixLabors.ImageSharp.Color lowerColor, SixLabors.ImageSharp.Processing.BinaryThresholdMode mode, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryThresholdExtensions.BinaryThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float threshold, SixLabors.ImageSharp.Color upperColor, SixLabors.ImageSharp.Color lowerColor, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryThresholdExtensions.BinaryThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float threshold, SixLabors.ImageSharp.Processing.BinaryThresholdMode mode) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryThresholdExtensions.BinaryThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float threshold, SixLabors.ImageSharp.Processing.BinaryThresholdMode mode, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BinaryThresholdExtensions.BinaryThreshold(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float threshold, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BlackWhiteExtensions.BlackWhite(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BlackWhiteExtensions.BlackWhite(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BokehBlurExtensions.BokehBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BokehBlurExtensions.BokehBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int radius, int components, float gamma) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BokehBlurExtensions.BokehBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int radius, int components, float gamma, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BokehBlurExtensions.BokehBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BoxBlurExtensions.BoxBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BoxBlurExtensions.BoxBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int radius) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BoxBlurExtensions.BoxBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int radius, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BoxBlurExtensions.BoxBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int radius, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeX, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeY) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BrightnessExtensions.Brightness(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.BrightnessExtensions.Brightness(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ColorBlindnessExtensions.ColorBlindness(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.ColorBlindnessMode colorBlindness) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ColorBlindnessExtensions.ColorBlindness(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.ColorBlindnessMode colorBlindnessMode, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ContrastExtensions.Contrast(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ContrastExtensions.Contrast(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.CropExtensions.Crop(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int width, int height) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.CropExtensions.Crop(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle cropRectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel kernel) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel kernel, bool grayscale) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel kernel, bool grayscale, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel kernel, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel kernel) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel kernel, bool grayscale) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel kernel, bool grayscale, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel kernel, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel kernel) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel kernel, bool grayscale) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel kernel, bool grayscale, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel kernel, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DetectEdgesExtensions.DetectEdges(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, float ditherScale) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, float ditherScale, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, float ditherScale, System.ReadOnlyMemory<SixLabors.ImageSharp.Color> palette) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, float ditherScale, System.ReadOnlyMemory<SixLabors.ImageSharp.Color> palette, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, System.ReadOnlyMemory<SixLabors.ImageSharp.Color> palette) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! dither, System.ReadOnlyMemory<SixLabors.ImageSharp.Color> palette, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DitherExtensions.Dither(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.GraphicsOptions! options) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorBlending, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorBlending, SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode alphaComposition, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Point location, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Point location, SixLabors.ImageSharp.GraphicsOptions! options) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Point location, SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorBlending, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Point location, SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorBlending, SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode alphaComposition, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Point location, SixLabors.ImageSharp.Rectangle rectangle, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Point location, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.GraphicsOptions! options) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Point location, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorBlending, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Point location, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorBlending, SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode alphaComposition, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Rectangle rectangle, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.GraphicsOptions! options) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorBlending, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.DrawImageExtensions.DrawImage(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Image! image, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorBlending, SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode alphaComposition, float opacity) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.EntropyCropExtensions.EntropyCrop(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.EntropyCropExtensions.EntropyCrop(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float threshold) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.FilterExtensions.Filter(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.ColorMatrix matrix) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.FilterExtensions.Filter(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.ColorMatrix matrix, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.FlipExtensions.Flip(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.FlipMode flipMode) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GaussianBlurExtensions.GaussianBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GaussianBlurExtensions.GaussianBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float sigma) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GaussianBlurExtensions.GaussianBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float sigma, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GaussianBlurExtensions.GaussianBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float sigma, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeX, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeY) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GaussianSharpenExtensions.GaussianSharpen(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GaussianSharpenExtensions.GaussianSharpen(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float sigma) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GaussianSharpenExtensions.GaussianSharpen(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float sigma, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GaussianSharpenExtensions.GaussianSharpen(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float sigma, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeX, SixLabors.ImageSharp.Processing.Processors.Convolution.BorderWrappingMode borderWrapModeY) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float radius) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color color, float radius, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, float radius) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Color color, float radius, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GlowExtensions.Glow(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GrayscaleExtensions.Grayscale(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GrayscaleExtensions.Grayscale(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GrayscaleExtensions.Grayscale(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GrayscaleExtensions.Grayscale(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.GrayscaleMode mode) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GrayscaleExtensions.Grayscale(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.GrayscaleMode mode, float amount) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GrayscaleExtensions.Grayscale(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.GrayscaleMode mode, float amount, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GrayscaleExtensions.Grayscale(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.GrayscaleMode mode, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.GrayscaleExtensions.Grayscale(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.HistogramEqualizationExtensions.HistogramEqualization(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.HistogramEqualizationExtensions.HistogramEqualization(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions! options) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.HueExtensions.Hue(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float degrees) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.HueExtensions.Hue(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float degrees, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.InvertExtensions.Invert(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.InvertExtensions.Invert(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Atkinson.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Bayer16x16.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Bayer2x2.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Bayer4x4.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Bayer8x8.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Burks.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.FloydSteinberg.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.JarvisJudiceNinke.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Ordered3x3.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Sierra2.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Sierra3.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.SierraLite.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.StevensonArce.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownDitherings.Stucki.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.Kayyali.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.Kirsch.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.Laplacian3x3.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.Laplacian5x5.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.LaplacianOfGaussian.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.Prewitt.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.RobertsCross.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.Robinson.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.Scharr.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static SixLabors.ImageSharp.Processing.KnownEdgeDetectorKernels.Sobel.get -> SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.AchromatomalyFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.AchromatopsiaFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.BlackWhiteFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateBrightnessFilter(float amount) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateContrastFilter(float amount) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateGrayscaleBt601Filter(float amount) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateGrayscaleBt709Filter(float amount) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateHueFilter(float degrees) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateInvertFilter(float amount) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateLightnessFilter(float amount) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateOpacityFilter(float amount) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateSaturateFilter(float amount) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.CreateSepiaFilter(float amount) -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.DeuteranomalyFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.DeuteranopiaFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.KodachromeFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.LomographFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.PolaroidFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.ProtanomalyFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.ProtanopiaFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.TritanomalyFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownFilterMatrices.TritanopiaFilter.get -> SixLabors.ImageSharp.ColorMatrix
+static SixLabors.ImageSharp.Processing.KnownQuantizers.Octree.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer!
+static SixLabors.ImageSharp.Processing.KnownQuantizers.WebSafe.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer!
+static SixLabors.ImageSharp.Processing.KnownQuantizers.Werner.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer!
+static SixLabors.ImageSharp.Processing.KnownQuantizers.Wu.get -> SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Bicubic.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Box.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.CatmullRom.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Hermite.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Lanczos2.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Lanczos3.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Lanczos5.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Lanczos8.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.MitchellNetravali.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.NearestNeighbor.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Robidoux.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.RobidouxSharp.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Spline.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Triangle.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KnownResamplers.Welch.get -> SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler!
+static SixLabors.ImageSharp.Processing.KodachromeExtensions.Kodachrome(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.KodachromeExtensions.Kodachrome(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.LightnessExtensions.Lightness(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.LightnessExtensions.Lightness(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.LomographExtensions.Lomograph(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.LomographExtensions.Lomograph(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.MedianBlurExtensions.MedianBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int radius, bool preserveAlpha) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.MedianBlurExtensions.MedianBlur(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int radius, bool preserveAlpha, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.OilPaintExtensions.OilPaint(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.OilPaintExtensions.OilPaint(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int levels, int brushSize) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.OilPaintExtensions.OilPaint(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int levels, int brushSize, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.OilPaintExtensions.OilPaint(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.OpacityExtensions.Opacity(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.OpacityExtensions.Opacity(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PadExtensions.Pad(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int width, int height) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PadExtensions.Pad(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int width, int height, SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelateExtensions.Pixelate(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelateExtensions.Pixelate(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int size) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelateExtensions.Pixelate(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int size, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.PixelRowOperation! rowOperation) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.PixelRowOperation! rowOperation, SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers modifiers) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.PixelRowOperation! rowOperation, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.PixelRowOperation! rowOperation, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers modifiers) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.PixelRowOperation<SixLabors.ImageSharp.Point>! rowOperation) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.PixelRowOperation<SixLabors.ImageSharp.Point>! rowOperation, SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers modifiers) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.PixelRowOperation<SixLabors.ImageSharp.Point>! rowOperation, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PixelRowDelegateExtensions.ProcessPixelRowsAsVector4(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.PixelRowOperation<SixLabors.ImageSharp.Point>! rowOperation, SixLabors.ImageSharp.Rectangle rectangle, SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers modifiers) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PolaroidExtensions.Polaroid(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.PolaroidExtensions.Polaroid(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.ApplyProcessors(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, params SixLabors.ImageSharp.Processing.Processors.IImageProcessor![]! operations) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.CalculateIntegralImage<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source) -> SixLabors.ImageSharp.Memory.Buffer2D<ulong>!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.CalculateIntegralImage<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle bounds) -> SixLabors.ImageSharp.Memory.Buffer2D<ulong>!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.CalculateIntegralImage<TPixel>(this SixLabors.ImageSharp.ImageFrame<TPixel>! source) -> SixLabors.ImageSharp.Memory.Buffer2D<ulong>!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.CalculateIntegralImage<TPixel>(this SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.Rectangle bounds) -> SixLabors.ImageSharp.Memory.Buffer2D<ulong>!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Clone(this SixLabors.ImageSharp.Image! source, SixLabors.ImageSharp.Configuration! configuration, System.Action<SixLabors.ImageSharp.Processing.IImageProcessingContext!>! operation) -> SixLabors.ImageSharp.Image!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Clone(this SixLabors.ImageSharp.Image! source, System.Action<SixLabors.ImageSharp.Processing.IImageProcessingContext!>! operation) -> SixLabors.ImageSharp.Image!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Clone<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, params SixLabors.ImageSharp.Processing.Processors.IImageProcessor![]! operations) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Clone<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Configuration! configuration, params SixLabors.ImageSharp.Processing.Processors.IImageProcessor![]! operations) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Clone<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Configuration! configuration, System.Action<SixLabors.ImageSharp.Processing.IImageProcessingContext!>! operation) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Clone<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, System.Action<SixLabors.ImageSharp.Processing.IImageProcessingContext!>! operation) -> SixLabors.ImageSharp.Image<TPixel>!
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Mutate(this SixLabors.ImageSharp.Image! source, SixLabors.ImageSharp.Configuration! configuration, System.Action<SixLabors.ImageSharp.Processing.IImageProcessingContext!>! operation) -> void
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Mutate(this SixLabors.ImageSharp.Image! source, System.Action<SixLabors.ImageSharp.Processing.IImageProcessingContext!>! operation) -> void
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Mutate<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, params SixLabors.ImageSharp.Processing.Processors.IImageProcessor![]! operations) -> void
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Mutate<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Configuration! configuration, params SixLabors.ImageSharp.Processing.Processors.IImageProcessor![]! operations) -> void
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Mutate<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Configuration! configuration, System.Action<SixLabors.ImageSharp.Processing.IImageProcessingContext!>! operation) -> void
+static SixLabors.ImageSharp.Processing.ProcessingExtensions.Mutate<TPixel>(this SixLabors.ImageSharp.Image<TPixel>! source, System.Action<SixLabors.ImageSharp.Processing.IImageProcessingContext!>! operation) -> void
+static SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.operator !=(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel left, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel.operator ==(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel left, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetector2DKernel right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.operator !=(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel left, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel.operator ==(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel left, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorCompassKernel right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.operator !=(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel left, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel.operator ==(SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel left, SixLabors.ImageSharp.Processing.Processors.Convolution.EdgeDetectorKernel right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.operator !=(SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither left, SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.operator !=(SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither left, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.operator !=(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! left, SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.operator ==(SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither left, SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.operator ==(SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither left, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither.operator ==(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! left, SixLabors.ImageSharp.Processing.Processors.Dithering.ErrorDither right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.operator !=(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! left, SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.operator !=(SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither left, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.operator !=(SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither left, SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.operator ==(SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! left, SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.operator ==(SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither left, SixLabors.ImageSharp.Processing.Processors.Dithering.IDither! right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither.operator ==(SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither left, SixLabors.ImageSharp.Processing.Processors.Dithering.OrderedDither right) -> bool
+static SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationProcessor.FromOptions(SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationOptions! options) -> SixLabors.ImageSharp.Processing.Processors.Normalization.HistogramEqualizationProcessor!
+static SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerConstants.DefaultDither.get -> SixLabors.ImageSharp.Processing.Processors.Dithering.IDither!
+static SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerUtilities.BuildPalette<TPixel>(this SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>! quantizer, SixLabors.ImageSharp.Processing.Processors.Quantization.IPixelSamplingStrategy! pixelSamplingStrategy, SixLabors.ImageSharp.Image<TPixel>! source) -> void
+static SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerUtilities.BuildPalette<TPixel>(this SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>! quantizer, SixLabors.ImageSharp.Processing.Processors.Quantization.IPixelSamplingStrategy! pixelSamplingStrategy, SixLabors.ImageSharp.ImageFrame<TPixel>! source) -> void
+static SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerUtilities.BuildPaletteAndQuantizeFrame<TPixel>(this SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer<TPixel>! quantizer, SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.Rectangle bounds) -> SixLabors.ImageSharp.IndexedImageFrame<TPixel>!
+static SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerUtilities.CheckPaletteState<TPixel>(in System.ReadOnlyMemory<TPixel> palette) -> void
+static SixLabors.ImageSharp.Processing.Processors.Quantization.QuantizerUtilities.QuantizeFrame<TFrameQuantizer, TPixel>(ref TFrameQuantizer quantizer, SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.Rectangle bounds) -> SixLabors.ImageSharp.IndexedImageFrame<TPixel>!
+static SixLabors.ImageSharp.Processing.QuantizeExtensions.Quantize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.QuantizeExtensions.Quantize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer! quantizer) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.QuantizeExtensions.Quantize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.Processors.Quantization.IQuantizer! quantizer, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.QuantizeExtensions.Quantize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int width, int height) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int width, int height, bool compand) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int width, int height, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int width, int height, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler, bool compand) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int width, int height, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler, SixLabors.ImageSharp.Rectangle sourceRectangle, SixLabors.ImageSharp.Rectangle targetRectangle, bool compand) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, int width, int height, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler, SixLabors.ImageSharp.Rectangle targetRectangle, bool compand) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.ResizeOptions! options) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Size size) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Size size, bool compand) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.ResizeExtensions.Resize(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Size size, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler, bool compand) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.RotateExtensions.Rotate(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float degrees) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.RotateExtensions.Rotate(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float degrees, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.RotateExtensions.Rotate(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.RotateMode rotateMode) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.RotateFlipExtensions.RotateFlip(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.RotateMode rotateMode, SixLabors.ImageSharp.Processing.FlipMode flipMode) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.SaturateExtensions.Saturate(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.SaturateExtensions.Saturate(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.SepiaExtensions.Sepia(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.SepiaExtensions.Sepia(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.SepiaExtensions.Sepia(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float amount, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.SepiaExtensions.Sepia(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.SkewExtensions.Skew(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float degreesX, float degreesY) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.SkewExtensions.Skew(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float degreesX, float degreesY, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.SwizzleExtensions.Swizzle<TSwizzler>(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, TSwizzler swizzler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.TransformExtensions.Transform(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.AffineTransformBuilder! builder) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.TransformExtensions.Transform(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.AffineTransformBuilder! builder, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.TransformExtensions.Transform(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder! builder) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.TransformExtensions.Transform(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder! builder, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.TransformExtensions.Transform(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle sourceRectangle, SixLabors.ImageSharp.Processing.AffineTransformBuilder! builder, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.TransformExtensions.Transform(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle sourceRectangle, SixLabors.ImageSharp.Processing.ProjectiveTransformBuilder! builder, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.TransformExtensions.Transform(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle sourceRectangle, System.Numerics.Matrix3x2 transform, SixLabors.ImageSharp.Size targetDimensions, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.TransformExtensions.Transform(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle sourceRectangle, System.Numerics.Matrix4x4 transform, SixLabors.ImageSharp.Size targetDimensions, SixLabors.ImageSharp.Processing.Processors.Transforms.IResampler! sampler) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, float radiusX, float radiusY) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Color color, float radiusX, float radiusY, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, float radiusX, float radiusY) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Color color) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Color color, float radiusX, float radiusY, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.GraphicsOptions! options, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Processing.VignetteExtensions.Vignette(this SixLabors.ImageSharp.Processing.IImageProcessingContext! source, SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Processing.IImageProcessingContext!
+static SixLabors.ImageSharp.Rational.FromDouble(double value) -> SixLabors.ImageSharp.Rational
+static SixLabors.ImageSharp.Rational.FromDouble(double value, bool bestPrecision) -> SixLabors.ImageSharp.Rational
+static SixLabors.ImageSharp.Rational.operator !=(SixLabors.ImageSharp.Rational left, SixLabors.ImageSharp.Rational right) -> bool
+static SixLabors.ImageSharp.Rational.operator ==(SixLabors.ImageSharp.Rational left, SixLabors.ImageSharp.Rational right) -> bool
+static SixLabors.ImageSharp.Rectangle.Ceiling(SixLabors.ImageSharp.RectangleF rectangle) -> SixLabors.ImageSharp.Rectangle
+static SixLabors.ImageSharp.Rectangle.Center(SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Rectangle.FromLTRB(int left, int top, int right, int bottom) -> SixLabors.ImageSharp.Rectangle
+static SixLabors.ImageSharp.Rectangle.implicit operator SixLabors.ImageSharp.RectangleF(SixLabors.ImageSharp.Rectangle rectangle) -> SixLabors.ImageSharp.RectangleF
+static SixLabors.ImageSharp.Rectangle.implicit operator System.Numerics.Vector4(SixLabors.ImageSharp.Rectangle rectangle) -> System.Numerics.Vector4
+static SixLabors.ImageSharp.Rectangle.Inflate(SixLabors.ImageSharp.Rectangle rectangle, int x, int y) -> SixLabors.ImageSharp.Rectangle
+static SixLabors.ImageSharp.Rectangle.Intersect(SixLabors.ImageSharp.Rectangle a, SixLabors.ImageSharp.Rectangle b) -> SixLabors.ImageSharp.Rectangle
+static SixLabors.ImageSharp.Rectangle.operator !=(SixLabors.ImageSharp.Rectangle left, SixLabors.ImageSharp.Rectangle right) -> bool
+static SixLabors.ImageSharp.Rectangle.operator ==(SixLabors.ImageSharp.Rectangle left, SixLabors.ImageSharp.Rectangle right) -> bool
+static SixLabors.ImageSharp.Rectangle.Round(SixLabors.ImageSharp.RectangleF rectangle) -> SixLabors.ImageSharp.Rectangle
+static SixLabors.ImageSharp.Rectangle.Transform(SixLabors.ImageSharp.Rectangle rectangle, System.Numerics.Matrix3x2 matrix) -> SixLabors.ImageSharp.RectangleF
+static SixLabors.ImageSharp.Rectangle.Truncate(SixLabors.ImageSharp.RectangleF rectangle) -> SixLabors.ImageSharp.Rectangle
+static SixLabors.ImageSharp.Rectangle.Union(SixLabors.ImageSharp.Rectangle a, SixLabors.ImageSharp.Rectangle b) -> SixLabors.ImageSharp.Rectangle
+static SixLabors.ImageSharp.RectangleF.Center(SixLabors.ImageSharp.RectangleF rectangle) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.RectangleF.explicit operator SixLabors.ImageSharp.Rectangle(SixLabors.ImageSharp.RectangleF rectangle) -> SixLabors.ImageSharp.Rectangle
+static SixLabors.ImageSharp.RectangleF.FromLTRB(float left, float top, float right, float bottom) -> SixLabors.ImageSharp.RectangleF
+static SixLabors.ImageSharp.RectangleF.Inflate(SixLabors.ImageSharp.RectangleF rectangle, float x, float y) -> SixLabors.ImageSharp.RectangleF
+static SixLabors.ImageSharp.RectangleF.Intersect(SixLabors.ImageSharp.RectangleF a, SixLabors.ImageSharp.RectangleF b) -> SixLabors.ImageSharp.RectangleF
+static SixLabors.ImageSharp.RectangleF.operator !=(SixLabors.ImageSharp.RectangleF left, SixLabors.ImageSharp.RectangleF right) -> bool
+static SixLabors.ImageSharp.RectangleF.operator ==(SixLabors.ImageSharp.RectangleF left, SixLabors.ImageSharp.RectangleF right) -> bool
+static SixLabors.ImageSharp.RectangleF.Transform(SixLabors.ImageSharp.RectangleF rectangle, System.Numerics.Matrix3x2 matrix) -> SixLabors.ImageSharp.RectangleF
+static SixLabors.ImageSharp.RectangleF.Union(SixLabors.ImageSharp.RectangleF a, SixLabors.ImageSharp.RectangleF b) -> SixLabors.ImageSharp.RectangleF
+static SixLabors.ImageSharp.SignedRational.FromDouble(double value) -> SixLabors.ImageSharp.SignedRational
+static SixLabors.ImageSharp.SignedRational.FromDouble(double value, bool bestPrecision) -> SixLabors.ImageSharp.SignedRational
+static SixLabors.ImageSharp.SignedRational.operator !=(SixLabors.ImageSharp.SignedRational left, SixLabors.ImageSharp.SignedRational right) -> bool
+static SixLabors.ImageSharp.SignedRational.operator ==(SixLabors.ImageSharp.SignedRational left, SixLabors.ImageSharp.SignedRational right) -> bool
+static SixLabors.ImageSharp.Size.Add(SixLabors.ImageSharp.Size left, SixLabors.ImageSharp.Size right) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Size.Ceiling(SixLabors.ImageSharp.SizeF size) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Size.explicit operator SixLabors.ImageSharp.Point(SixLabors.ImageSharp.Size size) -> SixLabors.ImageSharp.Point
+static SixLabors.ImageSharp.Size.implicit operator SixLabors.ImageSharp.SizeF(SixLabors.ImageSharp.Size size) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.Size.operator !=(SixLabors.ImageSharp.Size left, SixLabors.ImageSharp.Size right) -> bool
+static SixLabors.ImageSharp.Size.operator *(float left, SixLabors.ImageSharp.Size right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.Size.operator *(int left, SixLabors.ImageSharp.Size right) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Size.operator *(SixLabors.ImageSharp.Size left, float right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.Size.operator *(SixLabors.ImageSharp.Size left, int right) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Size.operator +(SixLabors.ImageSharp.Size left, SixLabors.ImageSharp.Size right) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Size.operator -(SixLabors.ImageSharp.Size left, SixLabors.ImageSharp.Size right) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Size.operator /(SixLabors.ImageSharp.Size left, float right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.Size.operator /(SixLabors.ImageSharp.Size left, int right) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Size.operator ==(SixLabors.ImageSharp.Size left, SixLabors.ImageSharp.Size right) -> bool
+static SixLabors.ImageSharp.Size.Round(SixLabors.ImageSharp.SizeF size) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Size.Subtract(SixLabors.ImageSharp.Size left, SixLabors.ImageSharp.Size right) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.Size.Transform(SixLabors.ImageSharp.Size size, System.Numerics.Matrix3x2 matrix) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.Size.Truncate(SixLabors.ImageSharp.SizeF size) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.SizeF.Add(SixLabors.ImageSharp.SizeF left, SixLabors.ImageSharp.SizeF right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.SizeF.explicit operator SixLabors.ImageSharp.PointF(SixLabors.ImageSharp.SizeF size) -> SixLabors.ImageSharp.PointF
+static SixLabors.ImageSharp.SizeF.explicit operator SixLabors.ImageSharp.Size(SixLabors.ImageSharp.SizeF size) -> SixLabors.ImageSharp.Size
+static SixLabors.ImageSharp.SizeF.implicit operator System.Numerics.Vector2(SixLabors.ImageSharp.SizeF point) -> System.Numerics.Vector2
+static SixLabors.ImageSharp.SizeF.operator !=(SixLabors.ImageSharp.SizeF left, SixLabors.ImageSharp.SizeF right) -> bool
+static SixLabors.ImageSharp.SizeF.operator *(float left, SixLabors.ImageSharp.SizeF right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.SizeF.operator *(SixLabors.ImageSharp.SizeF left, float right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.SizeF.operator +(SixLabors.ImageSharp.SizeF left, SixLabors.ImageSharp.SizeF right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.SizeF.operator -(SixLabors.ImageSharp.SizeF left, SixLabors.ImageSharp.SizeF right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.SizeF.operator /(SixLabors.ImageSharp.SizeF left, float right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.SizeF.operator ==(SixLabors.ImageSharp.SizeF left, SixLabors.ImageSharp.SizeF right) -> bool
+static SixLabors.ImageSharp.SizeF.Subtract(SixLabors.ImageSharp.SizeF left, SixLabors.ImageSharp.SizeF right) -> SixLabors.ImageSharp.SizeF
+static SixLabors.ImageSharp.SizeF.Transform(SixLabors.ImageSharp.SizeF size, System.Numerics.Matrix3x2 matrix) -> SixLabors.ImageSharp.SizeF
+virtual SixLabors.ImageSharp.Memory.MemoryAllocator.ReleaseRetainedResources() -> void
+virtual SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry.Equals(SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry? other) -> bool
+virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.From<TSourcePixel>(SixLabors.ImageSharp.Configuration! configuration, System.ReadOnlySpan<TSourcePixel> sourcePixels, System.Span<TPixel> destinationPixels) -> void
+virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromVector4Destructive(SixLabors.ImageSharp.Configuration! configuration, System.Span<System.Numerics.Vector4> sourceVectors, System.Span<TPixel> destinationPixels, SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers modifiers) -> void
+virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.GetPixelBlender(SixLabors.ImageSharp.PixelFormats.PixelColorBlendingMode colorMode, SixLabors.ImageSharp.PixelFormats.PixelAlphaCompositionMode alphaMode) -> SixLabors.ImageSharp.PixelFormats.PixelBlender<TPixel>!
+virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.GetPixelTypeInfo() -> SixLabors.ImageSharp.Formats.PixelTypeInfo!
+virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.To<TDestinationPixel>(SixLabors.ImageSharp.Configuration! configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<TDestinationPixel> destinationPixels) -> void
+virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToVector4(SixLabors.ImageSharp.Configuration! configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<System.Numerics.Vector4> destinationVectors, SixLabors.ImageSharp.PixelFormats.PixelConversionModifiers modifiers) -> void
+virtual SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.AfterFrameApply(SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.ImageFrame<TPixel>! destination) -> void
+virtual SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.AfterImageApply(SixLabors.ImageSharp.Image<TPixel>! destination) -> void
+virtual SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.BeforeFrameApply(SixLabors.ImageSharp.ImageFrame<TPixel>! source, SixLabors.ImageSharp.ImageFrame<TPixel>! destination) -> void
+virtual SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.BeforeImageApply(SixLabors.ImageSharp.Image<TPixel>! destination) -> void
+virtual SixLabors.ImageSharp.Processing.Processors.CloningImageProcessor<TPixel>.Dispose(bool disposing) -> void
+virtual SixLabors.ImageSharp.Processing.Processors.Filters.FilterProcessor.CreatePixelSpecificProcessor<TPixel>(SixLabors.ImageSharp.Configuration! configuration, SixLabors.ImageSharp.Image<TPixel>! source, SixLabors.ImageSharp.Rectangle sourceRectangle) -> SixLabors.ImageSharp.Processing.Processors.IImageProcessor<TPixel>!
+virtual SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.AfterFrameApply(SixLabors.ImageSharp.ImageFrame<TPixel>! source) -> void
+virtual SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.AfterImageApply() -> void
+virtual SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.BeforeFrameApply(SixLabors.ImageSharp.ImageFrame<TPixel>! source) -> void
+virtual SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.BeforeImageApply() -> void
+virtual SixLabors.ImageSharp.Processing.Processors.ImageProcessor<TPixel>.Dispose(bool disposing) -> void
+~override SixLabors.ImageSharp.Formats.Png.PngEncoder.Encode<TPixel>(SixLabors.ImageSharp.Image<TPixel> image, System.IO.Stream stream, System.Threading.CancellationToken cancellationToken) -> void
+~SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors.LzwString.Concatenate(byte other) -> SixLabors.ImageSharp.Formats.Tiff.Compression.Decompressors.LzwString
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile.DeepClone() -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile.Entries.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccTagDataEntry[]
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile.Header.get -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile.Header.set -> void
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile.IccProfile(byte[] data) -> void
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile.ToByteArray() -> byte[]
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.CmmType.get -> string
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.CmmType.set -> void
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.CreatorSignature.get -> string
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.CreatorSignature.set -> void
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.FileSignature.get -> string
+~SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileHeader.FileSignature.set -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromAbgr32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromArgb32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromBgr24Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromBgra32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromBgra5551Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromL16Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromL8Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromLa16Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromLa32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromRgb24Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromRgb48Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromRgba32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromRgba64Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<byte> sourceBytes, System.Span<TPixel> destinationPixels, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToAbgr32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToArgb32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToBgr24Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToBgra32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToBgra5551Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToL16Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToL8Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToLa16Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToLa32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToRgb24Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToRgb48Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToRgba32Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToRgba64Bytes(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<byte> destBytes, int count) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsBmp(this SixLabors.ImageSharp.Image source, string path) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsBmp(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Bmp.BmpEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsBmp(this SixLabors.ImageSharp.Image source, System.IO.Stream stream) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsBmp(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Bmp.BmpEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsBmpAsync(this SixLabors.ImageSharp.Image source, string path) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsBmpAsync(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Bmp.BmpEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsBmpAsync(this SixLabors.ImageSharp.Image source, string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsBmpAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Bmp.BmpEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsBmpAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsGif(this SixLabors.ImageSharp.Image source, string path) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsGif(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Gif.GifEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsGif(this SixLabors.ImageSharp.Image source, System.IO.Stream stream) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsGif(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Gif.GifEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsGifAsync(this SixLabors.ImageSharp.Image source, string path) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsGifAsync(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Gif.GifEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsGifAsync(this SixLabors.ImageSharp.Image source, string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsGifAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Gif.GifEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsGifAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsJpeg(this SixLabors.ImageSharp.Image source, string path) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsJpeg(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsJpeg(this SixLabors.ImageSharp.Image source, System.IO.Stream stream) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsJpeg(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsJpegAsync(this SixLabors.ImageSharp.Image source, string path) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsJpegAsync(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsJpegAsync(this SixLabors.ImageSharp.Image source, string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsJpegAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsJpegAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPbm(this SixLabors.ImageSharp.Image source, string path) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPbm(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Pbm.PbmEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPbm(this SixLabors.ImageSharp.Image source, System.IO.Stream stream) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPbm(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Pbm.PbmEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPbmAsync(this SixLabors.ImageSharp.Image source, string path) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPbmAsync(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Pbm.PbmEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPbmAsync(this SixLabors.ImageSharp.Image source, string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPbmAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Pbm.PbmEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPbmAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPng(this SixLabors.ImageSharp.Image source, string path) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPng(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Png.PngEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPng(this SixLabors.ImageSharp.Image source, System.IO.Stream stream) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPng(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Png.PngEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPngAsync(this SixLabors.ImageSharp.Image source, string path) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPngAsync(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Png.PngEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPngAsync(this SixLabors.ImageSharp.Image source, string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPngAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Png.PngEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsPngAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTga(this SixLabors.ImageSharp.Image source, string path) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTga(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Tga.TgaEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTga(this SixLabors.ImageSharp.Image source, System.IO.Stream stream) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTga(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Tga.TgaEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTgaAsync(this SixLabors.ImageSharp.Image source, string path) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTgaAsync(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Tga.TgaEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTgaAsync(this SixLabors.ImageSharp.Image source, string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTgaAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Tga.TgaEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTgaAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTiff(this SixLabors.ImageSharp.Image source, string path) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTiff(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Tiff.TiffEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTiff(this SixLabors.ImageSharp.Image source, System.IO.Stream stream) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTiff(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Tiff.TiffEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTiffAsync(this SixLabors.ImageSharp.Image source, string path) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTiffAsync(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Tiff.TiffEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTiffAsync(this SixLabors.ImageSharp.Image source, string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTiffAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Tiff.TiffEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsTiffAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsWebp(this SixLabors.ImageSharp.Image source, string path) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsWebp(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Webp.WebpEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsWebp(this SixLabors.ImageSharp.Image source, System.IO.Stream stream) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsWebp(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Webp.WebpEncoder encoder) -> void
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsWebpAsync(this SixLabors.ImageSharp.Image source, string path) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsWebpAsync(this SixLabors.ImageSharp.Image source, string path, SixLabors.ImageSharp.Formats.Webp.WebpEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsWebpAsync(this SixLabors.ImageSharp.Image source, string path, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsWebpAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, SixLabors.ImageSharp.Formats.Webp.WebpEncoder encoder, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.ImageExtensions.SaveAsWebpAsync(this SixLabors.ImageSharp.Image source, System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+~static SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfile.CalculateHash(byte[] data) -> SixLabors.ImageSharp.Metadata.Profiles.Icc.IccProfileId
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromAbgr32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.Abgr32> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromArgb32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.Argb32> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromBgr24(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.Bgr24> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromBgra32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.Bgra32> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromBgra5551(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.Bgra5551> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromL16(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.L16> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromL8(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.L8> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromLa16(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.La16> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromLa32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.La32> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromRgb24(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.Rgb24> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromRgb48(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.Rgb48> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromRgba32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.Rgba32> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.FromRgba64(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<SixLabors.ImageSharp.PixelFormats.Rgba64> source, System.Span<TPixel> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToAbgr32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.Abgr32> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToArgb32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.Argb32> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToBgr24(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.Bgr24> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToBgra32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.Bgra32> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToBgra5551(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.Bgra5551> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToL16(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.L16> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToL8(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.L8> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToLa16(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.La16> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToLa32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.La32> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToRgb24(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.Rgb24> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToRgb48(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.Rgb48> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToRgba32(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.Rgba32> destinationPixels) -> void
+~virtual SixLabors.ImageSharp.PixelFormats.PixelOperations<TPixel>.ToRgba64(SixLabors.ImageSharp.Configuration configuration, System.ReadOnlySpan<TPixel> sourcePixels, System.Span<SixLabors.ImageSharp.PixelFormats.Rgba64> destinationPixels) -> void


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR adds the PublicApiAnalyzer to this project.

I added everything to the shipped file. Now when someone makes a change to a public api, the diff must be in the unshipped file.

With the help of this file a comprehensive api diff can be "generated" for the next release.

A script to copy the unshipped api to the shipped api file is located here: https://github.com/dotnet/roslyn/tree/main/scripts/PublicApi

I disabled the Rule RS0041 because some public apis still have #nullable disable.

The documentation of this Analyzer is located here: 
https://github.com/dotnet/roslyn-analyzers/blob/main/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md

The list to the possible Analyzer warnings is documented here: https://github.com/dotnet/roslyn-analyzers/blob/main/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.md
