### PR TITLE
Add Arm intrinsics to JpegColorConverter RGB

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
             sdk-preview: true
             runtime: -x64
             codecov: false
-          - os: buildjet-8vcpu-ubuntu-2204-arm
+          - os: buildjet-4vcpu-ubuntu-2204-arm
             framework: net7.0
             sdk: 7.0.x
             sdk-preview: true
@@ -59,7 +59,7 @@ jobs:
         exclude:
           - isARM: false
             options:
-              os: buildjet-8vcpu-ubuntu-2204-arm
+              os: buildjet-4vcpu-ubuntu-2204-arm
 
     runs-on: ${{matrix.options.os}}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,8 @@ jobs:
             codecov: false
           - os: buildjet-4vcpu-ubuntu-2204-arm
             framework: net6.0
-            sdk: 6.0.x
+            sdk: 7.0.x
+            sdk-preview: true
             runtime: -x64
             codecov: false
         exclude:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
             sdk-preview: true
             runtime: -x64
             codecov: false
-          - os: buildjet-4vcpu-ubuntu-2204-arm
+          - os: buildjet-8vcpu-ubuntu-2204-arm
             framework: net7.0
             sdk: 7.0.x
             sdk-preview: true
@@ -56,16 +56,15 @@ jobs:
             sdk: 6.0.x
             runtime: -x64
             codecov: false
-          - os: buildjet-4vcpu-ubuntu-2204-arm
+          - os: buildjet-8vcpu-ubuntu-2204-arm
             framework: net6.0
-            sdk: 7.0.x
-            sdk-preview: true
+            sdk: 6.0.x
             runtime: -x64
             codecov: false
         exclude:
           - isARM: false
             options:
-              os: buildjet-4vcpu-ubuntu-2204-arm
+              os: buildjet-8vcpu-ubuntu-2204-arm
 
     runs-on: ${{matrix.options.os}}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,8 @@ jobs:
             codecov: false
           - os: buildjet-8vcpu-ubuntu-2204-arm
             framework: net6.0
-            sdk: 6.0.x
+            sdk: 7.0.x
+            sdk-preview: true
             runtime: -x64
             codecov: false
         exclude:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
             sdk-preview: true
             runtime: -x64
             codecov: false
-          - os: buildjet-8vcpu-ubuntu-2204-arm
+          - os: buildjet-16vcpu-ubuntu-2204-arm
             framework: net7.0
             sdk: 7.0.x
             sdk-preview: true
@@ -56,7 +56,7 @@ jobs:
             sdk: 6.0.x
             runtime: -x64
             codecov: false
-          - os: buildjet-8vcpu-ubuntu-2204-arm
+          - os: buildjet-16vcpu-ubuntu-2204-arm
             framework: net6.0
             sdk: 7.0.x
             sdk-preview: true
@@ -65,7 +65,7 @@ jobs:
         exclude:
           - isARM: false
             options:
-              os: buildjet-8vcpu-ubuntu-2204-arm
+              os: buildjet-16vcpu-ubuntu-2204-arm
 
     runs-on: ${{matrix.options.os}}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
             sdk-preview: true
             runtime: -x64
             codecov: false
-          - os: buildjet-16vcpu-ubuntu-2204-arm
+          - os: buildjet-8vcpu-ubuntu-2204-arm
             framework: net7.0
             sdk: 7.0.x
             sdk-preview: true
@@ -56,16 +56,10 @@ jobs:
             sdk: 6.0.x
             runtime: -x64
             codecov: false
-          - os: buildjet-16vcpu-ubuntu-2204-arm
-            framework: net6.0
-            sdk: 7.0.x
-            sdk-preview: true
-            runtime: -x64
-            codecov: false
         exclude:
           - isARM: false
             options:
-              os: buildjet-16vcpu-ubuntu-2204-arm
+              os: buildjet-8vcpu-ubuntu-2204-arm
 
     runs-on: ${{matrix.options.os}}
 

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace SixLabors.ImageSharp.Formats.Jpeg.Components;
+
+internal abstract partial class JpegColorConverterBase
+{
+    internal sealed class RgbArm : JpegColorConverterArm
+    {
+        public RgbArm(int precision)
+            : base(JpegColorSpace.RGB, precision)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void ConvertToRgbInplace(in ComponentValues values)
+        {
+            ref Vector128<float> rBase =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component0));
+            ref Vector128<float> gBase =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component1));
+            ref Vector128<float> bBase =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component2));
+
+            // Used for the color conversion
+            var scale = Vector128.Create(1 / this.MaximumValue);
+            nint n = values.Component0.Length / Vector128<float>.Count;
+            for (nint i = 0; i < n; i++)
+            {
+                ref Vector128<float> r = ref Unsafe.Add(ref rBase, i);
+                ref Vector128<float> g = ref Unsafe.Add(ref gBase, i);
+                ref Vector128<float> b = ref Unsafe.Add(ref bBase, i);
+                r = AdvSimd.Multiply(r, scale);
+                g = AdvSimd.Multiply(g, scale);
+                b = AdvSimd.Multiply(b, scale);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void ConvertFromRgb(in ComponentValues values, Span<float> rLane, Span<float> gLane, Span<float> bLane)
+        {
+            rLane.CopyTo(values.Component0);
+            gLane.CopyTo(values.Component1);
+            bLane.CopyTo(values.Component2);
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
@@ -30,7 +30,7 @@ internal abstract partial class JpegColorConverterBase
 
             // Used for the color conversion
             var scale = Vector128.Create(1 / this.MaximumValue);
-            nint n = values.Component0.Length / Vector128<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector128<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 ref Vector128<float> r = ref Unsafe.Add(ref rBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterArm.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace SixLabors.ImageSharp.Formats.Jpeg.Components;
+
+internal abstract partial class JpegColorConverterBase
+{
+    /// <summary>
+    /// <see cref="JpegColorConverterBase"/> abstract base for implementations
+    /// based on <see cref="Avx"/> instructions.
+    /// </summary>
+    /// <remarks>
+    /// Converters of this family would expect input buffers lengths to be
+    /// divisible by 8 without a remainder.
+    /// This is guaranteed by real-life data as jpeg stores pixels via 8x8 blocks.
+    /// DO NOT pass test data of invalid size to these converters as they
+    /// potentially won't do a bound check and return a false positive result.
+    /// </remarks>
+    internal abstract class JpegColorConverterArm : JpegColorConverterBase
+    {
+        protected JpegColorConverterArm(JpegColorSpace colorSpace, int precision)
+            : base(colorSpace, precision)
+        {
+        }
+
+        public static bool IsSupported => AdvSimd.IsSupported;
+
+        public sealed override bool IsAvailable => IsSupported;
+
+        public sealed override int ElementsPerBatch => Vector128<float>.Count;
+    }
+}

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
@@ -214,6 +214,11 @@ internal abstract partial class JpegColorConverterBase
             return new RgbAvx(precision);
         }
 
+        if (JpegColorConverterArm.IsSupported)
+        {
+            return new RgbArm(precision);
+        }
+
         if (JpegColorConverterVector.IsSupported)
         {
             return new RgbScalar(precision);

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/ColorConversion/RgbColorConversion.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/ColorConversion/RgbColorConversion.cs
@@ -37,4 +37,12 @@ public class RgbColorConversion : ColorConversionBenchmark
 
         new JpegColorConverterBase.RgbAvx(8).ConvertToRgbInplace(values);
     }
+
+    [Benchmark]
+    public void SimdVectorArm()
+    {
+        var values = new JpegColorConverterBase.ComponentValues(this.Input, 0);
+
+        new JpegColorConverterBase.RgbArm(8).ConvertToRgbInplace(values);
+    }
 }

--- a/tests/ImageSharp.Tests/PixelFormats/PixelBlenders/PorterDuffFunctionsTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelBlenders/PorterDuffFunctionsTests.cs
@@ -3,6 +3,8 @@
 
 using System.Numerics;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Castle.Components.DictionaryAdapter;
 using SixLabors.ImageSharp.PixelFormats.PixelBlenders;
 using SixLabors.ImageSharp.Tests.TestUtilities;
 
@@ -84,6 +86,11 @@ public class PorterDuffFunctionsTests
     [MemberData(nameof(AddFunctionData))]
     public void AddFunction256(TestVector4 back, TestVector4 source, float amount, TestVector4 expected)
     {
+        if (!Avx.IsSupported)
+        {
+            return;
+        }
+
         Vector256<float> back256 = Vector256.Create(back.X, back.Y, back.Z, back.W, back.X, back.Y, back.Z, back.W);
         Vector256<float> source256 = Vector256.Create(source.X, source.Y, source.Z, source.W, source.X, source.Y, source.Z, source.W);
 
@@ -111,6 +118,11 @@ public class PorterDuffFunctionsTests
     [MemberData(nameof(SubtractFunctionData))]
     public void SubtractFunction256(TestVector4 back, TestVector4 source, float amount, TestVector4 expected)
     {
+        if (!Avx.IsSupported)
+        {
+            return;
+        }
+
         Vector256<float> back256 = Vector256.Create(back.X, back.Y, back.Z, back.W, back.X, back.Y, back.Z, back.W);
         Vector256<float> source256 = Vector256.Create(source.X, source.Y, source.Z, source.W, source.X, source.Y, source.Z, source.W);
 
@@ -138,6 +150,11 @@ public class PorterDuffFunctionsTests
     [MemberData(nameof(ScreenFunctionData))]
     public void ScreenFunction256(TestVector4 back, TestVector4 source, float amount, TestVector4 expected)
     {
+        if (!Avx.IsSupported)
+        {
+            return;
+        }
+
         Vector256<float> back256 = Vector256.Create(back.X, back.Y, back.Z, back.W, back.X, back.Y, back.Z, back.W);
         Vector256<float> source256 = Vector256.Create(source.X, source.Y, source.Z, source.W, source.X, source.Y, source.Z, source.W);
 
@@ -165,6 +182,11 @@ public class PorterDuffFunctionsTests
     [MemberData(nameof(DarkenFunctionData))]
     public void DarkenFunction256(TestVector4 back, TestVector4 source, float amount, TestVector4 expected)
     {
+        if (!Avx.IsSupported)
+        {
+            return;
+        }
+
         Vector256<float> back256 = Vector256.Create(back.X, back.Y, back.Z, back.W, back.X, back.Y, back.Z, back.W);
         Vector256<float> source256 = Vector256.Create(source.X, source.Y, source.Z, source.W, source.X, source.Y, source.Z, source.W);
 
@@ -192,6 +214,11 @@ public class PorterDuffFunctionsTests
     [MemberData(nameof(LightenFunctionData))]
     public void LightenFunction256(TestVector4 back, TestVector4 source, float amount, TestVector4 expected)
     {
+        if (!Avx.IsSupported)
+        {
+            return;
+        }
+
         Vector256<float> back256 = Vector256.Create(back.X, back.Y, back.Z, back.W, back.X, back.Y, back.Z, back.W);
         Vector256<float> source256 = Vector256.Create(source.X, source.Y, source.Z, source.W, source.X, source.Y, source.Z, source.W);
 
@@ -219,6 +246,11 @@ public class PorterDuffFunctionsTests
     [MemberData(nameof(OverlayFunctionData))]
     public void OverlayFunction256(TestVector4 back, TestVector4 source, float amount, TestVector4 expected)
     {
+        if (!Avx.IsSupported)
+        {
+            return;
+        }
+
         Vector256<float> back256 = Vector256.Create(back.X, back.Y, back.Z, back.W, back.X, back.Y, back.Z, back.W);
         Vector256<float> source256 = Vector256.Create(source.X, source.Y, source.Z, source.W, source.X, source.Y, source.Z, source.W);
 
@@ -246,6 +278,11 @@ public class PorterDuffFunctionsTests
     [MemberData(nameof(HardLightFunctionData))]
     public void HardLightFunction256(TestVector4 back, TestVector4 source, float amount, TestVector4 expected)
     {
+        if (!Avx.IsSupported)
+        {
+            return;
+        }
+
         Vector256<float> back256 = Vector256.Create(back.X, back.Y, back.Z, back.W, back.X, back.Y, back.Z, back.W);
         Vector256<float> source256 = Vector256.Create(source.X, source.Y, source.Z, source.W, source.X, source.Y, source.Z, source.W);
 

--- a/tests/ImageSharp.Tests/PixelFormats/PixelBlenders/PorterDuffFunctionsTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelBlenders/PorterDuffFunctionsTests.cs
@@ -32,6 +32,11 @@ public class PorterDuffFunctionsTests
     [MemberData(nameof(NormalBlendFunctionData))]
     public void NormalBlendFunction256(TestVector4 back, TestVector4 source, float amount, TestVector4 expected)
     {
+        if (!Avx.IsSupported)
+        {
+            return;
+        }
+
         Vector256<float> back256 = Vector256.Create(back.X, back.Y, back.Z, back.W, back.X, back.Y, back.Z, back.W);
         Vector256<float> source256 = Vector256.Create(source.X, source.Y, source.Z, source.W, source.X, source.Y, source.Z, source.W);
 
@@ -59,6 +64,11 @@ public class PorterDuffFunctionsTests
     [MemberData(nameof(MultiplyFunctionData))]
     public void MultiplyFunction256(TestVector4 back, TestVector4 source, float amount, TestVector4 expected)
     {
+        if (!Avx.IsSupported)
+        {
+            return;
+        }
+
         Vector256<float> back256 = Vector256.Create(back.X, back.Y, back.Z, back.W, back.X, back.Y, back.Z, back.W);
         Vector256<float> source256 = Vector256.Create(source.X, source.Y, source.Z, source.W, source.X, source.Y, source.Z, source.W);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This is my first attempt in learning something about intrinsics. 
So I picked something which looked straight forward (for me) for a port to arm.

I will also try to see if there is already an benchmark for this, or going to look into writing one

