### PR TITLE
Low-hanging fruit codegen optimizations

### DIFF
--- a/src/ImageSharp/ColorSpaces/Companding/SRgbCompanding.cs
+++ b/src/ImageSharp/ColorSpaces/Companding/SRgbCompanding.cs
@@ -175,7 +175,7 @@ public static class SRgbCompanding
 
             // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
             ref Vector256<float> vectorsBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(vectors));
-            ref Vector256<float> vectorsLast = ref Unsafe.Add(ref vectorsBase, (IntPtr)((uint)vectors.Length / 2u));
+            ref Vector256<float> vectorsLast = ref Unsafe.Add(ref vectorsBase, (uint)vectors.Length / 2u);
 
             while (Unsafe.IsAddressLessThan(ref vectorsBase, ref vectorsLast))
             {
@@ -204,7 +204,7 @@ public static class SRgbCompanding
             Vector4 zero = Vector4.Zero;
             var scale = new Vector4(Scale);
             ref Vector4 vectorsBase = ref MemoryMarshal.GetReference(vectors);
-            ref Vector4 vectorsLast = ref Unsafe.Add(ref vectorsBase, vectors.Length);
+            ref Vector4 vectorsLast = ref Unsafe.Add(ref vectorsBase, (uint)vectors.Length);
 
             while (Unsafe.IsAddressLessThan(ref vectorsBase, ref vectorsLast))
             {

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLab.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLab.cs
@@ -37,7 +37,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -70,7 +70,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -103,7 +103,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -136,7 +136,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -169,7 +169,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -266,7 +266,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -299,7 +299,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -332,7 +332,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -365,7 +365,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -398,7 +398,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -431,7 +431,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLab.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLab.cs
@@ -37,7 +37,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -70,7 +70,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -103,7 +103,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -136,7 +136,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -169,7 +169,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -266,7 +266,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -299,7 +299,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -332,7 +332,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -365,7 +365,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -398,7 +398,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);
@@ -431,7 +431,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLab dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLch.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLch.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -200,7 +200,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -233,7 +233,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -266,7 +266,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -299,7 +299,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -332,7 +332,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -365,7 +365,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -398,7 +398,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -431,7 +431,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLch.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLch.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -200,7 +200,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -233,7 +233,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -266,7 +266,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -299,7 +299,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -332,7 +332,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -365,7 +365,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -398,7 +398,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);
@@ -431,7 +431,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLch destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLch dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLchuv.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLchuv.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -267,7 +267,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -300,7 +300,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -333,7 +333,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -366,7 +366,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -399,7 +399,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -431,7 +431,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLchuv.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLchuv.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -267,7 +267,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -300,7 +300,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -333,7 +333,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -366,7 +366,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -399,7 +399,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);
@@ -431,7 +431,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLchuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLchuv dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLuv.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLuv.cs
@@ -35,7 +35,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -67,7 +67,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -169,7 +169,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -233,7 +233,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -265,7 +265,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -297,7 +297,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -329,7 +329,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -361,7 +361,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -393,7 +393,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -425,7 +425,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLuv.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieLuv.cs
@@ -35,7 +35,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -67,7 +67,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -169,7 +169,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -233,7 +233,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -265,7 +265,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -297,7 +297,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -329,7 +329,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -361,7 +361,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -393,7 +393,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);
@@ -425,7 +425,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieLuv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieLuv dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyy.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyy.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -163,7 +163,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -196,7 +196,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -229,7 +229,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -262,7 +262,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -295,7 +295,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -328,7 +328,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -361,7 +361,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -394,7 +394,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -427,7 +427,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyy.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyy.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -163,7 +163,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -196,7 +196,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -229,7 +229,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -262,7 +262,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -295,7 +295,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -328,7 +328,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -361,7 +361,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -394,7 +394,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);
@@ -427,7 +427,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyy destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyy dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyz.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyz.cs
@@ -41,7 +41,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -76,7 +76,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -111,7 +111,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -146,7 +146,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -177,7 +177,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -210,7 +210,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -243,7 +243,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -277,7 +277,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -310,7 +310,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -345,7 +345,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -374,7 +374,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -407,7 +407,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -440,7 +440,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyz.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.CieXyz.cs
@@ -41,7 +41,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -76,7 +76,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -111,7 +111,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -146,7 +146,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -177,7 +177,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -210,7 +210,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -243,7 +243,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -277,7 +277,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -310,7 +310,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -345,7 +345,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -374,7 +374,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -407,7 +407,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);
@@ -440,7 +440,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Cmyk.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Cmyk.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -267,7 +267,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -300,7 +300,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -333,7 +333,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -366,7 +366,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -394,7 +394,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -427,7 +427,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Cmyk.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Cmyk.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -267,7 +267,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -300,7 +300,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -333,7 +333,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -366,7 +366,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -394,7 +394,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);
@@ -427,7 +427,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Cmyk destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Cmyk dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Hsl.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Hsl.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -267,7 +267,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -300,7 +300,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -333,7 +333,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -366,7 +366,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -394,7 +394,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -427,7 +427,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Hsl.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Hsl.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -267,7 +267,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -300,7 +300,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -333,7 +333,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -366,7 +366,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -394,7 +394,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);
@@ -427,7 +427,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsl destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsl dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Hsv.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Hsv.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -267,7 +267,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -300,7 +300,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -333,7 +333,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -366,7 +366,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -394,7 +394,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -427,7 +427,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Hsv.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Hsv.cs
@@ -36,7 +36,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -69,7 +69,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -102,7 +102,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -135,7 +135,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -168,7 +168,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -201,7 +201,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -267,7 +267,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -300,7 +300,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -333,7 +333,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -366,7 +366,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -394,7 +394,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);
@@ -427,7 +427,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Hsv destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Hsv dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.HunterLab.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.HunterLab.cs
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -276,7 +276,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.HunterLab.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.HunterLab.cs
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);
@@ -276,7 +276,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref HunterLab destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref HunterLab dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.LinearRgb.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.LinearRgb.cs
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -276,7 +276,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.LinearRgb.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.LinearRgb.cs
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);
@@ -276,7 +276,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref LinearRgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref LinearRgb dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Lms.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Lms.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 using System.Runtime.CompilerServices;
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -276,7 +276,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Lms.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Lms.cs
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);
@@ -276,7 +276,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Lms destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Lms dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Rgb.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Rgb.cs
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -276,7 +276,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Rgb.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.Rgb.cs
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLchuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLchuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);
@@ -276,7 +276,7 @@ public partial class ColorSpaceConverter
         ref YCbCr sourceRef = ref MemoryMarshal.GetReference(source);
         ref Rgb destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref YCbCr sp = ref Unsafe.Add(ref sourceRef, i);
             ref Rgb dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.YCbCr.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.YCbCr.cs
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.YCbCr.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/ColorSpaceConverter.YCbCr.cs
@@ -24,7 +24,7 @@ public partial class ColorSpaceConverter
         ref CieLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -45,7 +45,7 @@ public partial class ColorSpaceConverter
         ref CieLch sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLch sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -66,7 +66,7 @@ public partial class ColorSpaceConverter
         ref CieLuv sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieLuv sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -87,7 +87,7 @@ public partial class ColorSpaceConverter
         ref CieXyy sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyy sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -108,7 +108,7 @@ public partial class ColorSpaceConverter
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -129,7 +129,7 @@ public partial class ColorSpaceConverter
         ref Cmyk sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Cmyk sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -150,7 +150,7 @@ public partial class ColorSpaceConverter
         ref Hsl sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsl sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -171,7 +171,7 @@ public partial class ColorSpaceConverter
         ref Hsv sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Hsv sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -192,7 +192,7 @@ public partial class ColorSpaceConverter
         ref HunterLab sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref HunterLab sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -213,7 +213,7 @@ public partial class ColorSpaceConverter
         ref LinearRgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref LinearRgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -234,7 +234,7 @@ public partial class ColorSpaceConverter
         ref Lms sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Lms sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);
@@ -255,7 +255,7 @@ public partial class ColorSpaceConverter
         ref Rgb sourceRef = ref MemoryMarshal.GetReference(source);
         ref YCbCr destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb sp = ref Unsafe.Add(ref sourceRef, i);
             ref YCbCr dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/Implementation/Converters/CieXyzToCieLabConverter.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/Implementation/Converters/CieXyzToCieLabConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 using System.Runtime.CompilerServices;
@@ -42,9 +42,11 @@ internal sealed class CieXyzToCieLabConverter
 
         float xr = input.X / wx, yr = input.Y / wy, zr = input.Z / wz;
 
-        float fx = xr > CieConstants.Epsilon ? MathF.Pow(xr, 0.3333333F) : ((CieConstants.Kappa * xr) + 16F) / 116F;
-        float fy = yr > CieConstants.Epsilon ? MathF.Pow(yr, 0.3333333F) : ((CieConstants.Kappa * yr) + 16F) / 116F;
-        float fz = zr > CieConstants.Epsilon ? MathF.Pow(zr, 0.3333333F) : ((CieConstants.Kappa * zr) + 16F) / 116F;
+        const float inv116 = 1 / 116F;
+
+        float fx = xr > CieConstants.Epsilon ? MathF.Pow(xr, 0.3333333F) : ((CieConstants.Kappa * xr) + 16F) * inv116;
+        float fy = yr > CieConstants.Epsilon ? MathF.Pow(yr, 0.3333333F) : ((CieConstants.Kappa * yr) + 16F) * inv116;
+        float fz = zr > CieConstants.Epsilon ? MathF.Pow(zr, 0.3333333F) : ((CieConstants.Kappa * zr) + 16F) * inv116;
 
         float l = (116F * fy) - 16F;
         float a = 500F * (fx - fy);

--- a/src/ImageSharp/ColorSpaces/Conversion/Implementation/VonKriesChromaticAdaptation.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/Implementation/VonKriesChromaticAdaptation.cs
@@ -81,7 +81,7 @@ public sealed class VonKriesChromaticAdaptation : IChromaticAdaptation
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/ColorSpaces/Conversion/Implementation/VonKriesChromaticAdaptation.cs
+++ b/src/ImageSharp/ColorSpaces/Conversion/Implementation/VonKriesChromaticAdaptation.cs
@@ -81,7 +81,7 @@ public sealed class VonKriesChromaticAdaptation : IChromaticAdaptation
         ref CieXyz sourceRef = ref MemoryMarshal.GetReference(source);
         ref CieXyz destRef = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref CieXyz sp = ref Unsafe.Add(ref sourceRef, i);
             ref CieXyz dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/Common/Helpers/HexConverter.cs
+++ b/src/ImageSharp/Common/Helpers/HexConverter.cs
@@ -16,12 +16,12 @@ internal static class HexConverter
     /// <returns>The number of bytes written to <paramref name="bytes"/>.</returns>
     public static int HexStringToBytes(ReadOnlySpan<char> chars, Span<byte> bytes)
     {
-        if ((chars.Length & 1 /* bit-hack for % 2 */) != 0)
+        if (Numerics.Modulo2(chars.Length) != 0)
         {
             throw new ArgumentException("Input string length must be a multiple of 2", nameof(chars));
         }
 
-        if ((bytes.Length << 1 /* bit-hack for * 2 */) < chars.Length)
+        if ((bytes.Length << 1 /* bit-hack for *2 */) < chars.Length)
         {
             throw new ArgumentException("Output span must be at least half the length of the input string");
         }
@@ -55,7 +55,7 @@ internal static class HexConverter
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 255
             };
 
-            return c >= charToHexLookup.Length ? 0xFF : charToHexLookup[c];
+            return (uint)c >= (uint)charToHexLookup.Length ? 0xFF : charToHexLookup[c];
         }
 
         // See https://source.dot.net/#System.Private.CoreLib/HexConverter.cs,4681d45a0aa0b361

--- a/src/ImageSharp/Common/Helpers/HexConverter.cs
+++ b/src/ImageSharp/Common/Helpers/HexConverter.cs
@@ -16,12 +16,12 @@ internal static class HexConverter
     /// <returns>The number of bytes written to <paramref name="bytes"/>.</returns>
     public static int HexStringToBytes(ReadOnlySpan<char> chars, Span<byte> bytes)
     {
-        if ((chars.Length & 1) != 0)    // bit-hack for % 2
+        if ((chars.Length & 1 /* bit-hack for % 2 */) != 0)
         {
             throw new ArgumentException("Input string length must be a multiple of 2", nameof(chars));
         }
 
-        if ((bytes.Length << 1) < chars.Length) // bit-hack for * 2
+        if ((bytes.Length << 1 /* bit-hack for * 2 */) < chars.Length)
         {
             throw new ArgumentException("Output span must be at least half the length of the input string");
         }

--- a/src/ImageSharp/Common/Helpers/HexConverter.cs
+++ b/src/ImageSharp/Common/Helpers/HexConverter.cs
@@ -16,21 +16,19 @@ internal static class HexConverter
     /// <returns>The number of bytes written to <paramref name="bytes"/>.</returns>
     public static int HexStringToBytes(ReadOnlySpan<char> chars, Span<byte> bytes)
     {
-        if ((chars.Length % 2) != 0)
+        if ((chars.Length & 1) != 0)    // bit-hack for % 2
         {
             throw new ArgumentException("Input string length must be a multiple of 2", nameof(chars));
         }
 
-        if ((bytes.Length * 2) < chars.Length)
+        if ((bytes.Length << 1) < chars.Length) // bit-hack for * 2
         {
             throw new ArgumentException("Output span must be at least half the length of the input string");
         }
-        else
-        {
-            // Slightly better performance in the loop below, allows us to skip a bounds check
-            // while still supporting output buffers that are larger than necessary
-            bytes = bytes[..(chars.Length / 2)];
-        }
+
+        // Slightly better performance in the loop below, allows us to skip a bounds check
+        // while still supporting output buffers that are larger than necessary
+        bytes = bytes[..(chars.Length >> 1)];   // bit-hack for / 2
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static int FromChar(int c)

--- a/src/ImageSharp/Common/Helpers/Numerics.cs
+++ b/src/ImageSharp/Common/Helpers/Numerics.cs
@@ -297,7 +297,7 @@ internal static class Numerics
         if (remainder.Length > 0)
         {
             ref byte remainderStart = ref MemoryMarshal.GetReference(remainder);
-            ref byte remainderEnd = ref Unsafe.Add(ref remainderStart, remainder.Length);
+            ref byte remainderEnd = ref Unsafe.Add(ref remainderStart, (uint)remainder.Length);
 
             while (Unsafe.IsAddressLessThan(ref remainderStart, ref remainderEnd))
             {
@@ -322,7 +322,7 @@ internal static class Numerics
         if (remainder.Length > 0)
         {
             ref uint remainderStart = ref MemoryMarshal.GetReference(remainder);
-            ref uint remainderEnd = ref Unsafe.Add(ref remainderStart, remainder.Length);
+            ref uint remainderEnd = ref Unsafe.Add(ref remainderStart, (uint)remainder.Length);
 
             while (Unsafe.IsAddressLessThan(ref remainderStart, ref remainderEnd))
             {
@@ -347,7 +347,7 @@ internal static class Numerics
         if (remainder.Length > 0)
         {
             ref int remainderStart = ref MemoryMarshal.GetReference(remainder);
-            ref int remainderEnd = ref Unsafe.Add(ref remainderStart, remainder.Length);
+            ref int remainderEnd = ref Unsafe.Add(ref remainderStart, (uint)remainder.Length);
 
             while (Unsafe.IsAddressLessThan(ref remainderStart, ref remainderEnd))
             {
@@ -372,7 +372,7 @@ internal static class Numerics
         if (remainder.Length > 0)
         {
             ref float remainderStart = ref MemoryMarshal.GetReference(remainder);
-            ref float remainderEnd = ref Unsafe.Add(ref remainderStart, remainder.Length);
+            ref float remainderEnd = ref Unsafe.Add(ref remainderStart, (uint)remainder.Length);
 
             while (Unsafe.IsAddressLessThan(ref remainderStart, ref remainderEnd))
             {
@@ -397,7 +397,7 @@ internal static class Numerics
         if (remainder.Length > 0)
         {
             ref double remainderStart = ref MemoryMarshal.GetReference(remainder);
-            ref double remainderEnd = ref Unsafe.Add(ref remainderStart, remainder.Length);
+            ref double remainderEnd = ref Unsafe.Add(ref remainderStart, (uint)remainder.Length);
 
             while (Unsafe.IsAddressLessThan(ref remainderStart, ref remainderEnd))
             {
@@ -497,7 +497,7 @@ internal static class Numerics
         {
             // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
             ref Vector256<float> vectorsBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(vectors));
-            ref Vector256<float> vectorsLast = ref Unsafe.Add(ref vectorsBase, (IntPtr)((uint)vectors.Length / 2u));
+            ref Vector256<float> vectorsLast = ref Unsafe.Add(ref vectorsBase, (uint)vectors.Length / 2u);
 
             while (Unsafe.IsAddressLessThan(ref vectorsBase, ref vectorsLast))
             {
@@ -516,7 +516,7 @@ internal static class Numerics
         else
         {
             ref Vector4 vectorsStart = ref MemoryMarshal.GetReference(vectors);
-            ref Vector4 vectorsEnd = ref Unsafe.Add(ref vectorsStart, vectors.Length);
+            ref Vector4 vectorsEnd = ref Unsafe.Add(ref vectorsStart, (uint)vectors.Length);
 
             while (Unsafe.IsAddressLessThan(ref vectorsStart, ref vectorsEnd))
             {
@@ -562,7 +562,7 @@ internal static class Numerics
         {
             // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
             ref Vector256<float> vectorsBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(vectors));
-            ref Vector256<float> vectorsLast = ref Unsafe.Add(ref vectorsBase, (IntPtr)((uint)vectors.Length / 2u));
+            ref Vector256<float> vectorsLast = ref Unsafe.Add(ref vectorsBase, (uint)vectors.Length / 2u);
             Vector256<float> epsilon = Vector256.Create(Constants.Epsilon);
 
             while (Unsafe.IsAddressLessThan(ref vectorsBase, ref vectorsLast))
@@ -582,7 +582,7 @@ internal static class Numerics
         else
         {
             ref Vector4 vectorsStart = ref MemoryMarshal.GetReference(vectors);
-            ref Vector4 vectorsEnd = ref Unsafe.Add(ref vectorsStart, vectors.Length);
+            ref Vector4 vectorsEnd = ref Unsafe.Add(ref vectorsStart, (uint)vectors.Length);
 
             while (Unsafe.IsAddressLessThan(ref vectorsStart, ref vectorsEnd))
             {
@@ -656,7 +656,7 @@ internal static class Numerics
     public static unsafe void CubePowOnXYZ(Span<Vector4> vectors)
     {
         ref Vector4 baseRef = ref MemoryMarshal.GetReference(vectors);
-        ref Vector4 endRef = ref Unsafe.Add(ref baseRef, vectors.Length);
+        ref Vector4 endRef = ref Unsafe.Add(ref baseRef, (uint)vectors.Length);
 
         while (Unsafe.IsAddressLessThan(ref baseRef, ref endRef))
         {
@@ -687,7 +687,7 @@ internal static class Numerics
         if (Sse41.IsSupported)
         {
             ref Vector128<float> vectors128Ref = ref Unsafe.As<Vector4, Vector128<float>>(ref MemoryMarshal.GetReference(vectors));
-            ref Vector128<float> vectors128End = ref Unsafe.Add(ref vectors128Ref, vectors.Length);
+            ref Vector128<float> vectors128End = ref Unsafe.Add(ref vectors128Ref, (uint)vectors.Length);
 
             var v128_341 = Vector128.Create(341);
             Vector128<int> v128_negativeZero = Vector128.Create(-0.0f).AsInt32();
@@ -736,7 +736,7 @@ internal static class Numerics
         else
         {
             ref Vector4 vectorsRef = ref MemoryMarshal.GetReference(vectors);
-            ref Vector4 vectorsEnd = ref Unsafe.Add(ref vectorsRef, vectors.Length);
+            ref Vector4 vectorsEnd = ref Unsafe.Add(ref vectorsRef, (uint)vectors.Length);
 
             // Fallback with scalar preprocessing and vectorized approximation steps
             while (Unsafe.IsAddressLessThan(ref vectorsRef, ref vectorsEnd))

--- a/src/ImageSharp/Common/Helpers/Numerics.cs
+++ b/src/ImageSharp/Common/Helpers/Numerics.cs
@@ -56,6 +56,12 @@ internal static class Numerics
     public static int Modulo4(int x) => x & 3;
 
     /// <summary>
+    /// Calculates <paramref name="x"/> % 4
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static nint Modulo4(nint x) => x & 3;
+
+    /// <summary>
     /// Calculates <paramref name="x"/> % 8
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -430,9 +436,9 @@ internal static class Numerics
         var vmin = new Vector<T>(min);
         var vmax = new Vector<T>(max);
 
-        int n = span.Length / Vector<T>.Count;
-        int m = Modulo4(n);
-        int u = n - m;
+        nint n = (nint)(uint)span.Length / Vector<T>.Count;
+        nint m = Modulo4(n);
+        nint u = n - m;
 
         ref Vector<T> vs0 = ref Unsafe.As<T, Vector<T>>(ref MemoryMarshal.GetReference(span));
         ref Vector<T> vs1 = ref Unsafe.Add(ref vs0, 1);

--- a/src/ImageSharp/Common/Helpers/Shuffle/IComponentShuffle.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IComponentShuffle.cs
@@ -84,9 +84,9 @@ internal readonly struct WXYZShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = (int)((uint)source.Length / 4);
+        uint n = (uint)source.Length / 4;
 
-        for (nuint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -108,9 +108,9 @@ internal readonly struct WZYXShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = (int)((uint)source.Length / 4);
+        uint n = (uint)source.Length / 4;
 
-        for (nuint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -132,9 +132,9 @@ internal readonly struct YZWXShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = (int)((uint)source.Length / 4);
+        uint n = (uint)source.Length / 4;
 
-        for (nuint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -156,9 +156,9 @@ internal readonly struct ZYXWShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = (int)((uint)source.Length / 4);
+        uint n = (uint)source.Length / 4;
 
-        for (nuint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -187,9 +187,9 @@ internal readonly struct XWZYShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = (int)((uint)source.Length / 4);
+        uint n = (uint)source.Length / 4;
 
-        for (nuint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 

--- a/src/ImageSharp/Common/Helpers/Shuffle/IComponentShuffle.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IComponentShuffle.cs
@@ -63,12 +63,12 @@ internal readonly struct DefaultShuffle4 : IShuffle4
 
         Shuffle.InverseMMShuffle(this.Control, out int p3, out int p2, out int p1, out int p0);
 
-        for (int i = 0; i < source.Length; i += 4)
+        for (nint i = 0; i < (uint)source.Length; i += 4)
         {
-            Unsafe.Add(ref dBase, i) = Unsafe.Add(ref sBase, p0 + i);
-            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
-            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
-            Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, p3 + i);
+            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, (nint)(uint)p0 + i);
+            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, (nint)(uint)p1 + i);
+            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, (nint)(uint)p2 + i);
+            Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, (nint)(uint)p3 + i);
         }
     }
 }
@@ -86,7 +86,7 @@ internal readonly struct WXYZShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = source.Length / 4;
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -110,7 +110,7 @@ internal readonly struct WZYXShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = source.Length / 4;
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -134,7 +134,7 @@ internal readonly struct YZWXShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = source.Length / 4;
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -158,7 +158,7 @@ internal readonly struct ZYXWShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = source.Length / 4;
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -189,7 +189,7 @@ internal readonly struct XWZYShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = source.Length / 4;
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 

--- a/src/ImageSharp/Common/Helpers/Shuffle/IComponentShuffle.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IComponentShuffle.cs
@@ -61,14 +61,14 @@ internal readonly struct DefaultShuffle4 : IShuffle4
         ref byte sBase = ref MemoryMarshal.GetReference(source);
         ref byte dBase = ref MemoryMarshal.GetReference(dest);
 
-        Shuffle.InverseMMShuffle(this.Control, out int p3, out int p2, out int p1, out int p0);
+        Shuffle.InverseMMShuffle(this.Control, out uint p3, out uint p2, out uint p1, out uint p0);
 
-        for (nint i = 0; i < (uint)source.Length; i += 4)
+        for (nuint i = 0; i < (uint)source.Length; i += 4)
         {
-            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, (nint)(uint)p0 + i);
-            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, (nint)(uint)p1 + i);
-            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, (nint)(uint)p2 + i);
-            Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, (nint)(uint)p3 + i);
+            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, p0 + i);
+            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
+            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
+            Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, p3 + i);
         }
     }
 }
@@ -86,7 +86,7 @@ internal readonly struct WXYZShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = (int)((uint)source.Length / 4);
 
-        for (nint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -110,7 +110,7 @@ internal readonly struct WZYXShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = (int)((uint)source.Length / 4);
 
-        for (nint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -134,7 +134,7 @@ internal readonly struct YZWXShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = (int)((uint)source.Length / 4);
 
-        for (nint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -158,7 +158,7 @@ internal readonly struct ZYXWShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = (int)((uint)source.Length / 4);
 
-        for (nint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 
@@ -189,7 +189,7 @@ internal readonly struct XWZYShuffle4 : IShuffle4
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
         int n = (int)((uint)source.Length / 4);
 
-        for (nint i = 0; i < (uint)n; i++)
+        for (nuint i = 0; i < (uint)n; i++)
         {
             uint packed = Unsafe.Add(ref sBase, i);
 

--- a/src/ImageSharp/Common/Helpers/Shuffle/IComponentShuffle.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IComponentShuffle.cs
@@ -84,7 +84,7 @@ internal readonly struct WXYZShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = source.Length / 4;
+        int n = (int)((uint)source.Length / 4);
 
         for (nint i = 0; i < (uint)n; i++)
         {
@@ -108,7 +108,7 @@ internal readonly struct WZYXShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = source.Length / 4;
+        int n = (int)((uint)source.Length / 4);
 
         for (nint i = 0; i < (uint)n; i++)
         {
@@ -132,7 +132,7 @@ internal readonly struct YZWXShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = source.Length / 4;
+        int n = (int)((uint)source.Length / 4);
 
         for (nint i = 0; i < (uint)n; i++)
         {
@@ -156,7 +156,7 @@ internal readonly struct ZYXWShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = source.Length / 4;
+        int n = (int)((uint)source.Length / 4);
 
         for (nint i = 0; i < (uint)n; i++)
         {
@@ -187,7 +187,7 @@ internal readonly struct XWZYShuffle4 : IShuffle4
     {
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref uint dBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(dest));
-        int n = source.Length / 4;
+        int n = (int)((uint)source.Length / 4);
 
         for (nint i = 0; i < (uint)n; i++)
         {

--- a/src/ImageSharp/Common/Helpers/Shuffle/IPad3Shuffle4.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IPad3Shuffle4.cs
@@ -29,21 +29,21 @@ internal readonly struct DefaultPad3Shuffle4 : IPad3Shuffle4
         ref byte sBase = ref MemoryMarshal.GetReference(source);
         ref byte dBase = ref MemoryMarshal.GetReference(dest);
 
-        Shuffle.InverseMMShuffle(this.Control, out int p3, out int p2, out int p1, out int p0);
+        Shuffle.InverseMMShuffle(this.Control, out uint p3, out uint p2, out uint p1, out uint p0);
 
         Span<byte> temp = stackalloc byte[4];
         ref byte t = ref MemoryMarshal.GetReference(temp);
         ref uint tu = ref Unsafe.As<byte, uint>(ref t);
 
-        for (nint i = 0, j = 0; i < (uint)source.Length; i += 3, j += 4)
+        for (nuint i = 0, j = 0; i < (uint)source.Length; i += 3, j += 4)
         {
             ref byte s = ref Unsafe.Add(ref sBase, i);
             tu = Unsafe.As<byte, uint>(ref s) | 0xFF000000;
 
-            Unsafe.Add(ref dBase, j + 0) = Unsafe.Add(ref t, (uint)p0);
-            Unsafe.Add(ref dBase, j + 1) = Unsafe.Add(ref t, (uint)p1);
-            Unsafe.Add(ref dBase, j + 2) = Unsafe.Add(ref t, (uint)p2);
-            Unsafe.Add(ref dBase, j + 3) = Unsafe.Add(ref t, (uint)p3);
+            Unsafe.Add(ref dBase, j + 0) = Unsafe.Add(ref t, p0);
+            Unsafe.Add(ref dBase, j + 1) = Unsafe.Add(ref t, p1);
+            Unsafe.Add(ref dBase, j + 2) = Unsafe.Add(ref t, p2);
+            Unsafe.Add(ref dBase, j + 3) = Unsafe.Add(ref t, p3);
         }
     }
 }

--- a/src/ImageSharp/Common/Helpers/Shuffle/IPad3Shuffle4.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IPad3Shuffle4.cs
@@ -35,15 +35,15 @@ internal readonly struct DefaultPad3Shuffle4 : IPad3Shuffle4
         ref byte t = ref MemoryMarshal.GetReference(temp);
         ref uint tu = ref Unsafe.As<byte, uint>(ref t);
 
-        for (int i = 0, j = 0; i < source.Length; i += 3, j += 4)
+        for (nint i = 0, j = 0; i < (uint)source.Length; i += 3, j += 4)
         {
             ref byte s = ref Unsafe.Add(ref sBase, i);
             tu = Unsafe.As<byte, uint>(ref s) | 0xFF000000;
 
-            Unsafe.Add(ref dBase, j) = Unsafe.Add(ref t, p0);
-            Unsafe.Add(ref dBase, j + 1) = Unsafe.Add(ref t, p1);
-            Unsafe.Add(ref dBase, j + 2) = Unsafe.Add(ref t, p2);
-            Unsafe.Add(ref dBase, j + 3) = Unsafe.Add(ref t, p3);
+            Unsafe.Add(ref dBase, j + 0) = Unsafe.Add(ref t, (uint)p0);
+            Unsafe.Add(ref dBase, j + 1) = Unsafe.Add(ref t, (uint)p1);
+            Unsafe.Add(ref dBase, j + 2) = Unsafe.Add(ref t, (uint)p2);
+            Unsafe.Add(ref dBase, j + 3) = Unsafe.Add(ref t, (uint)p3);
         }
     }
 }
@@ -60,7 +60,7 @@ internal readonly struct XYZWPad3Shuffle4 : IPad3Shuffle4
         ref byte sBase = ref MemoryMarshal.GetReference(source);
         ref byte dBase = ref MemoryMarshal.GetReference(dest);
 
-        ref byte sEnd = ref Unsafe.Add(ref sBase, source.Length);
+        ref byte sEnd = ref Unsafe.Add(ref sBase, (uint)source.Length);
         ref byte sLoopEnd = ref Unsafe.Subtract(ref sEnd, 4);
 
         while (Unsafe.IsAddressLessThan(ref sBase, ref sLoopEnd))

--- a/src/ImageSharp/Common/Helpers/Shuffle/IShuffle3.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IShuffle3.cs
@@ -29,13 +29,13 @@ internal readonly struct DefaultShuffle3 : IShuffle3
         ref byte sBase = ref MemoryMarshal.GetReference(source);
         ref byte dBase = ref MemoryMarshal.GetReference(dest);
 
-        Shuffle.InverseMMShuffle(this.Control, out _, out int p2, out int p1, out int p0);
+        Shuffle.InverseMMShuffle(this.Control, out _, out uint p2, out uint p1, out uint p0);
 
-        for (nint i = 0; i < (uint)source.Length; i += 3)
+        for (nuint i = 0; i < (uint)source.Length; i += 3)
         {
-            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, (nint)(uint)p0 + i);
-            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, (nint)(uint)p1 + i);
-            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, (nint)(uint)p2 + i);
+            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, p0 + i);
+            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
+            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
         }
     }
 }

--- a/src/ImageSharp/Common/Helpers/Shuffle/IShuffle3.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IShuffle3.cs
@@ -31,11 +31,11 @@ internal readonly struct DefaultShuffle3 : IShuffle3
 
         Shuffle.InverseMMShuffle(this.Control, out _, out int p2, out int p1, out int p0);
 
-        for (int i = 0; i < source.Length; i += 3)
+        for (nint i = 0; i < (uint)source.Length; i += 3)
         {
-            Unsafe.Add(ref dBase, i) = Unsafe.Add(ref sBase, p0 + i);
-            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
-            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
+            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, (nint)(uint)p0 + i);
+            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, (nint)(uint)p1 + i);
+            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, (nint)(uint)p2 + i);
         }
     }
 }

--- a/src/ImageSharp/Common/Helpers/Shuffle/IShuffle4Slice3.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IShuffle4Slice3.cs
@@ -29,13 +29,13 @@ internal readonly struct DefaultShuffle4Slice3 : IShuffle4Slice3
         ref byte sBase = ref MemoryMarshal.GetReference(source);
         ref byte dBase = ref MemoryMarshal.GetReference(dest);
 
-        Shuffle.InverseMMShuffle(this.Control, out _, out int p2, out int p1, out int p0);
+        Shuffle.InverseMMShuffle(this.Control, out _, out uint p2, out uint p1, out uint p0);
 
-        for (nint i = 0, j = 0; i < (uint)dest.Length; i += 3, j += 4)
+        for (nuint i = 0, j = 0; i < (uint)dest.Length; i += 3, j += 4)
         {
-            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, (nint)(uint)p0 + j);
-            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, (nint)(uint)p1 + j);
-            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, (nint)(uint)p2 + j);
+            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, p0 + j);
+            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + j);
+            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + j);
         }
     }
 }

--- a/src/ImageSharp/Common/Helpers/Shuffle/IShuffle4Slice3.cs
+++ b/src/ImageSharp/Common/Helpers/Shuffle/IShuffle4Slice3.cs
@@ -31,11 +31,11 @@ internal readonly struct DefaultShuffle4Slice3 : IShuffle4Slice3
 
         Shuffle.InverseMMShuffle(this.Control, out _, out int p2, out int p1, out int p0);
 
-        for (int i = 0, j = 0; i < dest.Length; i += 3, j += 4)
+        for (nint i = 0, j = 0; i < (uint)dest.Length; i += 3, j += 4)
         {
-            Unsafe.Add(ref dBase, i) = Unsafe.Add(ref sBase, p0 + j);
-            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + j);
-            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + j);
+            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, (nint)(uint)p0 + j);
+            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, (nint)(uint)p1 + j);
+            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, (nint)(uint)p2 + j);
         }
     }
 }
@@ -52,9 +52,9 @@ internal readonly struct XYZWShuffle4Slice3 : IShuffle4Slice3
         ref uint sBase = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
         ref Byte3 dBase = ref Unsafe.As<byte, Byte3>(ref MemoryMarshal.GetReference(dest));
 
-        int n = source.Length / 4;
-        int m = Numerics.Modulo4(n);
-        int u = n - m;
+        nint n = (nint)(uint)source.Length / 4;
+        nint m = Numerics.Modulo4(n);
+        nint u = n - m;
 
         ref uint sLoopEnd = ref Unsafe.Add(ref sBase, u);
         ref uint sEnd = ref Unsafe.Add(ref sBase, n);

--- a/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
@@ -97,12 +97,12 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, Vector<byte>.Count);
 
-            int n = dest.Length / Vector<byte>.Count;
+            nint n = (nint)(uint)dest.Length / Vector<byte>.Count;
 
             ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference(source));
             ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dest));
 
-            for (int i = 0; i < n; i++)
+            for (nint i = 0; i < n; i++)
             {
                 Vector<byte> b = Unsafe.Add(ref sourceBase, i);
 
@@ -132,13 +132,13 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, Vector<byte>.Count);
 
-            int n = dest.Length / Vector<byte>.Count;
+            nint n = (nint)(uint)dest.Length / Vector<byte>.Count;
 
             ref Vector<float> sourceBase =
                 ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(source));
             ref Vector<byte> destBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference(dest));
 
-            for (int i = 0; i < n; i++)
+            for (nint i = 0; i < n; i++)
             {
                 ref Vector<float> s = ref Unsafe.Add(ref sourceBase, i * 4);
 

--- a/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
@@ -97,7 +97,7 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, Vector<byte>.Count);
 
-            nuint n = (uint)(dest.Length / Vector<byte>.Count);
+            nuint n = (uint)dest.Length / (uint)Vector<byte>.Count;
 
             ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference(source));
             ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dest));
@@ -132,7 +132,7 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, Vector<byte>.Count);
 
-            nuint n = (uint)(dest.Length / Vector<byte>.Count);
+            nuint n = (uint)dest.Length / (uint)Vector<byte>.Count;
 
             ref Vector<float> sourceBase =
                 ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(source));

--- a/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
@@ -97,12 +97,12 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, Vector<byte>.Count);
 
-            nint n = (nint)(uint)dest.Length / Vector<byte>.Count;
+            nuint n = (uint)(dest.Length / Vector<byte>.Count);
 
             ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference(source));
             ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dest));
 
-            for (nint i = 0; i < n; i++)
+            for (nuint i = 0; i < n; i++)
             {
                 Vector<byte> b = Unsafe.Add(ref sourceBase, i);
 
@@ -132,13 +132,13 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, Vector<byte>.Count);
 
-            nint n = (nint)(uint)dest.Length / Vector<byte>.Count;
+            nuint n = (uint)(dest.Length / Vector<byte>.Count);
 
             ref Vector<float> sourceBase =
                 ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(source));
             ref Vector<byte> destBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference(dest));
 
-            for (nint i = 0; i < n; i++)
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> s = ref Unsafe.Add(ref sourceBase, i * 4);
 

--- a/src/ImageSharp/Common/Helpers/SimdUtils.FallbackIntrinsics128.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.FallbackIntrinsics128.cs
@@ -83,7 +83,7 @@ internal static partial class SimdUtils
             const float scale = 1f / 255f;
             Vector4 d = default;
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 ref ByteVector4 s = ref Unsafe.Add(ref sBase, i);
                 d.X = s.X;
@@ -117,7 +117,7 @@ internal static partial class SimdUtils
             var half = new Vector4(0.5f);
             var maxBytes = new Vector4(255f);
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Vector4 s = Unsafe.Add(ref sBase, i);
                 s *= maxBytes;

--- a/src/ImageSharp/Common/Helpers/SimdUtils.FallbackIntrinsics128.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.FallbackIntrinsics128.cs
@@ -71,7 +71,7 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, 4);
 
-            int count = dest.Length / 4;
+            int count = (int)((uint)dest.Length / 4);
             if (count == 0)
             {
                 return;
@@ -105,7 +105,7 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, 4);
 
-            int count = source.Length / 4;
+            int count = (int)((uint)source.Length / 4);
             if (count == 0)
             {
                 return;

--- a/src/ImageSharp/Common/Helpers/SimdUtils.FallbackIntrinsics128.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.FallbackIntrinsics128.cs
@@ -71,7 +71,7 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, 4);
 
-            int count = (int)((uint)dest.Length / 4);
+            uint count = (uint)dest.Length / 4;
             if (count == 0)
             {
                 return;
@@ -83,7 +83,7 @@ internal static partial class SimdUtils
             const float scale = 1f / 255f;
             Vector4 d = default;
 
-            for (nuint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < count; i++)
             {
                 ref ByteVector4 s = ref Unsafe.Add(ref sBase, i);
                 d.X = s.X;
@@ -105,7 +105,7 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, 4);
 
-            int count = (int)((uint)source.Length / 4);
+            uint count = (uint)source.Length / 4;
             if (count == 0)
             {
                 return;
@@ -117,7 +117,7 @@ internal static partial class SimdUtils
             var half = new Vector4(0.5f);
             var maxBytes = new Vector4(255f);
 
-            for (nuint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < count; i++)
             {
                 Vector4 s = Unsafe.Add(ref sBase, i);
                 s *= maxBytes;

--- a/src/ImageSharp/Common/Helpers/SimdUtils.FallbackIntrinsics128.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.FallbackIntrinsics128.cs
@@ -83,7 +83,7 @@ internal static partial class SimdUtils
             const float scale = 1f / 255f;
             Vector4 d = default;
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 ref ByteVector4 s = ref Unsafe.Add(ref sBase, i);
                 d.X = s.X;
@@ -117,7 +117,7 @@ internal static partial class SimdUtils
             var half = new Vector4(0.5f);
             var maxBytes = new Vector4(255f);
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Vector4 s = Unsafe.Add(ref sBase, i);
                 s *= maxBytes;

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -391,7 +391,7 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                nuint n = (uint)(source.Length / Vector128<byte>.Count);
+                nuint n = (uint)source.Length / (uint)Vector128<byte>.Count;
 
                 for (nuint i = 0; i < n; i += 3)
                 {
@@ -454,7 +454,7 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                nuint n = (uint)(source.Length / Vector128<byte>.Count);
+                nuint n = (uint)source.Length / (uint)Vector128<byte>.Count;
 
                 for (nuint i = 0, j = 0; i < n; i += 3, j += 4)
                 {
@@ -498,7 +498,7 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                nuint n = (uint)(source.Length / Vector128<byte>.Count);
+                nuint n = (uint)source.Length / (uint)Vector128<byte>.Count;
 
                 for (nuint i = 0, j = 0; i < n; i += 4, j += 3)
                 {
@@ -650,7 +650,7 @@ internal static partial class SimdUtils
                 {
                     VerifySpanInput(source, dest, Vector256<byte>.Count);
 
-                    nuint n = (uint)(dest.Length / Vector256<byte>.Count);
+                    nuint n = (uint)dest.Length / (uint)Vector256<byte>.Count;
 
                     ref Vector256<float> destBase =
                         ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(dest));
@@ -683,7 +683,7 @@ internal static partial class SimdUtils
                     // Sse
                     VerifySpanInput(source, dest, Vector128<byte>.Count);
 
-                    nuint n = (uint)(dest.Length / Vector128<byte>.Count);
+                    nuint n = (uint)dest.Length / (uint)Vector128<byte>.Count;
 
                     ref Vector128<float> destBase =
                         ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(dest));
@@ -782,7 +782,7 @@ internal static partial class SimdUtils
             {
                 VerifySpanInput(source, dest, Vector256<byte>.Count);
 
-                nuint n = (uint)(dest.Length / Vector256<byte>.Count);
+                nuint n = (uint)dest.Length / (uint)Vector256<byte>.Count;
 
                 ref Vector256<float> sourceBase =
                     ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -821,7 +821,7 @@ internal static partial class SimdUtils
                 // Sse
                 VerifySpanInput(source, dest, Vector128<byte>.Count);
 
-                nuint n = (uint)(dest.Length / Vector128<byte>.Count);
+                nuint n = (uint)dest.Length / (uint)Vector128<byte>.Count;
 
                 ref Vector128<float> sourceBase =
                     ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(source));
@@ -864,7 +864,7 @@ internal static partial class SimdUtils
             ref Vector256<byte> bBase = ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(blueChannel));
             ref byte dBase = ref Unsafe.As<Rgb24, byte>(ref MemoryMarshal.GetReference(destination));
 
-            nuint count = (uint)(redChannel.Length / Vector256<byte>.Count);
+            nuint count = (uint)redChannel.Length / (uint)Vector256<byte>.Count;
 
             ref byte control1Bytes = ref MemoryMarshal.GetReference(PermuteMaskEvenOdd8x32);
             Vector256<uint> control1 = Unsafe.As<byte, Vector256<uint>>(ref control1Bytes);
@@ -936,7 +936,7 @@ internal static partial class SimdUtils
             ref Vector256<byte> bBase = ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(blueChannel));
             ref Vector256<byte> dBase = ref Unsafe.As<Rgba32, Vector256<byte>>(ref MemoryMarshal.GetReference(destination));
 
-            nuint count = (uint)(redChannel.Length / Vector256<byte>.Count);
+            nuint count = (uint)redChannel.Length / (uint)Vector256<byte>.Count;
             ref byte control1Bytes = ref MemoryMarshal.GetReference(PermuteMaskEvenOdd8x32);
             Vector256<uint> control1 = Unsafe.As<byte, Vector256<uint>>(ref control1Bytes);
             var a = Vector256.Create((byte)255);

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -159,7 +159,7 @@ internal static partial class SimdUtils
                 int remainder = source.Length % (Vector128<byte>.Count * 3);
 
                 int sourceCount = source.Length - remainder;
-                int destCount = sourceCount * 4 / 3;
+                int destCount = (int)((uint)sourceCount * 4 / 3);
 
                 if (sourceCount > 0)
                 {
@@ -192,7 +192,7 @@ internal static partial class SimdUtils
                 int remainder = source.Length % (Vector128<byte>.Count * 4);
 
                 int sourceCount = source.Length - remainder;
-                int destCount = sourceCount * 3 / 4;
+                int destCount = (int)((uint)sourceCount * 3 / 4);
 
                 if (sourceCount > 0)
                 {

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -221,7 +221,7 @@ internal static partial class SimdUtils
                 ref Vector256<float> destBase =
                     ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(dest));
 
-                nint n = (nint)(uint)dest.Length / Vector256<float>.Count;
+                nint n = (nint)(uint)(dest.Length / Vector256<float>.Count);
                 nint m = Numerics.Modulo4(n);
                 nint u = n - m;
 
@@ -391,9 +391,9 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                nint n = (nint)(uint)source.Length / Vector128<byte>.Count;
+                nuint n = (uint)(source.Length / Vector128<byte>.Count);
 
-                for (nint i = 0; i < n; i += 3)
+                for (nuint i = 0; i < n; i += 3)
                 {
                     ref Vector128<byte> vs = ref Unsafe.Add(ref sourceBase, i);
 
@@ -454,9 +454,9 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                nint n = (nint)(uint)source.Length / Vector128<byte>.Count;
+                nuint n = (uint)(source.Length / Vector128<byte>.Count);
 
-                for (nint i = 0, j = 0; i < n; i += 3, j += 4)
+                for (nuint i = 0, j = 0; i < n; i += 3, j += 4)
                 {
                     ref Vector128<byte> v0 = ref Unsafe.Add(ref sourceBase, i);
                     Vector128<byte> v1 = Unsafe.Add(ref v0, 1);
@@ -498,9 +498,9 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                nint n = (nint)(uint)source.Length / Vector128<byte>.Count;
+                nuint n = (uint)(source.Length / Vector128<byte>.Count);
 
-                for (nint i = 0, j = 0; i < n; i += 4, j += 3)
+                for (nuint i = 0, j = 0; i < n; i += 4, j += 3)
                 {
                     ref Vector128<byte> vs = ref Unsafe.Add(ref sourceBase, i);
 
@@ -650,16 +650,16 @@ internal static partial class SimdUtils
                 {
                     VerifySpanInput(source, dest, Vector256<byte>.Count);
 
-                    nint n = (nint)(uint)dest.Length / Vector256<byte>.Count;
+                    nuint n = (uint)(dest.Length / Vector256<byte>.Count);
 
                     ref Vector256<float> destBase =
                         ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(dest));
 
                     var scale = Vector256.Create(1 / (float)byte.MaxValue);
 
-                    for (nint i = 0; i < n; i++)
+                    for (nuint i = 0; i < n; i++)
                     {
-                        nint si = Vector256<byte>.Count * i;
+                        nuint si = (uint)Vector256<byte>.Count * i;
                         Vector256<int> i0 = Avx2.ConvertToVector256Int32(sourceBase + si);
                         Vector256<int> i1 = Avx2.ConvertToVector256Int32(sourceBase + si + Vector256<int>.Count);
                         Vector256<int> i2 = Avx2.ConvertToVector256Int32(sourceBase + si + (Vector256<int>.Count * 2));
@@ -683,7 +683,7 @@ internal static partial class SimdUtils
                     // Sse
                     VerifySpanInput(source, dest, Vector128<byte>.Count);
 
-                    nint n = (nint)(uint)dest.Length / Vector128<byte>.Count;
+                    nuint n = (uint)(dest.Length / Vector128<byte>.Count);
 
                     ref Vector128<float> destBase =
                         ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(dest));
@@ -691,9 +691,9 @@ internal static partial class SimdUtils
                     var scale = Vector128.Create(1 / (float)byte.MaxValue);
                     Vector128<byte> zero = Vector128<byte>.Zero;
 
-                    for (nint i = 0; i < n; i++)
+                    for (nuint i = 0; i < n; i++)
                     {
-                        nint si = Vector128<byte>.Count * i;
+                        nuint si = (uint)Vector128<byte>.Count * i;
 
                         Vector128<int> i0, i1, i2, i3;
                         if (Sse41.IsSupported)
@@ -782,7 +782,7 @@ internal static partial class SimdUtils
             {
                 VerifySpanInput(source, dest, Vector256<byte>.Count);
 
-                nint n = (nint)(uint)dest.Length / Vector256<byte>.Count;
+                nuint n = (uint)(dest.Length / Vector256<byte>.Count);
 
                 ref Vector256<float> sourceBase =
                     ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -794,7 +794,7 @@ internal static partial class SimdUtils
                 ref byte maskBase = ref MemoryMarshal.GetReference(PermuteMaskDeinterleave8x32);
                 Vector256<int> mask = Unsafe.As<byte, Vector256<int>>(ref maskBase);
 
-                for (nint i = 0; i < n; i++)
+                for (nuint i = 0; i < n; i++)
                 {
                     ref Vector256<float> s = ref Unsafe.Add(ref sourceBase, i * 4);
 
@@ -821,7 +821,7 @@ internal static partial class SimdUtils
                 // Sse
                 VerifySpanInput(source, dest, Vector128<byte>.Count);
 
-                nint n = (nint)(uint)dest.Length / Vector128<byte>.Count;
+                nuint n = (uint)(dest.Length / Vector128<byte>.Count);
 
                 ref Vector128<float> sourceBase =
                     ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(source));
@@ -831,7 +831,7 @@ internal static partial class SimdUtils
 
                 var scale = Vector128.Create((float)byte.MaxValue);
 
-                for (nint i = 0; i < n; i++)
+                for (nuint i = 0; i < n; i++)
                 {
                     ref Vector128<float> s = ref Unsafe.Add(ref sourceBase, i * 4);
 
@@ -864,7 +864,7 @@ internal static partial class SimdUtils
             ref Vector256<byte> bBase = ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(blueChannel));
             ref byte dBase = ref Unsafe.As<Rgb24, byte>(ref MemoryMarshal.GetReference(destination));
 
-            nint count = (nint)(uint)redChannel.Length / Vector256<byte>.Count;
+            nuint count = (uint)(redChannel.Length / Vector256<byte>.Count);
 
             ref byte control1Bytes = ref MemoryMarshal.GetReference(PermuteMaskEvenOdd8x32);
             Vector256<uint> control1 = Unsafe.As<byte, Vector256<uint>>(ref control1Bytes);
@@ -875,7 +875,7 @@ internal static partial class SimdUtils
 
             Vector256<byte> shuffleAlpha = Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(ShuffleMaskShiftAlpha));
 
-            for (nint i = 0; i < count; i++)
+            for (nuint i = 0; i < count; i++)
             {
                 Vector256<byte> r0 = Unsafe.Add(ref rBase, i);
                 Vector256<byte> g0 = Unsafe.Add(ref gBase, i);
@@ -936,12 +936,12 @@ internal static partial class SimdUtils
             ref Vector256<byte> bBase = ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(blueChannel));
             ref Vector256<byte> dBase = ref Unsafe.As<Rgba32, Vector256<byte>>(ref MemoryMarshal.GetReference(destination));
 
-            nint count = (nint)(uint)redChannel.Length / Vector256<byte>.Count;
+            nuint count = (uint)(redChannel.Length / Vector256<byte>.Count);
             ref byte control1Bytes = ref MemoryMarshal.GetReference(PermuteMaskEvenOdd8x32);
             Vector256<uint> control1 = Unsafe.As<byte, Vector256<uint>>(ref control1Bytes);
             var a = Vector256.Create((byte)255);
 
-            for (nint i = 0; i < count; i++)
+            for (nuint i = 0; i < count; i++)
             {
                 Vector256<byte> r0 = Unsafe.Add(ref rBase, i);
                 Vector256<byte> g0 = Unsafe.Add(ref gBase, i);
@@ -994,8 +994,8 @@ internal static partial class SimdUtils
             Vector256<float> r, g, b;
 
             const int bytesPerRgbStride = 24;
-            int count = (int)((uint)source.Length / 8);
-            for (nint i = 0; i < (uint)count; i++)
+            nuint count = (uint)source.Length / 8;
+            for (nuint i = 0; i < count; i++)
             {
                 rgb = Avx2.PermuteVar8x32(Unsafe.AddByteOffset(ref rgbByteSpan, (uint)(bytesPerRgbStride * i)).AsUInt32(), extractToLanesMask).AsByte();
 
@@ -1013,7 +1013,7 @@ internal static partial class SimdUtils
                 Unsafe.Add(ref destBRef, i) = b;
             }
 
-            int sliceCount = count * 8;
+            int sliceCount = (int)(count * 8);
             redChannel = redChannel.Slice(sliceCount);
             greenChannel = greenChannel.Slice(sliceCount);
             blueChannel = blueChannel.Slice(sliceCount);

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -995,9 +995,9 @@ internal static partial class SimdUtils
 
             const int bytesPerRgbStride = 24;
             int count = (int)((uint)source.Length / 8);
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
-                rgb = Avx2.PermuteVar8x32(Unsafe.AddByteOffset(ref rgbByteSpan, (IntPtr)(bytesPerRgbStride * i)).AsUInt32(), extractToLanesMask).AsByte();
+                rgb = Avx2.PermuteVar8x32(Unsafe.AddByteOffset(ref rgbByteSpan, (uint)(bytesPerRgbStride * i)).AsUInt32(), extractToLanesMask).AsByte();
 
                 rgb = Avx2.Shuffle(rgb, extractRgbMask);
 

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -221,11 +221,11 @@ internal static partial class SimdUtils
                 ref Vector256<float> destBase =
                     ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(dest));
 
-                int n = dest.Length / Vector256<float>.Count;
-                int m = Numerics.Modulo4(n);
-                int u = n - m;
+                nint n = (nint)(uint)dest.Length / Vector256<float>.Count;
+                nint m = Numerics.Modulo4(n);
+                nint u = n - m;
 
-                for (int i = 0; i < u; i += 4)
+                for (nint i = 0; i < u; i += 4)
                 {
                     ref Vector256<float> vd0 = ref Unsafe.Add(ref destBase, i);
                     ref Vector256<float> vs0 = ref Unsafe.Add(ref sourceBase, i);
@@ -238,7 +238,7 @@ internal static partial class SimdUtils
 
                 if (m > 0)
                 {
-                    for (int i = u; i < n; i++)
+                    for (nint i = u; i < n; i++)
                     {
                         Unsafe.Add(ref destBase, i) = Avx.Permute(Unsafe.Add(ref sourceBase, i), control);
                     }
@@ -253,11 +253,11 @@ internal static partial class SimdUtils
                 ref Vector128<float> destBase =
                     ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(dest));
 
-                int n = dest.Length / Vector128<float>.Count;
-                int m = Numerics.Modulo4(n);
-                int u = n - m;
+                nint n = (nint)(uint)dest.Length / Vector128<float>.Count;
+                nint m = Numerics.Modulo4(n);
+                nint u = n - m;
 
-                for (int i = 0; i < u; i += 4)
+                for (nint i = 0; i < u; i += 4)
                 {
                     ref Vector128<float> vd0 = ref Unsafe.Add(ref destBase, i);
                     ref Vector128<float> vs0 = ref Unsafe.Add(ref sourceBase, i);
@@ -276,7 +276,7 @@ internal static partial class SimdUtils
 
                 if (m > 0)
                 {
-                    for (int i = u; i < n; i++)
+                    for (nint i = u; i < n; i++)
                     {
                         Vector128<float> vs = Unsafe.Add(ref sourceBase, i);
                         Unsafe.Add(ref destBase, i) = Sse.Shuffle(vs, vs, control);
@@ -306,11 +306,11 @@ internal static partial class SimdUtils
                 ref Vector256<byte> destBase =
                     ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                int n = dest.Length / Vector256<byte>.Count;
-                int m = Numerics.Modulo4(n);
-                int u = n - m;
+                nint n = (nint)(uint)dest.Length / Vector256<byte>.Count;
+                nint m = Numerics.Modulo4(n);
+                nint u = n - m;
 
-                for (int i = 0; i < u; i += 4)
+                for (nint i = 0; i < u; i += 4)
                 {
                     ref Vector256<byte> vs0 = ref Unsafe.Add(ref sourceBase, i);
                     ref Vector256<byte> vd0 = ref Unsafe.Add(ref destBase, i);
@@ -323,7 +323,7 @@ internal static partial class SimdUtils
 
                 if (m > 0)
                 {
-                    for (int i = u; i < n; i++)
+                    for (nint i = u; i < n; i++)
                     {
                         Unsafe.Add(ref destBase, i) = Avx2.Shuffle(Unsafe.Add(ref sourceBase, i), vshuffle);
                     }
@@ -342,11 +342,11 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                int n = dest.Length / Vector128<byte>.Count;
-                int m = Numerics.Modulo4(n);
-                int u = n - m;
+                nint n = (nint)(uint)dest.Length / Vector128<byte>.Count;
+                nint m = Numerics.Modulo4(n);
+                nint u = n - m;
 
-                for (int i = 0; i < u; i += 4)
+                for (nint i = 0; i < u; i += 4)
                 {
                     ref Vector128<byte> vs0 = ref Unsafe.Add(ref sourceBase, i);
                     ref Vector128<byte> vd0 = ref Unsafe.Add(ref destBase, i);
@@ -359,7 +359,7 @@ internal static partial class SimdUtils
 
                 if (m > 0)
                 {
-                    for (int i = u; i < n; i++)
+                    for (nint i = u; i < n; i++)
                     {
                         Unsafe.Add(ref destBase, i) = Ssse3.Shuffle(Unsafe.Add(ref sourceBase, i), vshuffle);
                     }
@@ -391,9 +391,9 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                int n = source.Length / Vector128<byte>.Count;
+                nint n = (nint)(uint)source.Length / Vector128<byte>.Count;
 
-                for (int i = 0; i < n; i += 3)
+                for (nint i = 0; i < n; i += 3)
                 {
                     ref Vector128<byte> vs = ref Unsafe.Add(ref sourceBase, i);
 
@@ -454,9 +454,9 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                int n = source.Length / Vector128<byte>.Count;
+                nint n = (nint)(uint)source.Length / Vector128<byte>.Count;
 
-                for (int i = 0, j = 0; i < n; i += 3, j += 4)
+                for (nint i = 0, j = 0; i < n; i += 3, j += 4)
                 {
                     ref Vector128<byte> v0 = ref Unsafe.Add(ref sourceBase, i);
                     Vector128<byte> v1 = Unsafe.Add(ref v0, 1);
@@ -498,9 +498,9 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                int n = source.Length / Vector128<byte>.Count;
+                nint n = (nint)(uint)source.Length / Vector128<byte>.Count;
 
-                for (int i = 0, j = 0; i < n; i += 4, j += 3)
+                for (nint i = 0, j = 0; i < n; i += 4, j += 3)
                 {
                     ref Vector128<byte> vs = ref Unsafe.Add(ref sourceBase, i);
 
@@ -650,16 +650,16 @@ internal static partial class SimdUtils
                 {
                     VerifySpanInput(source, dest, Vector256<byte>.Count);
 
-                    int n = dest.Length / Vector256<byte>.Count;
+                    nint n = (nint)(uint)dest.Length / Vector256<byte>.Count;
 
                     ref Vector256<float> destBase =
                         ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(dest));
 
                     var scale = Vector256.Create(1 / (float)byte.MaxValue);
 
-                    for (int i = 0; i < n; i++)
+                    for (nint i = 0; i < n; i++)
                     {
-                        int si = Vector256<byte>.Count * i;
+                        nint si = Vector256<byte>.Count * i;
                         Vector256<int> i0 = Avx2.ConvertToVector256Int32(sourceBase + si);
                         Vector256<int> i1 = Avx2.ConvertToVector256Int32(sourceBase + si + Vector256<int>.Count);
                         Vector256<int> i2 = Avx2.ConvertToVector256Int32(sourceBase + si + (Vector256<int>.Count * 2));
@@ -683,7 +683,7 @@ internal static partial class SimdUtils
                     // Sse
                     VerifySpanInput(source, dest, Vector128<byte>.Count);
 
-                    int n = dest.Length / Vector128<byte>.Count;
+                    nint n = (nint)(uint)dest.Length / Vector128<byte>.Count;
 
                     ref Vector128<float> destBase =
                         ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(dest));
@@ -691,9 +691,9 @@ internal static partial class SimdUtils
                     var scale = Vector128.Create(1 / (float)byte.MaxValue);
                     Vector128<byte> zero = Vector128<byte>.Zero;
 
-                    for (int i = 0; i < n; i++)
+                    for (nint i = 0; i < n; i++)
                     {
-                        int si = Vector128<byte>.Count * i;
+                        nint si = Vector128<byte>.Count * i;
 
                         Vector128<int> i0, i1, i2, i3;
                         if (Sse41.IsSupported)
@@ -782,7 +782,7 @@ internal static partial class SimdUtils
             {
                 VerifySpanInput(source, dest, Vector256<byte>.Count);
 
-                int n = dest.Length / Vector256<byte>.Count;
+                nint n = (nint)(uint)dest.Length / Vector256<byte>.Count;
 
                 ref Vector256<float> sourceBase =
                     ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -794,7 +794,7 @@ internal static partial class SimdUtils
                 ref byte maskBase = ref MemoryMarshal.GetReference(PermuteMaskDeinterleave8x32);
                 Vector256<int> mask = Unsafe.As<byte, Vector256<int>>(ref maskBase);
 
-                for (int i = 0; i < n; i++)
+                for (nint i = 0; i < n; i++)
                 {
                     ref Vector256<float> s = ref Unsafe.Add(ref sourceBase, i * 4);
 
@@ -821,7 +821,7 @@ internal static partial class SimdUtils
                 // Sse
                 VerifySpanInput(source, dest, Vector128<byte>.Count);
 
-                int n = dest.Length / Vector128<byte>.Count;
+                nint n = (nint)(uint)dest.Length / Vector128<byte>.Count;
 
                 ref Vector128<float> sourceBase =
                     ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(source));
@@ -831,7 +831,7 @@ internal static partial class SimdUtils
 
                 var scale = Vector128.Create((float)byte.MaxValue);
 
-                for (int i = 0; i < n; i++)
+                for (nint i = 0; i < n; i++)
                 {
                     ref Vector128<float> s = ref Unsafe.Add(ref sourceBase, i * 4);
 
@@ -864,7 +864,7 @@ internal static partial class SimdUtils
             ref Vector256<byte> bBase = ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(blueChannel));
             ref byte dBase = ref Unsafe.As<Rgb24, byte>(ref MemoryMarshal.GetReference(destination));
 
-            int count = redChannel.Length / Vector256<byte>.Count;
+            nint count = (nint)(uint)redChannel.Length / Vector256<byte>.Count;
 
             ref byte control1Bytes = ref MemoryMarshal.GetReference(PermuteMaskEvenOdd8x32);
             Vector256<uint> control1 = Unsafe.As<byte, Vector256<uint>>(ref control1Bytes);
@@ -875,7 +875,7 @@ internal static partial class SimdUtils
 
             Vector256<byte> shuffleAlpha = Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(ShuffleMaskShiftAlpha));
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < count; i++)
             {
                 Vector256<byte> r0 = Unsafe.Add(ref rBase, i);
                 Vector256<byte> g0 = Unsafe.Add(ref gBase, i);
@@ -918,7 +918,7 @@ internal static partial class SimdUtils
                 Unsafe.As<byte, Vector256<byte>>(ref d4) = rgb4;
             }
 
-            int slice = count * Vector256<byte>.Count;
+            int slice = (int)count * Vector256<byte>.Count;
             redChannel = redChannel[slice..];
             greenChannel = greenChannel[slice..];
             blueChannel = blueChannel[slice..];
@@ -936,12 +936,12 @@ internal static partial class SimdUtils
             ref Vector256<byte> bBase = ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(blueChannel));
             ref Vector256<byte> dBase = ref Unsafe.As<Rgba32, Vector256<byte>>(ref MemoryMarshal.GetReference(destination));
 
-            int count = redChannel.Length / Vector256<byte>.Count;
+            nint count = (nint)(uint)redChannel.Length / Vector256<byte>.Count;
             ref byte control1Bytes = ref MemoryMarshal.GetReference(PermuteMaskEvenOdd8x32);
             Vector256<uint> control1 = Unsafe.As<byte, Vector256<uint>>(ref control1Bytes);
             var a = Vector256.Create((byte)255);
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < count; i++)
             {
                 Vector256<byte> r0 = Unsafe.Add(ref rBase, i);
                 Vector256<byte> g0 = Unsafe.Add(ref gBase, i);
@@ -970,7 +970,7 @@ internal static partial class SimdUtils
                 Unsafe.Add(ref d0, 3) = rgb4;
             }
 
-            int slice = count * Vector256<byte>.Count;
+            int slice = (int)count * Vector256<byte>.Count;
             redChannel = redChannel[slice..];
             greenChannel = greenChannel[slice..];
             blueChannel = blueChannel[slice..];

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Pack.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Pack.cs
@@ -86,8 +86,8 @@ internal static partial class SimdUtils
         ref ByteTuple4 b = ref Unsafe.As<byte, ByteTuple4>(ref MemoryMarshal.GetReference(blueChannel));
         ref Rgb24 rgb = ref MemoryMarshal.GetReference(destination);
 
-        int count = redChannel.Length / 4;
-        for (int i = 0; i < count; i++)
+        uint count = (uint)redChannel.Length / 4;
+        for (nint i = 0; i < count; i++)
         {
             ref Rgb24 d0 = ref Unsafe.Add(ref rgb, i * 4);
             ref Rgb24 d1 = ref Unsafe.Add(ref d0, 1);
@@ -115,7 +115,7 @@ internal static partial class SimdUtils
             d3.B = bb.V3;
         }
 
-        int finished = count * 4;
+        int finished = (int)(count * 4);
         redChannel = redChannel[finished..];
         greenChannel = greenChannel[finished..];
         blueChannel = blueChannel[finished..];
@@ -133,9 +133,9 @@ internal static partial class SimdUtils
         ref ByteTuple4 b = ref Unsafe.As<byte, ByteTuple4>(ref MemoryMarshal.GetReference(blueChannel));
         ref Rgba32 rgb = ref MemoryMarshal.GetReference(destination);
 
-        int count = redChannel.Length / 4;
+        uint count = (uint)redChannel.Length / 4;
         destination.Fill(new Rgba32(0, 0, 0, 255));
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < count; i++)
         {
             ref Rgba32 d0 = ref Unsafe.Add(ref rgb, i * 4);
             ref Rgba32 d1 = ref Unsafe.Add(ref d0, 1);
@@ -163,7 +163,7 @@ internal static partial class SimdUtils
             d3.B = bb.V3;
         }
 
-        int finished = count * 4;
+        int finished = (int)(count * 4);
         redChannel = redChannel[finished..];
         greenChannel = greenChannel[finished..];
         blueChannel = blueChannel[finished..];
@@ -181,7 +181,7 @@ internal static partial class SimdUtils
         ref byte b = ref MemoryMarshal.GetReference(blueChannel);
         ref Rgb24 rgb = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < destination.Length; i++)
+        for (nint i = 0; i < (uint)destination.Length; i++)
         {
             ref Rgb24 d = ref Unsafe.Add(ref rgb, i);
             d.R = Unsafe.Add(ref r, i);
@@ -201,7 +201,7 @@ internal static partial class SimdUtils
         ref byte b = ref MemoryMarshal.GetReference(blueChannel);
         ref Rgba32 rgba = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < destination.Length; i++)
+        for (nint i = 0; i < (uint)destination.Length; i++)
         {
             ref Rgba32 d = ref Unsafe.Add(ref rgba, i);
             d.R = Unsafe.Add(ref r, i);
@@ -226,7 +226,7 @@ internal static partial class SimdUtils
         ref float b = ref MemoryMarshal.GetReference(blueChannel);
         ref Rgb24 rgb = ref MemoryMarshal.GetReference(source);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgb24 src = ref Unsafe.Add(ref rgb, i);
             Unsafe.Add(ref r, i) = src.R;

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Pack.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Pack.cs
@@ -86,8 +86,8 @@ internal static partial class SimdUtils
         ref ByteTuple4 b = ref Unsafe.As<byte, ByteTuple4>(ref MemoryMarshal.GetReference(blueChannel));
         ref Rgb24 rgb = ref MemoryMarshal.GetReference(destination);
 
-        uint count = (uint)redChannel.Length / 4;
-        for (nint i = 0; i < count; i++)
+        nuint count = (uint)redChannel.Length / 4;
+        for (nuint i = 0; i < count; i++)
         {
             ref Rgb24 d0 = ref Unsafe.Add(ref rgb, i * 4);
             ref Rgb24 d1 = ref Unsafe.Add(ref d0, 1);
@@ -133,9 +133,9 @@ internal static partial class SimdUtils
         ref ByteTuple4 b = ref Unsafe.As<byte, ByteTuple4>(ref MemoryMarshal.GetReference(blueChannel));
         ref Rgba32 rgb = ref MemoryMarshal.GetReference(destination);
 
-        uint count = (uint)redChannel.Length / 4;
+        nuint count = (uint)redChannel.Length / 4;
         destination.Fill(new Rgba32(0, 0, 0, 255));
-        for (nint i = 0; i < count; i++)
+        for (nuint i = 0; i < count; i++)
         {
             ref Rgba32 d0 = ref Unsafe.Add(ref rgb, i * 4);
             ref Rgba32 d1 = ref Unsafe.Add(ref d0, 1);
@@ -181,7 +181,7 @@ internal static partial class SimdUtils
         ref byte b = ref MemoryMarshal.GetReference(blueChannel);
         ref Rgb24 rgb = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)destination.Length; i++)
+        for (nuint i = 0; i < (uint)destination.Length; i++)
         {
             ref Rgb24 d = ref Unsafe.Add(ref rgb, i);
             d.R = Unsafe.Add(ref r, i);
@@ -201,7 +201,7 @@ internal static partial class SimdUtils
         ref byte b = ref MemoryMarshal.GetReference(blueChannel);
         ref Rgba32 rgba = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)destination.Length; i++)
+        for (nuint i = 0; i < (uint)destination.Length; i++)
         {
             ref Rgba32 d = ref Unsafe.Add(ref rgba, i);
             d.R = Unsafe.Add(ref r, i);
@@ -226,7 +226,7 @@ internal static partial class SimdUtils
         ref float b = ref MemoryMarshal.GetReference(blueChannel);
         ref Rgb24 rgb = ref MemoryMarshal.GetReference(source);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgb24 src = ref Unsafe.Add(ref rgb, i);
             Unsafe.Add(ref r, i) = src.R;

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
@@ -147,12 +147,12 @@ internal static partial class SimdUtils
         ref float dBase = ref MemoryMarshal.GetReference(dest);
         Shuffle.InverseMMShuffle(control, out int p3, out int p2, out int p1, out int p0);
 
-        for (int i = 0; i < source.Length; i += 4)
+        for (nint i = 0; i < (uint)source.Length; i += 4)
         {
-            Unsafe.Add(ref dBase, i) = Unsafe.Add(ref sBase, p0 + i);
-            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
-            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
-            Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, p3 + i);
+            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, (nint)(uint)p0 + i);
+            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, (nint)(uint)p1 + i);
+            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, (nint)(uint)p2 + i);
+            Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, (nint)(uint)p3 + i);
         }
     }
 
@@ -501,10 +501,10 @@ internal static partial class SimdUtils
 
             for (int i = 0; i < span.Length; i += 4)
             {
-                Unsafe.Add(ref spanBase, i) = (byte)(p0 + i);
-                Unsafe.Add(ref spanBase, i + 1) = (byte)(p1 + i);
-                Unsafe.Add(ref spanBase, i + 2) = (byte)(p2 + i);
-                Unsafe.Add(ref spanBase, i + 3) = (byte)(p3 + i);
+                Unsafe.Add(ref spanBase, (uint)(i + 0)) = (byte)(p0 + i);
+                Unsafe.Add(ref spanBase, (uint)(i + 1)) = (byte)(p1 + i);
+                Unsafe.Add(ref spanBase, (uint)(i + 2)) = (byte)(p2 + i);
+                Unsafe.Add(ref spanBase, (uint)(i + 3)) = (byte)(p3 + i);
             }
         }
 

--- a/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.Shuffle.cs
@@ -145,14 +145,14 @@ internal static partial class SimdUtils
     {
         ref float sBase = ref MemoryMarshal.GetReference(source);
         ref float dBase = ref MemoryMarshal.GetReference(dest);
-        Shuffle.InverseMMShuffle(control, out int p3, out int p2, out int p1, out int p0);
+        Shuffle.InverseMMShuffle(control, out uint p3, out uint p2, out uint p1, out uint p0);
 
-        for (nint i = 0; i < (uint)source.Length; i += 4)
+        for (nuint i = 0; i < (uint)source.Length; i += 4)
         {
-            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, (nint)(uint)p0 + i);
-            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, (nint)(uint)p1 + i);
-            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, (nint)(uint)p2 + i);
-            Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, (nint)(uint)p3 + i);
+            Unsafe.Add(ref dBase, i + 0) = Unsafe.Add(ref sBase, p0 + i);
+            Unsafe.Add(ref dBase, i + 1) = Unsafe.Add(ref sBase, p1 + i);
+            Unsafe.Add(ref dBase, i + 2) = Unsafe.Add(ref sBase, p2 + i);
+            Unsafe.Add(ref dBase, i + 3) = Unsafe.Add(ref sBase, p3 + i);
         }
     }
 
@@ -492,34 +492,34 @@ internal static partial class SimdUtils
         {
             InverseMMShuffle(
                  control,
-                 out int p3,
-                 out int p2,
-                 out int p1,
-                 out int p0);
+                 out uint p3,
+                 out uint p2,
+                 out uint p1,
+                 out uint p0);
 
             ref byte spanBase = ref MemoryMarshal.GetReference(span);
 
-            for (int i = 0; i < span.Length; i += 4)
+            for (nuint i = 0; i < (uint)span.Length; i += 4)
             {
-                Unsafe.Add(ref spanBase, (uint)(i + 0)) = (byte)(p0 + i);
-                Unsafe.Add(ref spanBase, (uint)(i + 1)) = (byte)(p1 + i);
-                Unsafe.Add(ref spanBase, (uint)(i + 2)) = (byte)(p2 + i);
-                Unsafe.Add(ref spanBase, (uint)(i + 3)) = (byte)(p3 + i);
+                Unsafe.Add(ref spanBase, i + 0) = (byte)(p0 + i);
+                Unsafe.Add(ref spanBase, i + 1) = (byte)(p1 + i);
+                Unsafe.Add(ref spanBase, i + 2) = (byte)(p2 + i);
+                Unsafe.Add(ref spanBase, i + 3) = (byte)(p3 + i);
             }
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]
         public static void InverseMMShuffle(
             byte control,
-            out int p3,
-            out int p2,
-            out int p1,
-            out int p0)
+            out uint p3,
+            out uint p2,
+            out uint p1,
+            out uint p0)
         {
-            p3 = (control >> 6) & 0x3;
-            p2 = (control >> 4) & 0x3;
-            p1 = (control >> 2) & 0x3;
-            p0 = (control >> 0) & 0x3;
+            p3 = (uint)((control >> 6) & 0x3);
+            p2 = (uint)((control >> 4) & 0x3);
+            p1 = (uint)((control >> 2) & 0x3);
+            p0 = (uint)((control >> 0) & 0x3);
         }
     }
 }

--- a/src/ImageSharp/Compression/Zlib/Crc32.cs
+++ b/src/ImageSharp/Compression/Zlib/Crc32.cs
@@ -300,7 +300,7 @@ internal static partial class Crc32
 
         for (int i = 0; i < buffer.Length; i++)
         {
-            crc = Unsafe.Add(ref crcTableRef, (int)((crc ^ Unsafe.Add(ref bufferRef, i)) & 0xFF)) ^ (crc >> 8);
+            crc = Unsafe.Add(ref crcTableRef, (crc ^ Unsafe.Add(ref bufferRef, i)) & 0xFF) ^ (crc >> 8);
         }
 
         return crc;

--- a/src/ImageSharp/Compression/Zlib/DeflaterEngine.cs
+++ b/src/ImageSharp/Compression/Zlib/DeflaterEngine.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.Memory;
 
 namespace SixLabors.ImageSharp.Compression.Zlib;
@@ -426,8 +427,8 @@ internal sealed unsafe class DeflaterEngine : IDisposable
     private void SlideWindow()
     {
         Unsafe.CopyBlockUnaligned(
-            ref this.window.Span[0],
-            ref this.window.Span[DeflaterConstants.WSIZE],
+            ref MemoryMarshal.GetReference(this.window.Span),
+            ref Unsafe.Add(ref MemoryMarshal.GetReference(this.window.Span), DeflaterConstants.WSIZE),
             DeflaterConstants.WSIZE);
 
         this.matchStart -= DeflaterConstants.WSIZE;

--- a/src/ImageSharp/Compression/Zlib/DeflaterHuffman.cs
+++ b/src/ImageSharp/Compression/Zlib/DeflaterHuffman.cs
@@ -206,8 +206,8 @@ internal sealed unsafe class DeflaterHuffman : IDisposable
                 int lc = Lcode(litlen);
                 this.literalTree.WriteSymbol(pendingBuffer, lc);
 
-                int bits = (lc - 261) / 4;
-                if (bits > 0 && bits <= 5)
+                int bits = (int)(((uint)lc - 261) / 4);
+                if (bits is > 0 and <= 5)
                 {
                     this.Pending.WriteBits(litlen & ((1 << bits) - 1), bits);
                 }
@@ -364,7 +364,7 @@ internal sealed unsafe class DeflaterHuffman : IDisposable
         this.literalTree.Frequencies[lc]++;
         if (lc >= 265 && lc < 285)
         {
-            this.extraBits += (lc - 261) / 4;
+            this.extraBits += (int)(((uint)lc - 261) / 4);
         }
 
         int dc = Dcode(distance - 1);

--- a/src/ImageSharp/Compression/Zlib/DeflaterHuffman.cs
+++ b/src/ImageSharp/Compression/Zlib/DeflaterHuffman.cs
@@ -286,13 +286,13 @@ internal sealed unsafe class DeflaterHuffman : IDisposable
 
         int static_len = this.extraBits;
         ref byte staticLLengthRef = ref MemoryMarshal.GetReference(StaticLLength);
-        for (nint i = 0; i < LiteralNumber; i++)
+        for (nuint i = 0; i < LiteralNumber; i++)
         {
             static_len += this.literalTree.Frequencies[i] * Unsafe.Add(ref staticLLengthRef, i);
         }
 
         ref byte staticDLengthRef = ref MemoryMarshal.GetReference(StaticDLength);
-        for (nint i = 0; i < DistanceNumber; i++)
+        for (nuint i = 0; i < DistanceNumber; i++)
         {
             static_len += this.distTree.Frequencies[i] * Unsafe.Add(ref staticDLengthRef, i);
         }
@@ -625,10 +625,10 @@ internal sealed unsafe class DeflaterHuffman : IDisposable
                     ref int valuesRef = ref MemoryMarshal.GetReference(valuesMemoryOwner.Memory.Span);
                     int numNodes = numLeafs;
 
-                    for (nint i = 0; i < (uint)heapLen; i++)
+                    for (nuint i = 0; i < (uint)heapLen; i++)
                     {
                         int node = Unsafe.Add(ref heapRef, i);
-                        nint i2 = 2 * i;
+                        nuint i2 = 2 * i;
                         Unsafe.Add(ref childrenRef, i2) = node;
                         Unsafe.Add(ref childrenRef, i2 + 1) = -1;
                         Unsafe.Add(ref valuesRef, i) = this.Frequencies[node] << 8;

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -489,7 +489,7 @@ internal sealed class BmpDecoderCore : IImageDecoderInternals
                         // If the second byte > 2, we are in 'absolute mode'.
                         // The second byte contains the number of color indexes that follow.
                         int max = cmd[1];
-                        int bytesToRead = (max + 1) / 2;
+                        int bytesToRead = (int)(((uint)max + 1) / 2);
 
                         byte[] run = new byte[bytesToRead];
 

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -1361,7 +1361,7 @@ internal sealed class BmpDecoderCore : IImageDecoderInternals
             this.metadata.VerticalResolution = Math.Round(UnitConverter.InchToMeter(ImageMetadata.DefaultVerticalResolution));
         }
 
-        short bitsPerPixel = this.infoHeader.BitsPerPixel;
+        ushort bitsPerPixel = this.infoHeader.BitsPerPixel;
         this.bmpMetadata = this.metadata.GetBmpMetadata();
         this.bmpMetadata.InfoHeaderType = infoHeaderType;
         this.bmpMetadata.BitsPerPixel = (BmpBitsPerPixel)bitsPerPixel;

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -124,7 +124,7 @@ internal sealed class BmpEncoderCore : IImageEncoderInternals
         this.bitsPerPixel ??= bmpMetadata.BitsPerPixel;
 
         short bpp = (short)this.bitsPerPixel;
-        int bytesPerLine = 4 * (((image.Width * bpp) + 31) / 32);
+        int bytesPerLine = (int)(4 * ((((uint)image.Width * (ushort)bpp) + 31) / 32));
         this.padding = bytesPerLine - (int)(image.Width * (bpp / 8F));
 
         int colorPaletteSize = this.bitsPerPixel switch

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -123,8 +123,8 @@ internal sealed class BmpEncoderCore : IImageEncoderInternals
         BmpMetadata bmpMetadata = metadata.GetBmpMetadata();
         this.bitsPerPixel ??= bmpMetadata.BitsPerPixel;
 
-        short bpp = (short)this.bitsPerPixel;
-        int bytesPerLine = (int)(4 * ((((uint)image.Width * (ushort)bpp) + 31) / 32));
+        ushort bpp = (ushort)this.bitsPerPixel;
+        int bytesPerLine = (int)(4 * ((((uint)image.Width * bpp) + 31) / 32));
         this.padding = bytesPerLine - (int)(image.Width * (bpp / 8F));
 
         int colorPaletteSize = this.bitsPerPixel switch
@@ -176,7 +176,7 @@ internal sealed class BmpEncoderCore : IImageEncoderInternals
     /// <param name="metadata">The metadata.</param>
     /// <param name="iccProfileData">The icc profile data.</param>
     /// <returns>The bitmap information header.</returns>
-    private BmpInfoHeader CreateBmpInfoHeader(int width, int height, int infoHeaderSize, short bpp, int bytesPerLine, ImageMetadata metadata, byte[]? iccProfileData)
+    private BmpInfoHeader CreateBmpInfoHeader(int width, int height, int infoHeaderSize, ushort bpp, int bytesPerLine, ImageMetadata metadata, byte[]? iccProfileData)
     {
         int hResolution = 0;
         int vResolution = 0;
@@ -212,7 +212,7 @@ internal sealed class BmpEncoderCore : IImageEncoderInternals
             width: width,
             height: height,
             planes: 1,
-            bitsPerPixel: bpp,
+            bitsPerPixel: (short)bpp,
             imageSize: height * bytesPerLine,
             xPelsPerMeter: hResolution,
             yPelsPerMeter: vResolution,

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -212,7 +212,7 @@ internal sealed class BmpEncoderCore : IImageEncoderInternals
             width: width,
             height: height,
             planes: 1,
-            bitsPerPixel: (short)bpp,
+            bitsPerPixel: bpp,
             imageSize: height * bytesPerLine,
             xPelsPerMeter: hResolution,
             yPelsPerMeter: vResolution,

--- a/src/ImageSharp/Formats/Bmp/BmpInfoHeader.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpInfoHeader.cs
@@ -70,7 +70,7 @@ internal struct BmpInfoHeader
         int width,
         int height,
         short planes,
-        short bitsPerPixel,
+        ushort bitsPerPixel,
         BmpCompression compression = default,
         int imageSize = 0,
         int xPelsPerMeter = 0,
@@ -157,7 +157,7 @@ internal struct BmpInfoHeader
     /// Gets or sets the number of bits per pixel, which is the color depth of the image.
     /// Typical values are 1, 4, 8, 16, 24 and 32.
     /// </summary>
-    public short BitsPerPixel { get; set; }
+    public ushort BitsPerPixel { get; set; }
 
     /// <summary>
     /// Gets or sets the compression method being used.
@@ -311,7 +311,7 @@ internal struct BmpInfoHeader
             width: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(4, 2)),
             height: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(6, 2)),
             planes: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(8, 2)),
-            bitsPerPixel: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(10, 2)));
+            bitsPerPixel: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(10, 2)));
 
     /// <summary>
     /// Parses a short variant of the OS22XBITMAPHEADER. It is identical to the BITMAPCOREHEADER, except that the width and height
@@ -325,7 +325,7 @@ internal struct BmpInfoHeader
             width: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(4, 4)),
             height: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(8, 4)),
             planes: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(12, 2)),
-            bitsPerPixel: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(14, 2)));
+            bitsPerPixel: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(14, 2)));
 
     /// <summary>
     /// Parses the full BMP Version 3 BITMAPINFOHEADER header (40 bytes).
@@ -338,7 +338,7 @@ internal struct BmpInfoHeader
             width: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(4, 4)),
             height: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(8, 4)),
             planes: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(12, 2)),
-            bitsPerPixel: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(14, 2)),
+            bitsPerPixel: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(14, 2)),
             compression: (BmpCompression)BinaryPrimitives.ReadInt32LittleEndian(data.Slice(16, 4)),
             imageSize: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(20, 4)),
             xPelsPerMeter: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(24, 4)),
@@ -359,7 +359,7 @@ internal struct BmpInfoHeader
             width: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(4, 4)),
             height: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(8, 4)),
             planes: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(12, 2)),
-            bitsPerPixel: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(14, 2)),
+            bitsPerPixel: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(14, 2)),
             compression: (BmpCompression)BinaryPrimitives.ReadInt32LittleEndian(data.Slice(16, 4)),
             imageSize: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(20, 4)),
             xPelsPerMeter: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(24, 4)),
@@ -386,7 +386,7 @@ internal struct BmpInfoHeader
             width: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(4, 4)),
             height: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(8, 4)),
             planes: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(12, 2)),
-            bitsPerPixel: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(14, 2)));
+            bitsPerPixel: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(14, 2)));
 
         // The compression value in OS/2 bitmap has a different meaning than in windows bitmaps.
         // Map the OS/2 value to the windows values.
@@ -431,7 +431,7 @@ internal struct BmpInfoHeader
         width: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(4, 4)),
         height: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(8, 4)),
         planes: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(12, 2)),
-        bitsPerPixel: BinaryPrimitives.ReadInt16LittleEndian(data.Slice(14, 2)),
+        bitsPerPixel: BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(14, 2)),
         compression: (BmpCompression)BinaryPrimitives.ReadInt32LittleEndian(data.Slice(16, 4)),
         imageSize: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(20, 4)),
         xPelsPerMeter: BinaryPrimitives.ReadInt32LittleEndian(data.Slice(24, 4)),
@@ -484,7 +484,7 @@ internal struct BmpInfoHeader
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(4, 4), this.Width);
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(8, 4), this.Height);
         BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(12, 2), this.Planes);
-        BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(14, 2), this.BitsPerPixel);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(14, 2), this.BitsPerPixel);
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(16, 4), (int)this.Compression);
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(20, 4), this.ImageSize);
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(24, 4), this.XPelsPerMeter);
@@ -504,7 +504,7 @@ internal struct BmpInfoHeader
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(4, 4), this.Width);
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(8, 4), this.Height);
         BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(12, 2), this.Planes);
-        BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(14, 2), this.BitsPerPixel);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(14, 2), this.BitsPerPixel);
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(16, 4), (int)this.Compression);
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(20, 4), this.ImageSize);
         BinaryPrimitives.WriteInt32LittleEndian(buffer.Slice(24, 4), this.XPelsPerMeter);

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -578,8 +578,8 @@ internal sealed class GifDecoderCore : IImageDecoderInternals
                 // #403 The left + width value can be larger than the image width
                 for (int x = descriptorLeft; x < descriptorRight && x < imageWidth; x++)
                 {
-                    int index = Numerics.Clamp(Unsafe.Add(ref indicesRowRef, x - descriptorLeft), 0, colorTableMaxIdx);
-                    ref TPixel pixel = ref Unsafe.Add(ref rowRef, x);
+                    int index = Numerics.Clamp(Unsafe.Add(ref indicesRowRef, (uint)(x - descriptorLeft)), 0, colorTableMaxIdx);
+                    ref TPixel pixel = ref Unsafe.Add(ref rowRef, (uint)x);
                     Rgb24 rgb = colorTable[index];
                     pixel.FromRgb24(rgb);
                 }
@@ -588,7 +588,7 @@ internal sealed class GifDecoderCore : IImageDecoderInternals
             {
                 for (int x = descriptorLeft; x < descriptorRight && x < imageWidth; x++)
                 {
-                    int rawIndex = Unsafe.Add(ref indicesRowRef, x - descriptorLeft);
+                    int rawIndex = Unsafe.Add(ref indicesRowRef, (uint)(x - descriptorLeft));
 
                     // Treat any out of bounds values as transparent.
                     if (rawIndex > colorTableMaxIdx || rawIndex == transIndex)
@@ -597,7 +597,7 @@ internal sealed class GifDecoderCore : IImageDecoderInternals
                     }
 
                     int index = Numerics.Clamp(rawIndex, 0, colorTableMaxIdx);
-                    ref TPixel pixel = ref Unsafe.Add(ref rowRef, x);
+                    ref TPixel pixel = ref Unsafe.Add(ref rowRef, (uint)x);
                     Rgb24 rgb = colorTable[index];
                     pixel.FromRgb24(rgb);
                 }

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -254,7 +254,7 @@ internal sealed class GifEncoderCore : IImageEncoderInternals
 
         for (int i = rgbaSpan.Length - 1; i >= 0; i--)
         {
-            if (Unsafe.Add(ref rgbaSpanRef, i).Equals(default))
+            if (Unsafe.Add(ref rgbaSpanRef, (uint)i).Equals(default))
             {
                 index = i;
             }

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -115,7 +115,7 @@ internal sealed class LzwDecoder : IDisposable
 
         for (code = 0; code < clearCode; code++)
         {
-            Unsafe.Add(ref suffixRef, code) = (byte)code;
+            Unsafe.Add(ref suffixRef, (uint)code) = (byte)code;
         }
 
         Span<byte> buffer = stackalloc byte[byte.MaxValue];
@@ -182,7 +182,7 @@ internal sealed class LzwDecoder : IDisposable
 
                 if (oldCode == NullCode)
                 {
-                    Unsafe.Add(ref pixelStackRef, top++) = Unsafe.Add(ref suffixRef, code);
+                    Unsafe.Add(ref pixelStackRef, (uint)top++) = Unsafe.Add(ref suffixRef, (uint)code);
                     oldCode = code;
                     first = code;
                     continue;
@@ -191,27 +191,27 @@ internal sealed class LzwDecoder : IDisposable
                 int inCode = code;
                 if (code == availableCode)
                 {
-                    Unsafe.Add(ref pixelStackRef, top++) = (byte)first;
+                    Unsafe.Add(ref pixelStackRef, (uint)top++) = (byte)first;
 
                     code = oldCode;
                 }
 
                 while (code > clearCode)
                 {
-                    Unsafe.Add(ref pixelStackRef, top++) = Unsafe.Add(ref suffixRef, code);
-                    code = Unsafe.Add(ref prefixRef, code);
+                    Unsafe.Add(ref pixelStackRef, (uint)top++) = Unsafe.Add(ref suffixRef, (uint)code);
+                    code = Unsafe.Add(ref prefixRef, (uint)code);
                 }
 
-                int suffixCode = Unsafe.Add(ref suffixRef, code);
+                int suffixCode = Unsafe.Add(ref suffixRef, (uint)code);
                 first = suffixCode;
-                Unsafe.Add(ref pixelStackRef, top++) = suffixCode;
+                Unsafe.Add(ref pixelStackRef, (uint)top++) = suffixCode;
 
                 // Fix for Gifs that have "deferred clear code" as per here :
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=55918
                 if (availableCode < MaxStackSize)
                 {
-                    Unsafe.Add(ref prefixRef, availableCode) = oldCode;
-                    Unsafe.Add(ref suffixRef, availableCode) = first;
+                    Unsafe.Add(ref prefixRef, (uint)availableCode) = oldCode;
+                    Unsafe.Add(ref suffixRef, (uint)availableCode) = first;
                     availableCode++;
                     if (availableCode == codeMask + 1 && availableCode < MaxStackSize)
                     {
@@ -228,7 +228,7 @@ internal sealed class LzwDecoder : IDisposable
 
             // Clear missing pixels
             xyz++;
-            Unsafe.Add(ref pixelsRowRef, x++) = (byte)Unsafe.Add(ref pixelStackRef, top);
+            Unsafe.Add(ref pixelsRowRef, (uint)x++) = (byte)Unsafe.Add(ref pixelStackRef, (uint)top);
         }
     }
 
@@ -282,7 +282,7 @@ internal sealed class LzwDecoder : IDisposable
 
         for (code = 0; code < clearCode; code++)
         {
-            Unsafe.Add(ref suffixRef, code) = (byte)code;
+            Unsafe.Add(ref suffixRef, (uint)code) = (byte)code;
         }
 
         Span<byte> buffer = stackalloc byte[byte.MaxValue];
@@ -336,7 +336,7 @@ internal sealed class LzwDecoder : IDisposable
 
                 if (oldCode == NullCode)
                 {
-                    Unsafe.Add(ref pixelStackRef, top++) = Unsafe.Add(ref suffixRef, code);
+                    Unsafe.Add(ref pixelStackRef, (uint)top++) = Unsafe.Add(ref suffixRef, (uint)code);
                     oldCode = code;
                     first = code;
                     continue;
@@ -345,27 +345,27 @@ internal sealed class LzwDecoder : IDisposable
                 int inCode = code;
                 if (code == availableCode)
                 {
-                    Unsafe.Add(ref pixelStackRef, top++) = (byte)first;
+                    Unsafe.Add(ref pixelStackRef, (uint)top++) = (byte)first;
 
                     code = oldCode;
                 }
 
                 while (code > clearCode)
                 {
-                    Unsafe.Add(ref pixelStackRef, top++) = Unsafe.Add(ref suffixRef, code);
-                    code = Unsafe.Add(ref prefixRef, code);
+                    Unsafe.Add(ref pixelStackRef, (uint)top++) = Unsafe.Add(ref suffixRef, (uint)code);
+                    code = Unsafe.Add(ref prefixRef, (uint)code);
                 }
 
-                int suffixCode = Unsafe.Add(ref suffixRef, code);
+                int suffixCode = Unsafe.Add(ref suffixRef, (uint)code);
                 first = suffixCode;
-                Unsafe.Add(ref pixelStackRef, top++) = suffixCode;
+                Unsafe.Add(ref pixelStackRef, (uint)top++) = suffixCode;
 
                 // Fix for Gifs that have "deferred clear code" as per here :
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=55918
                 if (availableCode < MaxStackSize)
                 {
-                    Unsafe.Add(ref prefixRef, availableCode) = oldCode;
-                    Unsafe.Add(ref suffixRef, availableCode) = first;
+                    Unsafe.Add(ref prefixRef, (uint)availableCode) = oldCode;
+                    Unsafe.Add(ref suffixRef, (uint)availableCode) = first;
                     availableCode++;
                     if (availableCode == codeMask + 1 && availableCode < MaxStackSize)
                     {

--- a/src/ImageSharp/Formats/Gif/LzwEncoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwEncoder.cs
@@ -216,7 +216,7 @@ internal sealed class LzwEncoder : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void AddCharacter(byte c, ref byte accumulatorsRef, Stream stream)
     {
-        Unsafe.Add(ref accumulatorsRef, this.accumulatorCount++) = c;
+        Unsafe.Add(ref accumulatorsRef, (uint)this.accumulatorCount++) = c;
         if (this.accumulatorCount >= 254)
         {
             this.FlushPacket(stream);
@@ -278,18 +278,18 @@ internal sealed class LzwEncoder : IDisposable
 
             for (int x = offsetX; x < indexedPixels.Width; x++)
             {
-                int code = Unsafe.Add(ref rowSpanRef, x);
+                int code = Unsafe.Add(ref rowSpanRef, (uint)x);
                 int freeCode = (code << MaxBits) + entry;
                 int hashIndex = (code << HashShift) ^ entry;
 
-                if (Unsafe.Add(ref hashTableRef, hashIndex) == freeCode)
+                if (Unsafe.Add(ref hashTableRef, (uint)hashIndex) == freeCode)
                 {
-                    entry = Unsafe.Add(ref codeTableRef, hashIndex);
+                    entry = Unsafe.Add(ref codeTableRef, (uint)hashIndex);
                     continue;
                 }
 
                 // Non-empty slot
-                if (Unsafe.Add(ref hashTableRef, hashIndex) >= 0)
+                if (Unsafe.Add(ref hashTableRef, (uint)hashIndex) >= 0)
                 {
                     int disp = 1;
                     if (hashIndex != 0)
@@ -304,15 +304,15 @@ internal sealed class LzwEncoder : IDisposable
                             hashIndex += HashSize;
                         }
 
-                        if (Unsafe.Add(ref hashTableRef, hashIndex) == freeCode)
+                        if (Unsafe.Add(ref hashTableRef, (uint)hashIndex) == freeCode)
                         {
-                            entry = Unsafe.Add(ref codeTableRef, hashIndex);
+                            entry = Unsafe.Add(ref codeTableRef, (uint)hashIndex);
                             break;
                         }
                     }
-                    while (Unsafe.Add(ref hashTableRef, hashIndex) >= 0);
+                    while (Unsafe.Add(ref hashTableRef, (uint)hashIndex) >= 0);
 
-                    if (Unsafe.Add(ref hashTableRef, hashIndex) == freeCode)
+                    if (Unsafe.Add(ref hashTableRef, (uint)hashIndex) == freeCode)
                     {
                         continue;
                     }
@@ -322,8 +322,8 @@ internal sealed class LzwEncoder : IDisposable
                 entry = code;
                 if (this.freeEntry < MaxMaxCode)
                 {
-                    Unsafe.Add(ref codeTableRef, hashIndex) = this.freeEntry++; // code -> hashtable
-                    Unsafe.Add(ref hashTableRef, hashIndex) = freeCode;
+                    Unsafe.Add(ref codeTableRef, (uint)hashIndex) = this.freeEntry++; // code -> hashtable
+                    Unsafe.Add(ref hashTableRef, (uint)hashIndex) = freeCode;
                 }
                 else
                 {

--- a/src/ImageSharp/Formats/ImageExtensions.Save.tt
+++ b/src/ImageSharp/Formats/ImageExtensions.Save.tt
@@ -77,7 +77,7 @@ public static partial class ImageExtensions
     public static void SaveAs<#= fmt #>(this Image source, string path, <#= fmt #>Encoder encoder) =>
         source.Save(
             path,
-            encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(<#= fmt #>Format.Instance));
+            encoder ?? source.GetConfiguration().ImageFormatsManager.GetEncoder(<#= fmt #>Format.Instance));
 
     /// <summary>
     /// Saves the image to the given stream with the <#= fmt #> format.
@@ -91,7 +91,7 @@ public static partial class ImageExtensions
     public static Task SaveAs<#= fmt #>Async(this Image source, string path, <#= fmt #>Encoder encoder, CancellationToken cancellationToken = default)
         => source.SaveAsync(
               path,
-              encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(<#= fmt #>Format.Instance),
+              encoder ?? source.GetConfiguration().ImageFormatsManager.GetEncoder(<#= fmt #>Format.Instance),
               cancellationToken);
 
     /// <summary>
@@ -124,7 +124,7 @@ public static partial class ImageExtensions
     public static void SaveAs<#= fmt #>(this Image source, Stream stream, <#= fmt #>Encoder encoder)
         => source.Save(
               stream,
-              encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(<#= fmt #>Format.Instance));
+              encoder ?? source.GetConfiguration().ImageFormatsManager.GetEncoder(<#= fmt #>Format.Instance));
 
     /// <summary>
     /// Saves the image to the given stream with the <#= fmt #> format.
@@ -138,7 +138,7 @@ public static partial class ImageExtensions
     public static Task SaveAs<#= fmt #>Async(this Image source, Stream stream, <#= fmt #>Encoder encoder, CancellationToken cancellationToken = default)
         => source.SaveAsync(
               stream,
-              encoder ?? source.GetConfiguration().ImageFormatsManager.FindEncoder(<#= fmt #>Format.Instance),
+              encoder ?? source.GetConfiguration().ImageFormatsManager.GetEncoder(<#= fmt #>Format.Instance),
               cancellationToken);
 
 <#

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8.cs
@@ -47,7 +47,7 @@ internal unsafe partial struct Block8x8
             DebugGuard.MustBeBetweenOrEqualTo(idx, 0, Size - 1, nameof(idx));
 
             ref short selfRef = ref Unsafe.As<Block8x8, short>(ref this);
-            return Unsafe.Add(ref selfRef, idx);
+            return Unsafe.Add(ref selfRef, (uint)idx);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -56,7 +56,7 @@ internal unsafe partial struct Block8x8
             DebugGuard.MustBeBetweenOrEqualTo(idx, 0, Size - 1, nameof(idx));
 
             ref short selfRef = ref Unsafe.As<Block8x8, short>(ref this);
-            Unsafe.Add(ref selfRef, idx) = value;
+            Unsafe.Add(ref selfRef, (uint)idx) = value;
         }
     }
 
@@ -207,12 +207,12 @@ internal unsafe partial struct Block8x8
 
                     // Given mask is not actually suitable for lzcnt as 1's represent zero elements and 0's represent non-zero elements
                     // So we need to invert it
-                    int lzcnt = BitOperations.LeadingZeroCount(~(uint)areEqual);
+                    uint lzcnt = (uint)BitOperations.LeadingZeroCount(~(uint)areEqual);
 
                     // As input number is represented by 2 bits in the mask, we need to divide lzcnt result by 2
                     // to get the exact number of zero elements in the stride
-                    int strideRelativeIndex = 15 - (lzcnt / 2);
-                    return (i * 16) + strideRelativeIndex;
+                    uint strideRelativeIndex = 15 - (lzcnt / 2);
+                    return (i * 16) + (nint)strideRelativeIndex;
                 }
             }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.cs
@@ -16,7 +16,7 @@ internal partial struct Block8x8F
     {
         var CMin4 = new Vector4(0F);
         var CMax4 = new Vector4(maximum);
-        var COff4 = new Vector4(MathF.Ceiling(maximum * 0.5F));    // /2
+        var COff4 = new Vector4(MathF.Ceiling(maximum * 0.5F));
 
         this.V0L = Numerics.Clamp(this.V0L + COff4, CMin4, CMax4);
         this.V0R = Numerics.Clamp(this.V0R + COff4, CMin4, CMax4);
@@ -42,7 +42,7 @@ internal partial struct Block8x8F
     [MethodImpl(InliningOptions.ShortMethod)]
     public void NormalizeColorsAndRoundInPlaceVector8(float maximum)
     {
-        var off = new Vector<float>(MathF.Ceiling(maximum * 0.5F));    // /2
+        var off = new Vector<float>(MathF.Ceiling(maximum * 0.5F));
         var max = new Vector<float>(maximum);
         
         ref Vector<float> row0 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V0L);

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.cs
@@ -16,7 +16,7 @@ internal partial struct Block8x8F
     {
         var CMin4 = new Vector4(0F);
         var CMax4 = new Vector4(maximum);
-        var COff4 = new Vector4(MathF.Ceiling(maximum / 2));
+        var COff4 = new Vector4(MathF.Ceiling(maximum * 0.5F));    // /2
 
         this.V0L = Numerics.Clamp(this.V0L + COff4, CMin4, CMax4);
         this.V0R = Numerics.Clamp(this.V0R + COff4, CMin4, CMax4);
@@ -42,7 +42,7 @@ internal partial struct Block8x8F
     [MethodImpl(InliningOptions.ShortMethod)]
     public void NormalizeColorsAndRoundInPlaceVector8(float maximum)
     {
-        var off = new Vector<float>(MathF.Ceiling(maximum / 2));
+        var off = new Vector<float>(MathF.Ceiling(maximum * 0.5F));    // /2
         var max = new Vector<float>(maximum);
         
         ref Vector<float> row0 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V0L);

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.cs
@@ -44,31 +44,31 @@ internal partial struct Block8x8F
     {
         var off = new Vector<float>(MathF.Ceiling(maximum / 2));
         var max = new Vector<float>(maximum);
-
+        
         ref Vector<float> row0 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V0L);
         row0 = NormalizeAndRound(row0, off, max);
-
+            
         ref Vector<float> row1 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V1L);
         row1 = NormalizeAndRound(row1, off, max);
-
+            
         ref Vector<float> row2 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V2L);
         row2 = NormalizeAndRound(row2, off, max);
-
+            
         ref Vector<float> row3 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V3L);
         row3 = NormalizeAndRound(row3, off, max);
-
+            
         ref Vector<float> row4 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V4L);
         row4 = NormalizeAndRound(row4, off, max);
-
+            
         ref Vector<float> row5 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V5L);
         row5 = NormalizeAndRound(row5, off, max);
-
+            
         ref Vector<float> row6 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V6L);
         row6 = NormalizeAndRound(row6, off, max);
-
+            
         ref Vector<float> row7 = ref Unsafe.As<Vector4, Vector<float>>(ref this.V7L);
         row7 = NormalizeAndRound(row7, off, max);
-
+            
     }
 
     /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.tt
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.tt
@@ -29,7 +29,7 @@ internal partial struct Block8x8F
     {
         var CMin4 = new Vector4(0F);
         var CMax4 = new Vector4(maximum);
-        var COff4 = new Vector4(MathF.Ceiling(maximum * 0.5F));    // /2
+        var COff4 = new Vector4(MathF.Ceiling(maximum * 0.5F));
 
         <#
 
@@ -53,7 +53,7 @@ internal partial struct Block8x8F
     [MethodImpl(InliningOptions.ShortMethod)]
     public void NormalizeColorsAndRoundInPlaceVector8(float maximum)
     {
-        var off = new Vector<float>(MathF.Ceiling(maximum * 0.5F));    // /2
+        var off = new Vector<float>(MathF.Ceiling(maximum * 0.5F));
         var max = new Vector<float>(maximum);
         <#
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.tt
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Generated.tt
@@ -29,7 +29,7 @@ internal partial struct Block8x8F
     {
         var CMin4 = new Vector4(0F);
         var CMax4 = new Vector4(maximum);
-        var COff4 = new Vector4(MathF.Ceiling(maximum / 2));
+        var COff4 = new Vector4(MathF.Ceiling(maximum * 0.5F));    // /2
 
         <#
 
@@ -53,7 +53,7 @@ internal partial struct Block8x8F
     [MethodImpl(InliningOptions.ShortMethod)]
     public void NormalizeColorsAndRoundInPlaceVector8(float maximum)
     {
-        var off = new Vector<float>(MathF.Ceiling(maximum / 2));
+        var off = new Vector<float>(MathF.Ceiling(maximum * 0.5F));    // /2
         var max = new Vector<float>(maximum);
         <#
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Intrinsic.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Intrinsic.cs
@@ -51,7 +51,7 @@ internal partial struct Block8x8F
             Vector256<short> row = Avx2.PackSignedSaturate(row0, row1);
             row = Avx2.PermuteVar8x32(row.AsInt32(), multiplyIntoInt16ShuffleMask).AsInt16();
 
-            Unsafe.Add(ref destRef, (IntPtr)((uint)i / 2)) = row;
+            Unsafe.Add(ref destRef, i / 2) = row;
         }
     }
 
@@ -64,13 +64,13 @@ internal partial struct Block8x8F
 
         ref Vector128<short> destBase = ref Unsafe.As<Block8x8, Vector128<short>>(ref dest);
 
-        for (int i = 0; i < 16; i += 2)
+        for (nint i = 0; i < 16; i += 2)
         {
             Vector128<int> left = Sse2.ConvertToVector128Int32(Sse.Multiply(Unsafe.Add(ref aBase, i + 0), Unsafe.Add(ref bBase, i + 0)));
             Vector128<int> right = Sse2.ConvertToVector128Int32(Sse.Multiply(Unsafe.Add(ref aBase, i + 1), Unsafe.Add(ref bBase, i + 1)));
 
             Vector128<short> row = Sse2.PackSignedSaturate(left, right);
-            Unsafe.Add(ref destBase, (IntPtr)((uint)i / 2)) = row;
+            Unsafe.Add(ref destBase, i / 2) = row;
         }
     }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Intrinsic.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.Intrinsic.cs
@@ -41,9 +41,9 @@ internal partial struct Block8x8F
         ref Vector256<float> bBase = ref b.V0;
 
         ref Vector256<short> destRef = ref dest.V01;
-        var multiplyIntoInt16ShuffleMask = Vector256.Create(0, 1, 4, 5, 2, 3, 6, 7);
+        Vector256<int> multiplyIntoInt16ShuffleMask = Vector256.Create(0, 1, 4, 5, 2, 3, 6, 7);
 
-        for (nint i = 0; i < 8; i += 2)
+        for (nuint i = 0; i < 8; i += 2)
         {
             Vector256<int> row0 = Avx.ConvertToVector256Int32(Avx.Multiply(Unsafe.Add(ref aBase, i + 0), Unsafe.Add(ref bBase, i + 0)));
             Vector256<int> row1 = Avx.ConvertToVector256Int32(Avx.Multiply(Unsafe.Add(ref aBase, i + 1), Unsafe.Add(ref bBase, i + 1)));
@@ -64,7 +64,7 @@ internal partial struct Block8x8F
 
         ref Vector128<short> destBase = ref Unsafe.As<Block8x8, Vector128<short>>(ref dest);
 
-        for (nint i = 0; i < 16; i += 2)
+        for (nuint i = 0; i < 16; i += 2)
         {
             Vector128<int> left = Sse2.ConvertToVector128Int32(Sse.Multiply(Unsafe.Add(ref aBase, i + 0), Unsafe.Add(ref bBase, i + 0)));
             Vector128<int> right = Sse2.ConvertToVector128Int32(Sse.Multiply(Unsafe.Add(ref aBase, i + 1), Unsafe.Add(ref bBase, i + 1)));

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.ScaledCopy.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.ScaledCopy.cs
@@ -98,7 +98,7 @@ internal partial struct Block8x8F
                 nuint xx = x * horizontalScale;
 
                 float value = this[(int)(y8 + x)];
-                nuint baseIdx = (uint)((yy * areaStride) + xx);
+                nuint baseIdx = (yy * areaStride) + xx;
 
                 for (nuint i = 0; i < verticalScale; i++, baseIdx += areaStride)
                 {

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.ScaledCopy.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.ScaledCopy.cs
@@ -30,13 +30,13 @@ internal partial struct Block8x8F
         }
 
         // TODO: Optimize: implement all cases with scale-specific, loopless code!
-        this.CopyArbitraryScale(ref areaOrigin, areaStride, horizontalScale, verticalScale);
+        this.CopyArbitraryScale(ref areaOrigin, (uint)areaStride, (uint)horizontalScale, (uint)verticalScale);
     }
 
     private void CopyTo2x2Scale(ref float areaOrigin, int areaStride)
     {
         ref Vector2 destBase = ref Unsafe.As<float, Vector2>(ref areaOrigin);
-        int destStride = (int)((uint)areaStride / 2);
+        nuint destStride = (uint)areaStride / 2;
 
         WidenCopyRowImpl2x2(ref this.V0L, ref destBase, 0, destStride);
         WidenCopyRowImpl2x2(ref this.V0L, ref destBase, 1, destStride);
@@ -48,12 +48,12 @@ internal partial struct Block8x8F
         WidenCopyRowImpl2x2(ref this.V0L, ref destBase, 7, destStride);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static void WidenCopyRowImpl2x2(ref Vector4 selfBase, ref Vector2 destBase, nint row, nint destStride)
+        static void WidenCopyRowImpl2x2(ref Vector4 selfBase, ref Vector2 destBase, nuint row, nuint destStride)
         {
             ref Vector4 sLeft = ref Unsafe.Add(ref selfBase, 2 * row);
             ref Vector4 sRight = ref Unsafe.Add(ref sLeft, 1);
 
-            nint offset = 2 * row * destStride;
+            nuint offset = 2 * row * destStride;
             ref Vector4 dTopLeft = ref Unsafe.As<Vector2, Vector4>(ref Unsafe.Add(ref destBase, offset));
             ref Vector4 dBottomLeft = ref Unsafe.As<Vector2, Vector4>(ref Unsafe.Add(ref destBase, offset + destStride));
 
@@ -86,23 +86,23 @@ internal partial struct Block8x8F
     }
 
     [MethodImpl(InliningOptions.ColdPath)]
-    private void CopyArbitraryScale(ref float areaOrigin, int areaStride, int horizontalScale, int verticalScale)
+    private void CopyArbitraryScale(ref float areaOrigin, uint areaStride, uint horizontalScale, uint verticalScale)
     {
-        for (int y = 0; y < 8; y++)
+        for (nuint y = 0; y < 8; y++)
         {
-            int yy = y * verticalScale;
-            int y8 = y * 8;
+            nuint yy = y * verticalScale;
+            nuint y8 = y * 8;
 
-            for (int x = 0; x < 8; x++)
+            for (nuint x = 0; x < 8; x++)
             {
-                int xx = x * horizontalScale;
+                nuint xx = x * horizontalScale;
 
-                float value = this[y8 + x];
-                nint baseIdx = (nint)(uint)((yy * areaStride) + xx);
+                float value = this[(int)(y8 + x)];
+                nuint baseIdx = (uint)((yy * areaStride) + xx);
 
-                for (nint i = 0; i < verticalScale; i++, baseIdx += areaStride)
+                for (nuint i = 0; i < verticalScale; i++, baseIdx += areaStride)
                 {
-                    for (nint j = 0; j < (uint)horizontalScale; j++)
+                    for (nuint j = 0; j < horizontalScale; j++)
                     {
                         // area[xx + j, yy + i] = value;
                         Unsafe.Add(ref areaOrigin, baseIdx + j) = value;

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.ScaledCopy.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.ScaledCopy.cs
@@ -98,11 +98,11 @@ internal partial struct Block8x8F
                 int xx = x * horizontalScale;
 
                 float value = this[y8 + x];
-                nint baseIdx = (yy * areaStride) + xx;
+                nint baseIdx = (nint)(uint)((yy * areaStride) + xx);
 
                 for (nint i = 0; i < verticalScale; i++, baseIdx += areaStride)
                 {
-                    for (nint j = 0; j < horizontalScale; j++)
+                    for (nint j = 0; j < (uint)horizontalScale; j++)
                     {
                         // area[xx + j, yy + i] = value;
                         Unsafe.Add(ref areaOrigin, baseIdx + j) = value;
@@ -128,8 +128,8 @@ internal partial struct Block8x8F
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void CopyRowImpl(ref byte origin, ref byte dest, int destStride, int row)
         {
-            origin = ref Unsafe.Add(ref origin, row * 8 * sizeof(float));
-            dest = ref Unsafe.Add(ref dest, row * destStride);
+            origin = ref Unsafe.Add(ref origin, (uint)row * 8 * sizeof(float));
+            dest = ref Unsafe.Add(ref dest, (uint)(row * destStride));
             Unsafe.CopyBlock(ref dest, ref origin, 8 * sizeof(float));
         }
     }
@@ -150,8 +150,8 @@ internal partial struct Block8x8F
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void CopyRowImpl(ref byte origin, ref byte dest, int sourceStride, int row)
         {
-            origin = ref Unsafe.Add(ref origin, row * sourceStride);
-            dest = ref Unsafe.Add(ref dest, row * 8 * sizeof(float));
+            origin = ref Unsafe.Add(ref origin, (uint)(row * sourceStride));
+            dest = ref Unsafe.Add(ref dest, (uint)row * 8 * sizeof(float));
             Unsafe.CopyBlock(ref dest, ref origin, 8 * sizeof(float));
         }
     }

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
@@ -72,27 +72,33 @@ internal partial struct Block8x8F : IEquatable<Block8x8F>
     /// <returns>The float value at the specified index</returns>
     public float this[int idx]
     {
+        get => this[(uint)idx];
+        set => this[(uint)idx] = value;
+    }
+
+    internal float this[nuint idx]
+    {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            DebugGuard.MustBeBetweenOrEqualTo(idx, 0, Size - 1, nameof(idx));
+            DebugGuard.MustBeBetweenOrEqualTo((int)idx, 0, Size - 1, nameof(idx));
             ref float selfRef = ref Unsafe.As<Block8x8F, float>(ref this);
-            return Unsafe.Add(ref selfRef, (nint)(uint)idx);
+            return Unsafe.Add(ref selfRef, idx);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set
         {
-            DebugGuard.MustBeBetweenOrEqualTo(idx, 0, Size - 1, nameof(idx));
+            DebugGuard.MustBeBetweenOrEqualTo((int)idx, 0, Size - 1, nameof(idx));
             ref float selfRef = ref Unsafe.As<Block8x8F, float>(ref this);
-            Unsafe.Add(ref selfRef, (nint)(uint)idx) = value;
+            Unsafe.Add(ref selfRef, idx) = value;
         }
     }
 
     public float this[int x, int y]
     {
-        get => this[(y * 8) + x];
-        set => this[(y * 8) + x] = value;
+        get => this[((uint)y * 8) + (uint)x];
+        set => this[((uint)y * 8) + (uint)x] = value;
     }
 
     public static Block8x8F Load(Span<float> data)
@@ -425,7 +431,7 @@ internal partial struct Block8x8F : IEquatable<Block8x8F>
             Vector256<int> targetVector = Vector256.Create(value);
             ref Vector256<float> blockStride = ref this.V0;
 
-            for (nint i = 0; i < RowCount; i++)
+            for (nuint i = 0; i < RowCount; i++)
             {
                 Vector256<int> areEqual = Avx2.CompareEqual(Avx.ConvertToVector256Int32WithTruncation(Unsafe.Add(ref this.V0, i)), targetVector);
                 if (Avx2.MoveMask(areEqual.AsByte()) != equalityMask)
@@ -439,7 +445,7 @@ internal partial struct Block8x8F : IEquatable<Block8x8F>
 
         ref float scalars = ref Unsafe.As<Block8x8F, float>(ref this);
 
-        for (nint i = 0; i < Size; i++)
+        for (nuint i = 0; i < Size; i++)
         {
             if ((int)Unsafe.Add(ref scalars, i) != value)
             {

--- a/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Block8x8F.cs
@@ -425,7 +425,7 @@ internal partial struct Block8x8F : IEquatable<Block8x8F>
             Vector256<int> targetVector = Vector256.Create(value);
             ref Vector256<float> blockStride = ref this.V0;
 
-            for (int i = 0; i < RowCount; i++)
+            for (nint i = 0; i < RowCount; i++)
             {
                 Vector256<int> areEqual = Avx2.CompareEqual(Avx.ConvertToVector256Int32WithTruncation(Unsafe.Add(ref this.V0, i)), targetVector);
                 if (Avx2.MoveMask(areEqual.AsByte()) != equalityMask)
@@ -439,7 +439,7 @@ internal partial struct Block8x8F : IEquatable<Block8x8F>
 
         ref float scalars = ref Unsafe.As<Block8x8F, float>(ref this);
 
-        for (int i = 0; i < Size; i++)
+        for (nint i = 0; i < Size; i++)
         {
             if ((int)Unsafe.Add(ref scalars, i) != value)
             {

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykAvx.cs
@@ -32,7 +32,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector256.Create(1 / (this.MaximumValue * this.MaximumValue));
 
-            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> c = ref Unsafe.Add(ref c0Base, i);
@@ -71,7 +71,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = Vector256.Create(maxValue);
 
-            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 Vector256<float> ctmp = Avx.Subtract(scale, Unsafe.Add(ref srcR, i));

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykAvx.cs
@@ -32,8 +32,8 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector256.Create(1 / (this.MaximumValue * this.MaximumValue));
 
-            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> c = ref Unsafe.Add(ref c0Base, i);
                 ref Vector256<float> m = ref Unsafe.Add(ref c1Base, i);
@@ -71,8 +71,8 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = Vector256.Create(maxValue);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 Vector256<float> ctmp = Avx.Subtract(scale, Unsafe.Add(ref srcR, i));
                 Vector256<float> mtmp = Avx.Subtract(scale, Unsafe.Add(ref srcG, i));

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykAvx.cs
@@ -32,7 +32,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector256.Create(1 / (this.MaximumValue * this.MaximumValue));
 
-            nint n = values.Component0.Length / Vector256<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 ref Vector256<float> c = ref Unsafe.Add(ref c0Base, i);
@@ -71,7 +71,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = Vector256.Create(maxValue);
 
-            nint n = values.Component0.Length / Vector256<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 Vector256<float> ctmp = Avx.Subtract(scale, Unsafe.Add(ref srcR, i));

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykVector.cs
@@ -30,7 +30,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / (this.MaximumValue * this.MaximumValue));
 
-            nint n = values.Component0.Length / Vector<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 ref Vector<float> c = ref Unsafe.Add(ref cBase, i);
@@ -78,7 +78,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = new Vector<float>(maxValue);
 
-            nint n = values.Component0.Length / Vector<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 Vector<float> ctmp = scale - Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykVector.cs
@@ -30,7 +30,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / (this.MaximumValue * this.MaximumValue));
 
-            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> c = ref Unsafe.Add(ref cBase, i);
@@ -78,7 +78,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = new Vector<float>(maxValue);
 
-            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 Vector<float> ctmp = scale - Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykVector.cs
@@ -30,8 +30,8 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / (this.MaximumValue * this.MaximumValue));
 
-            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> c = ref Unsafe.Add(ref cBase, i);
                 ref Vector<float> m = ref Unsafe.Add(ref mBase, i);
@@ -78,8 +78,8 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = new Vector<float>(maxValue);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 Vector<float> ctmp = scale - Unsafe.Add(ref srcR, i);
                 Vector<float> mtmp = scale - Unsafe.Add(ref srcG, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleAvx.cs
@@ -27,7 +27,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector256.Create(1 / this.MaximumValue);
 
-            nint n = values.Component0.Length / Vector256<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 ref Vector256<float> c0 = ref Unsafe.Add(ref c0Base, i);
@@ -53,7 +53,7 @@ internal abstract partial class JpegColorConverterBase
             var f0587 = Vector256.Create(0.587f);
             var f0114 = Vector256.Create(0.114f);
 
-            nint n = values.Component0.Length / Vector256<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 ref Vector256<float> r = ref Unsafe.Add(ref srcRed, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleAvx.cs
@@ -27,8 +27,8 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector256.Create(1 / this.MaximumValue);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> c0 = ref Unsafe.Add(ref c0Base, i);
                 c0 = Avx.Multiply(c0, scale);
@@ -53,8 +53,8 @@ internal abstract partial class JpegColorConverterBase
             var f0587 = Vector256.Create(0.587f);
             var f0114 = Vector256.Create(0.114f);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> r = ref Unsafe.Add(ref srcRed, i);
                 ref Vector256<float> g = ref Unsafe.Add(ref srcGreen, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleAvx.cs
@@ -27,7 +27,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector256.Create(1 / this.MaximumValue);
 
-            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> c0 = ref Unsafe.Add(ref c0Base, i);
@@ -53,7 +53,7 @@ internal abstract partial class JpegColorConverterBase
             var f0587 = Vector256.Create(0.587f);
             var f0114 = Vector256.Create(0.114f);
 
-            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> r = ref Unsafe.Add(ref srcRed, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleScalar.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleScalar.cs
@@ -28,7 +28,7 @@ internal abstract partial class JpegColorConverterBase
             ref float valuesRef = ref MemoryMarshal.GetReference(values);
             float scale = 1 / maxValue;
 
-            for (nint i = 0; i < values.Length; i++)
+            for (nint i = 0; i < (uint)values.Length; i++)
             {
                 Unsafe.Add(ref valuesRef, i) *= scale;
             }

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleScalar.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleScalar.cs
@@ -28,7 +28,7 @@ internal abstract partial class JpegColorConverterBase
             ref float valuesRef = ref MemoryMarshal.GetReference(values);
             float scale = 1 / maxValue;
 
-            for (nint i = 0; i < (uint)values.Length; i++)
+            for (nuint i = 0; i < (uint)values.Length; i++)
             {
                 Unsafe.Add(ref valuesRef, i) *= scale;
             }

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleVector.cs
@@ -24,7 +24,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / this.MaximumValue);
 
-            nint n = values.Component0.Length / Vector<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 ref Vector<float> c0 = ref Unsafe.Add(ref cBase, i);
@@ -53,7 +53,7 @@ internal abstract partial class JpegColorConverterBase
             var gMult = new Vector<float>(0.587f);
             var bMult = new Vector<float>(0.114f);
 
-            nint n = values.Component0.Length / Vector<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 Vector<float> r = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleVector.cs
@@ -24,7 +24,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / this.MaximumValue);
 
-            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> c0 = ref Unsafe.Add(ref cBase, i);
@@ -53,7 +53,7 @@ internal abstract partial class JpegColorConverterBase
             var gMult = new Vector<float>(0.587f);
             var bMult = new Vector<float>(0.114f);
 
-            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 Vector<float> r = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleVector.cs
@@ -24,8 +24,8 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / this.MaximumValue);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> c0 = ref Unsafe.Add(ref cBase, i);
                 c0 *= scale;
@@ -53,8 +53,8 @@ internal abstract partial class JpegColorConverterBase
             var gMult = new Vector<float>(0.587f);
             var bMult = new Vector<float>(0.114f);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 Vector<float> r = Unsafe.Add(ref srcR, i);
                 Vector<float> g = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
@@ -30,7 +30,7 @@ internal abstract partial class JpegColorConverterBase
 
             // Used for the color conversion
             var scale = Vector128.Create(1 / this.MaximumValue);
-            nuint n = (uint)(values.Component0.Length / Vector128<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector128<float> r = ref Unsafe.Add(ref rBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
@@ -30,8 +30,8 @@ internal abstract partial class JpegColorConverterBase
 
             // Used for the color conversion
             var scale = Vector128.Create(1 / this.MaximumValue);
-            nint n = (nint)(uint)values.Component0.Length / Vector128<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector128<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector128<float> r = ref Unsafe.Add(ref rBase, i);
                 ref Vector128<float> g = ref Unsafe.Add(ref gBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbAvx.cs
@@ -29,7 +29,7 @@ internal abstract partial class JpegColorConverterBase
 
             // Used for the color conversion
             var scale = Vector256.Create(1 / this.MaximumValue);
-            nint n = values.Component0.Length / Vector256<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 ref Vector256<float> r = ref Unsafe.Add(ref rBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbAvx.cs
@@ -29,7 +29,7 @@ internal abstract partial class JpegColorConverterBase
 
             // Used for the color conversion
             var scale = Vector256.Create(1 / this.MaximumValue);
-            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> r = ref Unsafe.Add(ref rBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbAvx.cs
@@ -29,8 +29,8 @@ internal abstract partial class JpegColorConverterBase
 
             // Used for the color conversion
             var scale = Vector256.Create(1 / this.MaximumValue);
-            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> r = ref Unsafe.Add(ref rBase, i);
                 ref Vector256<float> g = ref Unsafe.Add(ref gBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbVector.cs
@@ -28,7 +28,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / this.MaximumValue);
 
-            nint n = values.Component0.Length / Vector<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 ref Vector<float> r = ref Unsafe.Add(ref rBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbVector.cs
@@ -28,7 +28,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / this.MaximumValue);
 
-            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> r = ref Unsafe.Add(ref rBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbVector.cs
@@ -28,8 +28,8 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / this.MaximumValue);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> r = ref Unsafe.Add(ref rBase, i);
                 ref Vector<float> g = ref Unsafe.Add(ref gBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrAvx.cs
@@ -38,8 +38,8 @@ internal abstract partial class JpegColorConverterBase
             var bCbMult = Vector256.Create(YCbCrScalar.BCbMult);
 
             // Walking 8 elements at one step:
-            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
                 // cb = cbVals[i] - 128F;
@@ -98,8 +98,8 @@ internal abstract partial class JpegColorConverterBase
             var fn0081312F = Vector256.Create(-0.081312F);
             var f05 = Vector256.Create(0.5f);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 Vector256<float> r = Unsafe.Add(ref srcR, i);
                 Vector256<float> g = Unsafe.Add(ref srcG, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrAvx.cs
@@ -38,7 +38,7 @@ internal abstract partial class JpegColorConverterBase
             var bCbMult = Vector256.Create(YCbCrScalar.BCbMult);
 
             // Walking 8 elements at one step:
-            nint n = values.Component0.Length / Vector256<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -98,7 +98,7 @@ internal abstract partial class JpegColorConverterBase
             var fn0081312F = Vector256.Create(-0.081312F);
             var f05 = Vector256.Create(0.5f);
 
-            nint n = values.Component0.Length / Vector256<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 Vector256<float> r = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrAvx.cs
@@ -38,7 +38,7 @@ internal abstract partial class JpegColorConverterBase
             var bCbMult = Vector256.Create(YCbCrScalar.BCbMult);
 
             // Walking 8 elements at one step:
-            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -98,7 +98,7 @@ internal abstract partial class JpegColorConverterBase
             var fn0081312F = Vector256.Create(-0.081312F);
             var f05 = Vector256.Create(0.5f);
 
-            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 Vector256<float> r = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrVector.cs
@@ -35,7 +35,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(-YCbCrScalar.GCrMult);
             var bCbMult = new Vector<float>(YCbCrScalar.BCbMult);
 
-            nint n = values.Component0.Length / Vector<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -103,7 +103,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(0.418688f);
             var bCrMult = new Vector<float>(0.081312f);
 
-            nint n = values.Component0.Length / Vector<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 Vector<float> r = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrVector.cs
@@ -35,7 +35,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(-YCbCrScalar.GCrMult);
             var bCbMult = new Vector<float>(YCbCrScalar.BCbMult);
 
-            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -103,7 +103,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(0.418688f);
             var bCrMult = new Vector<float>(0.081312f);
 
-            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 Vector<float> r = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrVector.cs
@@ -35,8 +35,8 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(-YCbCrScalar.GCrMult);
             var bCbMult = new Vector<float>(YCbCrScalar.BCbMult);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
                 // cb = cbVals[i] - 128F;
@@ -103,8 +103,8 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(0.418688f);
             var bCrMult = new Vector<float>(0.081312f);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 Vector<float> r = Unsafe.Add(ref srcR, i);
                 Vector<float> g = Unsafe.Add(ref srcG, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKAvx.cs
@@ -40,7 +40,7 @@ internal abstract partial class JpegColorConverterBase
             var bCbMult = Vector256.Create(YCbCrScalar.BCbMult);
 
             // Walking 8 elements at one step:
-            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -109,7 +109,7 @@ internal abstract partial class JpegColorConverterBase
             var fn0081312F = Vector256.Create(-0.081312F);
             var f05 = Vector256.Create(0.5f);
 
-            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 Vector256<float> r = Avx.Subtract(maxSampleValue, Unsafe.Add(ref srcR, i));

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKAvx.cs
@@ -40,7 +40,7 @@ internal abstract partial class JpegColorConverterBase
             var bCbMult = Vector256.Create(YCbCrScalar.BCbMult);
 
             // Walking 8 elements at one step:
-            nint n = values.Component0.Length / Vector256<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -109,7 +109,7 @@ internal abstract partial class JpegColorConverterBase
             var fn0081312F = Vector256.Create(-0.081312F);
             var f05 = Vector256.Create(0.5f);
 
-            nint n = values.Component0.Length / Vector256<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 Vector256<float> r = Avx.Subtract(maxSampleValue, Unsafe.Add(ref srcR, i));

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKAvx.cs
@@ -40,8 +40,8 @@ internal abstract partial class JpegColorConverterBase
             var bCbMult = Vector256.Create(YCbCrScalar.BCbMult);
 
             // Walking 8 elements at one step:
-            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
                 // cb = cbVals[i] - 128F;
@@ -109,8 +109,8 @@ internal abstract partial class JpegColorConverterBase
             var fn0081312F = Vector256.Create(-0.081312F);
             var f05 = Vector256.Create(0.5f);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector256<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector256<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 Vector256<float> r = Avx.Subtract(maxSampleValue, Unsafe.Add(ref srcR, i));
                 Vector256<float> g = Avx.Subtract(maxSampleValue, Unsafe.Add(ref srcG, i));

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKVector.cs
@@ -36,7 +36,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(-YCbCrScalar.GCrMult);
             var bCbMult = new Vector<float>(YCbCrScalar.BCbMult);
 
-            nint n = values.Component0.Length / Vector<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -107,7 +107,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(0.418688f);
             var bCrMult = new Vector<float>(0.081312f);
 
-            nint n = values.Component0.Length / Vector<float>.Count;
+            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
             for (nint i = 0; i < n; i++)
             {
                 Vector<float> r = maxSampleValue - Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKVector.cs
@@ -36,7 +36,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(-YCbCrScalar.GCrMult);
             var bCbMult = new Vector<float>(YCbCrScalar.BCbMult);
 
-            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -107,7 +107,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(0.418688f);
             var bCrMult = new Vector<float>(0.081312f);
 
-            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
             for (nuint i = 0; i < n; i++)
             {
                 Vector<float> r = maxSampleValue - Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKVector.cs
@@ -36,8 +36,8 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(-YCbCrScalar.GCrMult);
             var bCbMult = new Vector<float>(YCbCrScalar.BCbMult);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
                 // cb = cbVals[i] - 128F;
@@ -107,8 +107,8 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(0.418688f);
             var bCrMult = new Vector<float>(0.081312f);
 
-            nint n = (nint)(uint)values.Component0.Length / Vector<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)(values.Component0.Length / Vector<float>.Count);
+            for (nuint i = 0; i < n; i++)
             {
                 Vector<float> r = maxSampleValue - Unsafe.Add(ref srcR, i);
                 Vector<float> g = maxSampleValue - Unsafe.Add(ref srcG, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
@@ -26,7 +26,7 @@ internal abstract partial class JpegColorConverterBase
         this.ColorSpace = colorSpace;
         this.Precision = precision;
         this.MaximumValue = MathF.Pow(2, precision) - 1;
-        this.HalfValue = MathF.Ceiling(this.MaximumValue / 2);
+        this.HalfValue = MathF.Ceiling(this.MaximumValue * 0.5F);   // /2
     }
 
     /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
@@ -470,7 +470,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
                             this.DecodeBlockBaseline(
                                 component,
-                                ref Unsafe.Add(ref blockRef, (nint)(uint)blockCol),
+                                ref Unsafe.Add(ref blockRef, (uint)blockCol),
                                 ref acDecodingTable,
                                 ref dcDecodingTable);
                         }
@@ -521,7 +521,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
                     this.DecodeBlockBaseline(
                         component,
-                        ref Unsafe.Add(ref blockRef, (nint)(uint)k),
+                        ref Unsafe.Add(ref blockRef, (uint)k),
                         ref acDecodingTable,
                         ref dcDecodingTable);
 
@@ -560,7 +560,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
                 this.DecodeBlockBaseline(
                     component,
-                    ref Unsafe.Add(ref blockRef, (nint)(uint)i),
+                    ref Unsafe.Add(ref blockRef, (uint)i),
                     ref acDecodingTable,
                     ref dcDecodingTable);
 
@@ -611,7 +611,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
                             this.DecodeBlockProgressiveDc(
                                 component,
-                                ref Unsafe.Add(ref blockRef, (nint)(uint)blockCol),
+                                ref Unsafe.Add(ref blockRef, (uint)blockCol),
                                 ref dcDecodingTable);
                         }
                     }
@@ -653,7 +653,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
                     this.DecodeBlockProgressiveDc(
                         component,
-                        ref Unsafe.Add(ref blockRef, (nint)(uint)i),
+                        ref Unsafe.Add(ref blockRef, (uint)i),
                         ref dcDecodingTable);
 
                     this.HandleRestart();
@@ -680,7 +680,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
                     this.DecodeBlockProgressiveAc(
                             component,
-                            ref Unsafe.Add(ref blockRef, (nint)(uint)i),
+                            ref Unsafe.Add(ref blockRef, (uint)i),
                             ref acDecodingTable);
 
                     this.HandleRestart();
@@ -717,7 +717,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
                 // Figure F.21: Decoding nonzero value v.
                 // Figure F.22: Decoding the sign of v.
                 int sign = this.DecodeBinaryDecision(ref reader, ref Unsafe.Add(ref st, 1));
-                st = ref Unsafe.Add(ref st, (nint)(uint)(2 + sign));
+                st = ref Unsafe.Add(ref st, (uint)(2 + sign));
 
                 // Figure F.23: Decoding the magnitude category of v.
                 int m = this.DecodeBinaryDecision(ref reader, ref st);
@@ -967,7 +967,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
             // Figure F.21: Decoding nonzero value v
             // Figure F.22: Decoding the sign of v
             int sign = this.DecodeBinaryDecision(ref reader, ref Unsafe.Add(ref st, 1));
-            st = ref Unsafe.Add(ref st, (nint)(uint)(2 + sign));
+            st = ref Unsafe.Add(ref st, (uint)(2 + sign));
 
             // Figure F.23: Decoding the magnitude category of v.
             int m = this.DecodeBinaryDecision(ref reader, ref st);

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
@@ -53,6 +53,8 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
     private ArithmeticDecodingTable[] acDecodingTables;
 
+    private static readonly byte[] FixedBin = { 113, 0, 0, 0 };
+
     private readonly CancellationToken cancellationToken;
 
     private static readonly int[] ArithmeticTable =
@@ -229,13 +231,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
         }
     }
 
-    private static ref byte GetFixedBinReference()
-    {
-        // This uses C#'s optimization to refer to the static data segment of the assembly.
-        // No allocation occurs.
-        ReadOnlySpan<byte> fixedBin = new byte[] { 113, 0, 0, 0 };
-        return ref MemoryMarshal.GetReference(fixedBin);
-    }
+    private static ref byte GetFixedBinReference() => ref MemoryMarshal.GetArrayDataReference(FixedBin);
 
     /// <summary>
     /// Decodes the entropy coded data.
@@ -765,7 +761,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
                     }
                 }
 
-                v += 1;
+                v++;
                 if (sign != 0)
                 {
                     v = -v;
@@ -860,7 +856,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
                     }
                 }
 
-                v += 1;
+                v++;
                 if (sign != 0)
                 {
                     v = -v;
@@ -1016,7 +1012,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
                 }
             }
 
-            v += 1;
+            v++;
             if (sign != 0)
             {
                 v = -v;
@@ -1086,7 +1082,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
                 }
             }
 
-            v += 1;
+            v++;
             if (sign != 0)
             {
                 v = -v;

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
@@ -705,7 +705,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
             // Sections F.2.4.1 & F.1.4.4.1: Decoding of DC coefficients.
 
             // Table F.4: Point to statistics bin S0 for DC coefficient coding.
-            ref byte st = ref Unsafe.Add(ref component.DcStatistics.GetReference(), component.DcContext);
+            ref byte st = ref Unsafe.Add(ref component.DcStatistics.GetReference(), (uint)component.DcContext);
 
             // Figure F.19: Decode_DC_DIFF
             if (this.DecodeBinaryDecision(ref reader, ref st) == 0)
@@ -955,7 +955,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
         // Sections F.2.4.1 & F.1.4.4.1: Decoding of DC coefficients.
 
         // Table F.4: Point to statistics bin S0 for DC coefficient coding.
-        ref byte st = ref Unsafe.Add(ref component.DcStatistics.GetReference(), component.DcContext);
+        ref byte st = ref Unsafe.Add(ref component.DcStatistics.GetReference(), (uint)component.DcContext);
 
         /* Figure F.19: Decode_DC_DIFF */
         if (this.DecodeBinaryDecision(ref reader, ref st) == 0)

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
@@ -53,7 +53,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
     private ArithmeticDecodingTable[] acDecodingTables;
 
-    private static readonly byte[] FixedBin = { 113, 0, 0, 0 };
+    private readonly byte[] fixedBin = { 113, 0, 0, 0 };
 
     private readonly CancellationToken cancellationToken;
 
@@ -231,7 +231,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
         }
     }
 
-    private static ref byte GetFixedBinReference() => ref MemoryMarshal.GetArrayDataReference(FixedBin);
+    private ref byte GetFixedBinReference() => ref MemoryMarshal.GetArrayDataReference(this.fixedBin);
 
     /// <summary>
     /// Decodes the entropy coded data.
@@ -775,7 +775,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
         else
         {
             // Refinement scan.
-            ref byte st = ref GetFixedBinReference();
+            ref byte st = ref this.GetFixedBinReference();
 
             blockDataRef |= (short)(this.DecodeBinaryDecision(ref reader, ref st) << this.SuccessiveLow);
         }
@@ -821,7 +821,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
                 // Figure F.21: Decoding nonzero value v.
                 // Figure F.22: Decoding the sign of v.
-                int sign = this.DecodeBinaryDecision(ref reader, ref GetFixedBinReference());
+                int sign = this.DecodeBinaryDecision(ref reader, ref this.GetFixedBinReference());
                 st = ref Unsafe.Add(ref st, 2);
 
                 // Figure F.23: Decoding the magnitude category of v.
@@ -917,7 +917,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
                 if (this.DecodeBinaryDecision(ref reader, ref Unsafe.Add(ref st, 1)) != 0)
                 {
-                    bool flag = this.DecodeBinaryDecision(ref reader, ref GetFixedBinReference()) != 0;
+                    bool flag = this.DecodeBinaryDecision(ref reader, ref this.GetFixedBinReference()) != 0;
                     coef = (short)(coef + (flag ? m1 : p1));
 
                     break;
@@ -1047,7 +1047,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
             // Figure F.21: Decoding nonzero value v.
             // Figure F.22: Decoding the sign of v.
-            int sign = this.DecodeBinaryDecision(ref reader, ref GetFixedBinReference());
+            int sign = this.DecodeBinaryDecision(ref reader, ref this.GetFixedBinReference());
             st = ref Unsafe.Add(ref st, 2);
 
             // Figure F.23: Decoding the magnitude category of v.

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticScanDecoder.cs
@@ -53,7 +53,8 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
 
     private ArithmeticDecodingTable[] acDecodingTables;
 
-    private readonly byte[] fixedBin = { 113, 0, 0, 0 };
+    // Use C#'s optimization to refer to assembly's data segment, no allocation occurs.
+    private ReadOnlySpan<byte> fixedBin => new byte[] { 113, 0, 0, 0 };
 
     private readonly CancellationToken cancellationToken;
 
@@ -231,7 +232,7 @@ internal class ArithmeticScanDecoder : IJpegScanDecoder
         }
     }
 
-    private ref byte GetFixedBinReference() => ref this.fixedBin[0];
+    private ref byte GetFixedBinReference() => ref MemoryMarshal.GetReference(fixedBin);
 
     /// <summary>
     /// Decodes the entropy coded data.

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticStatistics.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ArithmeticStatistics.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Runtime.InteropServices;
+
 namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
 
 internal class ArithmeticStatistics
@@ -18,7 +20,7 @@ internal class ArithmeticStatistics
 
     public int Identifier { get; private set; }
 
-    public ref byte GetReference() => ref this.statistics[0];
+    public ref byte GetReference() => ref MemoryMarshal.GetArrayDataReference(this.statistics);
 
     public ref byte GetReference(int offset) => ref this.statistics[offset];
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor2.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor2.cs
@@ -67,30 +67,30 @@ internal sealed class DownScalingComponentProcessor2 : ComponentProcessor
     public static void ScaledCopyTo(ref Block8x8F block, ref float destRef, int destStrideWidth, int horizontalScale, int verticalScale)
     {
         // TODO: Optimize: implement all cases with scale-specific, loopless code!
-        CopyArbitraryScale(ref block, ref destRef, destStrideWidth, horizontalScale, verticalScale);
+        CopyArbitraryScale(ref block, ref destRef, (uint)destStrideWidth, (uint)horizontalScale, (uint)verticalScale);
 
         [MethodImpl(InliningOptions.ColdPath)]
-        static void CopyArbitraryScale(ref Block8x8F block, ref float areaOrigin, int areaStride, int horizontalScale, int verticalScale)
+        static void CopyArbitraryScale(ref Block8x8F block, ref float areaOrigin, uint areaStride, uint horizontalScale, uint verticalScale)
         {
-            for (int y = 0; y < 4; y++)
+            for (nuint y = 0; y < 4; y++)
             {
-                int yy = y * verticalScale;
-                int y8 = y * 8;
+                nuint yy = y * verticalScale;
+                nuint y8 = y * 8;
 
-                for (int x = 0; x < 4; x++)
+                for (nuint x = 0; x < 4; x++)
                 {
-                    int xx = x * horizontalScale;
+                    nuint xx = x * horizontalScale;
 
                     float value = block[y8 + x];
 
-                    for (int i = 0; i < verticalScale; i++)
+                    for (nuint i = 0; i < verticalScale; i++)
                     {
-                        int baseIdx = ((yy + i) * areaStride) + xx;
+                        nuint baseIdx = ((yy + i) * areaStride) + xx;
 
-                        for (int j = 0; j < horizontalScale; j++)
+                        for (nuint j = 0; j < horizontalScale; j++)
                         {
                             // area[xx + j, yy + i] = value;
-                            Unsafe.Add(ref areaOrigin, (nint)(uint)(baseIdx + j)) = value;
+                            Unsafe.Add(ref areaOrigin, baseIdx + j) = value;
                         }
                     }
                 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor2.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor2.cs
@@ -25,7 +25,7 @@ internal sealed class DownScalingComponentProcessor2 : ComponentProcessor
         Buffer2D<Block8x8> spectralBuffer = this.Component.SpectralBlocks;
 
         float maximumValue = this.Frame.MaxColorChannelValue;
-        float normalizationValue = MathF.Ceiling(maximumValue * 0.5F);  // /2
+        float normalizationValue = MathF.Ceiling(maximumValue * 0.5F);
 
         int destAreaStride = this.ColorBuffer.Width;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor2.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor2.cs
@@ -25,7 +25,7 @@ internal sealed class DownScalingComponentProcessor2 : ComponentProcessor
         Buffer2D<Block8x8> spectralBuffer = this.Component.SpectralBlocks;
 
         float maximumValue = this.Frame.MaxColorChannelValue;
-        float normalizationValue = MathF.Ceiling(maximumValue / 2);
+        float normalizationValue = MathF.Ceiling(maximumValue * 0.5F);  // /2
 
         int destAreaStride = this.ColorBuffer.Width;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor4.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor4.cs
@@ -25,7 +25,7 @@ internal sealed class DownScalingComponentProcessor4 : ComponentProcessor
         Buffer2D<Block8x8> spectralBuffer = this.Component.SpectralBlocks;
 
         float maximumValue = this.Frame.MaxColorChannelValue;
-        float normalizationValue = MathF.Ceiling(maximumValue / 2);
+        float normalizationValue = MathF.Ceiling(maximumValue * 0.5F);  // /2
 
         int destAreaStride = this.ColorBuffer.Width;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor4.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor4.cs
@@ -25,7 +25,7 @@ internal sealed class DownScalingComponentProcessor4 : ComponentProcessor
         Buffer2D<Block8x8> spectralBuffer = this.Component.SpectralBlocks;
 
         float maximumValue = this.Frame.MaxColorChannelValue;
-        float normalizationValue = MathF.Ceiling(maximumValue * 0.5F);  // /2
+        float normalizationValue = MathF.Ceiling(maximumValue * 0.5F);
 
         int destAreaStride = this.ColorBuffer.Width;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor4.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor4.cs
@@ -67,30 +67,30 @@ internal sealed class DownScalingComponentProcessor4 : ComponentProcessor
     public static void ScaledCopyTo(ref Block8x8F block, ref float destRef, int destStrideWidth, int horizontalScale, int verticalScale)
     {
         // TODO: Optimize: implement all cases with scale-specific, loopless code!
-        CopyArbitraryScale(ref block, ref destRef, destStrideWidth, horizontalScale, verticalScale);
+        CopyArbitraryScale(ref block, ref destRef, (uint)destStrideWidth, (uint)horizontalScale, (uint)verticalScale);
 
         [MethodImpl(InliningOptions.ColdPath)]
-        static void CopyArbitraryScale(ref Block8x8F block, ref float areaOrigin, int areaStride, int horizontalScale, int verticalScale)
+        static void CopyArbitraryScale(ref Block8x8F block, ref float areaOrigin, uint areaStride, uint horizontalScale, uint verticalScale)
         {
-            for (int y = 0; y < 2; y++)
+            for (nuint y = 0; y < 2; y++)
             {
-                int yy = y * verticalScale;
-                int y8 = y * 8;
+                nuint yy = y * verticalScale;
+                nuint y8 = y * 8;
 
-                for (int x = 0; x < 2; x++)
+                for (nuint x = 0; x < 2; x++)
                 {
-                    int xx = x * horizontalScale;
+                    nuint xx = x * horizontalScale;
 
                     float value = block[y8 + x];
 
-                    for (int i = 0; i < verticalScale; i++)
+                    for (nuint i = 0; i < verticalScale; i++)
                     {
-                        int baseIdx = ((yy + i) * areaStride) + xx;
+                        nuint baseIdx = ((yy + i) * areaStride) + xx;
 
-                        for (int j = 0; j < horizontalScale; j++)
+                        for (nuint j = 0; j < horizontalScale; j++)
                         {
                             // area[xx + j, yy + i] = value;
-                            Unsafe.Add(ref areaOrigin, (nint)(uint)(baseIdx + j)) = value;
+                            Unsafe.Add(ref areaOrigin, baseIdx + j) = value;
                         }
                     }
                 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor8.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor8.cs
@@ -67,20 +67,20 @@ internal sealed class DownScalingComponentProcessor8 : ComponentProcessor
         {
             destRef = value;
             Unsafe.Add(ref destRef, 1) = value;
-            Unsafe.Add(ref destRef, 0 + (nint)(uint)destStrideWidth) = value;
-            Unsafe.Add(ref destRef, 1 + (nint)(uint)destStrideWidth) = value;
+            Unsafe.Add(ref destRef, 0 + (uint)destStrideWidth) = value;
+            Unsafe.Add(ref destRef, 1 + (uint)destStrideWidth) = value;
             return;
         }
 
         // TODO: Optimize: implement all cases with scale-specific, loopless code!
-        for (int y = 0; y < verticalScale; y++)
+        for (nuint y = 0; y < (uint)verticalScale; y++)
         {
-            for (int x = 0; x < horizontalScale; x++)
+            for (nuint x = 0; x < (uint)horizontalScale; x++)
             {
-                Unsafe.Add(ref destRef, (nint)(uint)x) = value;
+                Unsafe.Add(ref destRef, x) = value;
             }
 
-            destRef = ref Unsafe.Add(ref destRef, (nint)(uint)destStrideWidth);
+            destRef = ref Unsafe.Add(ref destRef, (uint)destStrideWidth);
         }
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor8.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor8.cs
@@ -22,7 +22,7 @@ internal sealed class DownScalingComponentProcessor8 : ComponentProcessor
         Buffer2D<Block8x8> spectralBuffer = this.Component.SpectralBlocks;
 
         float maximumValue = this.Frame.MaxColorChannelValue;
-        float normalizationValue = MathF.Ceiling(maximumValue * 0.5F);  // /2
+        float normalizationValue = MathF.Ceiling(maximumValue * 0.5F);
 
         int destAreaStride = this.ColorBuffer.Width;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor8.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/DownScalingComponentProcessor8.cs
@@ -22,7 +22,7 @@ internal sealed class DownScalingComponentProcessor8 : ComponentProcessor
         Buffer2D<Block8x8> spectralBuffer = this.Component.SpectralBlocks;
 
         float maximumValue = this.Frame.MaxColorChannelValue;
-        float normalizationValue = MathF.Ceiling(maximumValue / 2);
+        float normalizationValue = MathF.Ceiling(maximumValue * 0.5F);  // /2
 
         int destAreaStride = this.ColorBuffer.Width;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanDecoder.cs
@@ -211,7 +211,7 @@ internal class HuffmanScanDecoder : IJpegScanDecoder
 
                             this.DecodeBlockBaseline(
                                 component,
-                                ref Unsafe.Add(ref blockRef, blockCol),
+                                ref Unsafe.Add(ref blockRef, (uint)blockCol),
                                 ref dcHuffmanTable,
                                 ref acHuffmanTable);
                         }
@@ -255,7 +255,7 @@ internal class HuffmanScanDecoder : IJpegScanDecoder
 
                 this.DecodeBlockBaseline(
                     component,
-                    ref Unsafe.Add(ref blockRef, i),
+                    ref Unsafe.Add(ref blockRef, (uint)i),
                     ref dcHuffmanTable,
                     ref acHuffmanTable);
 
@@ -297,7 +297,7 @@ internal class HuffmanScanDecoder : IJpegScanDecoder
 
                     this.DecodeBlockBaseline(
                         component,
-                        ref Unsafe.Add(ref blockRef, k),
+                        ref Unsafe.Add(ref blockRef, (uint)k),
                         ref dcHuffmanTable,
                         ref acHuffmanTable);
 
@@ -417,7 +417,7 @@ internal class HuffmanScanDecoder : IJpegScanDecoder
 
                             this.DecodeBlockProgressiveDC(
                                 component,
-                                ref Unsafe.Add(ref blockRef, blockCol),
+                                ref Unsafe.Add(ref blockRef, (uint)blockCol),
                                 ref dcHuffmanTable);
                         }
                     }
@@ -459,7 +459,7 @@ internal class HuffmanScanDecoder : IJpegScanDecoder
 
                     this.DecodeBlockProgressiveDC(
                         component,
-                        ref Unsafe.Add(ref blockRef, i),
+                        ref Unsafe.Add(ref blockRef, (uint)i),
                         ref dcHuffmanTable);
 
                     this.HandleRestart();
@@ -485,7 +485,7 @@ internal class HuffmanScanDecoder : IJpegScanDecoder
                     }
 
                     this.DecodeBlockProgressiveAC(
-                        ref Unsafe.Add(ref blockRef, i),
+                        ref Unsafe.Add(ref blockRef, (uint)i),
                         ref acHuffmanTable);
 
                     this.HandleRestart();

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
@@ -141,7 +141,7 @@ internal class ComponentProcessor : IDisposable
 
                 ref float targetRef = ref MemoryMarshal.GetReference(target);
                 ref float sourceRef = ref MemoryMarshal.GetReference(source);
-                for (nint i = count * Vector<float>.Count; i < source.Length; i++)
+                for (nint i = count * Vector<float>.Count; i < (uint)source.Length; i++)
                 {
                     Unsafe.Add(ref targetRef, i) += Unsafe.Add(ref sourceRef, i);
                 }
@@ -166,16 +166,16 @@ internal class ComponentProcessor : IDisposable
                 source = source.Slice(touchedCount);
                 target = target.Slice(touchedCount / factor);
 
-                uint length = (uint)touchedCount / (uint)Vector256<float>.Count;
+                nint length = (nint)(uint)touchedCount / Vector256<float>.Count;
 
                 for (int i = 0; i < haddIterationsCount; i++)
                 {
                     length /= 2;
 
-                    for (nuint j = 0; j < length; j++)
+                    for (nint j = 0; j < length; j++)
                     {
-                        nuint indexLeft = j * 2;
-                        nuint indexRight = indexLeft + 1;
+                        nint indexLeft = j * 2;
+                        nint indexRight = indexLeft + 1;
                         Vector256<float> sum = Avx.HorizontalAdd(Unsafe.Add(ref targetRef, indexLeft), Unsafe.Add(ref targetRef, indexRight));
                         Unsafe.Add(ref targetRef, j) = Avx2.Permute4x64(sum.AsDouble(), 0b11_01_10_00).AsSingle();
                     }
@@ -219,7 +219,7 @@ internal class ComponentProcessor : IDisposable
                 }
 
                 ref float targetRef = ref MemoryMarshal.GetReference(target);
-                for (nint i = count * Vector<float>.Count; i < target.Length; i++)
+                for (nint i = count * Vector<float>.Count; i < (uint)target.Length; i++)
                 {
                     Unsafe.Add(ref targetRef, i) *= multiplier;
                 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
@@ -157,7 +157,7 @@ internal class ComponentProcessor : IDisposable
 
                 // Ideally we need to use log2: Numerics.Log2((uint)factor)
                 // but division by 2 works just fine in this case
-                int haddIterationsCount = (int)((uint)factor / 2);
+                uint haddIterationsCount = (uint)factor / 2;
 
                 // Transform spans so that it only contains 'remainder'
                 // values for the scalar fallback code
@@ -168,7 +168,7 @@ internal class ComponentProcessor : IDisposable
 
                 nuint length = (uint)(touchedCount / Vector256<float>.Count);
 
-                for (int i = 0; i < haddIterationsCount; i++)
+                for (uint i = 0; i < haddIterationsCount; i++)
                 {
                     length /= 2;
 

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
@@ -122,8 +122,8 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> sourceVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(source));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
-                nint count = (nint)(uint)source.Length / Vector256<float>.Count;
-                for (nint i = 0; i < count; i++)
+                nuint count = (uint)(source.Length / Vector256<float>.Count);
+                for (nuint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) = Avx.Add(Unsafe.Add(ref targetVectorRef, i), Unsafe.Add(ref sourceVectorRef, i));
                 }
@@ -133,15 +133,15 @@ internal class ComponentProcessor : IDisposable
                 ref Vector<float> targetVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(target));
                 ref Vector<float> sourceVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(source));
 
-                nint count = (nint)(uint)source.Length / Vector<float>.Count;
-                for (nint i = 0; i < count; i++)
+                nuint count = (uint)(source.Length / Vector<float>.Count);
+                for (nuint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) += Unsafe.Add(ref sourceVectorRef, i);
                 }
 
                 ref float targetRef = ref MemoryMarshal.GetReference(target);
                 ref float sourceRef = ref MemoryMarshal.GetReference(source);
-                for (nint i = count * Vector<float>.Count; i < (uint)source.Length; i++)
+                for (nuint i = count * (uint)Vector<float>.Count; i < (uint)source.Length; i++)
                 {
                     Unsafe.Add(ref targetRef, i) += Unsafe.Add(ref sourceRef, i);
                 }
@@ -166,16 +166,16 @@ internal class ComponentProcessor : IDisposable
                 source = source.Slice(touchedCount);
                 target = target.Slice(touchedCount / factor);
 
-                nint length = (nint)(uint)touchedCount / Vector256<float>.Count;
+                nuint length = (uint)(touchedCount / Vector256<float>.Count);
 
                 for (int i = 0; i < haddIterationsCount; i++)
                 {
                     length /= 2;
 
-                    for (nint j = 0; j < length; j++)
+                    for (nuint j = 0; j < length; j++)
                     {
-                        nint indexLeft = j * 2;
-                        nint indexRight = indexLeft + 1;
+                        nuint indexLeft = j * 2;
+                        nuint indexRight = indexLeft + 1;
                         Vector256<float> sum = Avx.HorizontalAdd(Unsafe.Add(ref targetRef, indexLeft), Unsafe.Add(ref targetRef, indexRight));
                         Unsafe.Add(ref targetRef, j) = Avx2.Permute4x64(sum.AsDouble(), 0b11_01_10_00).AsSingle();
                     }
@@ -200,9 +200,9 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> targetVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(target));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
-                nint count = (nint)(uint)target.Length / Vector256<float>.Count;
+                nuint count = (uint)(target.Length / Vector256<float>.Count);
                 var multiplierVector = Vector256.Create(multiplier);
-                for (nint i = 0; i < count; i++)
+                for (nuint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) = Avx.Multiply(Unsafe.Add(ref targetVectorRef, i), multiplierVector);
                 }
@@ -211,15 +211,15 @@ internal class ComponentProcessor : IDisposable
             {
                 ref Vector<float> targetVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(target));
 
-                nint count = (nint)(uint)target.Length / Vector<float>.Count;
+                nuint count = (uint)(target.Length / Vector<float>.Count);
                 var multiplierVector = new Vector<float>(multiplier);
-                for (nint i = 0; i < count; i++)
+                for (nuint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) *= multiplierVector;
                 }
 
                 ref float targetRef = ref MemoryMarshal.GetReference(target);
-                for (nint i = count * Vector<float>.Count; i < (uint)target.Length; i++)
+                for (nuint i = count * (uint)Vector<float>.Count; i < (uint)target.Length; i++)
                 {
                     Unsafe.Add(ref targetRef, i) *= multiplier;
                 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
@@ -122,7 +122,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> sourceVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(source));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
-                nint count = source.Length / Vector256<float>.Count;
+                nint count = (nint)(uint)source.Length / Vector256<float>.Count;
                 for (nint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) = Avx.Add(Unsafe.Add(ref targetVectorRef, i), Unsafe.Add(ref sourceVectorRef, i));
@@ -133,7 +133,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector<float> targetVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(target));
                 ref Vector<float> sourceVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(source));
 
-                nint count = source.Length / Vector<float>.Count;
+                nint count = (nint)(uint)source.Length / Vector<float>.Count;
                 for (nint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) += Unsafe.Add(ref sourceVectorRef, i);
@@ -200,7 +200,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> targetVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(target));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
-                nint count = target.Length / Vector256<float>.Count;
+                nint count = (nint)(uint)target.Length / Vector256<float>.Count;
                 var multiplierVector = Vector256.Create(multiplier);
                 for (nint i = 0; i < count; i++)
                 {
@@ -211,7 +211,7 @@ internal class ComponentProcessor : IDisposable
             {
                 ref Vector<float> targetVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(target));
 
-                nint count = target.Length / Vector<float>.Count;
+                nint count = (nint)(uint)target.Length / Vector<float>.Count;
                 var multiplierVector = new Vector<float>(multiplier);
                 for (nint i = 0; i < count; i++)
                 {

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
@@ -122,7 +122,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> sourceVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(source));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
-                nuint count = (uint)(source.Length / Vector256<float>.Count);
+                nuint count = (uint)source.Length / (uint)Vector256<float>.Count;
                 for (nuint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) = Avx.Add(Unsafe.Add(ref targetVectorRef, i), Unsafe.Add(ref sourceVectorRef, i));
@@ -133,7 +133,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector<float> targetVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(target));
                 ref Vector<float> sourceVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(source));
 
-                nuint count = (uint)(source.Length / Vector<float>.Count);
+                nuint count = (uint)source.Length / (uint)Vector<float>.Count;
                 for (nuint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) += Unsafe.Add(ref sourceVectorRef, i);
@@ -166,7 +166,7 @@ internal class ComponentProcessor : IDisposable
                 source = source.Slice(touchedCount);
                 target = target.Slice(touchedCount / factor);
 
-                nuint length = (uint)(touchedCount / Vector256<float>.Count);
+                nuint length = (uint)touchedCount / (uint)Vector256<float>.Count;
 
                 for (uint i = 0; i < haddIterationsCount; i++)
                 {
@@ -200,7 +200,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> targetVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(target));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
-                nuint count = (uint)(target.Length / Vector256<float>.Count);
+                nuint count = (uint)target.Length / (uint)Vector256<float>.Count;
                 var multiplierVector = Vector256.Create(multiplier);
                 for (nuint i = 0; i < count; i++)
                 {
@@ -211,7 +211,7 @@ internal class ComponentProcessor : IDisposable
             {
                 ref Vector<float> targetVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(target));
 
-                nuint count = (uint)(target.Length / Vector<float>.Count);
+                nuint count = (uint)target.Length / (uint)Vector<float>.Count;
                 var multiplierVector = new Vector<float>(multiplier);
                 for (nuint i = 0; i < count; i++)
                 {

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/HuffmanScanEncoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/HuffmanScanEncoder.cs
@@ -180,7 +180,7 @@ internal class HuffmanScanEncoder
             Span<Block8x8> blockSpan = component.SpectralBlocks.DangerousGetRowSpan(y: 0);
             ref Block8x8 blockRef = ref MemoryMarshal.GetReference(blockSpan);
 
-            for (nint k = 0; k < w; k++)
+            for (nint k = 0; k < (uint)w; k++)
             {
                 this.WriteBlock(
                     component,
@@ -219,7 +219,7 @@ internal class HuffmanScanEncoder
             Span<Block8x8> blockSpan = component.SpectralBlocks.DangerousGetRowSpan(y: i);
             ref Block8x8 blockRef = ref MemoryMarshal.GetReference(blockSpan);
 
-            for (nint k = 0; k < w; k++)
+            for (nint k = 0; k < (uint)w; k++)
             {
                 this.WriteBlock(
                     component,

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/HuffmanScanEncoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/HuffmanScanEncoder.cs
@@ -123,7 +123,7 @@ internal class HuffmanScanEncoder
     private bool IsStreamFlushNeeded
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => this.emitWriteIndex < (uint)this.emitBuffer.Length / 2;
+        get => this.emitWriteIndex < (int)((uint)this.emitBuffer.Length / 2);
     }
 
     public void BuildHuffmanTable(JpegHuffmanTableConfig tableConfig)

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/HuffmanScanEncoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/HuffmanScanEncoder.cs
@@ -180,7 +180,7 @@ internal class HuffmanScanEncoder
             Span<Block8x8> blockSpan = component.SpectralBlocks.DangerousGetRowSpan(y: 0);
             ref Block8x8 blockRef = ref MemoryMarshal.GetReference(blockSpan);
 
-            for (nint k = 0; k < (uint)w; k++)
+            for (nuint k = 0; k < (uint)w; k++)
             {
                 this.WriteBlock(
                     component,
@@ -219,7 +219,7 @@ internal class HuffmanScanEncoder
             Span<Block8x8> blockSpan = component.SpectralBlocks.DangerousGetRowSpan(y: i);
             ref Block8x8 blockRef = ref MemoryMarshal.GetReference(blockSpan);
 
-            for (nint k = 0; k < (uint)w; k++)
+            for (nuint k = 0; k < (uint)w; k++)
             {
                 this.WriteBlock(
                     component,
@@ -246,9 +246,9 @@ internal class HuffmanScanEncoder
     private void EncodeScanBaselineInterleaved<TPixel>(JpegFrame frame, SpectralConverter<TPixel> converter, CancellationToken cancellationToken)
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        nint mcu = 0;
-        nint mcusPerColumn = frame.McusPerColumn;
-        nint mcusPerLine = frame.McusPerLine;
+        int mcu = 0;
+        int mcusPerColumn = frame.McusPerColumn;
+        int mcusPerLine = frame.McusPerLine;
 
         for (int j = 0; j < mcusPerColumn; j++)
         {
@@ -258,21 +258,21 @@ internal class HuffmanScanEncoder
             converter.ConvertStrideBaseline();
 
             // Encode spectral to binary
-            for (nint i = 0; i < mcusPerLine; i++)
+            for (int i = 0; i < mcusPerLine; i++)
             {
                 // Scan an interleaved mcu... process components in order
-                nint mcuCol = mcu % mcusPerLine;
-                for (nint k = 0; k < frame.Components.Length; k++)
+                int mcuCol = mcu % mcusPerLine;
+                for (int k = 0; k < frame.Components.Length; k++)
                 {
                     Component component = frame.Components[k];
 
                     ref HuffmanLut dcHuffmanTable = ref this.dcHuffmanTables[component.DcTableId];
                     ref HuffmanLut acHuffmanTable = ref this.acHuffmanTables[component.AcTableId];
 
-                    nint h = component.HorizontalSamplingFactor;
+                    int h = component.HorizontalSamplingFactor;
                     int v = component.VerticalSamplingFactor;
 
-                    nint blockColBase = mcuCol * h;
+                    nuint blockColBase = (uint)(mcuCol * h);
 
                     // Scan out an mcu's worth of this component; that's just determined
                     // by the basic H and V specified for the component
@@ -281,9 +281,9 @@ internal class HuffmanScanEncoder
                         Span<Block8x8> blockSpan = component.SpectralBlocks.DangerousGetRowSpan(y);
                         ref Block8x8 blockRef = ref MemoryMarshal.GetReference(blockSpan);
 
-                        for (nint x = 0; x < h; x++)
+                        for (nuint x = 0; x < (uint)h; x++)
                         {
-                            nint blockCol = blockColBase + x;
+                            nuint blockCol = blockColBase + x;
 
                             this.WriteBlock(
                                 component,
@@ -315,8 +315,8 @@ internal class HuffmanScanEncoder
     private void EncodeThreeComponentBaselineInterleavedScanNoSubsampling<TPixel>(JpegFrame frame, SpectralConverter<TPixel> converter, CancellationToken cancellationToken)
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        nint mcusPerColumn = frame.McusPerColumn;
-        nint mcusPerLine = frame.McusPerLine;
+        nuint mcusPerColumn = (uint)frame.McusPerColumn;
+        nuint mcusPerLine = (uint)frame.McusPerLine;
 
         Component c2 = frame.Components[2];
         Component c1 = frame.Components[1];
@@ -333,7 +333,7 @@ internal class HuffmanScanEncoder
         ref Block8x8 c1BlockRef = ref MemoryMarshal.GetReference(c1.SpectralBlocks.DangerousGetRowSpan(y: 0));
         ref Block8x8 c2BlockRef = ref MemoryMarshal.GetReference(c2.SpectralBlocks.DangerousGetRowSpan(y: 0));
 
-        for (nint j = 0; j < mcusPerColumn; j++)
+        for (nuint j = 0; j < mcusPerColumn; j++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -341,7 +341,7 @@ internal class HuffmanScanEncoder
             converter.ConvertStrideBaseline();
 
             // Encode spectral to binary
-            for (nint i = 0; i < mcusPerLine; i++)
+            for (nuint i = 0; i < mcusPerLine; i++)
             {
                 this.WriteBlock(
                     c0,

--- a/src/ImageSharp/Formats/Jpeg/Components/FloatingPointDCT.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/FloatingPointDCT.cs
@@ -69,7 +69,7 @@ internal static partial class FloatingPointDCT
     {
         ref float tableRef = ref Unsafe.As<Block8x8F, float>(ref quantTable);
         ref float multipliersRef = ref MemoryMarshal.GetReference<float>(AdjustmentCoefficients);
-        for (nint i = 0; i < Block8x8F.Size; i++)
+        for (nuint i = 0; i < Block8x8F.Size; i++)
         {
             ref float elemRef = ref Unsafe.Add(ref tableRef, i);
             elemRef = 0.125f * elemRef * Unsafe.Add(ref multipliersRef, i);
@@ -88,7 +88,7 @@ internal static partial class FloatingPointDCT
     {
         ref float tableRef = ref Unsafe.As<Block8x8F, float>(ref quantTable);
         ref float multipliersRef = ref MemoryMarshal.GetReference<float>(AdjustmentCoefficients);
-        for (nint i = 0; i < Block8x8F.Size; i++)
+        for (nuint i = 0; i < Block8x8F.Size; i++)
         {
             ref float elemRef = ref Unsafe.Add(ref tableRef, i);
             elemRef = 0.125f / (elemRef * Unsafe.Add(ref multipliersRef, i));

--- a/src/ImageSharp/Formats/Jpeg/Components/ScaledFloatingPointDCT.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ScaledFloatingPointDCT.cs
@@ -103,10 +103,10 @@ internal static class ScaledFloatingPointDCT
             // temporal result is saved to +4 shifted indices
             // because result is saved into the top left 2x2 region of the
             // input block
-            block[(ctr * 8) + 0 + 4] = (tmp10 + tmp2) / 2;
-            block[(ctr * 8) + 3 + 4] = (tmp10 - tmp2) / 2;
-            block[(ctr * 8) + 1 + 4] = (tmp12 + tmp0) / 2;
-            block[(ctr * 8) + 2 + 4] = (tmp12 - tmp0) / 2;
+            block[(ctr * 8) + 0 + 4] = (tmp10 + tmp2) * 0.5F;
+            block[(ctr * 8) + 3 + 4] = (tmp10 - tmp2) * 0.5F;
+            block[(ctr * 8) + 1 + 4] = (tmp12 + tmp0) * 0.5F;
+            block[(ctr * 8) + 2 + 4] = (tmp12 - tmp0) * 0.5F;
         }
 
         for (int ctr = 0; ctr < 4; ctr++)
@@ -136,10 +136,10 @@ internal static class ScaledFloatingPointDCT
                    (z4 * FP32_2_562915447);
 
             // Save results to the top left 4x4 subregion
-            block[(ctr * 8) + 0] = MathF.Round(Numerics.Clamp(((tmp10 + tmp2) / 2) + normalizationValue, 0, maxValue));
-            block[(ctr * 8) + 3] = MathF.Round(Numerics.Clamp(((tmp10 - tmp2) / 2) + normalizationValue, 0, maxValue));
-            block[(ctr * 8) + 1] = MathF.Round(Numerics.Clamp(((tmp12 + tmp0) / 2) + normalizationValue, 0, maxValue));
-            block[(ctr * 8) + 2] = MathF.Round(Numerics.Clamp(((tmp12 - tmp0) / 2) + normalizationValue, 0, maxValue));
+            block[(ctr * 8) + 0] = MathF.Round(Numerics.Clamp(((tmp10 + tmp2) * 0.5F) + normalizationValue, 0, maxValue));
+            block[(ctr * 8) + 3] = MathF.Round(Numerics.Clamp(((tmp10 - tmp2) * 0.5F) + normalizationValue, 0, maxValue));
+            block[(ctr * 8) + 1] = MathF.Round(Numerics.Clamp(((tmp12 + tmp0) * 0.5F) + normalizationValue, 0, maxValue));
+            block[(ctr * 8) + 2] = MathF.Round(Numerics.Clamp(((tmp12 - tmp0) * 0.5F) + normalizationValue, 0, maxValue));
         }
     }
 
@@ -183,8 +183,8 @@ internal static class ScaledFloatingPointDCT
             // temporal result is saved to +2 shifted indices
             // because result is saved into the top left 2x2 region of the
             // input block
-            block[(ctr * 8) + 2] = (tmp10 + tmp0) / 4;
-            block[(ctr * 8) + 3] = (tmp10 - tmp0) / 4;
+            block[(ctr * 8) + 2] = (tmp10 + tmp0) * 0.25F;  // /4
+            block[(ctr * 8) + 3] = (tmp10 - tmp0) * 0.25F;  // /4
         }
 
         for (int ctr = 0; ctr < 2; ctr++)
@@ -199,8 +199,8 @@ internal static class ScaledFloatingPointDCT
                    (block[ctr + (8 * 1) + 2] * FP32_3_624509785);
 
             // Save results to the top left 2x2 subregion
-            block[(ctr * 8) + 0] = MathF.Round(Numerics.Clamp(((tmp10 + tmp0) / 4) + normalizationValue, 0, maxValue));
-            block[(ctr * 8) + 1] = MathF.Round(Numerics.Clamp(((tmp10 - tmp0) / 4) + normalizationValue, 0, maxValue));
+            block[(ctr * 8) + 0] = MathF.Round(Numerics.Clamp(((tmp10 + tmp0) * 0.25F) + normalizationValue, 0, maxValue));
+            block[(ctr * 8) + 1] = MathF.Round(Numerics.Clamp(((tmp10 - tmp0) * 0.25F) + normalizationValue, 0, maxValue));
         }
     }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/ScaledFloatingPointDCT.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ScaledFloatingPointDCT.cs
@@ -183,8 +183,8 @@ internal static class ScaledFloatingPointDCT
             // temporal result is saved to +2 shifted indices
             // because result is saved into the top left 2x2 region of the
             // input block
-            block[(ctr * 8) + 2] = (tmp10 + tmp0) * 0.25F;  // /4
-            block[(ctr * 8) + 3] = (tmp10 - tmp0) * 0.25F;  // /4
+            block[(ctr * 8) + 2] = (tmp10 + tmp0) * 0.25F;
+            block[(ctr * 8) + 3] = (tmp10 - tmp0) * 0.25F;
         }
 
         for (int ctr = 0; ctr < 2; ctr++)

--- a/src/ImageSharp/Formats/Jpeg/Components/ScaledFloatingPointDCT.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ScaledFloatingPointDCT.cs
@@ -40,7 +40,7 @@ internal static class ScaledFloatingPointDCT
     public static void AdjustToIDCT(ref Block8x8F quantTable)
     {
         ref float tableRef = ref Unsafe.As<Block8x8F, float>(ref quantTable);
-        for (nint i = 0; i < Block8x8F.Size; i++)
+        for (nuint i = 0; i < Block8x8F.Size; i++)
         {
             ref float elemRef = ref Unsafe.Add(ref tableRef, i);
             elemRef = 0.125f * elemRef;

--- a/src/ImageSharp/Formats/Png/Adam7.cs
+++ b/src/ImageSharp/Formats/Png/Adam7.cs
@@ -67,16 +67,22 @@ internal static class Adam7
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int ComputeColumns(int width, int passIndex)
     {
-        switch (passIndex)
+        uint w = (uint)width;
+
+        uint result = passIndex switch
         {
-            case 0: return (width + 7) / 8;
-            case 1: return (width + 3) / 8;
-            case 2: return (width + 3) / 4;
-            case 3: return (width + 1) / 4;
-            case 4: return (width + 1) / 2;
-            case 5: return width / 2;
-            case 6: return width;
-            default: throw new ArgumentException($"Not a valid pass index: {passIndex}");
-        }
+            0 => (w + 7) / 8,
+            1 => (w + 3) / 8,
+            2 => (w + 3) / 4,
+            3 => (w + 1) / 4,
+            4 => (w + 1) / 2,
+            5 => w / 2,
+            6 => w,
+            _ => Throw(passIndex)
+        };
+
+        return (int)result;
+
+        static uint Throw(int passIndex) => throw new ArgumentException($"Not a valid pass index: {passIndex}");
     }
 }

--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -42,7 +42,7 @@ internal static class AverageFilter
         }
         else
         {
-            DecodeScalar(scanline, previousScanline, bytesPerPixel);
+            DecodeScalar(scanline, previousScanline, (nint)(uint)bytesPerPixel);
         }
     }
 
@@ -88,7 +88,7 @@ internal static class AverageFilter
         Vector64<byte> d = Vector64<byte>.Zero;
 
         int rb = scanline.Length;
-        int offset = 1;
+        nint offset = 1;
         const int bytesPerBatch = 4;
         while (rb >= bytesPerBatch)
         {
@@ -108,7 +108,7 @@ internal static class AverageFilter
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void DecodeScalar(Span<byte> scanline, Span<byte> previousScanline, int bytesPerPixel)
+    private static void DecodeScalar(Span<byte> scanline, Span<byte> previousScanline, nint bytesPerPixel)
     {
         ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
         ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
@@ -121,7 +121,7 @@ internal static class AverageFilter
             scan = (byte)(scan + (above >> 1));
         }
 
-        for (; x < scanline.Length; ++x)
+        for (; x < (uint)scanline.Length; ++x)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
@@ -153,7 +153,7 @@ internal static class AverageFilter
         resultBaseRef = (byte)FilterType.Average;
 
         nint x = 0;
-        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        for (; x < (uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -169,7 +169,7 @@ internal static class AverageFilter
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
             Vector256<byte> allBitsSet = Avx2.CompareEqual(sumAccumulator, sumAccumulator).AsByte();
 
-            for (nint xLeft = x - bytesPerPixel; x <= scanline.Length - Vector256<byte>.Count; xLeft += Vector256<byte>.Count)
+            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (uint)scanline.Length - Vector256<byte>.Count; xLeft += Vector256<byte>.Count)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> left = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -192,7 +192,7 @@ internal static class AverageFilter
             Vector128<int> sumAccumulator = Vector128<int>.Zero;
             Vector128<byte> allBitsSet = Sse2.CompareEqual(sumAccumulator, sumAccumulator).AsByte();
 
-            for (nint xLeft = x - bytesPerPixel; x <= scanline.Length - Vector128<byte>.Count; xLeft += Vector128<byte>.Count)
+            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (uint)scanline.Length - Vector128<byte>.Count; xLeft += Vector128<byte>.Count)
             {
                 Vector128<byte> scan = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector128<byte> left = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -221,7 +221,7 @@ internal static class AverageFilter
             sum += Numerics.EvenReduceSum(sumAccumulator);
         }
 
-        for (nint xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, xLeft);

--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -42,7 +42,7 @@ internal static class AverageFilter
         }
         else
         {
-            DecodeScalar(scanline, previousScanline, (nint)(uint)bytesPerPixel);
+            DecodeScalar(scanline, previousScanline, (uint)bytesPerPixel);
         }
     }
 
@@ -56,7 +56,7 @@ internal static class AverageFilter
         Vector128<byte> ones = Vector128.Create((byte)1);
 
         int rb = scanline.Length;
-        nint offset = 1;
+        nuint offset = 1;
         while (rb >= 4)
         {
             ref byte scanRef = ref Unsafe.Add(ref scanBaseRef, offset);
@@ -88,7 +88,7 @@ internal static class AverageFilter
         Vector64<byte> d = Vector64<byte>.Zero;
 
         int rb = scanline.Length;
-        nint offset = 1;
+        nuint offset = 1;
         const int bytesPerBatch = 4;
         while (rb >= bytesPerBatch)
         {
@@ -108,12 +108,12 @@ internal static class AverageFilter
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void DecodeScalar(Span<byte> scanline, Span<byte> previousScanline, nint bytesPerPixel)
+    private static void DecodeScalar(Span<byte> scanline, Span<byte> previousScanline, uint bytesPerPixel)
     {
         ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
         ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
 
-        nint x = 1;
+        nuint x = 1;
         for (; x <= bytesPerPixel /* Note the <= because x starts at 1 */; ++x)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
@@ -139,7 +139,7 @@ internal static class AverageFilter
     /// <param name="bytesPerPixel">The bytes per pixel.</param>
     /// <param name="sum">The sum of the total variance of the filtered row.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Encode(ReadOnlySpan<byte> scanline, ReadOnlySpan<byte> previousScanline, Span<byte> result, int bytesPerPixel, out int sum)
+    public static void Encode(ReadOnlySpan<byte> scanline, ReadOnlySpan<byte> previousScanline, Span<byte> result, uint bytesPerPixel, out int sum)
     {
         DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
         DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
@@ -152,8 +152,8 @@ internal static class AverageFilter
         // Average(x) = Raw(x) - floor((Raw(x-bpp)+Prior(x))/2)
         resultBaseRef = (byte)FilterType.Average;
 
-        nint x = 0;
-        for (; x < (uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        nuint x = 0;
+        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -169,7 +169,7 @@ internal static class AverageFilter
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
             Vector256<byte> allBitsSet = Avx2.CompareEqual(sumAccumulator, sumAccumulator).AsByte();
 
-            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (uint)scanline.Length - Vector256<byte>.Count; xLeft += Vector256<byte>.Count)
+            for (nuint xLeft = x - bytesPerPixel; x <= (uint)(scanline.Length - Vector256<byte>.Count); xLeft += (uint)Vector256<byte>.Count)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> left = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -179,7 +179,7 @@ internal static class AverageFilter
                 Vector256<byte> res = Avx2.Subtract(scan, avg);
 
                 Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref resultBaseRef, x + 1)) = res; // +1 to skip filter type
-                x += Vector256<byte>.Count;
+                x += (uint)Vector256<byte>.Count;
 
                 sumAccumulator = Avx2.Add(sumAccumulator, Avx2.SumAbsoluteDifferences(Avx2.Abs(res.AsSByte()), zero).AsInt32());
             }
@@ -192,7 +192,7 @@ internal static class AverageFilter
             Vector128<int> sumAccumulator = Vector128<int>.Zero;
             Vector128<byte> allBitsSet = Sse2.CompareEqual(sumAccumulator, sumAccumulator).AsByte();
 
-            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (uint)scanline.Length - Vector128<byte>.Count; xLeft += Vector128<byte>.Count)
+            for (nuint xLeft = x - bytesPerPixel; x <= (uint)(scanline.Length - Vector128<byte>.Count); xLeft += (uint)Vector128<byte>.Count)
             {
                 Vector128<byte> scan = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector128<byte> left = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -202,7 +202,7 @@ internal static class AverageFilter
                 Vector128<byte> res = Sse2.Subtract(scan, avg);
 
                 Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref resultBaseRef, x + 1)) = res; // +1 to skip filter type
-                x += Vector128<byte>.Count;
+                x += (uint)Vector128<byte>.Count;
 
                 Vector128<byte> absRes;
                 if (Ssse3.IsSupported)
@@ -221,7 +221,7 @@ internal static class AverageFilter
             sum += Numerics.EvenReduceSum(sumAccumulator);
         }
 
-        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (nuint xLeft = x - bytesPerPixel; x < (uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, xLeft);

--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -187,14 +187,14 @@ internal static class PaethFilter
         // Paeth(x) + PaethPredictor(Raw(x-bpp), Prior(x), Prior(x-bpp))
         int offset = bytesPerPixel + 1; // Add one because x starts at one.
         nint x = 1;
-        for (; x < offset; x++)
+        for (; x < (uint)offset; x++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
             scan = (byte)(scan + above);
         }
 
-        for (; x < scanline.Length; x++)
+        for (; x < (uint)scanline.Length; x++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
@@ -227,7 +227,7 @@ internal static class PaethFilter
         resultBaseRef = (byte)FilterType.Paeth;
 
         nint x = 0;
-        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        for (; x < (uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -242,7 +242,7 @@ internal static class PaethFilter
             Vector256<byte> zero = Vector256<byte>.Zero;
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
 
-            for (nint xLeft = x - bytesPerPixel; x <= scanline.Length - Vector256<byte>.Count; xLeft += Vector256<byte>.Count)
+            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (nint)(uint)scanline.Length - Vector256<byte>.Count; xLeft += Vector256<byte>.Count)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> left = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -262,7 +262,7 @@ internal static class PaethFilter
         {
             Vector<uint> sumAccumulator = Vector<uint>.Zero;
 
-            for (nint xLeft = x - bytesPerPixel; x <= scanline.Length - Vector<byte>.Count; xLeft += Vector<byte>.Count)
+            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (nint)(uint)scanline.Length - Vector<byte>.Count; xLeft += Vector<byte>.Count)
             {
                 Vector<byte> scan = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector<byte> left = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -282,7 +282,7 @@ internal static class PaethFilter
             }
         }
 
-        for (nint xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (nint)(uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, xLeft);

--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -45,7 +45,7 @@ internal static class PaethFilter
         }
         else
         {
-            DecodeScalar(scanline, previousScanline, bytesPerPixel);
+            DecodeScalar(scanline, previousScanline, (uint)bytesPerPixel);
         }
     }
 
@@ -59,7 +59,7 @@ internal static class PaethFilter
         Vector128<byte> d = Vector128<byte>.Zero;
 
         int rb = scanline.Length;
-        nint offset = 1;
+        nuint offset = 1;
         while (rb >= 4)
         {
             ref byte scanRef = ref Unsafe.Add(ref scanBaseRef, offset);
@@ -113,7 +113,7 @@ internal static class PaethFilter
         Vector128<byte> d = Vector128<byte>.Zero;
 
         int rb = scanline.Length;
-        nint offset = 1;
+        nuint offset = 1;
         const int bytesPerBatch = 4;
         while (rb >= bytesPerBatch)
         {
@@ -179,15 +179,15 @@ internal static class PaethFilter
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void DecodeScalar(Span<byte> scanline, Span<byte> previousScanline, int bytesPerPixel)
+    private static void DecodeScalar(Span<byte> scanline, Span<byte> previousScanline, uint bytesPerPixel)
     {
         ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
         ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
 
         // Paeth(x) + PaethPredictor(Raw(x-bpp), Prior(x), Prior(x-bpp))
-        int offset = bytesPerPixel + 1; // Add one because x starts at one.
-        nint x = 1;
-        for (; x < (uint)offset; x++)
+        nuint offset = bytesPerPixel + 1; // Add one because x starts at one.
+        nuint x = 1;
+        for (; x < offset; x++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -226,7 +226,7 @@ internal static class PaethFilter
         // Paeth(x) = Raw(x) - PaethPredictor(Raw(x-bpp), Prior(x), Prior(x - bpp))
         resultBaseRef = (byte)FilterType.Paeth;
 
-        nint x = 0;
+        nuint x = 0;
         for (; x < (uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
@@ -242,7 +242,7 @@ internal static class PaethFilter
             Vector256<byte> zero = Vector256<byte>.Zero;
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
 
-            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (nint)(uint)scanline.Length - Vector256<byte>.Count; xLeft += Vector256<byte>.Count)
+            for (nuint xLeft = x - (uint)bytesPerPixel; (int)x <= scanline.Length - Vector256<byte>.Count; xLeft += (uint)Vector256<byte>.Count)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> left = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -251,7 +251,7 @@ internal static class PaethFilter
 
                 Vector256<byte> res = Avx2.Subtract(scan, PaethPredictor(left, above, upperLeft));
                 Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref resultBaseRef, x + 1)) = res; // +1 to skip filter type
-                x += Vector256<byte>.Count;
+                x += (uint)Vector256<byte>.Count;
 
                 sumAccumulator = Avx2.Add(sumAccumulator, Avx2.SumAbsoluteDifferences(Avx2.Abs(res.AsSByte()), zero).AsInt32());
             }
@@ -262,7 +262,7 @@ internal static class PaethFilter
         {
             Vector<uint> sumAccumulator = Vector<uint>.Zero;
 
-            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (nint)(uint)scanline.Length - Vector<byte>.Count; xLeft += Vector<byte>.Count)
+            for (nuint xLeft = x - (uint)bytesPerPixel; (int)x <= scanline.Length - Vector<byte>.Count; xLeft += (uint)Vector<byte>.Count)
             {
                 Vector<byte> scan = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector<byte> left = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -271,7 +271,7 @@ internal static class PaethFilter
 
                 Vector<byte> res = scan - PaethPredictor(left, above, upperLeft);
                 Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref resultBaseRef, x + 1)) = res; // +1 to skip filter type
-                x += Vector<byte>.Count;
+                x += (uint)Vector<byte>.Count;
 
                 Numerics.Accumulate(ref sumAccumulator, Vector.AsVectorByte(Vector.Abs(Vector.AsVectorSByte(res))));
             }
@@ -282,7 +282,7 @@ internal static class PaethFilter
             }
         }
 
-        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (nint)(uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (nuint xLeft = x - (uint)bytesPerPixel; (int)x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, xLeft);

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -36,7 +36,7 @@ internal static class SubFilter
         }
         else
         {
-            DecodeScalar(scanline, bytesPerPixel);
+            DecodeScalar(scanline, (nint)(uint)bytesPerPixel);
         }
     }
 
@@ -70,7 +70,7 @@ internal static class SubFilter
         Vector64<byte> d = Vector64<byte>.Zero;
 
         int rb = scanline.Length;
-        int offset = 1;
+        nint offset = 1;
         const int bytesPerBatch = 4;
         while (rb >= bytesPerBatch)
         {
@@ -87,7 +87,7 @@ internal static class SubFilter
         }
     }
 
-    private static void DecodeScalar(Span<byte> scanline, int bytesPerPixel)
+    private static void DecodeScalar(Span<byte> scanline, nint bytesPerPixel)
     {
         ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
 
@@ -122,7 +122,7 @@ internal static class SubFilter
         resultBaseRef = (byte)FilterType.Sub;
 
         nint x = 0;
-        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        for (; x < (nint)(uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             ++x;
@@ -136,7 +136,7 @@ internal static class SubFilter
             Vector256<byte> zero = Vector256<byte>.Zero;
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
 
-            for (nint xLeft = x - bytesPerPixel; x <= scanline.Length - Vector256<byte>.Count; xLeft += Vector256<byte>.Count)
+            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (nint)(uint)scanline.Length - Vector256<byte>.Count; xLeft += Vector256<byte>.Count)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> prev = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -154,7 +154,7 @@ internal static class SubFilter
         {
             Vector<uint> sumAccumulator = Vector<uint>.Zero;
 
-            for (nint xLeft = x - bytesPerPixel; x <= scanline.Length - Vector<byte>.Count; xLeft += Vector<byte>.Count)
+            for (nint xLeft = x - (nint)(uint)bytesPerPixel; x <= (nint)(uint)scanline.Length - Vector<byte>.Count; xLeft += Vector<byte>.Count)
             {
                 Vector<byte> scan = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector<byte> prev = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -172,7 +172,7 @@ internal static class SubFilter
             }
         }
 
-        for (nint xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (nint)(uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte prev = Unsafe.Add(ref scanBaseRef, xLeft);

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -66,7 +66,7 @@ internal static class UpFilter
         }
 
         // Handle left over.
-        for (nint i = offset; i < scanline.Length; i++)
+        for (nint i = offset; i < (uint)scanline.Length; i++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, offset);
             byte above = Unsafe.Add(ref prevBaseRef, offset);
@@ -96,7 +96,7 @@ internal static class UpFilter
         }
 
         // Handle left over.
-        for (nint i = offset; i < scanline.Length; i++)
+        for (nint i = offset; i < (uint)scanline.Length; i++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, offset);
             byte above = Unsafe.Add(ref prevBaseRef, offset);
@@ -127,7 +127,7 @@ internal static class UpFilter
         }
 
         // Handle left over.
-        for (nint i = offset; i < scanline.Length; i++)
+        for (nint i = offset; i < (uint)scanline.Length; i++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, offset);
             byte above = Unsafe.Add(ref prevBaseRef, offset);
@@ -143,7 +143,7 @@ internal static class UpFilter
         ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
 
         // Up(x) + Prior(x)
-        for (nint x = 1; x < scanline.Length; x++)
+        for (nint x = 1; x < (uint)scanline.Length; x++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -179,7 +179,7 @@ internal static class UpFilter
             Vector256<byte> zero = Vector256<byte>.Zero;
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
 
-            for (; x <= scanline.Length - Vector256<byte>.Count;)
+            for (; x <= (nint)(uint)(scanline.Length - Vector256<byte>.Count);)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> above = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref prevBaseRef, x));
@@ -197,7 +197,7 @@ internal static class UpFilter
         {
             Vector<uint> sumAccumulator = Vector<uint>.Zero;
 
-            for (; x <= scanline.Length - Vector<byte>.Count;)
+            for (; x <= (nint)(uint)(scanline.Length - Vector<byte>.Count);)
             {
                 Vector<byte> scan = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector<byte> above = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref prevBaseRef, x));
@@ -215,7 +215,7 @@ internal static class UpFilter
             }
         }
 
-        for (; x < scanline.Length; /* Note: ++x happens in the body to avoid one add operation */)
+        for (; x < (nint)(uint)scanline.Length; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -52,7 +52,7 @@ internal static class UpFilter
 
         // Up(x) + Prior(x)
         int rb = scanline.Length;
-        nint offset = 1;
+        nuint offset = 1;
         while (rb >= Vector256<byte>.Count)
         {
             ref byte scanRef = ref Unsafe.Add(ref scanBaseRef, offset);
@@ -61,12 +61,12 @@ internal static class UpFilter
 
             Unsafe.As<byte, Vector256<byte>>(ref scanRef) = Avx2.Add(up, prior);
 
-            offset += Vector256<byte>.Count;
+            offset += (uint)Vector256<byte>.Count;
             rb -= Vector256<byte>.Count;
         }
 
         // Handle left over.
-        for (nint i = offset; i < (uint)scanline.Length; i++)
+        for (nuint i = offset; i < (uint)scanline.Length; i++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, offset);
             byte above = Unsafe.Add(ref prevBaseRef, offset);
@@ -82,7 +82,7 @@ internal static class UpFilter
 
         // Up(x) + Prior(x)
         int rb = scanline.Length;
-        nint offset = 1;
+        nuint offset = 1;
         while (rb >= Vector128<byte>.Count)
         {
             ref byte scanRef = ref Unsafe.Add(ref scanBaseRef, offset);
@@ -91,12 +91,12 @@ internal static class UpFilter
 
             Unsafe.As<byte, Vector128<byte>>(ref scanRef) = Sse2.Add(up, prior);
 
-            offset += Vector128<byte>.Count;
+            offset += (uint)Vector128<byte>.Count;
             rb -= Vector128<byte>.Count;
         }
 
         // Handle left over.
-        for (nint i = offset; i < (uint)scanline.Length; i++)
+        for (nuint i = offset; i < (uint)scanline.Length; i++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, offset);
             byte above = Unsafe.Add(ref prevBaseRef, offset);
@@ -112,7 +112,7 @@ internal static class UpFilter
 
         // Up(x) + Prior(x)
         int rb = scanline.Length;
-        nint offset = 1;
+        nuint offset = 1;
         const int bytesPerBatch = 16;
         while (rb >= bytesPerBatch)
         {
@@ -127,7 +127,7 @@ internal static class UpFilter
         }
 
         // Handle left over.
-        for (nint i = offset; i < (uint)scanline.Length; i++)
+        for (nuint i = offset; i < (uint)scanline.Length; i++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, offset);
             byte above = Unsafe.Add(ref prevBaseRef, offset);
@@ -143,7 +143,7 @@ internal static class UpFilter
         ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);
 
         // Up(x) + Prior(x)
-        for (nint x = 1; x < (uint)scanline.Length; x++)
+        for (nuint x = 1; x < (uint)scanline.Length; x++)
         {
             ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -172,21 +172,21 @@ internal static class UpFilter
         // Up(x) = Raw(x) - Prior(x)
         resultBaseRef = (byte)FilterType.Up;
 
-        nint x = 0;
+        nuint x = 0;
 
         if (Avx2.IsSupported)
         {
             Vector256<byte> zero = Vector256<byte>.Zero;
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
 
-            for (; x <= (nint)(uint)(scanline.Length - Vector256<byte>.Count);)
+            for (; x <= (uint)(scanline.Length - Vector256<byte>.Count);)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> above = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref prevBaseRef, x));
 
                 Vector256<byte> res = Avx2.Subtract(scan, above);
                 Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref resultBaseRef, x + 1)) = res; // +1 to skip filter type
-                x += Vector256<byte>.Count;
+                x += (uint)Vector256<byte>.Count;
 
                 sumAccumulator = Avx2.Add(sumAccumulator, Avx2.SumAbsoluteDifferences(Avx2.Abs(res.AsSByte()), zero).AsInt32());
             }
@@ -197,14 +197,14 @@ internal static class UpFilter
         {
             Vector<uint> sumAccumulator = Vector<uint>.Zero;
 
-            for (; x <= (nint)(uint)(scanline.Length - Vector<byte>.Count);)
+            for (; x <= (uint)(scanline.Length - Vector<byte>.Count);)
             {
                 Vector<byte> scan = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector<byte> above = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref prevBaseRef, x));
 
                 Vector<byte> res = scan - above;
                 Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref resultBaseRef, x + 1)) = res; // +1 to skip filter type
-                x += Vector<byte>.Count;
+                x += (uint)Vector<byte>.Count;
 
                 Numerics.Accumulate(ref sumAccumulator, Vector.AsVectorByte(Vector.Abs(Vector.AsVectorSByte(res))));
             }
@@ -215,7 +215,7 @@ internal static class UpFilter
             }
         }
 
-        for (; x < (nint)(uint)scanline.Length; /* Note: ++x happens in the body to avoid one add operation */)
+        for (; x < (uint)scanline.Length; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -777,8 +777,8 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                         this.header,
                         scanlineSpan,
                         rowSpan,
-                        this.bytesPerPixel,
-                        this.bytesPerSample);
+                        (uint)this.bytesPerPixel,
+                        (uint)this.bytesPerSample);
 
                     break;
 
@@ -858,8 +858,8 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                         this.header,
                         scanlineSpan,
                         rowSpan,
-                        pixelOffset,
-                        increment,
+                        (uint)pixelOffset,
+                        (uint)increment,
                         pngMetadata.HasTransparency,
                         pngMetadata.TransparentL16.GetValueOrDefault(),
                         pngMetadata.TransparentL8.GetValueOrDefault());
@@ -871,10 +871,10 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                         this.header,
                         scanlineSpan,
                         rowSpan,
-                        pixelOffset,
-                        increment,
-                        this.bytesPerPixel,
-                        this.bytesPerSample);
+                        (uint)pixelOffset,
+                        (uint)increment,
+                        (uint)this.bytesPerPixel,
+                        (uint)this.bytesPerSample);
 
                     break;
 
@@ -883,8 +883,8 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                         this.header,
                         scanlineSpan,
                         rowSpan,
-                        pixelOffset,
-                        increment,
+                        (uint)pixelOffset,
+                        (uint)increment,
                         this.palette,
                         this.paletteAlpha);
 
@@ -895,8 +895,8 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                         this.header,
                         scanlineSpan,
                         rowSpan,
-                        pixelOffset,
-                        increment,
+                        (uint)pixelOffset,
+                        (uint)increment,
                         this.bytesPerPixel,
                         this.bytesPerSample,
                         pngMetadata.HasTransparency,
@@ -910,8 +910,8 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                         this.header,
                         scanlineSpan,
                         rowSpan,
-                        pixelOffset,
-                        increment,
+                        (uint)pixelOffset,
+                        (uint)increment,
                         this.bytesPerPixel,
                         this.bytesPerSample);
 

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -414,11 +414,11 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
 
         for (int i = 0; i < bytesPerScanline; i++)
         {
-            byte b = Unsafe.Add(ref sourceRef, i);
+            byte b = Unsafe.Add(ref sourceRef, (uint)i);
             for (int shift = 0; shift < 8; shift += bits)
             {
                 int colorIndex = (b >> (8 - bits - shift)) & mask;
-                Unsafe.Add(ref resultRef, resultOffset) = (byte)colorIndex;
+                Unsafe.Add(ref resultRef, (uint)resultOffset) = (byte)colorIndex;
                 resultOffset++;
             }
         }

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -455,7 +455,7 @@ internal sealed class PngEncoderCore : IImageEncoderInternals, IDisposable
                 break;
 
             case PngFilterMethod.Average:
-                AverageFilter.Encode(this.currentScanline.GetSpan(), this.previousScanline.GetSpan(), filter, this.bytesPerPixel, out int _);
+                AverageFilter.Encode(this.currentScanline.GetSpan(), this.previousScanline.GetSpan(), filter, (uint)this.bytesPerPixel, out int _);
                 break;
 
             case PngFilterMethod.Paeth:
@@ -547,7 +547,7 @@ internal sealed class PngEncoderCore : IImageEncoderInternals, IDisposable
             RuntimeUtility.Swap(ref filter, ref attempt);
         }
 
-        AverageFilter.Encode(current, previous, attempt, this.bytesPerPixel, out sum);
+        AverageFilter.Encode(current, previous, attempt, (uint)this.bytesPerPixel, out sum);
         if (sum < min)
         {
             min = sum;

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -266,7 +266,7 @@ internal sealed class PngEncoderCore : IImageEncoderInternals, IDisposable
                 // Can't map directly to byte array as it's big-endian.
                 for (int x = 0, o = 0; x < luminanceSpan.Length; x++, o += 2)
                 {
-                    L16 luminance = Unsafe.Add(ref luminanceRef, x);
+                    L16 luminance = Unsafe.Add(ref luminanceRef, (uint)x);
                     BinaryPrimitives.WriteUInt16BigEndian(rawScanlineSpan.Slice(o, 2), luminance.PackedValue);
                 }
             }
@@ -306,7 +306,7 @@ internal sealed class PngEncoderCore : IImageEncoderInternals, IDisposable
             // Can't map directly to byte array as it's big endian.
             for (int x = 0, o = 0; x < laSpan.Length; x++, o += 4)
             {
-                La32 la = Unsafe.Add(ref laRef, x);
+                La32 la = Unsafe.Add(ref laRef, (uint)x);
                 BinaryPrimitives.WriteUInt16BigEndian(rawScanlineSpan.Slice(o, 2), la.L);
                 BinaryPrimitives.WriteUInt16BigEndian(rawScanlineSpan.Slice(o + 2, 2), la.A);
             }
@@ -366,7 +366,7 @@ internal sealed class PngEncoderCore : IImageEncoderInternals, IDisposable
                     // Can't map directly to byte array as it's big endian.
                     for (int x = 0, o = 0; x < rowSpan.Length; x++, o += 8)
                     {
-                        Rgba64 rgba = Unsafe.Add(ref rgbaRef, x);
+                        Rgba64 rgba = Unsafe.Add(ref rgbaRef, (uint)x);
                         BinaryPrimitives.WriteUInt16BigEndian(rawScanlineSpan.Slice(o, 2), rgba.R);
                         BinaryPrimitives.WriteUInt16BigEndian(rawScanlineSpan.Slice(o + 2, 2), rgba.G);
                         BinaryPrimitives.WriteUInt16BigEndian(rawScanlineSpan.Slice(o + 4, 2), rgba.B);
@@ -388,7 +388,7 @@ internal sealed class PngEncoderCore : IImageEncoderInternals, IDisposable
                     // Can't map directly to byte array as it's big endian.
                     for (int x = 0, o = 0; x < rowSpan.Length; x++, o += 6)
                     {
-                        Rgb48 rgb = Unsafe.Add(ref rgbRef, x);
+                        Rgb48 rgb = Unsafe.Add(ref rgbRef, (uint)x);
                         BinaryPrimitives.WriteUInt16BigEndian(rawScanlineSpan.Slice(o, 2), rgb.R);
                         BinaryPrimitives.WriteUInt16BigEndian(rawScanlineSpan.Slice(o + 2, 2), rgb.G);
                         BinaryPrimitives.WriteUInt16BigEndian(rawScanlineSpan.Slice(o + 4, 2), rgb.B);
@@ -617,17 +617,17 @@ internal sealed class PngEncoderCore : IImageEncoderInternals, IDisposable
         // Loop, assign, and extract alpha values from the palette.
         for (int i = 0; i < paletteLength; i++)
         {
-            Rgba32 rgba = Unsafe.Add(ref rgbaPaletteRef, i);
+            Rgba32 rgba = Unsafe.Add(ref rgbaPaletteRef, (uint)i);
             byte alpha = rgba.A;
 
-            Unsafe.Add(ref colorTableRef, i) = rgba.Rgb;
+            Unsafe.Add(ref colorTableRef, (uint)i) = rgba.Rgb;
             if (alpha > this.encoder.Threshold)
             {
                 alpha = byte.MaxValue;
             }
 
             hasAlpha = hasAlpha || alpha < byte.MaxValue;
-            Unsafe.Add(ref alphaTableRef, i) = alpha;
+            Unsafe.Add(ref alphaTableRef, (uint)i) = alpha;
         }
 
         this.WriteChunk(stream, PngChunkType.Palette, colorTable.GetSpan(), 0, colorTableLength);

--- a/src/ImageSharp/Formats/Png/PngEncoderHelpers.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderHelpers.cs
@@ -31,13 +31,13 @@ internal static class PngEncoderHelpers
 
         for (int i = 0; i < source.Length; i++)
         {
-            int value = ((int)MathF.Round(Unsafe.Add(ref sourceRef, i) / scale)) & mask;
+            int value = ((int)MathF.Round(Unsafe.Add(ref sourceRef, (uint)i) / scale)) & mask;
             v |= value << shift;
 
             if (shift == 0)
             {
                 shift = shift0;
-                Unsafe.Add(ref resultRef, resultOffset) = (byte)v;
+                Unsafe.Add(ref resultRef, (uint)resultOffset) = (byte)v;
                 resultOffset++;
                 v = 0;
             }
@@ -49,7 +49,7 @@ internal static class PngEncoderHelpers
 
         if (shift != shift0)
         {
-            Unsafe.Add(ref resultRef, resultOffset) = (byte)v;
+            Unsafe.Add(ref resultRef, (uint)resultOffset) = (byte)v;
         }
     }
 }

--- a/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
+++ b/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
@@ -255,7 +255,7 @@ internal static class PngScanlineProcessor
             // If the alpha palette is not null and has one or more entries, this means, that the image contains an alpha
             // channel and we should try to read it.
             Rgba32 rgba = default;
-            ref byte paletteAlphaRef = ref paletteAlpha[0];
+            ref byte paletteAlphaRef = ref MemoryMarshal.GetArrayDataReference(paletteAlpha);
 
             for (int x = 0; x < header.Width; x++)
             {
@@ -301,7 +301,7 @@ internal static class PngScanlineProcessor
             // If the alpha palette is not null and has one or more entries, this means, that the image contains an alpha
             // channel and we should try to read it.
             Rgba32 rgba = default;
-            ref byte paletteAlphaRef = ref paletteAlpha[0];
+            ref byte paletteAlphaRef = ref MemoryMarshal.GetArrayDataReference(paletteAlpha);
             for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
             {
                 int index = Unsafe.Add(ref scanlineSpanRef, (uint)o);

--- a/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
+++ b/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
@@ -32,20 +32,21 @@ internal static class PngScanlineProcessor
         {
             if (header.BitDepth == 16)
             {
-                for (int x = 0, o = 0; x < header.Width; x++, o += 2)
+                int o = 0;
+                for (nuint x = 0; x < (uint)header.Width; x++, o += 2)
                 {
                     ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
                     pixel.FromL16(Unsafe.As<ushort, L16>(ref luminance));
-                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
                 }
             }
             else
             {
-                for (int x = 0; x < header.Width; x++)
+                for (nuint x = 0; x < (uint)header.Width; x++)
                 {
-                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, (uint)x) * scaleFactor);
+                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, x) * scaleFactor);
                     pixel.FromL8(Unsafe.As<byte, L8>(ref luminance));
-                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
                 }
             }
 
@@ -55,28 +56,29 @@ internal static class PngScanlineProcessor
         if (header.BitDepth == 16)
         {
             La32 source = default;
-            for (int x = 0, o = 0; x < header.Width; x++, o += 2)
+            int o = 0;
+            for (nuint x = 0; x < (uint)header.Width; x++, o += 2)
             {
                 ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
                 source.L = luminance;
                 source.A = luminance.Equals(luminance16Trans.PackedValue) ? ushort.MinValue : ushort.MaxValue;
 
                 pixel.FromLa32(source);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
         else
         {
             La16 source = default;
             byte scaledLuminanceTrans = (byte)(luminanceTrans.PackedValue * scaleFactor);
-            for (int x = 0; x < header.Width; x++)
+            for (nuint x = 0; x < (uint)header.Width; x++)
             {
-                byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, (uint)x) * scaleFactor);
+                byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, x) * scaleFactor);
                 source.L = luminance;
                 source.A = luminance.Equals(scaledLuminanceTrans) ? byte.MinValue : byte.MaxValue;
 
                 pixel.FromLa16(source);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
     }
@@ -85,8 +87,8 @@ internal static class PngScanlineProcessor
         in PngHeader header,
         ReadOnlySpan<byte> scanlineSpan,
         Span<TPixel> rowSpan,
-        int pixelOffset,
-        int increment,
+        uint pixelOffset,
+        uint increment,
         bool hasTrans,
         L16 luminance16Trans,
         L8 luminanceTrans)
@@ -101,20 +103,21 @@ internal static class PngScanlineProcessor
         {
             if (header.BitDepth == 16)
             {
-                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += 2)
+                int o = 0;
+                for (nuint x = pixelOffset; x < (uint)header.Width; x += increment, o += 2)
                 {
                     ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
                     pixel.FromL16(Unsafe.As<ushort, L16>(ref luminance));
-                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
                 }
             }
             else
             {
-                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
+                for (nuint x = pixelOffset, o = 0; x < (uint)header.Width; x += increment, o++)
                 {
-                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, (uint)o) * scaleFactor);
+                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, o) * scaleFactor);
                     pixel.FromL8(Unsafe.As<byte, L8>(ref luminance));
-                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
                 }
             }
 
@@ -124,28 +127,29 @@ internal static class PngScanlineProcessor
         if (header.BitDepth == 16)
         {
             La32 source = default;
-            for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += 2)
+            int o = 0;
+            for (nuint x = pixelOffset; x < (uint)header.Width; x += increment, o += 2)
             {
                 ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
                 source.L = luminance;
                 source.A = luminance.Equals(luminance16Trans.PackedValue) ? ushort.MinValue : ushort.MaxValue;
 
                 pixel.FromLa32(source);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
         else
         {
             La16 source = default;
             byte scaledLuminanceTrans = (byte)(luminanceTrans.PackedValue * scaleFactor);
-            for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
+            for (nuint x = pixelOffset, o = 0; x < (uint)header.Width; x += increment, o++)
             {
-                byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, (uint)o) * scaleFactor);
+                byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, o) * scaleFactor);
                 source.L = luminance;
                 source.A = luminance.Equals(scaledLuminanceTrans) ? byte.MinValue : byte.MaxValue;
 
                 pixel.FromLa16(source);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
     }
@@ -154,8 +158,8 @@ internal static class PngScanlineProcessor
         in PngHeader header,
         ReadOnlySpan<byte> scanlineSpan,
         Span<TPixel> rowSpan,
-        int bytesPerPixel,
-        int bytesPerSample)
+        uint bytesPerPixel,
+        uint bytesPerSample)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         TPixel pixel = default;
@@ -165,26 +169,27 @@ internal static class PngScanlineProcessor
         if (header.BitDepth == 16)
         {
             La32 source = default;
-            for (int x = 0, o = 0; x < header.Width; x++, o += 4)
+            int o = 0;
+            for (nuint x = 0; x < (uint)header.Width; x++, o += 4)
             {
                 source.L = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
                 source.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + 2, 2));
 
                 pixel.FromLa32(source);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
         else
         {
             La16 source = default;
-            for (int x = 0; x < header.Width; x++)
+            for (nuint x = 0; x < (uint)header.Width; x++)
             {
-                int offset = x * bytesPerPixel;
-                source.L = Unsafe.Add(ref scanlineSpanRef, (uint)offset);
-                source.A = Unsafe.Add(ref scanlineSpanRef, (uint)(offset + bytesPerSample));
+                nuint offset = x * bytesPerPixel;
+                source.L = Unsafe.Add(ref scanlineSpanRef, offset);
+                source.A = Unsafe.Add(ref scanlineSpanRef, offset + bytesPerSample);
 
                 pixel.FromLa16(source);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
     }
@@ -193,10 +198,10 @@ internal static class PngScanlineProcessor
         in PngHeader header,
         ReadOnlySpan<byte> scanlineSpan,
         Span<TPixel> rowSpan,
-        int pixelOffset,
-        int increment,
-        int bytesPerPixel,
-        int bytesPerSample)
+        uint pixelOffset,
+        uint increment,
+        uint bytesPerPixel,
+        uint bytesPerSample)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         TPixel pixel = default;
@@ -206,7 +211,8 @@ internal static class PngScanlineProcessor
         if (header.BitDepth == 16)
         {
             La32 source = default;
-            for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += 4)
+            int o = 0;
+            for (nuint x = pixelOffset; x < (uint)header.Width; x += increment, o += 4)
             {
                 source.L = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
                 source.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + 2, 2));
@@ -217,15 +223,15 @@ internal static class PngScanlineProcessor
         }
         else
         {
-            int offset = 0;
             La16 source = default;
-            for (int x = pixelOffset; x < header.Width; x += increment)
+            nuint offset = 0;
+            for (nuint x = pixelOffset; x < (uint)header.Width; x += increment)
             {
-                source.L = Unsafe.Add(ref scanlineSpanRef, (uint)offset);
-                source.A = Unsafe.Add(ref scanlineSpanRef, (uint)(offset + bytesPerSample));
+                source.L = Unsafe.Add(ref scanlineSpanRef, offset);
+                source.A = Unsafe.Add(ref scanlineSpanRef, offset + bytesPerSample);
 
                 pixel.FromLa16(source);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
                 offset += bytesPerPixel;
             }
         }
@@ -257,25 +263,25 @@ internal static class PngScanlineProcessor
             Rgba32 rgba = default;
             ref byte paletteAlphaRef = ref MemoryMarshal.GetArrayDataReference(paletteAlpha);
 
-            for (int x = 0; x < header.Width; x++)
+            for (nuint x = 0; x < (uint)header.Width; x++)
             {
-                int index = Unsafe.Add(ref scanlineSpanRef, (uint)x);
-                rgba.Rgb = Unsafe.Add(ref palettePixelsRef, (uint)index);
-                rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, (uint)index) : byte.MaxValue;
+                uint index = Unsafe.Add(ref scanlineSpanRef, x);
+                rgba.Rgb = Unsafe.Add(ref palettePixelsRef, index);
+                rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, index) : byte.MaxValue;
 
                 pixel.FromRgba32(rgba);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
         else
         {
-            for (int x = 0; x < header.Width; x++)
+            for (nuint x = 0; x < (uint)header.Width; x++)
             {
-                int index = Unsafe.Add(ref scanlineSpanRef, (uint)x);
-                Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, (uint)index);
+                int index = Unsafe.Add(ref scanlineSpanRef, x);
+                Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, index);
 
                 pixel.FromRgb24(rgb);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
     }
@@ -284,8 +290,8 @@ internal static class PngScanlineProcessor
         in PngHeader header,
         ReadOnlySpan<byte> scanlineSpan,
         Span<TPixel> rowSpan,
-        int pixelOffset,
-        int increment,
+        uint pixelOffset,
+        uint increment,
         ReadOnlySpan<byte> palette,
         byte[] paletteAlpha)
         where TPixel : unmanaged, IPixel<TPixel>
@@ -302,25 +308,25 @@ internal static class PngScanlineProcessor
             // channel and we should try to read it.
             Rgba32 rgba = default;
             ref byte paletteAlphaRef = ref MemoryMarshal.GetArrayDataReference(paletteAlpha);
-            for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
+            for (nuint x = pixelOffset, o = 0; x < (uint)header.Width; x += increment, o++)
             {
-                int index = Unsafe.Add(ref scanlineSpanRef, (uint)o);
-                rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, (uint)index) : byte.MaxValue;
-                rgba.Rgb = Unsafe.Add(ref palettePixelsRef, (uint)index);
+                uint index = Unsafe.Add(ref scanlineSpanRef, o);
+                rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, index) : byte.MaxValue;
+                rgba.Rgb = Unsafe.Add(ref palettePixelsRef, index);
 
                 pixel.FromRgba32(rgba);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
         else
         {
-            for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
+            for (nuint x = pixelOffset, o = 0; x < (uint)header.Width; x += increment, o++)
             {
-                int index = Unsafe.Add(ref scanlineSpanRef, (uint)o);
-                Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, (uint)index);
+                int index = Unsafe.Add(ref scanlineSpanRef, o);
+                Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, index);
 
                 pixel.FromRgb24(rgb);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
     }
@@ -345,14 +351,15 @@ internal static class PngScanlineProcessor
             if (header.BitDepth == 16)
             {
                 Rgb48 rgb48 = default;
-                for (int x = 0, o = 0; x < header.Width; x++, o += bytesPerPixel)
+                int o = 0;
+                for (nuint x = 0; x < (uint)header.Width; x++, o += bytesPerPixel)
                 {
                     rgb48.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
                     rgb48.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
                     rgb48.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
 
                     pixel.FromRgb48(rgb48);
-                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
                 }
             }
             else
@@ -367,7 +374,8 @@ internal static class PngScanlineProcessor
         {
             Rgb48 rgb48 = default;
             Rgba64 rgba64 = default;
-            for (int x = 0, o = 0; x < header.Width; x++, o += bytesPerPixel)
+            int o = 0;
+            for (nuint x = 0; x < (uint)header.Width; x++, o += bytesPerPixel)
             {
                 rgb48.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
                 rgb48.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
@@ -377,7 +385,7 @@ internal static class PngScanlineProcessor
                 rgba64.A = rgb48.Equals(rgb48Trans) ? ushort.MinValue : ushort.MaxValue;
 
                 pixel.FromRgba64(rgba64);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
         else
@@ -385,14 +393,14 @@ internal static class PngScanlineProcessor
             Rgba32 rgba32 = default;
             ReadOnlySpan<Rgb24> rgb24Span = MemoryMarshal.Cast<byte, Rgb24>(scanlineSpan);
             ref Rgb24 rgb24SpanRef = ref MemoryMarshal.GetReference(rgb24Span);
-            for (int x = 0; x < header.Width; x++)
+            for (nuint x = 0; x < (uint)header.Width; x++)
             {
-                ref readonly Rgb24 rgb24 = ref Unsafe.Add(ref rgb24SpanRef, (uint)x);
+                ref readonly Rgb24 rgb24 = ref Unsafe.Add(ref rgb24SpanRef, x);
                 rgba32.Rgb = rgb24;
                 rgba32.A = rgb24.Equals(rgb24Trans) ? byte.MinValue : byte.MaxValue;
 
                 pixel.FromRgba32(rgba32);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
     }
@@ -401,8 +409,8 @@ internal static class PngScanlineProcessor
         in PngHeader header,
         ReadOnlySpan<byte> scanlineSpan,
         Span<TPixel> rowSpan,
-        int pixelOffset,
-        int increment,
+        uint pixelOffset,
+        uint increment,
         int bytesPerPixel,
         int bytesPerSample,
         bool hasTrans,
@@ -420,7 +428,8 @@ internal static class PngScanlineProcessor
             {
                 Rgb48 rgb48 = default;
                 Rgba64 rgba64 = default;
-                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+                int o = 0;
+                for (nuint x = pixelOffset; x < (uint)header.Width; x += increment, o += bytesPerPixel)
                 {
                     rgb48.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
                     rgb48.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
@@ -430,20 +439,21 @@ internal static class PngScanlineProcessor
                     rgba64.A = rgb48.Equals(rgb48Trans) ? ushort.MinValue : ushort.MaxValue;
 
                     pixel.FromRgba64(rgba64);
-                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
                 }
             }
             else
             {
                 Rgb48 rgb48 = default;
-                for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+                int o = 0;
+                for (nuint x = pixelOffset; x < (uint)header.Width; x += increment, o += bytesPerPixel)
                 {
                     rgb48.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
                     rgb48.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
                     rgb48.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
 
                     pixel.FromRgb48(rgb48);
-                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, x) = pixel;
                 }
             }
 
@@ -453,7 +463,8 @@ internal static class PngScanlineProcessor
         if (hasTrans)
         {
             Rgba32 rgba = default;
-            for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+            int o = 0;
+            for (nuint x = pixelOffset; x < (uint)header.Width; x += increment, o += bytesPerPixel)
             {
                 rgba.R = Unsafe.Add(ref scanlineSpanRef, (uint)o);
                 rgba.G = Unsafe.Add(ref scanlineSpanRef, (uint)(o + bytesPerSample));
@@ -461,20 +472,21 @@ internal static class PngScanlineProcessor
                 rgba.A = rgb24Trans.Equals(rgba.Rgb) ? byte.MinValue : byte.MaxValue;
 
                 pixel.FromRgba32(rgba);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
         else
         {
             Rgb24 rgb = default;
-            for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+            int o = 0;
+            for (nuint x = pixelOffset; x < (uint)header.Width; x += increment, o += bytesPerPixel)
             {
                 rgb.R = Unsafe.Add(ref scanlineSpanRef, (uint)o);
                 rgb.G = Unsafe.Add(ref scanlineSpanRef, (uint)(o + bytesPerSample));
                 rgb.B = Unsafe.Add(ref scanlineSpanRef, (uint)(o + (2 * bytesPerSample)));
 
                 pixel.FromRgb24(rgb);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
     }
@@ -494,7 +506,8 @@ internal static class PngScanlineProcessor
         if (header.BitDepth == 16)
         {
             Rgba64 rgba64 = default;
-            for (int x = 0, o = 0; x < header.Width; x++, o += bytesPerPixel)
+            int o = 0;
+            for (nuint x = 0; x < (uint)header.Width; x++, o += bytesPerPixel)
             {
                 rgba64.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
                 rgba64.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
@@ -502,7 +515,7 @@ internal static class PngScanlineProcessor
                 rgba64.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (3 * bytesPerSample), bytesPerSample));
 
                 pixel.FromRgba64(rgba64);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
         else
@@ -515,8 +528,8 @@ internal static class PngScanlineProcessor
         in PngHeader header,
         ReadOnlySpan<byte> scanlineSpan,
         Span<TPixel> rowSpan,
-        int pixelOffset,
-        int increment,
+        uint pixelOffset,
+        uint increment,
         int bytesPerPixel,
         int bytesPerSample)
         where TPixel : unmanaged, IPixel<TPixel>
@@ -528,7 +541,8 @@ internal static class PngScanlineProcessor
         if (header.BitDepth == 16)
         {
             Rgba64 rgba64 = default;
-            for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+            int o = 0;
+            for (nuint x = pixelOffset; x < (uint)header.Width; x += increment, o += bytesPerPixel)
             {
                 rgba64.R = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, bytesPerSample));
                 rgba64.G = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + bytesPerSample, bytesPerSample));
@@ -536,13 +550,14 @@ internal static class PngScanlineProcessor
                 rgba64.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (3 * bytesPerSample), bytesPerSample));
 
                 pixel.FromRgba64(rgba64);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
         else
         {
             Rgba32 rgba = default;
-            for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
+            int o = 0;
+            for (nuint x = pixelOffset; x < (uint)header.Width; x += increment, o += bytesPerPixel)
             {
                 rgba.R = Unsafe.Add(ref scanlineSpanRef, (uint)o);
                 rgba.G = Unsafe.Add(ref scanlineSpanRef, (uint)(o + bytesPerSample));
@@ -550,7 +565,7 @@ internal static class PngScanlineProcessor
                 rgba.A = Unsafe.Add(ref scanlineSpanRef, (uint)(o + (3 * bytesPerSample)));
 
                 pixel.FromRgba32(rgba);
-                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
+                Unsafe.Add(ref rowSpanRef, x) = pixel;
             }
         }
     }

--- a/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
+++ b/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
@@ -36,16 +36,16 @@ internal static class PngScanlineProcessor
                 {
                     ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
                     pixel.FromL16(Unsafe.As<ushort, L16>(ref luminance));
-                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
                 }
             }
             else
             {
                 for (int x = 0; x < header.Width; x++)
                 {
-                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, x) * scaleFactor);
+                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, (uint)x) * scaleFactor);
                     pixel.FromL8(Unsafe.As<byte, L8>(ref luminance));
-                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
                 }
             }
 
@@ -62,7 +62,7 @@ internal static class PngScanlineProcessor
                 source.A = luminance.Equals(luminance16Trans.PackedValue) ? ushort.MinValue : ushort.MaxValue;
 
                 pixel.FromLa32(source);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
@@ -71,12 +71,12 @@ internal static class PngScanlineProcessor
             byte scaledLuminanceTrans = (byte)(luminanceTrans.PackedValue * scaleFactor);
             for (int x = 0; x < header.Width; x++)
             {
-                byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, x) * scaleFactor);
+                byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, (uint)x) * scaleFactor);
                 source.L = luminance;
                 source.A = luminance.Equals(scaledLuminanceTrans) ? byte.MinValue : byte.MaxValue;
 
                 pixel.FromLa16(source);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
     }
@@ -105,16 +105,16 @@ internal static class PngScanlineProcessor
                 {
                     ushort luminance = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o, 2));
                     pixel.FromL16(Unsafe.As<ushort, L16>(ref luminance));
-                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
                 }
             }
             else
             {
                 for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
                 {
-                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, o) * scaleFactor);
+                    byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, (uint)o) * scaleFactor);
                     pixel.FromL8(Unsafe.As<byte, L8>(ref luminance));
-                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
                 }
             }
 
@@ -131,7 +131,7 @@ internal static class PngScanlineProcessor
                 source.A = luminance.Equals(luminance16Trans.PackedValue) ? ushort.MinValue : ushort.MaxValue;
 
                 pixel.FromLa32(source);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
@@ -140,12 +140,12 @@ internal static class PngScanlineProcessor
             byte scaledLuminanceTrans = (byte)(luminanceTrans.PackedValue * scaleFactor);
             for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
             {
-                byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, o) * scaleFactor);
+                byte luminance = (byte)(Unsafe.Add(ref scanlineSpanRef, (uint)o) * scaleFactor);
                 source.L = luminance;
                 source.A = luminance.Equals(scaledLuminanceTrans) ? byte.MinValue : byte.MaxValue;
 
                 pixel.FromLa16(source);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
     }
@@ -171,7 +171,7 @@ internal static class PngScanlineProcessor
                 source.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + 2, 2));
 
                 pixel.FromLa32(source);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
@@ -180,11 +180,11 @@ internal static class PngScanlineProcessor
             for (int x = 0; x < header.Width; x++)
             {
                 int offset = x * bytesPerPixel;
-                source.L = Unsafe.Add(ref scanlineSpanRef, offset);
-                source.A = Unsafe.Add(ref scanlineSpanRef, offset + bytesPerSample);
+                source.L = Unsafe.Add(ref scanlineSpanRef, (uint)offset);
+                source.A = Unsafe.Add(ref scanlineSpanRef, (uint)(offset + bytesPerSample));
 
                 pixel.FromLa16(source);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
     }
@@ -212,7 +212,7 @@ internal static class PngScanlineProcessor
                 source.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + 2, 2));
 
                 pixel.FromLa32(source);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
@@ -221,11 +221,11 @@ internal static class PngScanlineProcessor
             La16 source = default;
             for (int x = pixelOffset; x < header.Width; x += increment)
             {
-                source.L = Unsafe.Add(ref scanlineSpanRef, offset);
-                source.A = Unsafe.Add(ref scanlineSpanRef, offset + bytesPerSample);
+                source.L = Unsafe.Add(ref scanlineSpanRef, (uint)offset);
+                source.A = Unsafe.Add(ref scanlineSpanRef, (uint)(offset + bytesPerSample));
 
                 pixel.FromLa16(source);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
                 offset += bytesPerPixel;
             }
         }
@@ -259,23 +259,23 @@ internal static class PngScanlineProcessor
 
             for (int x = 0; x < header.Width; x++)
             {
-                int index = Unsafe.Add(ref scanlineSpanRef, x);
-                rgba.Rgb = Unsafe.Add(ref palettePixelsRef, index);
-                rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, index) : byte.MaxValue;
+                int index = Unsafe.Add(ref scanlineSpanRef, (uint)x);
+                rgba.Rgb = Unsafe.Add(ref palettePixelsRef, (uint)index);
+                rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, (uint)index) : byte.MaxValue;
 
                 pixel.FromRgba32(rgba);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
         {
             for (int x = 0; x < header.Width; x++)
             {
-                int index = Unsafe.Add(ref scanlineSpanRef, x);
-                Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, index);
+                int index = Unsafe.Add(ref scanlineSpanRef, (uint)x);
+                Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, (uint)index);
 
                 pixel.FromRgb24(rgb);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
     }
@@ -304,23 +304,23 @@ internal static class PngScanlineProcessor
             ref byte paletteAlphaRef = ref paletteAlpha[0];
             for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
             {
-                int index = Unsafe.Add(ref scanlineSpanRef, o);
-                rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, index) : byte.MaxValue;
-                rgba.Rgb = Unsafe.Add(ref palettePixelsRef, index);
+                int index = Unsafe.Add(ref scanlineSpanRef, (uint)o);
+                rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, (uint)index) : byte.MaxValue;
+                rgba.Rgb = Unsafe.Add(ref palettePixelsRef, (uint)index);
 
                 pixel.FromRgba32(rgba);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
         {
             for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o++)
             {
-                int index = Unsafe.Add(ref scanlineSpanRef, o);
-                Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, index);
+                int index = Unsafe.Add(ref scanlineSpanRef, (uint)o);
+                Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, (uint)index);
 
                 pixel.FromRgb24(rgb);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
     }
@@ -352,7 +352,7 @@ internal static class PngScanlineProcessor
                     rgb48.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
 
                     pixel.FromRgb48(rgb48);
-                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
                 }
             }
             else
@@ -377,7 +377,7 @@ internal static class PngScanlineProcessor
                 rgba64.A = rgb48.Equals(rgb48Trans) ? ushort.MinValue : ushort.MaxValue;
 
                 pixel.FromRgba64(rgba64);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
@@ -387,12 +387,12 @@ internal static class PngScanlineProcessor
             ref Rgb24 rgb24SpanRef = ref MemoryMarshal.GetReference(rgb24Span);
             for (int x = 0; x < header.Width; x++)
             {
-                ref readonly Rgb24 rgb24 = ref Unsafe.Add(ref rgb24SpanRef, x);
+                ref readonly Rgb24 rgb24 = ref Unsafe.Add(ref rgb24SpanRef, (uint)x);
                 rgba32.Rgb = rgb24;
                 rgba32.A = rgb24.Equals(rgb24Trans) ? byte.MinValue : byte.MaxValue;
 
                 pixel.FromRgba32(rgba32);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
     }
@@ -430,7 +430,7 @@ internal static class PngScanlineProcessor
                     rgba64.A = rgb48.Equals(rgb48Trans) ? ushort.MinValue : ushort.MaxValue;
 
                     pixel.FromRgba64(rgba64);
-                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
                 }
             }
             else
@@ -443,7 +443,7 @@ internal static class PngScanlineProcessor
                     rgb48.B = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (2 * bytesPerSample), bytesPerSample));
 
                     pixel.FromRgb48(rgb48);
-                    Unsafe.Add(ref rowSpanRef, x) = pixel;
+                    Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
                 }
             }
 
@@ -455,13 +455,13 @@ internal static class PngScanlineProcessor
             Rgba32 rgba = default;
             for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
             {
-                rgba.R = Unsafe.Add(ref scanlineSpanRef, o);
-                rgba.G = Unsafe.Add(ref scanlineSpanRef, o + bytesPerSample);
-                rgba.B = Unsafe.Add(ref scanlineSpanRef, o + (2 * bytesPerSample));
+                rgba.R = Unsafe.Add(ref scanlineSpanRef, (uint)o);
+                rgba.G = Unsafe.Add(ref scanlineSpanRef, (uint)(o + bytesPerSample));
+                rgba.B = Unsafe.Add(ref scanlineSpanRef, (uint)(o + (2 * bytesPerSample)));
                 rgba.A = rgb24Trans.Equals(rgba.Rgb) ? byte.MinValue : byte.MaxValue;
 
                 pixel.FromRgba32(rgba);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
@@ -469,12 +469,12 @@ internal static class PngScanlineProcessor
             Rgb24 rgb = default;
             for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
             {
-                rgb.R = Unsafe.Add(ref scanlineSpanRef, o);
-                rgb.G = Unsafe.Add(ref scanlineSpanRef, o + bytesPerSample);
-                rgb.B = Unsafe.Add(ref scanlineSpanRef, o + (2 * bytesPerSample));
+                rgb.R = Unsafe.Add(ref scanlineSpanRef, (uint)o);
+                rgb.G = Unsafe.Add(ref scanlineSpanRef, (uint)(o + bytesPerSample));
+                rgb.B = Unsafe.Add(ref scanlineSpanRef, (uint)(o + (2 * bytesPerSample)));
 
                 pixel.FromRgb24(rgb);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
     }
@@ -502,7 +502,7 @@ internal static class PngScanlineProcessor
                 rgba64.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (3 * bytesPerSample), bytesPerSample));
 
                 pixel.FromRgba64(rgba64);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
@@ -536,7 +536,7 @@ internal static class PngScanlineProcessor
                 rgba64.A = BinaryPrimitives.ReadUInt16BigEndian(scanlineSpan.Slice(o + (3 * bytesPerSample), bytesPerSample));
 
                 pixel.FromRgba64(rgba64);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
         else
@@ -544,13 +544,13 @@ internal static class PngScanlineProcessor
             Rgba32 rgba = default;
             for (int x = pixelOffset, o = 0; x < header.Width; x += increment, o += bytesPerPixel)
             {
-                rgba.R = Unsafe.Add(ref scanlineSpanRef, o);
-                rgba.G = Unsafe.Add(ref scanlineSpanRef, o + bytesPerSample);
-                rgba.B = Unsafe.Add(ref scanlineSpanRef, o + (2 * bytesPerSample));
-                rgba.A = Unsafe.Add(ref scanlineSpanRef, o + (3 * bytesPerSample));
+                rgba.R = Unsafe.Add(ref scanlineSpanRef, (uint)o);
+                rgba.G = Unsafe.Add(ref scanlineSpanRef, (uint)(o + bytesPerSample));
+                rgba.B = Unsafe.Add(ref scanlineSpanRef, (uint)(o + (2 * bytesPerSample)));
+                rgba.A = Unsafe.Add(ref scanlineSpanRef, (uint)(o + (3 * bytesPerSample)));
 
                 pixel.FromRgba32(rgba);
-                Unsafe.Add(ref rowSpanRef, x) = pixel;
+                Unsafe.Add(ref rowSpanRef, (uint)x) = pixel;
             }
         }
     }

--- a/src/ImageSharp/Formats/Tga/TgaDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tga/TgaDecoderCore.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.IO;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Metadata;
@@ -429,11 +430,11 @@ internal sealed class TgaDecoderCore : IImageDecoderInternals
 
                     if (this.fileHeader.ImageType == TgaImageType.BlackAndWhite)
                     {
-                        color.FromLa16(Unsafe.As<byte, La16>(ref this.scratchBuffer[0]));
+                        color.FromLa16(Unsafe.As<byte, La16>(ref MemoryMarshal.GetArrayDataReference(this.scratchBuffer)));
                     }
                     else
                     {
-                        color.FromBgra5551(Unsafe.As<byte, Bgra5551>(ref this.scratchBuffer[0]));
+                        color.FromBgra5551(Unsafe.As<byte, Bgra5551>(ref MemoryMarshal.GetArrayDataReference(this.scratchBuffer)));
                     }
 
                     pixelSpan[x] = color;
@@ -695,7 +696,7 @@ internal sealed class TgaDecoderCore : IImageDecoderInternals
             TgaThrowHelper.ThrowInvalidImageContentException("Not enough data to read a bgr pixel");
         }
 
-        color.FromBgr24(Unsafe.As<byte, Bgr24>(ref this.scratchBuffer[0]));
+        color.FromBgr24(Unsafe.As<byte, Bgr24>(ref MemoryMarshal.GetArrayDataReference(this.scratchBuffer)));
         pixelSpan[x] = color;
     }
 

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -78,7 +78,7 @@ internal sealed class T6TiffCompression : TiffBaseDecompressor
         nint bitPos = Numerics.Modulo8(bitsWritten);
         nint bufferPos = bitsWritten / 8;
         ref byte scanLineRef = ref MemoryMarshal.GetReference(scanLine);
-        for (nint i = 0; i < (uint)scanLine.Length; i++)
+        for (nuint i = 0; i < (uint)scanLine.Length; i++)
         {
             if (Unsafe.Add(ref scanLineRef, i) != this.white)
             {

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -78,7 +78,7 @@ internal sealed class T6TiffCompression : TiffBaseDecompressor
         nint bitPos = Numerics.Modulo8(bitsWritten);
         nint bufferPos = bitsWritten / 8;
         ref byte scanLineRef = ref MemoryMarshal.GetReference(scanLine);
-        for (nint i = 0; i < scanLine.Length; i++)
+        for (nint i = 0; i < (uint)scanLine.Length; i++)
         {
             if (Unsafe.Add(ref scanLineRef, i) != this.white)
             {

--- a/src/ImageSharp/Formats/Tiff/Compression/TiffBaseCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/TiffBaseCompression.cs
@@ -16,7 +16,7 @@ internal abstract class TiffBaseCompression : IDisposable
         this.Width = width;
         this.BitsPerPixel = bitsPerPixel;
         this.Predictor = predictor;
-        this.BytesPerRow = ((width * bitsPerPixel) + 7) / 8;
+        this.BytesPerRow = (int)(((uint)(width * bitsPerPixel) + 7) / 8);
     }
 
     /// <summary>

--- a/src/ImageSharp/Formats/Tiff/Compression/TiffBaseCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/TiffBaseCompression.cs
@@ -16,7 +16,7 @@ internal abstract class TiffBaseCompression : IDisposable
         this.Width = width;
         this.BitsPerPixel = bitsPerPixel;
         this.Predictor = predictor;
-        this.BytesPerRow = (int)(((uint)(width * bitsPerPixel) + 7) / 8);
+        this.BytesPerRow = ((width * bitsPerPixel) + 7) / 8;
     }
 
     /// <summary>

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero1TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero1TiffColor{TPixel}.cs
@@ -18,21 +18,21 @@ internal class BlackIsZero1TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
     /// <inheritdoc/>
     public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
     {
-        nint offset = 0;
-        var colorBlack = default(TPixel);
-        var colorWhite = default(TPixel);
+        nuint offset = 0;
+        TPixel colorBlack = default;
+        TPixel colorWhite = default;
 
         colorBlack.FromRgba32(Color.Black);
         colorWhite.FromRgba32(Color.White);
         ref byte dataRef = ref MemoryMarshal.GetReference(data);
-        for (nint y = top; y < top + height; y++)
+        for (nuint y = (uint)top; y < (uint)(top + height); y++)
         {
             Span<TPixel> pixelRowSpan = pixels.DangerousGetRowSpan((int)y);
             ref TPixel pixelRowRef = ref MemoryMarshal.GetReference(pixelRowSpan);
-            for (nint x = (nint)(uint)left; x < (nint)(uint)(left + width); x += 8)
+            for (nuint x = (uint)left; x < (uint)(left + width); x += 8)
             {
                 byte b = Unsafe.Add(ref dataRef, offset++);
-                nint maxShift = Math.Min(left + width - x, 8);
+                nuint maxShift = Math.Min((uint)(left + width) - x, 8);
 
                 if (maxShift == 8)
                 {
@@ -70,7 +70,7 @@ internal class BlackIsZero1TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
                 }
                 else
                 {
-                    for (nint shift = 0; shift < maxShift; shift++)
+                    for (nuint shift = 0; shift < maxShift; shift++)
                     {
                         int bit = (b >> (7 - (int)shift)) & 1;
 

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero1TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/BlackIsZero1TiffColor{TPixel}.cs
@@ -29,7 +29,7 @@ internal class BlackIsZero1TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
         {
             Span<TPixel> pixelRowSpan = pixels.DangerousGetRowSpan((int)y);
             ref TPixel pixelRowRef = ref MemoryMarshal.GetReference(pixelRowSpan);
-            for (nint x = left; x < left + width; x += 8)
+            for (nint x = (nint)(uint)left; x < (nint)(uint)(left + width); x += 8)
             {
                 byte b = Unsafe.Add(ref dataRef, offset++);
                 nint maxShift = Math.Min(left + width - x, 8);
@@ -70,9 +70,9 @@ internal class BlackIsZero1TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
                 }
                 else
                 {
-                    for (int shift = 0; shift < maxShift; shift++)
+                    for (nint shift = 0; shift < maxShift; shift++)
                     {
-                        int bit = (b >> (7 - shift)) & 1;
+                        int bit = (b >> (7 - (int)shift)) & 1;
 
                         ref TPixel pixel = ref Unsafe.Add(ref pixelRowRef, x + shift);
                         pixel = bit == 0 ? colorBlack : colorWhite;

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/WhiteIsZero1TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/WhiteIsZero1TiffColor{TPixel}.cs
@@ -24,11 +24,11 @@ internal class WhiteIsZero1TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
         colorBlack.FromRgba32(Color.Black);
         colorWhite.FromRgba32(Color.White);
         ref byte dataRef = ref MemoryMarshal.GetReference(data);
-        for (nint y = top; y < top + height; y++)
+        for (nint y = top; y < (nint)(uint)(top + height); y++)
         {
             Span<TPixel> pixelRowSpan = pixels.DangerousGetRowSpan((int)y);
             ref TPixel pixelRowRef = ref MemoryMarshal.GetReference(pixelRowSpan);
-            for (nint x = left; x < left + width; x += 8)
+            for (nint x = left; x < (nint)(uint)(left + width); x += 8)
             {
                 byte b = Unsafe.Add(ref dataRef, offset++);
                 nint maxShift = Math.Min(left + width - x, 8);
@@ -73,7 +73,7 @@ internal class WhiteIsZero1TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
                     {
                         int bit = (b >> (7 - shift)) & 1;
 
-                        ref TPixel pixel = ref Unsafe.Add(ref pixelRowRef, x + shift);
+                        ref TPixel pixel = ref Unsafe.Add(ref pixelRowRef, x + (nint)(uint)shift);
                         pixel = bit == 0 ? colorWhite : colorBlack;
                     }
                 }

--- a/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/WhiteIsZero1TiffColor{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/PhotometricInterpretation/WhiteIsZero1TiffColor{TPixel}.cs
@@ -17,21 +17,21 @@ internal class WhiteIsZero1TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
     /// <inheritdoc/>
     public override void Decode(ReadOnlySpan<byte> data, Buffer2D<TPixel> pixels, int left, int top, int width, int height)
     {
-        nint offset = 0;
+        nuint offset = 0;
         var colorBlack = default(TPixel);
         var colorWhite = default(TPixel);
 
         colorBlack.FromRgba32(Color.Black);
         colorWhite.FromRgba32(Color.White);
         ref byte dataRef = ref MemoryMarshal.GetReference(data);
-        for (nint y = top; y < (nint)(uint)(top + height); y++)
+        for (nuint y = (uint)top; y < (uint)(top + height); y++)
         {
             Span<TPixel> pixelRowSpan = pixels.DangerousGetRowSpan((int)y);
             ref TPixel pixelRowRef = ref MemoryMarshal.GetReference(pixelRowSpan);
-            for (nint x = left; x < (nint)(uint)(left + width); x += 8)
+            for (nuint x = (uint)left; x < (uint)(left + width); x += 8)
             {
                 byte b = Unsafe.Add(ref dataRef, offset++);
-                nint maxShift = Math.Min(left + width - x, 8);
+                nuint maxShift = Math.Min((uint)(left + width) - x, 8);
 
                 if (maxShift == 8)
                 {
@@ -69,11 +69,11 @@ internal class WhiteIsZero1TiffColor<TPixel> : TiffBaseColorDecoder<TPixel>
                 }
                 else
                 {
-                    for (int shift = 0; shift < maxShift; shift++)
+                    for (nuint shift = 0; shift < maxShift; shift++)
                     {
-                        int bit = (b >> (7 - shift)) & 1;
+                        int bit = (b >> (7 - (int)shift)) & 1;
 
-                        ref TPixel pixel = ref Unsafe.Add(ref pixelRowRef, x + (nint)(uint)shift);
+                        ref TPixel pixel = ref Unsafe.Add(ref pixelRowRef, x + shift);
                         pixel = bit == 0 ? colorWhite : colorBlack;
                     }
                 }

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -793,7 +793,7 @@ internal class TiffDecoderCore : IImageDecoderInternals
             }
         }
 
-        int bytesPerRow = (int)(((uint)(width * bitsPerPixel) + 7) / 8);
+        int bytesPerRow = ((width * bitsPerPixel) + 7) / 8;
         return bytesPerRow * height;
     }
 

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -793,7 +793,7 @@ internal class TiffDecoderCore : IImageDecoderInternals
             }
         }
 
-        int bytesPerRow = ((width * bitsPerPixel) + 7) / 8;
+        int bytesPerRow = (int)(((uint)(width * bitsPerPixel) + 7) / 8);
         return bytesPerRow * height;
     }
 

--- a/src/ImageSharp/Formats/Tiff/Writers/TiffBaseColorWriter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Tiff/Writers/TiffBaseColorWriter{TPixel}.cs
@@ -29,7 +29,7 @@ internal abstract class TiffBaseColorWriter<TPixel> : IDisposable
     /// <summary>
     /// Gets the bytes per row.
     /// </summary>
-    public int BytesPerRow => ((this.Image.Width * this.BitsPerPixel) + 7) / 8;
+    public int BytesPerRow => (int)(((uint)(this.Image.Width * this.BitsPerPixel) + 7) / 8);
 
     protected ImageFrame<TPixel> Image { get; }
 

--- a/src/ImageSharp/Formats/Webp/AlphaDecoder.cs
+++ b/src/ImageSharp/Formats/Webp/AlphaDecoder.cs
@@ -376,7 +376,7 @@ internal class AlphaDecoder : IDisposable
                 Unsafe.As<byte, Vector256<byte>>(ref outputRef) = c0;
             }
 
-            for (; i < (uint)   width; i++)
+            for (; i < (uint)width; i++)
             {
                 dst[(int)i] = (byte)(prev[(int)i] + input[(int)i]);
             }

--- a/src/ImageSharp/Formats/Webp/AlphaDecoder.cs
+++ b/src/ImageSharp/Formats/Webp/AlphaDecoder.cs
@@ -322,7 +322,8 @@ internal class AlphaDecoder : IDisposable
             nint i;
             Vector128<int> last = Vector128<int>.Zero.WithElement(0, dst[0]);
             ref byte srcRef = ref MemoryMarshal.GetReference(input);
-            for (i = 1; i + 8 <= width; i += 8)
+            ref byte dstRef = ref MemoryMarshal.GetReference(dst);
+            for (i = 1; i <= (uint)width - 8; i += 8)
             {
                 Vector128<long> a0 = Vector128.Create(Unsafe.As<byte, long>(ref Unsafe.Add(ref srcRef, i)), 0);
                 Vector128<byte> a1 = Sse2.Add(a0.AsByte(), last.AsByte());
@@ -333,12 +334,12 @@ internal class AlphaDecoder : IDisposable
                 Vector128<byte> a6 = Sse2.ShiftLeftLogical128BitLane(a5, 4);
                 Vector128<byte> a7 = Sse2.Add(a5, a6);
 
-                ref byte outputRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(dst), i);
+                ref byte outputRef = ref Unsafe.Add(ref dstRef, i);
                 Unsafe.As<byte, Vector64<byte>>(ref outputRef) = a7.GetLower();
                 last = Sse2.ShiftRightLogical(a7.AsInt64(), 56).AsInt32();
             }
 
-            for (; i < width; ++i)
+            for (; i < (uint)width; ++i)
             {
                 dst[(int)i] = (byte)(input[(int)i] + dst[(int)i - 1]);
             }
@@ -366,7 +367,7 @@ internal class AlphaDecoder : IDisposable
         {
             nint i;
             int maxPos = width & ~31;
-            for (i = 0; i < maxPos; i += 32)
+            for (i = 0; i < (uint)maxPos; i += 32)
             {
                 Vector256<int> a0 = Unsafe.As<byte, Vector256<int>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(input), i));
                 Vector256<int> b0 = Unsafe.As<byte, Vector256<int>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(prev), i));
@@ -375,7 +376,7 @@ internal class AlphaDecoder : IDisposable
                 Unsafe.As<byte, Vector256<byte>>(ref outputRef) = c0;
             }
 
-            for (; i < width; i++)
+            for (; i < (uint)   width; i++)
             {
                 dst[(int)i] = (byte)(prev[(int)i] + input[(int)i]);
             }

--- a/src/ImageSharp/Formats/Webp/BitWriter/Vp8BitWriter.cs
+++ b/src/ImageSharp/Formats/Webp/BitWriter/Vp8BitWriter.cs
@@ -457,7 +457,7 @@ internal class Vp8BitWriter : BitWriterBase
         this.Finish();
         uint numBytes = (uint)this.NumBytes();
         int mbSize = this.enc.Mbw * this.enc.Mbh;
-        int expectedSize = mbSize * 7 / 8;
+        int expectedSize = (int)((uint)mbSize * 7 / 8);
 
         Vp8BitWriter bitWriterPartZero = new(expectedSize, this.enc);
 

--- a/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
@@ -38,7 +38,7 @@ internal static class BackwardReferenceEncoder
         int width,
         int height,
         ReadOnlySpan<uint> bgra,
-        int quality,
+        uint quality,
         int lz77TypesToTry,
         ref int cacheBits,
         MemoryAllocator memoryAllocator,
@@ -123,7 +123,7 @@ internal static class BackwardReferenceEncoder
     /// The local color cache is also disabled for the lower (smaller then 25) quality.
     /// </summary>
     /// <returns>Best cache size.</returns>
-    private static int CalculateBestCacheSize(ReadOnlySpan<uint> bgra, int quality, Vp8LBackwardRefs refs, int bestCacheBits)
+    private static int CalculateBestCacheSize(ReadOnlySpan<uint> bgra, uint quality, Vp8LBackwardRefs refs, int bestCacheBits)
     {
         int cacheBitsMax = quality <= 25 ? 0 : bestCacheBits;
         if (cacheBitsMax == 0)

--- a/src/ImageSharp/Formats/Webp/Lossless/ColorSpaceTransformUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/ColorSpaceTransformUtils.cs
@@ -27,10 +27,10 @@ internal static class ColorSpaceTransformUtils
             {
                 Span<uint> srcSpan = bgra[(y * stride)..];
                 ref uint inputRef = ref MemoryMarshal.GetReference(srcSpan);
-                for (nint x = 0; x <= tileWidth - span; x += span)
+                for (nuint x = 0; x <= (uint)tileWidth - span; x += span)
                 {
-                    nint input0Idx = x;
-                    nint input1Idx = x + (span / 2);
+                    nuint input0Idx = x;
+                    nuint input1Idx = x + (span / 2);
                     Vector256<byte> input0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref inputRef, input0Idx)).AsByte();
                     Vector256<byte> input1 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref inputRef, input1Idx)).AsByte();
                     Vector256<byte> r0 = Avx2.Shuffle(input0, collectColorBlueTransformsShuffleLowMask256);
@@ -77,10 +77,10 @@ internal static class ColorSpaceTransformUtils
             {
                 Span<uint> srcSpan = bgra[(y * stride)..];
                 ref uint inputRef = ref MemoryMarshal.GetReference(srcSpan);
-                for (nint x = 0; x <= tileWidth - span; x += span)
+                for (nuint x = 0; (int)x <= tileWidth - span; x += span)
                 {
-                    nint input0Idx = x;
-                    nint input1Idx = x + (span / 2);
+                    nuint input0Idx = x;
+                    nuint input1Idx = x + (span / 2);
                     Vector128<byte> input0 = Unsafe.As<uint, Vector128<uint>>(ref Unsafe.Add(ref inputRef, input0Idx)).AsByte();
                     Vector128<byte> input1 = Unsafe.As<uint, Vector128<uint>>(ref Unsafe.Add(ref inputRef, input1Idx)).AsByte();
                     Vector128<byte> r0 = Ssse3.Shuffle(input0, collectColorBlueTransformsShuffleLowMask);
@@ -146,10 +146,10 @@ internal static class ColorSpaceTransformUtils
             {
                 Span<uint> srcSpan = bgra[(y * stride)..];
                 ref uint inputRef = ref MemoryMarshal.GetReference(srcSpan);
-                for (nint x = 0; x <= tileWidth - span; x += span)
+                for (nuint x = 0; x <= (uint)tileWidth - span; x += span)
                 {
-                    nint input0Idx = x;
-                    nint input1Idx = x + (span / 2);
+                    nuint input0Idx = x;
+                    nuint input1Idx = x + (span / 2);
                     Vector256<byte> input0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref inputRef, input0Idx)).AsByte();
                     Vector256<byte> input1 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref inputRef, input1Idx)).AsByte();
                     Vector256<byte> g0 = Avx2.And(input0, collectColorRedTransformsGreenMask256); // 0 0  | g 0
@@ -189,10 +189,10 @@ internal static class ColorSpaceTransformUtils
             {
                 Span<uint> srcSpan = bgra[(y * stride)..];
                 ref uint inputRef = ref MemoryMarshal.GetReference(srcSpan);
-                for (nint x = 0; x <= tileWidth - span; x += span)
+                for (nuint x = 0; (int)x <= tileWidth - span; x += span)
                 {
-                    nint input0Idx = x;
-                    nint input1Idx = x + (span / 2);
+                    nuint input0Idx = x;
+                    nuint input1Idx = x + (span / 2);
                     Vector128<byte> input0 = Unsafe.As<uint, Vector128<uint>>(ref Unsafe.Add(ref inputRef, input0Idx)).AsByte();
                     Vector128<byte> input1 = Unsafe.As<uint, Vector128<uint>>(ref Unsafe.Add(ref inputRef, input1Idx)).AsByte();
                     Vector128<byte> g0 = Sse2.And(input0, collectColorRedTransformsGreenMask); // 0 0  | g 0

--- a/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
@@ -316,7 +316,7 @@ internal class HistogramEncoder
         int triesWithNoSuccess = 0;
         int numUsed = histograms.Count(h => h != null);
         int outerIters = numUsed;
-        int numTriesNoSuccess = outerIters / 2;
+        int numTriesNoSuccess = (int)((uint)outerIters / 2);
         var stats = new Vp8LStreaks();
         var bitsEntropy = new Vp8LBitEntropy();
 
@@ -346,7 +346,7 @@ internal class HistogramEncoder
         for (int iter = 0; iter < outerIters && numUsed >= minClusterSize && ++triesWithNoSuccess < numTriesNoSuccess; iter++)
         {
             double bestCost = histoPriorityList.Count == 0 ? 0.0d : histoPriorityList[0].CostDiff;
-            int numTries = numUsed / 2;
+            int numTries = (int)((uint)numUsed / 2);
             uint randRange = (uint)((numUsed - 1) * numUsed);
 
             // Pick random samples.

--- a/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
@@ -27,7 +27,7 @@ internal class HistogramEncoder
 
     private const ushort InvalidHistogramSymbol = ushort.MaxValue;
 
-    public static void GetHistoImageSymbols(int xSize, int ySize, Vp8LBackwardRefs refs, int quality, int histoBits, int cacheBits, List<Vp8LHistogram> imageHisto, Vp8LHistogram tmpHisto, ushort[] histogramSymbols)
+    public static void GetHistoImageSymbols(int xSize, int ySize, Vp8LBackwardRefs refs, uint quality, int histoBits, int cacheBits, List<Vp8LHistogram> imageHisto, Vp8LHistogram tmpHisto, ushort[] histogramSymbols)
     {
         int histoXSize = histoBits > 0 ? LosslessUtils.SubSampleSize(xSize, histoBits) : 1;
         int histoYSize = histoBits > 0 ? LosslessUtils.SubSampleSize(ySize, histoBits) : 1;
@@ -660,7 +660,7 @@ internal class HistogramEncoder
         output.TrivialSymbol = a.TrivialSymbol == b.TrivialSymbol ? a.TrivialSymbol : NonTrivialSym;
     }
 
-    private static double GetCombineCostFactor(int histoSize, int quality)
+    private static double GetCombineCostFactor(int histoSize, uint quality)
     {
         double combineCostFactor = 0.16d;
         if (quality < 90)

--- a/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
@@ -100,7 +100,7 @@ internal static class HuffmanUtils
                     uint k;
 
                     // The stride must end, collapse what we have, if we have enough (4).
-                    uint count = (uint)((sum + (stride / 2)) / stride);
+                    uint count = (sum + ((uint)stride / 2)) / (uint)stride;
                     if (count < 1)
                     {
                         count = 1;
@@ -144,7 +144,7 @@ internal static class HuffmanUtils
                 sum += counts[i];
                 if (stride >= 4)
                 {
-                    limit = (uint)((sum + (stride / 2)) / stride);
+                    limit = (sum + ((uint)stride / 2)) / (uint)stride;
                 }
             }
         }

--- a/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
@@ -51,7 +51,7 @@ internal static unsafe class LosslessUtils
         ref uint array1Ref = ref MemoryMarshal.GetReference(array1);
         ref uint array2Ref = ref MemoryMarshal.GetReference(array2);
 
-        while (matchLen < length && Unsafe.Add(ref array1Ref, matchLen) == Unsafe.Add(ref array2Ref, matchLen))
+        while (matchLen < length && Unsafe.Add(ref array1Ref, (uint)matchLen) == Unsafe.Add(ref array2Ref, (uint)matchLen))
         {
             matchLen++;
         }
@@ -99,7 +99,7 @@ internal static unsafe class LosslessUtils
             Vector256<byte> addGreenToBlueAndRedMaskAvx2 = Vector256.Create(1, 255, 1, 255, 5, 255, 5, 255, 9, 255, 9, 255, 13, 255, 13, 255, 17, 255, 17, 255, 21, 255, 21, 255, 25, 255, 25, 255, 29, 255, 29, 255);
             int numPixels = pixelData.Length;
             nint i;
-            for (i = 0; i <= numPixels - 8; i += 8)
+            for (i = 0; i <= (nint)(uint)numPixels - 8; i += 8)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector256<byte> input = Unsafe.As<uint, Vector256<uint>>(ref pos).AsByte();
@@ -118,7 +118,7 @@ internal static unsafe class LosslessUtils
             Vector128<byte> addGreenToBlueAndRedMaskSsse3 = Vector128.Create(1, 255, 1, 255, 5, 255, 5, 255, 9, 255, 9, 255, 13, 255, 13, 255);
             int numPixels = pixelData.Length;
             nint i;
-            for (i = 0; i <= numPixels - 4; i += 4)
+            for (i = 0; i <= (nint)(uint)numPixels - 4; i += 4)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector128<byte> input = Unsafe.As<uint, Vector128<uint>>(ref pos).AsByte();
@@ -136,7 +136,7 @@ internal static unsafe class LosslessUtils
         {
             int numPixels = pixelData.Length;
             nint i;
-            for (i = 0; i <= numPixels - 4; i += 4)
+            for (i = 0; i <= (nint)(uint)numPixels - 4; i += 4)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector128<byte> input = Unsafe.As<uint, Vector128<uint>>(ref pos).AsByte();
@@ -179,7 +179,7 @@ internal static unsafe class LosslessUtils
             Vector256<byte> subtractGreenFromBlueAndRedMaskAvx2 = Vector256.Create(1, 255, 1, 255, 5, 255, 5, 255, 9, 255, 9, 255, 13, 255, 13, 255, 17, 255, 17, 255, 21, 255, 21, 255, 25, 255, 25, 255, 29, 255, 29, 255);
             int numPixels = pixelData.Length;
             nint i;
-            for (i = 0; i <= numPixels - 8; i += 8)
+            for (i = 0; i <= (nint)(uint)numPixels - 8; i += 8)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector256<byte> input = Unsafe.As<uint, Vector256<uint>>(ref pos).AsByte();
@@ -198,7 +198,7 @@ internal static unsafe class LosslessUtils
             Vector128<byte> subtractGreenFromBlueAndRedMaskSsse3 = Vector128.Create(1, 255, 1, 255, 5, 255, 5, 255, 9, 255, 9, 255, 13, 255, 13, 255);
             int numPixels = pixelData.Length;
             nint i;
-            for (i = 0; i <= numPixels - 4; i += 4)
+            for (i = 0; i <= (nint)(uint)numPixels - 4; i += 4)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector128<byte> input = Unsafe.As<uint, Vector128<uint>>(ref pos).AsByte();
@@ -216,7 +216,7 @@ internal static unsafe class LosslessUtils
         {
             int numPixels = pixelData.Length;
             nint i;
-            for (i = 0; i <= numPixels - 4; i += 4)
+            for (i = 0; i <= (nint)(uint)numPixels - 4; i += 4)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector128<byte> input = Unsafe.As<uint, Vector128<uint>>(ref pos).AsByte();
@@ -373,7 +373,7 @@ internal static unsafe class LosslessUtils
             Vector256<int> multsb2 = MkCst32(Cst5b(m.RedToBlue), 0);
 
             nint idx;
-            for (idx = 0; idx <= numPixels - 8; idx += 8)
+            for (idx = 0; idx <= (nint)(uint)numPixels - 8; idx += 8)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), idx);
                 Vector256<uint> input = Unsafe.As<uint, Vector256<uint>>(ref pos);
@@ -402,7 +402,7 @@ internal static unsafe class LosslessUtils
             Vector128<int> multsrb = MkCst16(Cst5b(m.GreenToRed), Cst5b(m.GreenToBlue));
             Vector128<int> multsb2 = MkCst16(Cst5b(m.RedToBlue), 0);
             nint idx;
-            for (idx = 0; idx <= numPixels - 4; idx += 4)
+            for (idx = 0; idx <= (nint)(uint)numPixels - 4; idx += 4)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), idx);
                 Vector128<uint> input = Unsafe.As<uint, Vector128<uint>>(ref pos);
@@ -461,7 +461,7 @@ internal static unsafe class LosslessUtils
             Vector256<int> multsrb = MkCst32(Cst5b(m.GreenToRed), Cst5b(m.GreenToBlue));
             Vector256<int> multsb2 = MkCst32(Cst5b(m.RedToBlue), 0);
             nint idx;
-            for (idx = 0; idx <= pixelData.Length - 8; idx += 8)
+            for (idx = 0; idx <= (nint)(uint)pixelData.Length - 8; idx += 8)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), idx);
                 Vector256<uint> input = Unsafe.As<uint, Vector256<uint>>(ref pos);
@@ -491,7 +491,7 @@ internal static unsafe class LosslessUtils
             Vector128<int> multsb2 = MkCst16(Cst5b(m.RedToBlue), 0);
 
             nint idx;
-            for (idx = 0; idx <= pixelData.Length - 4; idx += 4)
+            for (idx = 0; idx <= (nint)(uint)pixelData.Length - 4; idx += 4)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), idx);
                 Vector128<uint> input = Unsafe.As<uint, Vector128<uint>>(ref pos);

--- a/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
@@ -94,49 +94,53 @@ internal static unsafe class LosslessUtils
     /// <param name="pixelData">The pixel data to apply the transformation.</param>
     public static void AddGreenToBlueAndRed(Span<uint> pixelData)
     {
-        if (Avx2.IsSupported)
+        if (Avx2.IsSupported && pixelData.Length >= 8)
         {
             Vector256<byte> addGreenToBlueAndRedMaskAvx2 = Vector256.Create(1, 255, 1, 255, 5, 255, 5, 255, 9, 255, 9, 255, 13, 255, 13, 255, 17, 255, 17, 255, 21, 255, 21, 255, 25, 255, 25, 255, 29, 255, 29, 255);
-            int numPixels = pixelData.Length;
-            nint i;
-            for (i = 0; i <= (nint)(uint)numPixels - 8; i += 8)
+            nuint numPixels = (uint)pixelData.Length;
+            nuint i = 0;
+            do
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector256<byte> input = Unsafe.As<uint, Vector256<uint>>(ref pos).AsByte();
                 Vector256<byte> in0g0g = Avx2.Shuffle(input, addGreenToBlueAndRedMaskAvx2);
                 Vector256<byte> output = Avx2.Add(input, in0g0g);
                 Unsafe.As<uint, Vector256<uint>>(ref pos) = output.AsUInt32();
+                i += 8;
             }
+            while (i <= numPixels - 8);
 
             if (i != numPixels)
             {
                 AddGreenToBlueAndRedScalar(pixelData[(int)i..]);
             }
         }
-        else if (Ssse3.IsSupported)
+        else if (Ssse3.IsSupported && pixelData.Length >= 4)
         {
             Vector128<byte> addGreenToBlueAndRedMaskSsse3 = Vector128.Create(1, 255, 1, 255, 5, 255, 5, 255, 9, 255, 9, 255, 13, 255, 13, 255);
-            int numPixels = pixelData.Length;
-            nint i;
-            for (i = 0; i <= (nint)(uint)numPixels - 4; i += 4)
+            nuint numPixels = (uint)pixelData.Length;
+            nuint i = 0;
+            do
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector128<byte> input = Unsafe.As<uint, Vector128<uint>>(ref pos).AsByte();
                 Vector128<byte> in0g0g = Ssse3.Shuffle(input, addGreenToBlueAndRedMaskSsse3);
                 Vector128<byte> output = Sse2.Add(input, in0g0g);
                 Unsafe.As<uint, Vector128<uint>>(ref pos) = output.AsUInt32();
+                i += 4;
             }
+            while (i <= numPixels - 4);
 
             if (i != numPixels)
             {
                 AddGreenToBlueAndRedScalar(pixelData[(int)i..]);
             }
         }
-        else if (Sse2.IsSupported)
+        else if (Sse2.IsSupported && pixelData.Length >= 4)
         {
-            int numPixels = pixelData.Length;
-            nint i;
-            for (i = 0; i <= (nint)(uint)numPixels - 4; i += 4)
+            nuint numPixels = (uint)pixelData.Length;
+            nuint i = 0;
+            do
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector128<byte> input = Unsafe.As<uint, Vector128<uint>>(ref pos).AsByte();
@@ -145,7 +149,9 @@ internal static unsafe class LosslessUtils
                 Vector128<ushort> c = Sse2.ShuffleHigh(b, SimdUtils.Shuffle.MMShuffle2200); // 0g0g
                 Vector128<byte> output = Sse2.Add(input.AsByte(), c.AsByte());
                 Unsafe.As<uint, Vector128<uint>>(ref pos) = output.AsUInt32();
+                i += 4;
             }
+            while (i <= numPixels - 4);
 
             if (i != numPixels)
             {
@@ -174,49 +180,53 @@ internal static unsafe class LosslessUtils
 
     public static void SubtractGreenFromBlueAndRed(Span<uint> pixelData)
     {
-        if (Avx2.IsSupported)
+        if (Avx2.IsSupported && pixelData.Length >= 8)
         {
             Vector256<byte> subtractGreenFromBlueAndRedMaskAvx2 = Vector256.Create(1, 255, 1, 255, 5, 255, 5, 255, 9, 255, 9, 255, 13, 255, 13, 255, 17, 255, 17, 255, 21, 255, 21, 255, 25, 255, 25, 255, 29, 255, 29, 255);
-            int numPixels = pixelData.Length;
-            nint i;
-            for (i = 0; i <= (nint)(uint)numPixels - 8; i += 8)
+            nuint numPixels = (uint)pixelData.Length;
+            nuint i = 0;
+            do
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector256<byte> input = Unsafe.As<uint, Vector256<uint>>(ref pos).AsByte();
                 Vector256<byte> in0g0g = Avx2.Shuffle(input, subtractGreenFromBlueAndRedMaskAvx2);
                 Vector256<byte> output = Avx2.Subtract(input, in0g0g);
                 Unsafe.As<uint, Vector256<uint>>(ref pos) = output.AsUInt32();
+                i += 8;
             }
+            while (i <= numPixels - 8);
 
             if (i != numPixels)
             {
                 SubtractGreenFromBlueAndRedScalar(pixelData[(int)i..]);
             }
         }
-        else if (Ssse3.IsSupported)
+        else if (Ssse3.IsSupported && pixelData.Length >= 4)
         {
             Vector128<byte> subtractGreenFromBlueAndRedMaskSsse3 = Vector128.Create(1, 255, 1, 255, 5, 255, 5, 255, 9, 255, 9, 255, 13, 255, 13, 255);
-            int numPixels = pixelData.Length;
-            nint i;
-            for (i = 0; i <= (nint)(uint)numPixels - 4; i += 4)
+            nuint numPixels = (uint)pixelData.Length;
+            nuint i = 0;
+            do
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector128<byte> input = Unsafe.As<uint, Vector128<uint>>(ref pos).AsByte();
                 Vector128<byte> in0g0g = Ssse3.Shuffle(input, subtractGreenFromBlueAndRedMaskSsse3);
                 Vector128<byte> output = Sse2.Subtract(input, in0g0g);
                 Unsafe.As<uint, Vector128<uint>>(ref pos) = output.AsUInt32();
+                i += 4;
             }
+            while (i <= numPixels - 4);
 
             if (i != numPixels)
             {
                 SubtractGreenFromBlueAndRedScalar(pixelData[(int)i..]);
             }
         }
-        else if (Sse2.IsSupported)
+        else if (Sse2.IsSupported && pixelData.Length >= 4)
         {
-            int numPixels = pixelData.Length;
-            nint i;
-            for (i = 0; i <= (nint)(uint)numPixels - 4; i += 4)
+            nuint numPixels = (uint)pixelData.Length;
+            nuint i = 0;
+            do
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), i);
                 Vector128<byte> input = Unsafe.As<uint, Vector128<uint>>(ref pos).AsByte();
@@ -225,7 +235,9 @@ internal static unsafe class LosslessUtils
                 Vector128<ushort> c = Sse2.ShuffleHigh(b, SimdUtils.Shuffle.MMShuffle2200); // 0g0g
                 Vector128<byte> output = Sse2.Subtract(input.AsByte(), c.AsByte());
                 Unsafe.As<uint, Vector128<uint>>(ref pos) = output.AsUInt32();
+                i += 4;
             }
+            while (i <= numPixels - 4);
 
             if (i != numPixels)
             {
@@ -372,8 +384,8 @@ internal static unsafe class LosslessUtils
             Vector256<int> multsrb = MkCst32(Cst5b(m.GreenToRed), Cst5b(m.GreenToBlue));
             Vector256<int> multsb2 = MkCst32(Cst5b(m.RedToBlue), 0);
 
-            nint idx;
-            for (idx = 0; idx <= (nint)(uint)numPixels - 8; idx += 8)
+            nuint idx = 0;
+            do
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), idx);
                 Vector256<uint> input = Unsafe.As<uint, Vector256<uint>>(ref pos);
@@ -388,21 +400,23 @@ internal static unsafe class LosslessUtils
                 Vector256<byte> i = Avx2.And(h, transformColorRedBlueMask256);
                 Vector256<byte> output = Avx2.Subtract(input.AsByte(), i);
                 Unsafe.As<uint, Vector256<uint>>(ref pos) = output.AsUInt32();
+                idx += 8;
             }
+            while (idx <= (uint)numPixels - 8);
 
-            if (idx != numPixels)
+            if (idx != (uint)numPixels)
             {
                 TransformColorScalar(m, pixelData[(int)idx..], numPixels - (int)idx);
             }
         }
-        else if (Sse2.IsSupported)
+        else if (Sse2.IsSupported && numPixels >= 4)
         {
             Vector128<byte> transformColorAlphaGreenMask = Vector128.Create(0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255);
             Vector128<byte> transformColorRedBlueMask = Vector128.Create(255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0);
             Vector128<int> multsrb = MkCst16(Cst5b(m.GreenToRed), Cst5b(m.GreenToBlue));
             Vector128<int> multsb2 = MkCst16(Cst5b(m.RedToBlue), 0);
-            nint idx;
-            for (idx = 0; idx <= (nint)(uint)numPixels - 4; idx += 4)
+            nuint idx = 0;
+            do
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), idx);
                 Vector128<uint> input = Unsafe.As<uint, Vector128<uint>>(ref pos);
@@ -417,9 +431,11 @@ internal static unsafe class LosslessUtils
                 Vector128<byte> i = Sse2.And(h, transformColorRedBlueMask);
                 Vector128<byte> output = Sse2.Subtract(input.AsByte(), i);
                 Unsafe.As<uint, Vector128<uint>>(ref pos) = output.AsUInt32();
+                idx += 4;
             }
+            while ((int)idx <= numPixels - 4);
 
-            if (idx != numPixels)
+            if ((int)idx != numPixels)
             {
                 TransformColorScalar(m, pixelData[(int)idx..], numPixels - (int)idx);
             }
@@ -460,8 +476,8 @@ internal static unsafe class LosslessUtils
             Vector256<byte> transformColorInverseAlphaGreenMask256 = Vector256.Create(0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255);
             Vector256<int> multsrb = MkCst32(Cst5b(m.GreenToRed), Cst5b(m.GreenToBlue));
             Vector256<int> multsb2 = MkCst32(Cst5b(m.RedToBlue), 0);
-            nint idx;
-            for (idx = 0; idx <= (nint)(uint)pixelData.Length - 8; idx += 8)
+            nuint idx;
+            for (idx = 0; idx <= (uint)pixelData.Length - 8; idx += 8)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), idx);
                 Vector256<uint> input = Unsafe.As<uint, Vector256<uint>>(ref pos);
@@ -479,19 +495,19 @@ internal static unsafe class LosslessUtils
                 Unsafe.As<uint, Vector256<uint>>(ref pos) = output.AsUInt32();
             }
 
-            if (idx != pixelData.Length)
+            if (idx != (uint)pixelData.Length)
             {
                 TransformColorInverseScalar(m, pixelData[(int)idx..]);
             }
         }
-        else if (Sse2.IsSupported)
+        else if (Sse2.IsSupported && pixelData.Length >= 4)
         {
             Vector128<byte> transformColorInverseAlphaGreenMask = Vector128.Create(0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255);
             Vector128<int> multsrb = MkCst16(Cst5b(m.GreenToRed), Cst5b(m.GreenToBlue));
             Vector128<int> multsb2 = MkCst16(Cst5b(m.RedToBlue), 0);
 
-            nint idx;
-            for (idx = 0; idx <= (nint)(uint)pixelData.Length - 4; idx += 4)
+            nuint idx;
+            for (idx = 0; idx <= (uint)pixelData.Length - 4; idx += 4)
             {
                 ref uint pos = ref Unsafe.Add(ref MemoryMarshal.GetReference(pixelData), idx);
                 Vector128<uint> input = Unsafe.As<uint, Vector128<uint>>(ref pos);
@@ -509,7 +525,7 @@ internal static unsafe class LosslessUtils
                 Unsafe.As<uint, Vector128<uint>>(ref pos) = output.AsUInt32();
             }
 
-            if (idx != pixelData.Length)
+            if (idx != (uint)pixelData.Length)
             {
                 TransformColorInverseScalar(m, pixelData[(int)idx..]);
             }
@@ -740,7 +756,7 @@ internal static unsafe class LosslessUtils
             Vector256<int> sumXY256 = Vector256<int>.Zero;
             Vector256<int> sumX256 = Vector256<int>.Zero;
             ref int tmpRef = ref Unsafe.As<Vector256<int>, int>(ref tmp);
-            for (nint i = 0; i < 256; i += 8)
+            for (nuint i = 0; i < 256; i += 8)
             {
                 Vector256<int> xVec = Unsafe.As<int, Vector256<int>>(ref Unsafe.Add(ref xRef, i));
                 Vector256<int> yVec = Unsafe.As<int, Vector256<int>>(ref Unsafe.Add(ref yRef, i));

--- a/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
@@ -1440,7 +1440,12 @@ internal static unsafe class LosslessUtils
     }
 
     [MethodImpl(InliningOptions.ShortMethod)]
-    private static int AddSubtractComponentHalf(int a, int b) => (int)Clip255((uint)(a + ((a - b) / 2)));
+    private static int AddSubtractComponentHalf(int a, int b)
+    {
+        uint ua = (uint)a;
+        uint ub = (uint)b;
+        return (int)Clip255(ua + ((ua - ub) / 2));
+    }
 
     [MethodImpl(InliningOptions.ShortMethod)]
     private static int AddSubtractComponentFull(int a, int b, int c) => (int)Clip255((uint)(a + b - c));

--- a/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
@@ -1440,12 +1440,7 @@ internal static unsafe class LosslessUtils
     }
 
     [MethodImpl(InliningOptions.ShortMethod)]
-    private static int AddSubtractComponentHalf(int a, int b)
-    {
-        uint ua = (uint)a;
-        uint ub = (uint)b;
-        return (int)Clip255(ua + ((ua - ub) / 2));
-    }
+    private static int AddSubtractComponentHalf(int a, int b) => (int)Clip255((uint)(a + ((a - b) >> 1)));  // >> 1 is bit-hack for / 2
 
     [MethodImpl(InliningOptions.ShortMethod)]
     private static int AddSubtractComponentFull(int a, int b, int c) => (int)Clip255((uint)(a + b - c));

--- a/src/ImageSharp/Formats/Webp/Lossless/PredictorEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/PredictorEncoder.cs
@@ -113,7 +113,7 @@ internal static unsafe class PredictorEncoder
             lowEffort);
     }
 
-    public static void ColorSpaceTransform(int width, int height, int bits, int quality, Span<uint> bgra, Span<uint> image, Span<int> scratch)
+    public static void ColorSpaceTransform(int width, int height, int bits, uint quality, Span<uint> bgra, Span<uint> image, Span<int> scratch)
     {
         int maxTileSize = 1 << bits;
         int tileXSize = LosslessUtils.SubSampleSize(width, bits);
@@ -837,7 +837,7 @@ internal static unsafe class PredictorEncoder
         int bits,
         Vp8LMultipliers prevX,
         Vp8LMultipliers prevY,
-        int quality,
+        uint quality,
         int xSize,
         int ySize,
         int[] accumulatedRedHisto,
@@ -871,14 +871,14 @@ internal static unsafe class PredictorEncoder
         int tileHeight,
         Vp8LMultipliers prevX,
         Vp8LMultipliers prevY,
-        int quality,
+        uint quality,
         int[] accumulatedRedHisto,
         ref Vp8LMultipliers bestTx)
     {
-        int maxIters = 4 + ((7 * quality) >> 8);  // in range [4..6]
+        uint maxIters = 4 + ((7 * quality) / 256);  // in range [4..6]
         int greenToRedBest = 0;
         double bestDiff = GetPredictionCostCrossColorRed(argb, stride, scratch, tileWidth, tileHeight, prevX, prevY, greenToRedBest, accumulatedRedHisto);
-        for (int iter = 0; iter < maxIters; iter++)
+        for (int iter = 0; iter < (int)maxIters; iter++)
         {
             // ColorTransformDelta is a 3.5 bit fixed point, so 32 is equal to
             // one in color computation. Having initial delta here as 1 is sufficient
@@ -901,7 +901,7 @@ internal static unsafe class PredictorEncoder
         bestTx.GreenToRed = (byte)(greenToRedBest & 0xff);
     }
 
-    private static void GetBestGreenRedToBlue(Span<uint> argb, int stride, Span<int> scratch, int tileWidth, int tileHeight, Vp8LMultipliers prevX, Vp8LMultipliers prevY, int quality, int[] accumulatedBlueHisto, ref Vp8LMultipliers bestTx)
+    private static void GetBestGreenRedToBlue(Span<uint> argb, int stride, Span<int> scratch, int tileWidth, int tileHeight, Vp8LMultipliers prevX, Vp8LMultipliers prevY, uint quality, int[] accumulatedBlueHisto, ref Vp8LMultipliers bestTx)
     {
         int iters = (quality < 25) ? 1 : (quality > 50) ? GreenRedToBlueMaxIters : 4;
         int greenToBlueBest = 0;

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -57,7 +57,7 @@ internal class Vp8LEncoder : IDisposable
     /// <summary>
     /// The quality, that will be used to encode the image.
     /// </summary>
-    private readonly int quality;
+    private readonly uint quality;
 
     /// <summary>
     /// Quality/speed trade-off (0=fast, 6=slower-better).
@@ -110,7 +110,7 @@ internal class Vp8LEncoder : IDisposable
         Configuration configuration,
         int width,
         int height,
-        int quality,
+        uint quality,
         bool skipMetadata,
         WebpEncodingMethod method,
         WebpTransparentColorMode transparentColorMode,
@@ -122,7 +122,7 @@ internal class Vp8LEncoder : IDisposable
 
         this.memoryAllocator = memoryAllocator;
         this.configuration = configuration;
-        this.quality = Numerics.Clamp(quality, 0, 100);
+        this.quality = Math.Min(quality, 100u);
         this.skipMetadata = skipMetadata;
         this.method = method;
         this.transparentColorMode = transparentColorMode;
@@ -772,7 +772,7 @@ internal class Vp8LEncoder : IDisposable
         this.EncodeImageNoHuffman(this.TransformData.GetSpan(), this.HashChain, this.Refs[0], this.Refs[1], transformWidth, transformHeight, this.quality, lowEffort);
     }
 
-    private void EncodeImageNoHuffman(Span<uint> bgra, Vp8LHashChain hashChain, Vp8LBackwardRefs refsTmp1, Vp8LBackwardRefs refsTmp2, int width, int height, int quality, bool lowEffort)
+    private void EncodeImageNoHuffman(Span<uint> bgra, Vp8LHashChain hashChain, Vp8LBackwardRefs refsTmp1, Vp8LBackwardRefs refsTmp2, int width, int height, uint quality, bool lowEffort)
     {
         int cacheBits = 0;
         ushort[] histogramSymbols = new ushort[1]; // Only one tree, one symbol.
@@ -1820,7 +1820,7 @@ internal class Vp8LEncoder : IDisposable
     {
         // VP8LResidualImage needs room for 2 scanlines of uint32 pixels with an extra
         // pixel in each, plus 2 regular scanlines of bytes.
-        int bgraScratchSize = this.UsePredictorTransform ? (int)((((uint)width + 1) * 2) + ((((uint)width * 2) + 4 - 1) / 4)) : 0;
+        int bgraScratchSize = this.UsePredictorTransform ? ((width + 1) * 2) + (((width * 2) + 4 - 1) / 4) : 0;
         int transformDataSize = this.UsePredictorTransform || this.UseCrossColorTransform ? LosslessUtils.SubSampleSize(width, this.TransformBits) * LosslessUtils.SubSampleSize(height, this.TransformBits) : 0;
 
         this.BgraScratch = this.memoryAllocator.Allocate<uint>(bgraScratchSize);

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -963,7 +963,7 @@ internal class Vp8LEncoder : IDisposable
             else
             {
                 int nBits = BitOperations.Log2((uint)trimmedLength - 2);
-                int nBitPairs = (nBits / 2) + 1;
+                int nBitPairs = (int)(((uint)nBits / 2) + 1);
                 this.bitWriter.PutBits((uint)nBitPairs - 1, 3);
                 this.bitWriter.PutBits((uint)trimmedLength - 2, nBitPairs * 2);
             }
@@ -1820,7 +1820,7 @@ internal class Vp8LEncoder : IDisposable
     {
         // VP8LResidualImage needs room for 2 scanlines of uint32 pixels with an extra
         // pixel in each, plus 2 regular scanlines of bytes.
-        int bgraScratchSize = this.UsePredictorTransform ? ((width + 1) * 2) + (((width * 2) + 4 - 1) / 4) : 0;
+        int bgraScratchSize = this.UsePredictorTransform ? (int)((((uint)width + 1) * 2) + ((((uint)width * 2) + 4 - 1) / 4)) : 0;
         int transformDataSize = this.UsePredictorTransform || this.UseCrossColorTransform ? LosslessUtils.SubSampleSize(width, this.TransformBits) * LosslessUtils.SubSampleSize(height, this.TransformBits) : 0;
 
         this.BgraScratch = this.memoryAllocator.Allocate<uint>(bgraScratchSize);

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHashChain.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHashChain.cs
@@ -59,7 +59,7 @@ internal sealed class Vp8LHashChain : IDisposable
     public void Fill(ReadOnlySpan<uint> bgra, int quality, int xSize, int ySize, bool lowEffort)
     {
         int size = xSize * ySize;
-        int iterMax = GetMaxItersForQuality(quality);
+        int iterMax = GetMaxItersForQuality((uint)quality);
         int windowSize = GetWindowSizeForHashChain(quality, xSize);
         int pos;
 
@@ -272,7 +272,7 @@ internal sealed class Vp8LHashChain : IDisposable
     /// <param name="quality">The quality.</param>
     /// <returns>Number of hash chain lookups.</returns>
     [MethodImpl(InliningOptions.ShortMethod)]
-    private static int GetMaxItersForQuality(int quality) => 8 + (quality * quality / 128);
+    private static int GetMaxItersForQuality(uint quality) => (int)(8 + (quality * quality / 128));
 
     [MethodImpl(InliningOptions.ShortMethod)]
     private static int GetWindowSizeForHashChain(int quality, int xSize)

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHashChain.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHashChain.cs
@@ -56,10 +56,10 @@ internal sealed class Vp8LHashChain : IDisposable
     /// </summary>
     public int Size { get; }
 
-    public void Fill(ReadOnlySpan<uint> bgra, int quality, int xSize, int ySize, bool lowEffort)
+    public void Fill(ReadOnlySpan<uint> bgra, uint quality, int xSize, int ySize, bool lowEffort)
     {
         int size = xSize * ySize;
-        int iterMax = GetMaxItersForQuality((uint)quality);
+        int iterMax = GetMaxItersForQuality(quality);
         int windowSize = GetWindowSizeForHashChain(quality, xSize);
         int pos;
 
@@ -275,11 +275,11 @@ internal sealed class Vp8LHashChain : IDisposable
     private static int GetMaxItersForQuality(uint quality) => (int)(8 + (quality * quality / 128));
 
     [MethodImpl(InliningOptions.ShortMethod)]
-    private static int GetWindowSizeForHashChain(int quality, int xSize)
+    private static int GetWindowSizeForHashChain(uint quality, int xSize)
     {
-        int maxWindowSize = quality > 75 ? WindowSize
-            : quality > 50 ? xSize << 8
-            : quality > 25 ? xSize << 6
+        int maxWindowSize = quality > 75u ? WindowSize
+            : quality > 50u ? xSize << 8
+            : quality > 25u ? xSize << 6
             : xSize << 4;
 
         return maxWindowSize > WindowSize ? WindowSize : maxWindowSize;

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
@@ -518,9 +518,9 @@ internal sealed class Vp8LHistogram : IDeepCloneable
             ref uint aRef = ref MemoryMarshal.GetReference(a);
             ref uint bRef = ref MemoryMarshal.GetReference(b);
             ref uint outputRef = ref MemoryMarshal.GetReference(output);
-            nint idx;
+            nuint idx;
 
-            for (idx = 0; idx <= (nint)(uint)count - 32; idx += 32)
+            for (idx = 0; idx <= (uint)count - 32; idx += 32)
             {
                 // Load values.
                 Vector256<uint> a0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx));

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
@@ -518,28 +518,29 @@ internal sealed class Vp8LHistogram : IDeepCloneable
             ref uint aRef = ref MemoryMarshal.GetReference(a);
             ref uint bRef = ref MemoryMarshal.GetReference(b);
             ref uint outputRef = ref MemoryMarshal.GetReference(output);
-            int i;
+            nint idx;
 
-            for (i = 0; i + 32 <= count; i += 32)
+            for (idx = 0; idx <= (nint)(uint)count - 32; idx += 32)
             {
                 // Load values.
-                Vector256<uint> a0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, i));
-                Vector256<uint> a1 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, i + 8));
-                Vector256<uint> a2 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, i + 16));
-                Vector256<uint> a3 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, i + 24));
-                Vector256<uint> b0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, i));
-                Vector256<uint> b1 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, i + 8));
-                Vector256<uint> b2 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, i + 16));
-                Vector256<uint> b3 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, i + 24));
+                Vector256<uint> a0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx));
+                Vector256<uint> a1 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx + 8));
+                Vector256<uint> a2 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx + 16));
+                Vector256<uint> a3 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx + 24));
+                Vector256<uint> b0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, idx));
+                Vector256<uint> b1 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, idx + 8));
+                Vector256<uint> b2 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, idx + 16));
+                Vector256<uint> b3 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, idx + 24));
 
                 // Note we are adding uint32_t's as *signed* int32's (using _mm_add_epi32). But
                 // that's ok since the histogram values are less than 1<<28 (max picture count).
-                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, i)) = Avx2.Add(a0, b0);
-                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, i + 8)) = Avx2.Add(a1, b1);
-                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, i + 16)) = Avx2.Add(a2, b2);
-                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, i + 24)) = Avx2.Add(a3, b3);
+                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, idx)) = Avx2.Add(a0, b0);
+                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, idx + 8)) = Avx2.Add(a1, b1);
+                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, idx + 16)) = Avx2.Add(a2, b2);
+                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, idx + 24)) = Avx2.Add(a3, b3);
             }
 
+            int i = (int)idx;
             for (; i < count; i++)
             {
                 output[i] = a[i] + b[i];

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
@@ -523,18 +523,18 @@ internal sealed class Vp8LHistogram : IDeepCloneable
             do
             {
                 // Load values.
-                Vector256<uint> a0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx));
+                Vector256<uint> a0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx + 0));
                 Vector256<uint> a1 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx + 8));
                 Vector256<uint> a2 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx + 16));
                 Vector256<uint> a3 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref aRef, idx + 24));
-                Vector256<uint> b0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, idx));
+                Vector256<uint> b0 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, idx + 0));
                 Vector256<uint> b1 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, idx + 8));
                 Vector256<uint> b2 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, idx + 16));
                 Vector256<uint> b3 = Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref bRef, idx + 24));
 
                 // Note we are adding uint32_t's as *signed* int32's (using _mm_add_epi32). But
                 // that's ok since the histogram values are less than 1<<28 (max picture count).
-                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, idx)) = Avx2.Add(a0, b0);
+                Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, idx + 0)) = Avx2.Add(a0, b0);
                 Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, idx + 8)) = Avx2.Add(a1, b1);
                 Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, idx + 16)) = Avx2.Add(a2, b2);
                 Unsafe.As<uint, Vector256<uint>>(ref Unsafe.Add(ref outputRef, idx + 24)) = Avx2.Add(a3, b3);

--- a/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
@@ -1553,7 +1553,7 @@ internal static class LossyUtils
             Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset - (3 * stride)))) = p2.AsInt32();
             Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset - (2 * stride)))) = p1.AsInt32();
             Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset - stride))) = p0.AsInt32();
-            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset))) = q0.AsInt32();
+            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)offset)) = q0.AsInt32();
             Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset + stride))) = q1.AsInt32();
             Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset + (2 * stride)))) = q2.AsInt32();
         }
@@ -1599,7 +1599,7 @@ internal static class LossyUtils
         if (Sse2.IsSupported)
         {
             ref byte pRef = ref MemoryMarshal.GetReference(p);
-            Vector128<byte> p3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset)));
+            Vector128<byte> p3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)offset));
             Vector128<byte> p2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + stride)));
             Vector128<byte> p1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + (2 * stride))));
             Vector128<byte> p0 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + (3 * stride))));

--- a/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
@@ -161,7 +161,7 @@ internal static class LossyUtils
     private static int Vp8_Sse16xN_Sse2(Span<byte> a, Span<byte> b, int numPairs)
     {
         Vector128<int> sum = Vector128<int>.Zero;
-        nint offset = 0;
+        nuint offset = 0;
         ref byte aRef = ref MemoryMarshal.GetReference(a);
         ref byte bRef = ref MemoryMarshal.GetReference(b);
         for (int i = 0; i < numPairs; i++)
@@ -186,7 +186,7 @@ internal static class LossyUtils
     private static int Vp8_Sse16xN_Avx2(Span<byte> a, Span<byte> b, int numPairs)
     {
         Vector256<int> sum = Vector256<int>.Zero;
-        nint offset = 0;
+        nuint offset = 0;
         ref byte aRef = ref MemoryMarshal.GetReference(a);
         ref byte bRef = ref MemoryMarshal.GetReference(b);
         for (int i = 0; i < numPairs; i++)
@@ -2278,8 +2278,8 @@ internal static class LossyUtils
         // q0 = 73 63 53 43 33 23 13 03 72 62 52 42 32 22 12 02
         // p0 = f1 e1 d1 c1 b1 a1 91 81 f0 e0 d0 c0 b0 a0 90 80
         // q1 = f3 e3 d3 c3 b3 a3 93 83 f2 e2 d2 c2 b2 a2 92 82
-        Load8x4(ref r0, (nint)(uint)stride, out Vector128<byte> t1, out Vector128<byte> t2);
-        Load8x4(ref r8, (nint)(uint)stride, out p0, out q1);
+        Load8x4(ref r0, (uint)stride, out Vector128<byte> t1, out Vector128<byte> t2);
+        Load8x4(ref r8, (uint)stride, out p0, out q1);
 
         // p1 = f0 e0 d0 c0 b0 a0 90 80 70 60 50 40 30 20 10 00
         // p0 = f1 e1 d1 c1 b1 a1 91 81 71 61 51 41 31 21 11 01
@@ -2292,7 +2292,7 @@ internal static class LossyUtils
     }
 
     // Reads 8 rows across a vertical edge.
-    private static void Load8x4(ref byte bRef, nint stride, out Vector128<byte> p, out Vector128<byte> q)
+    private static void Load8x4(ref byte bRef, nuint stride, out Vector128<byte> p, out Vector128<byte> q)
     {
         // A0 = 63 62 61 60 23 22 21 20 43 42 41 40 03 02 01 00
         // A1 = 73 72 71 70 33 32 31 30 53 52 51 50 13 12 11 10

--- a/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/LossyUtils.cs
@@ -1427,17 +1427,17 @@ internal static class LossyUtils
         if (Sse2.IsSupported)
         {
             // Load.
-            ref byte pRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(p), offset);
+            ref byte pRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(p), (uint)offset);
 
             Vector128<byte> p1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Subtract(ref pRef, 2 * stride));
             Vector128<byte> p0 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Subtract(ref pRef, stride));
             Vector128<byte> q0 = Unsafe.As<byte, Vector128<byte>>(ref pRef);
-            Vector128<byte> q1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, stride));
+            Vector128<byte> q1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)stride));
 
             DoFilter2Sse2(ref p1, ref p0, ref q0, ref q1, thresh);
 
             // Store.
-            ref byte outputRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(p), offset);
+            ref byte outputRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(p), (uint)offset);
             Unsafe.As<byte, Vector128<sbyte>>(ref Unsafe.Subtract(ref outputRef, stride)) = p0.AsSByte();
             Unsafe.As<byte, Vector128<sbyte>>(ref outputRef) = q0.AsSByte();
         }
@@ -1460,11 +1460,11 @@ internal static class LossyUtils
         if (Sse2.IsSupported)
         {
             // Beginning of p1
-            ref byte pRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(p), offset - 2);
+            ref byte pRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(p), (uint)(offset - 2));
 
-            Load16x4(ref pRef, ref Unsafe.Add(ref pRef, 8 * stride), stride, out Vector128<byte> p1, out Vector128<byte> p0, out Vector128<byte> q0, out Vector128<byte> q1);
+            Load16x4(ref pRef, ref Unsafe.Add(ref pRef, 8 * (uint)stride), stride, out Vector128<byte> p1, out Vector128<byte> p0, out Vector128<byte> q0, out Vector128<byte> q1);
             DoFilter2Sse2(ref p1, ref p0, ref q0, ref q1, thresh);
-            Store16x4(p1, p0, q0, q1, ref pRef, ref Unsafe.Add(ref pRef, 8 * stride), stride);
+            Store16x4(p1, p0, q0, q1, ref pRef, ref Unsafe.Add(ref pRef, 8 * (uint)stride), stride);
         }
         else
         {
@@ -1527,19 +1527,19 @@ internal static class LossyUtils
         if (Sse2.IsSupported)
         {
             ref byte pRef = ref MemoryMarshal.GetReference(p);
-            Vector128<byte> t1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset - (4 * stride)));
-            Vector128<byte> p2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset - (3 * stride)));
-            Vector128<byte> p1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset - (2 * stride)));
-            Vector128<byte> p0 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset - stride));
+            Vector128<byte> t1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset - (4 * stride))));
+            Vector128<byte> p2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset - (3 * stride))));
+            Vector128<byte> p1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset - (2 * stride))));
+            Vector128<byte> p0 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset - stride)));
 
             Vector128<byte> mask = Abs(p1, p0);
             mask = Sse2.Max(mask, Abs(t1, p2));
             mask = Sse2.Max(mask, Abs(p2, p1));
 
-            Vector128<byte> q0 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset));
-            Vector128<byte> q1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset + stride));
-            Vector128<byte> q2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset + (2 * stride)));
-            t1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset + (3 * stride)));
+            Vector128<byte> q0 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)offset));
+            Vector128<byte> q1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + stride)));
+            Vector128<byte> q2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + (2 * stride))));
+            t1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + (3 * stride))));
 
             mask = Sse2.Max(mask, Abs(q1, q0));
             mask = Sse2.Max(mask, Abs(t1, q2));
@@ -1550,12 +1550,12 @@ internal static class LossyUtils
 
             // Store.
             ref byte outputRef = ref MemoryMarshal.GetReference(p);
-            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, offset - (3 * stride))) = p2.AsInt32();
-            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, offset - (2 * stride))) = p1.AsInt32();
-            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, offset - stride)) = p0.AsInt32();
-            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, offset)) = q0.AsInt32();
-            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, offset + stride)) = q1.AsInt32();
-            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, offset + (2 * stride))) = q2.AsInt32();
+            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset - (3 * stride)))) = p2.AsInt32();
+            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset - (2 * stride)))) = p1.AsInt32();
+            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset - stride))) = p0.AsInt32();
+            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset))) = q0.AsInt32();
+            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset + stride))) = q1.AsInt32();
+            Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(offset + (2 * stride)))) = q2.AsInt32();
         }
         else
         {
@@ -1569,14 +1569,14 @@ internal static class LossyUtils
         if (Sse2.IsSupported)
         {
             ref byte pRef = ref MemoryMarshal.GetReference(p);
-            ref byte bRef = ref Unsafe.Add(ref pRef, offset - 4);
-            Load16x4(ref bRef, ref Unsafe.Add(ref bRef, 8 * stride), stride, out Vector128<byte> p3, out Vector128<byte> p2, out Vector128<byte> p1, out Vector128<byte> p0);
+            ref byte bRef = ref Unsafe.Add(ref pRef, (uint)offset - 4);
+            Load16x4(ref bRef, ref Unsafe.Add(ref bRef, 8 * (uint)stride), stride, out Vector128<byte> p3, out Vector128<byte> p2, out Vector128<byte> p1, out Vector128<byte> p0);
 
             Vector128<byte> mask = Abs(p1, p0);
             mask = Sse2.Max(mask, Abs(p3, p2));
             mask = Sse2.Max(mask, Abs(p2, p1));
 
-            Load16x4(ref Unsafe.Add(ref pRef, offset), ref Unsafe.Add(ref pRef, offset + (8 * stride)), stride, out Vector128<byte> q0, out Vector128<byte> q1, out Vector128<byte> q2, out Vector128<byte> q3);
+            Load16x4(ref Unsafe.Add(ref pRef, (uint)offset), ref Unsafe.Add(ref pRef, (uint)(offset + (8 * stride))), stride, out Vector128<byte> q0, out Vector128<byte> q1, out Vector128<byte> q2, out Vector128<byte> q3);
 
             mask = Sse2.Max(mask, Abs(q1, q0));
             mask = Sse2.Max(mask, Abs(q3, q2));
@@ -1585,8 +1585,8 @@ internal static class LossyUtils
             ComplexMask(p1, p0, q0, q1, thresh, ithresh, ref mask);
             DoFilter6Sse2(ref p2, ref p1, ref p0, ref q0, ref q1, ref q2, mask, hevThresh);
 
-            Store16x4(p3, p2, p1, p0, ref bRef, ref Unsafe.Add(ref bRef, 8 * stride), stride);
-            Store16x4(q0, q1, q2, q3, ref Unsafe.Add(ref pRef, offset), ref Unsafe.Add(ref pRef, offset + (8 * stride)), stride);
+            Store16x4(p3, p2, p1, p0, ref bRef, ref Unsafe.Add(ref bRef, 8 * (uint)stride), stride);
+            Store16x4(q0, q1, q2, q3, ref Unsafe.Add(ref pRef, (uint)offset), ref Unsafe.Add(ref pRef, (uint)(offset + (8 * stride))), stride);
         }
         else
         {
@@ -1599,10 +1599,10 @@ internal static class LossyUtils
         if (Sse2.IsSupported)
         {
             ref byte pRef = ref MemoryMarshal.GetReference(p);
-            Vector128<byte> p3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset));
-            Vector128<byte> p2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset + stride));
-            Vector128<byte> p1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset + (2 * stride)));
-            Vector128<byte> p0 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset + (3 * stride)));
+            Vector128<byte> p3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset)));
+            Vector128<byte> p2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + stride)));
+            Vector128<byte> p1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + (2 * stride))));
+            Vector128<byte> p0 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + (3 * stride))));
 
             for (int k = 3; k > 0; k--)
             {
@@ -1614,10 +1614,10 @@ internal static class LossyUtils
                 mask = Sse2.Max(mask, Abs(p3, p2));
                 mask = Sse2.Max(mask, Abs(p2, p1));
 
-                p3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset));
-                p2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset + stride));
-                Vector128<byte> tmp1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset + (2 * stride)));
-                Vector128<byte> tmp2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, offset + (3 * stride)));
+                p3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)offset));
+                p2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + stride)));
+                Vector128<byte> tmp1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + (2 * stride))));
+                Vector128<byte> tmp2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref pRef, (uint)(offset + (3 * stride))));
 
                 mask = Sse2.Max(mask, Abs(tmp1, tmp2));
                 mask = Sse2.Max(mask, Abs(p3, p2));
@@ -1631,9 +1631,9 @@ internal static class LossyUtils
                 // Store.
                 ref byte outputRef = ref MemoryMarshal.GetReference(b);
                 Unsafe.As<byte, Vector128<int>>(ref outputRef) = p1.AsInt32();
-                Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, stride)) = p0.AsInt32();
-                Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, stride * 2)) = p3.AsInt32();
-                Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, stride * 3)) = p2.AsInt32();
+                Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)stride)) = p0.AsInt32();
+                Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(stride * 2))) = p3.AsInt32();
+                Unsafe.As<byte, Vector128<int>>(ref Unsafe.Add(ref outputRef, (uint)(stride * 3))) = p2.AsInt32();
 
                 // Rotate samples.
                 p1 = tmp1;
@@ -1655,13 +1655,13 @@ internal static class LossyUtils
         if (Sse2.IsSupported)
         {
             ref byte pRef = ref MemoryMarshal.GetReference(p);
-            Load16x4(ref Unsafe.Add(ref pRef, offset), ref Unsafe.Add(ref pRef, offset + (8 * stride)), stride, out Vector128<byte> p3, out Vector128<byte> p2, out Vector128<byte> p1, out Vector128<byte> p0);
+            Load16x4(ref Unsafe.Add(ref pRef, (uint)offset), ref Unsafe.Add(ref pRef, (uint)(offset + (8 * stride))), stride, out Vector128<byte> p3, out Vector128<byte> p2, out Vector128<byte> p1, out Vector128<byte> p0);
 
             Vector128<byte> mask;
             for (int k = 3; k > 0; k--)
             {
                 // Beginning of p1.
-                ref byte bRef = ref Unsafe.Add(ref pRef, offset + 2);
+                ref byte bRef = ref Unsafe.Add(ref pRef, (uint)offset + 2);
 
                 // Beginning of q0 (and next span).
                 offset += 4;
@@ -1671,7 +1671,7 @@ internal static class LossyUtils
                 mask = Sse2.Max(mask, Abs(p3, p2));
                 mask = Sse2.Max(mask, Abs(p2, p1));
 
-                Load16x4(ref Unsafe.Add(ref pRef, offset), ref Unsafe.Add(ref pRef, offset + (8 * stride)), stride, out p3, out p2, out Vector128<byte> tmp1, out Vector128<byte> tmp2);
+                Load16x4(ref Unsafe.Add(ref pRef, (uint)offset), ref Unsafe.Add(ref pRef, (uint)(offset + (8 * stride))), stride, out p3, out p2, out Vector128<byte> tmp1, out Vector128<byte> tmp2);
 
                 mask = Sse2.Max(mask, Abs(tmp1, tmp2));
                 mask = Sse2.Max(mask, Abs(p3, p2));
@@ -1680,7 +1680,7 @@ internal static class LossyUtils
                 ComplexMask(p1, p0, p3, p2, thresh, ithresh, ref mask);
                 DoFilter4Sse2(ref p1, ref p0, ref p3, ref p2, mask, hevThresh);
 
-                Store16x4(p1, p0, p3, p2, ref bRef, ref Unsafe.Add(ref bRef, 8 * stride), stride);
+                Store16x4(p1, p0, p3, p2, ref bRef, ref Unsafe.Add(ref bRef, 8 * (uint)stride), stride);
 
                 // Rotate samples.
                 p1 = tmp1;
@@ -1749,13 +1749,13 @@ internal static class LossyUtils
         {
             ref byte uRef = ref MemoryMarshal.GetReference(u);
             ref byte vRef = ref MemoryMarshal.GetReference(v);
-            Load16x4(ref Unsafe.Add(ref uRef, offset - 4), ref Unsafe.Add(ref vRef, offset - 4), stride, out Vector128<byte> p3, out Vector128<byte> p2, out Vector128<byte> p1, out Vector128<byte> p0);
+            Load16x4(ref Unsafe.Add(ref uRef, (uint)offset - 4), ref Unsafe.Add(ref vRef, (uint)offset - 4), stride, out Vector128<byte> p3, out Vector128<byte> p2, out Vector128<byte> p1, out Vector128<byte> p0);
 
             Vector128<byte> mask = Abs(p1, p0);
             mask = Sse2.Max(mask, Abs(p3, p2));
             mask = Sse2.Max(mask, Abs(p2, p1));
 
-            Load16x4(ref Unsafe.Add(ref uRef, offset), ref Unsafe.Add(ref vRef, offset), stride, out Vector128<byte> q0, out Vector128<byte> q1, out Vector128<byte> q2, out Vector128<byte> q3);
+            Load16x4(ref Unsafe.Add(ref uRef, (uint)offset), ref Unsafe.Add(ref vRef, (uint)offset), stride, out Vector128<byte> q0, out Vector128<byte> q1, out Vector128<byte> q2, out Vector128<byte> q3);
 
             mask = Sse2.Max(mask, Abs(q1, q0));
             mask = Sse2.Max(mask, Abs(q3, q2));
@@ -1764,8 +1764,8 @@ internal static class LossyUtils
             ComplexMask(p1, p0, q0, q1, thresh, ithresh, ref mask);
             DoFilter6Sse2(ref p2, ref p1, ref p0, ref q0, ref q1, ref q2, mask, hevThresh);
 
-            Store16x4(p3, p2, p1, p0, ref Unsafe.Add(ref uRef, offset - 4), ref Unsafe.Add(ref vRef, offset - 4), stride);
-            Store16x4(q0, q1, q2, q3, ref Unsafe.Add(ref uRef, offset), ref Unsafe.Add(ref vRef, offset), stride);
+            Store16x4(p3, p2, p1, p0, ref Unsafe.Add(ref uRef, (uint)offset - 4), ref Unsafe.Add(ref vRef, (uint)offset - 4), stride);
+            Store16x4(q0, q1, q2, q3, ref Unsafe.Add(ref uRef, (uint)offset), ref Unsafe.Add(ref vRef, (uint)offset), stride);
         }
         else
         {
@@ -1826,7 +1826,7 @@ internal static class LossyUtils
         {
             ref byte uRef = ref MemoryMarshal.GetReference(u);
             ref byte vRef = ref MemoryMarshal.GetReference(v);
-            Load16x4(ref Unsafe.Add(ref uRef, offset), ref Unsafe.Add(ref vRef, offset), stride, out Vector128<byte> t2, out Vector128<byte> t1, out Vector128<byte> p1, out Vector128<byte> p0);
+            Load16x4(ref Unsafe.Add(ref uRef, (uint)offset), ref Unsafe.Add(ref vRef, (uint)offset), stride, out Vector128<byte> t2, out Vector128<byte> t1, out Vector128<byte> p1, out Vector128<byte> p0);
 
             Vector128<byte> mask = Abs(p1, p0);
             mask = Sse2.Max(mask, Abs(t2, t1));
@@ -1835,7 +1835,7 @@ internal static class LossyUtils
             // Beginning of q0.
             offset += 4;
 
-            Load16x4(ref Unsafe.Add(ref uRef, offset), ref Unsafe.Add(ref vRef, offset), stride, out Vector128<byte> q0, out Vector128<byte> q1, out t1, out t2);
+            Load16x4(ref Unsafe.Add(ref uRef, (uint)offset), ref Unsafe.Add(ref vRef, (uint)offset), stride, out Vector128<byte> q0, out Vector128<byte> q1, out t1, out t2);
 
             mask = Sse2.Max(mask, Abs(q1, q0));
             mask = Sse2.Max(mask, Abs(t2, t1));
@@ -1846,7 +1846,7 @@ internal static class LossyUtils
 
             // Beginning of p1.
             offset -= 2;
-            Store16x4(p1, p0, q0, q1, ref Unsafe.Add(ref uRef, offset), ref Unsafe.Add(ref vRef, offset), stride);
+            Store16x4(p1, p0, q0, q1, ref Unsafe.Add(ref uRef, (uint)offset), ref Unsafe.Add(ref vRef, (uint)offset), stride);
         }
         else
         {
@@ -2278,8 +2278,8 @@ internal static class LossyUtils
         // q0 = 73 63 53 43 33 23 13 03 72 62 52 42 32 22 12 02
         // p0 = f1 e1 d1 c1 b1 a1 91 81 f0 e0 d0 c0 b0 a0 90 80
         // q1 = f3 e3 d3 c3 b3 a3 93 83 f2 e2 d2 c2 b2 a2 92 82
-        Load8x4(ref r0, stride, out Vector128<byte> t1, out Vector128<byte> t2);
-        Load8x4(ref r8, stride, out p0, out q1);
+        Load8x4(ref r0, (nint)(uint)stride, out Vector128<byte> t1, out Vector128<byte> t2);
+        Load8x4(ref r8, (nint)(uint)stride, out p0, out q1);
 
         // p1 = f0 e0 d0 c0 b0 a0 90 80 70 60 50 40 30 20 10 00
         // p0 = f1 e1 d1 c1 b1 a1 91 81 71 61 51 41 31 21 11 01
@@ -2292,7 +2292,7 @@ internal static class LossyUtils
     }
 
     // Reads 8 rows across a vertical edge.
-    private static void Load8x4(ref byte bRef, int stride, out Vector128<byte> p, out Vector128<byte> q)
+    private static void Load8x4(ref byte bRef, nint stride, out Vector128<byte> p, out Vector128<byte> q)
     {
         // A0 = 63 62 61 60 23 22 21 20 43 42 41 40 03 02 01 00
         // A1 = 73 72 71 70 33 32 31 30 53 52 51 50 13 12 11 10
@@ -2349,10 +2349,10 @@ internal static class LossyUtils
         q1s = Sse2.UnpackHigh(t1.AsInt16(), q1s.AsInt16()).AsByte();
 
         Store4x4(p0s, ref r0Ref, stride);
-        Store4x4(q0s, ref Unsafe.Add(ref r0Ref, 4 * stride), stride);
+        Store4x4(q0s, ref Unsafe.Add(ref r0Ref, 4 * (uint)stride), stride);
 
         Store4x4(p1s, ref r8Ref, stride);
-        Store4x4(q1s, ref Unsafe.Add(ref r8Ref, 4 * stride), stride);
+        Store4x4(q1s, ref Unsafe.Add(ref r8Ref, 4 * (uint)stride), stride);
     }
 
     private static void Store4x4(Vector128<byte> x, ref byte dstRef, int stride)
@@ -2360,7 +2360,7 @@ internal static class LossyUtils
         int offset = 0;
         for (int i = 0; i < 4; i++)
         {
-            Unsafe.As<byte, int>(ref Unsafe.Add(ref dstRef, offset)) = Sse2.ConvertToInt32(x.AsInt32());
+            Unsafe.As<byte, int>(ref Unsafe.Add(ref dstRef, (uint)offset)) = Sse2.ConvertToInt32(x.AsInt32());
             x = Sse2.ShiftRightLogical128BitLane(x, 4);
             offset += stride;
         }
@@ -2421,16 +2421,16 @@ internal static class LossyUtils
     [MethodImpl(InliningOptions.ShortMethod)]
     private static Vector128<byte> LoadUvEdge(ref byte uRef, ref byte vRef, int offset)
     {
-        var uVec = Vector128.Create(Unsafe.As<byte, long>(ref Unsafe.Add(ref uRef, offset)), 0);
-        var vVec = Vector128.Create(Unsafe.As<byte, long>(ref Unsafe.Add(ref vRef, offset)), 0);
+        var uVec = Vector128.Create(Unsafe.As<byte, long>(ref Unsafe.Add(ref uRef, (uint)offset)), 0);
+        var vVec = Vector128.Create(Unsafe.As<byte, long>(ref Unsafe.Add(ref vRef, (uint)offset)), 0);
         return Sse2.UnpackLow(uVec, vVec).AsByte();
     }
 
     [MethodImpl(InliningOptions.ShortMethod)]
     private static void StoreUv(Vector128<byte> x, ref byte uRef, ref byte vRef, int offset)
     {
-        Unsafe.As<byte, Vector64<byte>>(ref Unsafe.Add(ref uRef, offset)) = x.GetLower();
-        Unsafe.As<byte, Vector64<byte>>(ref Unsafe.Add(ref vRef, offset)) = x.GetUpper();
+        Unsafe.As<byte, Vector64<byte>>(ref Unsafe.Add(ref uRef, (uint)offset)) = x.GetLower();
+        Unsafe.As<byte, Vector64<byte>>(ref Unsafe.Add(ref vRef, (uint)offset)) = x.GetUpper();
     }
 
     // Compute abs(p - q) = subs(p - q) OR subs(q - p)

--- a/src/ImageSharp/Formats/Webp/Lossy/PassStats.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/PassStats.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossy;
 /// </summary>
 internal class PassStats
 {
-    public PassStats(long targetSize, float targetPsnr, int qMin, int qMax, int quality)
+    public PassStats(long targetSize, float targetPsnr, int qMin, int qMax, uint quality)
     {
         bool doSizeSearch = targetSize != 0;
 

--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -789,7 +789,7 @@ internal static unsafe class QuantEnc
     {
         int score = 0;
         ref short levelsRef = ref MemoryMarshal.GetReference(levels);
-        int offset = 0;
+        nint offset = 0;
         while (numBlocks-- > 0)
         {
             for (nint i = 1; i < 16; i++)

--- a/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/QuantEnc.cs
@@ -770,7 +770,7 @@ internal static unsafe class QuantEnc
     {
         uint v = src[0] * 0x01010101u;
         Span<byte> vSpan = BitConverter.GetBytes(v).AsSpan();
-        for (nint i = 0; i < 16; i++)
+        for (nuint i = 0; i < 16; i++)
         {
             if (!src[..4].SequenceEqual(vSpan) || !src.Slice(4, 4).SequenceEqual(vSpan) ||
                 !src.Slice(8, 4).SequenceEqual(vSpan) || !src.Slice(12, 4).SequenceEqual(vSpan))
@@ -789,10 +789,10 @@ internal static unsafe class QuantEnc
     {
         int score = 0;
         ref short levelsRef = ref MemoryMarshal.GetReference(levels);
-        nint offset = 0;
+        nuint offset = 0;
         while (numBlocks-- > 0)
         {
-            for (nint i = 1; i < 16; i++)
+            for (nuint i = 1; i < 16; i++)
             {
                 // omit DC, we're only interested in AC
                 score += Unsafe.Add(ref levelsRef, offset) != 0 ? 1 : 0;

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8EncIterator.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8EncIterator.cs
@@ -347,12 +347,12 @@ internal class Vp8EncIterator
         }
     }
 
-    public int FastMbAnalyze(int quality)
+    public int FastMbAnalyze(uint quality)
     {
         // Empirical cut-off value, should be around 16 (~=block size). We use the
         // [8-17] range and favor intra4 at high quality, intra16 for low quality.
-        int q = quality;
-        int kThreshold = 8 + ((17 - 8) * q / 100);
+        uint q = quality;
+        uint kThreshold = 8 + ((17 - 8) * q / 100);
         int k;
         Span<uint> dc = stackalloc uint[16];
         uint m;

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
@@ -683,7 +683,7 @@ internal class Vp8Encoder : IDisposable
             {
                 if (accum[n] != 0)
                 {
-                    int newCenter = (distAccum[n] + (accum[n] / 2)) / accum[n];
+                    int newCenter = (distAccum[n] + (accum[n] >> 1)) / accum[n];    // >> 1 is bit-hack for / 2
                     displaced += Math.Abs(centers[n] - newCenter);
                     centers[n] = newCenter;
                     weightedAverage += newCenter * accum[n];
@@ -691,7 +691,7 @@ internal class Vp8Encoder : IDisposable
                 }
             }
 
-            weightedAverage = (weightedAverage + (totalWeight / 2)) / totalWeight;
+            weightedAverage = (weightedAverage + (totalWeight >> 1)) / totalWeight; // >> 1 is bit-hack for / 2
             if (displaced < 5)
             {
                 break;   // no need to keep on looping...
@@ -1177,6 +1177,6 @@ internal class Vp8Encoder : IDisposable
     {
         int total = a + b;
         return total == 0 ? 255 // that's the default probability.
-            : ((255 * a) + (total / 2)) / total;  // rounded proba
+            : ((255 * a) + (int)((uint)total / 2)) / total;  // rounded proba
     }
 }

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
@@ -31,7 +31,7 @@ internal class Vp8Encoder : IDisposable
     /// <summary>
     /// The quality, that will be used to encode the image.
     /// </summary>
-    private readonly int quality;
+    private readonly uint quality;
 
     /// <summary>
     /// Quality/speed trade-off (0=fast, 6=slower-better).
@@ -113,7 +113,7 @@ internal class Vp8Encoder : IDisposable
         Configuration configuration,
         int width,
         int height,
-        int quality,
+        uint quality,
         bool skipMetadata,
         WebpEncodingMethod method,
         int entropyPasses,
@@ -125,7 +125,7 @@ internal class Vp8Encoder : IDisposable
         this.configuration = configuration;
         this.Width = width;
         this.Height = height;
-        this.quality = Numerics.Clamp(quality, 0, 100);
+        this.quality = Math.Min(quality, 100);
         this.skipMetadata = skipMetadata;
         this.method = method;
         this.entropyPasses = Numerics.Clamp(entropyPasses, 1, 10);
@@ -1177,6 +1177,6 @@ internal class Vp8Encoder : IDisposable
     {
         int total = a + b;
         return total == 0 ? 255 // that's the default probability.
-            : ((255 * a) + (int)((uint)total / 2)) / total;  // rounded proba
+            : ((255 * a) + (total >> 1)) / total;  // rounded proba
     }
 }

--- a/src/ImageSharp/Formats/Webp/Lossy/WebpLossyDecoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/WebpLossyDecoder.cs
@@ -731,7 +731,7 @@ internal sealed class WebpLossyDecoder
         Span<byte> dst = buf[dstStartIdx..];
         int yEnd = io.MbY + io.MbH;
         int mbw = io.MbW;
-        int uvw = (int)(((uint)mbw + 1) / 2);
+        int uvw = (mbw + 1) >> 1;   // >> 1 is bit-hack for / 2
         int y = io.MbY;
         byte[] uvBuffer = new byte[(14 * 32) + 15];
 

--- a/src/ImageSharp/Formats/Webp/Lossy/WebpLossyDecoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/WebpLossyDecoder.cs
@@ -731,7 +731,7 @@ internal sealed class WebpLossyDecoder
         Span<byte> dst = buf[dstStartIdx..];
         int yEnd = io.MbY + io.MbH;
         int mbw = io.MbW;
-        int uvw = (mbw + 1) / 2;
+        int uvw = (int)(((uint)mbw + 1) / 2);
         int y = io.MbY;
         byte[] uvBuffer = new byte[(14 * 32) + 15];
 

--- a/src/ImageSharp/Formats/Webp/Lossy/YuvConversion.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/YuvConversion.cs
@@ -138,8 +138,8 @@ internal static class YuvConversion
         {
             for (pos = 1, uvPos = 0; pos + 32 + 1 <= len; pos += 32, uvPos += 16)
             {
-                UpSample32Pixels(ref Unsafe.Add(ref topURef, uvPos), ref Unsafe.Add(ref curURef, uvPos), ru);
-                UpSample32Pixels(ref Unsafe.Add(ref topVRef, uvPos), ref Unsafe.Add(ref curVRef, uvPos), rv);
+                UpSample32Pixels(ref Unsafe.Add(ref topURef, (uint)uvPos), ref Unsafe.Add(ref curURef, (uint)uvPos), ru);
+                UpSample32Pixels(ref Unsafe.Add(ref topVRef, (uint)uvPos), ref Unsafe.Add(ref curVRef, (uint)uvPos), rv);
                 ConvertYuvToBgrWithBottomYSse41(topY, bottomY, topDst, bottomDst, ru, rv, pos, xStep);
             }
         }
@@ -147,8 +147,8 @@ internal static class YuvConversion
         {
             for (pos = 1, uvPos = 0; pos + 32 + 1 <= len; pos += 32, uvPos += 16)
             {
-                UpSample32Pixels(ref Unsafe.Add(ref topURef, uvPos), ref Unsafe.Add(ref curURef, uvPos), ru);
-                UpSample32Pixels(ref Unsafe.Add(ref topVRef, uvPos), ref Unsafe.Add(ref curVRef, uvPos), rv);
+                UpSample32Pixels(ref Unsafe.Add(ref topURef, (uint)uvPos), ref Unsafe.Add(ref curURef, (uint)uvPos), ru);
+                UpSample32Pixels(ref Unsafe.Add(ref topVRef, (uint)uvPos), ref Unsafe.Add(ref curVRef, (uint)uvPos), rv);
                 ConvertYuvToBgrSse41(topY, topDst, ru, rv, pos, xStep);
             }
         }

--- a/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
@@ -27,7 +27,7 @@ internal sealed class WebpEncoderCore : IImageEncoderInternals
     /// <summary>
     /// Compression quality. Between 0 and 100.
     /// </summary>
-    private readonly int quality;
+    private readonly uint quality;
 
     /// <summary>
     /// Quality/speed trade-off (0=fast, 6=slower-better).
@@ -92,7 +92,7 @@ internal sealed class WebpEncoderCore : IImageEncoderInternals
         this.memoryAllocator = configuration.MemoryAllocator;
         this.alphaCompression = encoder.UseAlphaCompression;
         this.fileFormat = encoder.FileFormat;
-        this.quality = encoder.Quality;
+        this.quality = (uint)encoder.Quality;
         this.method = encoder.Method;
         this.entropyPasses = encoder.EntropyPasses;
         this.spatialNoiseShaping = encoder.SpatialNoiseShaping;

--- a/src/ImageSharp/IO/ChunkedMemoryStream.cs
+++ b/src/ImageSharp/IO/ChunkedMemoryStream.cs
@@ -547,7 +547,7 @@ internal sealed class ChunkedMemoryStream : Stream
 #pragma warning disable IDE1006 // Naming Styles
         const int _128K = 1 << 17;
         const int _4M = 1 << 22;
-        return i < 16 ? _128K * (1 << (i / 4)) : _4M;
+        return i < 16 ? _128K * (1 << (int)((uint)i / 4)) : _4M;
 #pragma warning restore IDE1006 // Naming Styles
     }
 

--- a/src/ImageSharp/Memory/Allocators/Internals/ManagedBufferBase.cs
+++ b/src/ImageSharp/Memory/Allocators/Internals/ManagedBufferBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 using System.Buffers;

--- a/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
@@ -156,7 +156,7 @@ internal sealed class UniformUnmanagedMemoryPoolMemoryAllocator : MemoryAllocato
             // Workaround for https://github.com/dotnet/runtime/issues/65466
             if (total > 0)
             {
-                return total / 8;
+                return (long)((ulong)total / 8);
             }
         }
 

--- a/src/ImageSharp/Memory/DiscontiguousBuffers/MemoryGroup{T}.cs
+++ b/src/ImageSharp/Memory/DiscontiguousBuffers/MemoryGroup{T}.cs
@@ -252,7 +252,7 @@ internal abstract partial class MemoryGroup<T> : IMemoryGroup<T>, IDisposable
             {
                 ref byte b0 = ref MemoryMarshal.GetReference<byte>(this.memoryGroupSpanCache.SingleArray);
                 ref T e0 = ref Unsafe.As<byte, T>(ref b0);
-                e0 = ref Unsafe.Add(ref e0, y * width);
+                e0 = ref Unsafe.Add(ref e0, (uint)(y * width));
                 return MemoryMarshal.CreateSpan(ref e0, width);
             }
 

--- a/src/ImageSharp/PixelFormats/PixelBlenders/DefaultPixelBlenders.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelBlenders/DefaultPixelBlenders.Generated.cs
@@ -52,7 +52,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -89,7 +89,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -157,7 +157,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -194,7 +194,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -262,7 +262,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -299,7 +299,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -367,7 +367,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -404,7 +404,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -472,7 +472,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -509,7 +509,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -577,7 +577,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -614,7 +614,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -682,7 +682,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -719,7 +719,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -787,7 +787,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -824,7 +824,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -892,7 +892,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -929,7 +929,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -997,7 +997,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1034,7 +1034,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1102,7 +1102,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1139,7 +1139,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1207,7 +1207,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1244,7 +1244,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1312,7 +1312,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1349,7 +1349,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1417,7 +1417,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1454,7 +1454,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1522,7 +1522,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1559,7 +1559,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1627,7 +1627,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1664,7 +1664,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1732,7 +1732,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1769,7 +1769,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1837,7 +1837,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1874,7 +1874,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1942,7 +1942,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -1979,7 +1979,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2047,7 +2047,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2084,7 +2084,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2152,7 +2152,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2189,7 +2189,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2257,7 +2257,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2294,7 +2294,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2362,7 +2362,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2399,7 +2399,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2467,7 +2467,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2504,7 +2504,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2572,7 +2572,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2609,7 +2609,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2677,7 +2677,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2714,7 +2714,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2782,7 +2782,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2819,7 +2819,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2887,7 +2887,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2924,7 +2924,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -2992,7 +2992,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3029,7 +3029,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3097,7 +3097,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3134,7 +3134,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3202,7 +3202,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3239,7 +3239,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3307,7 +3307,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3344,7 +3344,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3412,7 +3412,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3449,7 +3449,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3517,7 +3517,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3554,7 +3554,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3622,7 +3622,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3659,7 +3659,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3727,7 +3727,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3764,7 +3764,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3832,7 +3832,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3869,7 +3869,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3937,7 +3937,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -3974,7 +3974,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4042,7 +4042,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4079,7 +4079,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4147,7 +4147,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4184,7 +4184,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4252,7 +4252,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4289,7 +4289,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4357,7 +4357,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4394,7 +4394,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4462,7 +4462,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4499,7 +4499,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4567,7 +4567,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4604,7 +4604,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4672,7 +4672,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4709,7 +4709,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4777,7 +4777,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4814,7 +4814,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4882,7 +4882,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4919,7 +4919,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -4987,7 +4987,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5024,7 +5024,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5092,7 +5092,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5129,7 +5129,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5197,7 +5197,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5234,7 +5234,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5302,7 +5302,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5339,7 +5339,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5407,7 +5407,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5444,7 +5444,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5512,7 +5512,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5549,7 +5549,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5617,7 +5617,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5654,7 +5654,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5722,7 +5722,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5759,7 +5759,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5827,7 +5827,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5864,7 +5864,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5932,7 +5932,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -5969,7 +5969,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6037,7 +6037,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6074,7 +6074,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6142,7 +6142,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6179,7 +6179,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6247,7 +6247,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6284,7 +6284,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6352,7 +6352,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6389,7 +6389,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6457,7 +6457,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6494,7 +6494,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6562,7 +6562,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6599,7 +6599,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6667,7 +6667,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6704,7 +6704,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6772,7 +6772,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6809,7 +6809,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6877,7 +6877,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6914,7 +6914,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -6982,7 +6982,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7019,7 +7019,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7087,7 +7087,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7124,7 +7124,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7192,7 +7192,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7229,7 +7229,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7297,7 +7297,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7334,7 +7334,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7402,7 +7402,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7439,7 +7439,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7507,7 +7507,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7544,7 +7544,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7612,7 +7612,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7649,7 +7649,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7717,7 +7717,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7754,7 +7754,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7822,7 +7822,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7859,7 +7859,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7927,7 +7927,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -7964,7 +7964,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8032,7 +8032,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8069,7 +8069,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8137,7 +8137,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8174,7 +8174,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8242,7 +8242,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8279,7 +8279,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8347,7 +8347,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8384,7 +8384,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8452,7 +8452,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8489,7 +8489,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8557,7 +8557,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8594,7 +8594,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8662,7 +8662,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8699,7 +8699,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8767,7 +8767,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8804,7 +8804,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8872,7 +8872,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8909,7 +8909,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -8977,7 +8977,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9014,7 +9014,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9082,7 +9082,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9119,7 +9119,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9187,7 +9187,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9224,7 +9224,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9292,7 +9292,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9329,7 +9329,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9397,7 +9397,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9434,7 +9434,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9502,7 +9502,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9539,7 +9539,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9607,7 +9607,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9644,7 +9644,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9712,7 +9712,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9749,7 +9749,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9817,7 +9817,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9854,7 +9854,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9922,7 +9922,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -9959,7 +9959,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10027,7 +10027,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10064,7 +10064,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10132,7 +10132,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10169,7 +10169,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10237,7 +10237,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10274,7 +10274,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10342,7 +10342,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10379,7 +10379,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10447,7 +10447,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10484,7 +10484,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10552,7 +10552,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10589,7 +10589,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10657,7 +10657,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10694,7 +10694,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10762,7 +10762,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10799,7 +10799,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10867,7 +10867,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10904,7 +10904,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -10972,7 +10972,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -11009,7 +11009,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -11077,7 +11077,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -11114,7 +11114,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -11182,7 +11182,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -11219,7 +11219,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -11287,7 +11287,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -11324,7 +11324,7 @@ internal static class DefaultPixelBlenders<TPixel>
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));

--- a/src/ImageSharp/PixelFormats/PixelBlenders/DefaultPixelBlenders.Generated.tt
+++ b/src/ImageSharp/PixelFormats/PixelBlenders/DefaultPixelBlenders.Generated.tt
@@ -95,7 +95,7 @@ var blenders = new []{
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -132,7 +132,7 @@ var blenders = new []{
             {
                 // Divide by 2 as 4 elements per Vector4 and 8 per Vector256<float>
                 ref Vector256<float> destinationBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
-                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (IntPtr)((uint)destination.Length / 2u));
+                ref Vector256<float> destinationLast = ref Unsafe.Add(ref destinationBase, (uint)destination.Length / 2u);
 
                 ref Vector256<float> backgroundBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(background));
                 ref Vector256<float> sourceBase = ref Unsafe.As<Vector4, Vector256<float>>(ref MemoryMarshal.GetReference(source));

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Abgr32.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Abgr32.cs
@@ -216,7 +216,7 @@ public partial struct Abgr32 : IPixel<Abgr32>, IPackedVector<uint>
     {
         // We can assign the Bgr24 value directly to last three bytes of this instance.
         ref byte thisRef = ref Unsafe.As<Abgr32, byte>(ref this);
-        ref byte thisRefFromB = ref Unsafe.AddByteOffset(ref thisRef, new IntPtr(1));
+        ref byte thisRefFromB = ref Unsafe.AddByteOffset(ref thisRef, 1);
         Unsafe.As<byte, Bgr24>(ref thisRefFromB) = source;
         this.A = byte.MaxValue;
     }

--- a/src/ImageSharp/PixelFormats/PixelImplementations/Bgr24.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Bgr24.cs
@@ -190,7 +190,7 @@ public partial struct Bgr24 : IPixel<Bgr24>
     {
         // We can assign this instances value directly to last three bytes of the Abgr32.
         ref byte sourceRef = ref Unsafe.As<Abgr32, byte>(ref source);
-        ref byte sourceRefFromB = ref Unsafe.AddByteOffset(ref sourceRef, new IntPtr(1));
+        ref byte sourceRefFromB = ref Unsafe.AddByteOffset(ref sourceRef, 1);
         this = Unsafe.As<byte, Bgr24>(ref sourceRefFromB);
     }
 

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Abgr32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Abgr32.PixelOperations.Generated.cs
@@ -57,7 +57,7 @@ public partial struct Abgr32
         {
             Vector4Converters.RgbaCompatible.ToVector4(configuration, this, sourcePixels, destVectors, modifiers.Remove(PixelConversionModifiers.Scale));
         }
-
+    
         /// <inheritdoc />
         public override void ToRgba32(
             Configuration configuration,
@@ -71,7 +71,7 @@ public partial struct Abgr32
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToRgba32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgba32(
             Configuration configuration,
@@ -84,8 +84,8 @@ public partial struct Abgr32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgba32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToAbgr32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToArgb32(
             Configuration configuration,
@@ -99,7 +99,7 @@ public partial struct Abgr32
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToArgb32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromArgb32(
             Configuration configuration,
@@ -112,8 +112,8 @@ public partial struct Abgr32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Argb32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToAbgr32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgra32(
             Configuration configuration,
@@ -127,7 +127,7 @@ public partial struct Abgr32
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToBgra32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgra32(
             Configuration configuration,
@@ -140,8 +140,8 @@ public partial struct Abgr32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgra32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToAbgr32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToRgb24(
             Configuration configuration,
@@ -155,7 +155,7 @@ public partial struct Abgr32
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToRgb24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgb24(
             Configuration configuration,
@@ -168,8 +168,8 @@ public partial struct Abgr32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgb24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToAbgr32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgr24(
             Configuration configuration,
@@ -183,7 +183,7 @@ public partial struct Abgr32
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToBgr24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgr24(
             Configuration configuration,
@@ -196,7 +196,7 @@ public partial struct Abgr32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgr24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToAbgr32(source, dest);
-        }
+        }        
 
         /// <inheritdoc />
         public override void ToL8(
@@ -210,7 +210,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Abgr32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Abgr32.PixelOperations.Generated.cs
@@ -210,7 +210,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Abgr32
             ref Abgr32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Abgr32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Argb32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Argb32.PixelOperations.Generated.cs
@@ -57,7 +57,7 @@ public partial struct Argb32
         {
             Vector4Converters.RgbaCompatible.ToVector4(configuration, this, sourcePixels, destVectors, modifiers.Remove(PixelConversionModifiers.Scale));
         }
-
+    
         /// <inheritdoc />
         public override void ToRgba32(
             Configuration configuration,
@@ -71,7 +71,7 @@ public partial struct Argb32
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToRgba32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgba32(
             Configuration configuration,
@@ -84,8 +84,8 @@ public partial struct Argb32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgba32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToArgb32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToAbgr32(
             Configuration configuration,
@@ -99,7 +99,7 @@ public partial struct Argb32
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToAbgr32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromAbgr32(
             Configuration configuration,
@@ -112,8 +112,8 @@ public partial struct Argb32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Abgr32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToArgb32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgra32(
             Configuration configuration,
@@ -127,7 +127,7 @@ public partial struct Argb32
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToBgra32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgra32(
             Configuration configuration,
@@ -140,8 +140,8 @@ public partial struct Argb32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgra32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToArgb32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToRgb24(
             Configuration configuration,
@@ -155,7 +155,7 @@ public partial struct Argb32
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToRgb24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgb24(
             Configuration configuration,
@@ -168,8 +168,8 @@ public partial struct Argb32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgb24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToArgb32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgr24(
             Configuration configuration,
@@ -183,7 +183,7 @@ public partial struct Argb32
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToBgr24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgr24(
             Configuration configuration,
@@ -196,7 +196,7 @@ public partial struct Argb32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgr24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToArgb32(source, dest);
-        }
+        }        
 
         /// <inheritdoc />
         public override void ToL8(
@@ -210,7 +210,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Argb32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Argb32.PixelOperations.Generated.cs
@@ -210,7 +210,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Argb32
             ref Argb32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Argb32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgr24.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgr24.PixelOperations.Generated.cs
@@ -57,7 +57,7 @@ public partial struct Bgr24
         {
             Vector4Converters.RgbaCompatible.ToVector4(configuration, this, sourcePixels, destVectors, modifiers.Remove(PixelConversionModifiers.Scale | PixelConversionModifiers.Premultiply));
         }
-
+    
         /// <inheritdoc />
         public override void ToRgba32(
             Configuration configuration,
@@ -71,7 +71,7 @@ public partial struct Bgr24
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToRgba32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgba32(
             Configuration configuration,
@@ -84,8 +84,8 @@ public partial struct Bgr24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgba32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToBgr24(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToArgb32(
             Configuration configuration,
@@ -99,7 +99,7 @@ public partial struct Bgr24
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToArgb32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromArgb32(
             Configuration configuration,
@@ -112,8 +112,8 @@ public partial struct Bgr24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Argb32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToBgr24(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToAbgr32(
             Configuration configuration,
@@ -127,7 +127,7 @@ public partial struct Bgr24
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToAbgr32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromAbgr32(
             Configuration configuration,
@@ -140,8 +140,8 @@ public partial struct Bgr24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Abgr32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToBgr24(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgra32(
             Configuration configuration,
@@ -155,7 +155,7 @@ public partial struct Bgr24
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToBgra32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgra32(
             Configuration configuration,
@@ -168,8 +168,8 @@ public partial struct Bgr24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgra32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToBgr24(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToRgb24(
             Configuration configuration,
@@ -183,7 +183,7 @@ public partial struct Bgr24
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToRgb24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgb24(
             Configuration configuration,
@@ -196,7 +196,7 @@ public partial struct Bgr24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgb24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToBgr24(source, dest);
-        }
+        }        
 
         /// <inheritdoc />
         public override void ToL8(
@@ -210,7 +210,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgr24.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgr24.PixelOperations.Generated.cs
@@ -210,7 +210,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Bgr24
             ref Bgr24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgr24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgra32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgra32.PixelOperations.Generated.cs
@@ -57,7 +57,7 @@ public partial struct Bgra32
         {
             Vector4Converters.RgbaCompatible.ToVector4(configuration, this, sourcePixels, destVectors, modifiers.Remove(PixelConversionModifiers.Scale));
         }
-
+    
         /// <inheritdoc />
         public override void ToRgba32(
             Configuration configuration,
@@ -71,7 +71,7 @@ public partial struct Bgra32
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToRgba32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgba32(
             Configuration configuration,
@@ -84,8 +84,8 @@ public partial struct Bgra32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgba32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToBgra32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToArgb32(
             Configuration configuration,
@@ -99,7 +99,7 @@ public partial struct Bgra32
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToArgb32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromArgb32(
             Configuration configuration,
@@ -112,8 +112,8 @@ public partial struct Bgra32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Argb32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToBgra32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToAbgr32(
             Configuration configuration,
@@ -127,7 +127,7 @@ public partial struct Bgra32
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToAbgr32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromAbgr32(
             Configuration configuration,
@@ -140,8 +140,8 @@ public partial struct Bgra32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Abgr32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToBgra32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToRgb24(
             Configuration configuration,
@@ -155,7 +155,7 @@ public partial struct Bgra32
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToRgb24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgb24(
             Configuration configuration,
@@ -168,8 +168,8 @@ public partial struct Bgra32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgb24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToBgra32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgr24(
             Configuration configuration,
@@ -183,7 +183,7 @@ public partial struct Bgra32
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToBgr24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgr24(
             Configuration configuration,
@@ -196,7 +196,7 @@ public partial struct Bgra32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgr24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToBgra32(source, dest);
-        }
+        }        
 
         /// <inheritdoc />
         public override void ToL8(
@@ -210,7 +210,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgra32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgra32.PixelOperations.Generated.cs
@@ -210,7 +210,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Bgra32
             ref Bgra32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgra5551.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgra5551.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgra5551.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Bgra5551.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct Bgra5551
             ref Bgra5551 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Bgra5551 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/L16.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/L16.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/L16.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/L16.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct L16
             ref L16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/L8.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/L8.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/L8.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/L8.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct L8
             ref L8 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref L8 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/La16.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/La16.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/La16.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/La16.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct La16
             ref La16 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La16 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/La32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/La32.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct La32
             ref La32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref La32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgb24.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgb24.PixelOperations.Generated.cs
@@ -57,7 +57,7 @@ public partial struct Rgb24
         {
             Vector4Converters.RgbaCompatible.ToVector4(configuration, this, sourcePixels, destVectors, modifiers.Remove(PixelConversionModifiers.Scale | PixelConversionModifiers.Premultiply));
         }
-
+    
         /// <inheritdoc />
         public override void ToRgba32(
             Configuration configuration,
@@ -71,7 +71,7 @@ public partial struct Rgb24
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToRgba32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgba32(
             Configuration configuration,
@@ -84,8 +84,8 @@ public partial struct Rgb24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgba32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToRgb24(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToArgb32(
             Configuration configuration,
@@ -99,7 +99,7 @@ public partial struct Rgb24
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToArgb32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromArgb32(
             Configuration configuration,
@@ -112,8 +112,8 @@ public partial struct Rgb24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Argb32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToRgb24(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToAbgr32(
             Configuration configuration,
@@ -127,7 +127,7 @@ public partial struct Rgb24
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToAbgr32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromAbgr32(
             Configuration configuration,
@@ -140,8 +140,8 @@ public partial struct Rgb24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Abgr32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToRgb24(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgra32(
             Configuration configuration,
@@ -155,7 +155,7 @@ public partial struct Rgb24
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToBgra32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgra32(
             Configuration configuration,
@@ -168,8 +168,8 @@ public partial struct Rgb24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgra32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToRgb24(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgr24(
             Configuration configuration,
@@ -183,7 +183,7 @@ public partial struct Rgb24
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToBgr24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgr24(
             Configuration configuration,
@@ -196,7 +196,7 @@ public partial struct Rgb24
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgr24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToRgb24(source, dest);
-        }
+        }        
 
         /// <inheritdoc />
         public override void ToL8(
@@ -210,7 +210,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgb24.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgb24.PixelOperations.Generated.cs
@@ -210,7 +210,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -231,7 +231,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -252,7 +252,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -273,7 +273,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -294,7 +294,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -315,7 +315,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -336,7 +336,7 @@ public partial struct Rgb24
             ref Rgb24 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb24 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgb48.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgb48.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgb48.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgb48.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct Rgb48
             ref Rgb48 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgb48 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgba32.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgba32.PixelOperations.Generated.cs
@@ -37,7 +37,7 @@ public partial struct Rgba32
 
             sourcePixels.CopyTo(destinationPixels.Slice(0, sourcePixels.Length));
         }
-
+    
         /// <inheritdoc />
         public override void ToArgb32(
             Configuration configuration,
@@ -51,7 +51,7 @@ public partial struct Rgba32
             Span<byte> dest = MemoryMarshal.Cast<Argb32, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToArgb32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromArgb32(
             Configuration configuration,
@@ -64,8 +64,8 @@ public partial struct Rgba32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Argb32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromArgb32.ToRgba32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToAbgr32(
             Configuration configuration,
@@ -79,7 +79,7 @@ public partial struct Rgba32
             Span<byte> dest = MemoryMarshal.Cast<Abgr32, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToAbgr32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromAbgr32(
             Configuration configuration,
@@ -92,8 +92,8 @@ public partial struct Rgba32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Abgr32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromAbgr32.ToRgba32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgra32(
             Configuration configuration,
@@ -107,7 +107,7 @@ public partial struct Rgba32
             Span<byte> dest = MemoryMarshal.Cast<Bgra32, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToBgra32(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgra32(
             Configuration configuration,
@@ -120,8 +120,8 @@ public partial struct Rgba32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgra32, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromBgra32.ToRgba32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToRgb24(
             Configuration configuration,
@@ -135,7 +135,7 @@ public partial struct Rgba32
             Span<byte> dest = MemoryMarshal.Cast<Rgb24, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToRgb24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromRgb24(
             Configuration configuration,
@@ -148,8 +148,8 @@ public partial struct Rgba32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Rgb24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromRgb24.ToRgba32(source, dest);
-        }
-
+        }        
+    
         /// <inheritdoc />
         public override void ToBgr24(
             Configuration configuration,
@@ -163,7 +163,7 @@ public partial struct Rgba32
             Span<byte> dest = MemoryMarshal.Cast<Bgr24, byte>(destinationPixels);
             PixelConverter.FromRgba32.ToBgr24(source, dest);
         }
-
+        
         /// <inheritdoc />
         public override void FromBgr24(
             Configuration configuration,
@@ -176,7 +176,7 @@ public partial struct Rgba32
             ReadOnlySpan<byte> source = MemoryMarshal.Cast<Bgr24, byte>(sourcePixels);
             Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(destinationPixels);
             PixelConverter.FromBgr24.ToRgba32(source, dest);
-        }
+        }        
 
         /// <inheritdoc />
         public override void ToL8(
@@ -190,7 +190,7 @@ public partial struct Rgba32
             ref Rgba32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -211,7 +211,7 @@ public partial struct Rgba32
             ref Rgba32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -232,7 +232,7 @@ public partial struct Rgba32
             ref Rgba32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -253,7 +253,7 @@ public partial struct Rgba32
             ref Rgba32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -274,7 +274,7 @@ public partial struct Rgba32
             ref Rgba32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -295,7 +295,7 @@ public partial struct Rgba32
             ref Rgba32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba64 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba64 dp = ref Unsafe.Add(ref destRef, i);
@@ -316,7 +316,7 @@ public partial struct Rgba32
             ref Rgba32 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba32 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgba64.PixelOperations.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/Rgba64.PixelOperations.Generated.cs
@@ -50,7 +50,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Argb32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Argb32 dp = ref Unsafe.Add(ref destRef, i);
@@ -71,7 +71,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Abgr32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Abgr32 dp = ref Unsafe.Add(ref destRef, i);
@@ -92,7 +92,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgr24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgr24 dp = ref Unsafe.Add(ref destRef, i);
@@ -113,7 +113,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra32 dp = ref Unsafe.Add(ref destRef, i);
@@ -134,7 +134,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L8 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destRef, i);
@@ -155,7 +155,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref L16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destRef, i);
@@ -176,7 +176,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La16 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La16 dp = ref Unsafe.Add(ref destRef, i);
@@ -197,7 +197,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref La32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref La32 dp = ref Unsafe.Add(ref destRef, i);
@@ -218,7 +218,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb24 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb24 dp = ref Unsafe.Add(ref destRef, i);
@@ -239,7 +239,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgba32 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgba32 dp = ref Unsafe.Add(ref destRef, i);
@@ -260,7 +260,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Rgb48 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Rgb48 dp = ref Unsafe.Add(ref destRef, i);
@@ -281,7 +281,7 @@ public partial struct Rgba64
             ref Rgba64 sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref Bgra5551 destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Rgba64 sp = ref Unsafe.Add(ref sourceRef, i);
                 ref Bgra5551 dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/_Common.ttinclude
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/_Common.ttinclude
@@ -103,7 +103,7 @@ using SixLabors.ImageSharp.PixelFormats.Utils;
             ref <#=fromPixelType#> sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref <#=toPixelType#> destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref <#=fromPixelType#> sp = ref Unsafe.Add(ref sourceRef, i);
                 ref <#=toPixelType#> dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/_Common.ttinclude
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/Generated/_Common.ttinclude
@@ -103,7 +103,7 @@ using SixLabors.ImageSharp.PixelFormats.Utils;
             ref <#=fromPixelType#> sourceRef = ref MemoryMarshal.GetReference(sourcePixels);
             ref <#=toPixelType#> destRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref <#=fromPixelType#> sp = ref Unsafe.Add(ref sourceRef, i);
                 ref <#=toPixelType#> dp = ref Unsafe.Add(ref destRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/RgbaVector.PixelOperations.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/RgbaVector.PixelOperations.cs
@@ -72,7 +72,7 @@ public partial struct RgbaVector
             ref Vector4 sourceBaseRef = ref Unsafe.As<RgbaVector, Vector4>(ref MemoryMarshal.GetReference(sourcePixels));
             ref L8 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (int i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Vector4 sp = ref Unsafe.Add(ref sourceBaseRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -91,7 +91,7 @@ public partial struct RgbaVector
             ref Vector4 sourceBaseRef = ref Unsafe.As<RgbaVector, Vector4>(ref MemoryMarshal.GetReference(sourcePixels));
             ref L16 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (int i = 0; i < sourcePixels.Length; i++)
+            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Vector4 sp = ref Unsafe.Add(ref sourceBaseRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destBaseRef, i);

--- a/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/RgbaVector.PixelOperations.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/PixelOperations/RgbaVector.PixelOperations.cs
@@ -72,7 +72,7 @@ public partial struct RgbaVector
             ref Vector4 sourceBaseRef = ref Unsafe.As<RgbaVector, Vector4>(ref MemoryMarshal.GetReference(sourcePixels));
             ref L8 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Vector4 sp = ref Unsafe.Add(ref sourceBaseRef, i);
                 ref L8 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -91,7 +91,7 @@ public partial struct RgbaVector
             ref Vector4 sourceBaseRef = ref Unsafe.As<RgbaVector, Vector4>(ref MemoryMarshal.GetReference(sourcePixels));
             ref L16 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-            for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+            for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
             {
                 ref Vector4 sp = ref Unsafe.Add(ref sourceBaseRef, i);
                 ref L16 dp = ref Unsafe.Add(ref destBaseRef, i);

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.Generated.cs
@@ -22,7 +22,7 @@ public partial class PixelOperations<TPixel>
         ref Argb32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Argb32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -58,7 +58,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Argb32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Argb32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -94,7 +94,7 @@ public partial class PixelOperations<TPixel>
         ref Abgr32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Abgr32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -130,7 +130,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Abgr32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Abgr32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -166,7 +166,7 @@ public partial class PixelOperations<TPixel>
         ref Bgr24 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Bgr24 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -202,7 +202,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Bgr24 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Bgr24 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -238,7 +238,7 @@ public partial class PixelOperations<TPixel>
         ref Bgra32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Bgra32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -274,7 +274,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Bgra32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Bgra32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -310,7 +310,7 @@ public partial class PixelOperations<TPixel>
         ref L8 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref L8 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -346,7 +346,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref L8 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref L8 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -382,7 +382,7 @@ public partial class PixelOperations<TPixel>
         ref L16 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref L16 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -418,7 +418,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref L16 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref L16 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -454,7 +454,7 @@ public partial class PixelOperations<TPixel>
         ref La16 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref La16 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -490,7 +490,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref La16 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref La16 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -526,7 +526,7 @@ public partial class PixelOperations<TPixel>
         ref La32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref La32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -562,7 +562,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref La32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref La32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -598,7 +598,7 @@ public partial class PixelOperations<TPixel>
         ref Rgb24 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgb24 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -634,7 +634,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Rgb24 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Rgb24 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -670,7 +670,7 @@ public partial class PixelOperations<TPixel>
         ref Rgba32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgba32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -706,7 +706,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Rgba32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Rgba32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -742,7 +742,7 @@ public partial class PixelOperations<TPixel>
         ref Rgb48 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgb48 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -778,7 +778,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Rgb48 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Rgb48 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -814,7 +814,7 @@ public partial class PixelOperations<TPixel>
         ref Rgba64 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgba64 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -850,7 +850,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Rgba64 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Rgba64 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -886,7 +886,7 @@ public partial class PixelOperations<TPixel>
         ref Bgra5551 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Bgra5551 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -922,7 +922,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Bgra5551 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Bgra5551 dp = ref Unsafe.Add(ref destBaseRef, i);

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.Generated.cs
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.Generated.cs
@@ -22,7 +22,7 @@ public partial class PixelOperations<TPixel>
         ref Argb32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Argb32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -58,7 +58,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Argb32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Argb32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -94,7 +94,7 @@ public partial class PixelOperations<TPixel>
         ref Abgr32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Abgr32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -130,7 +130,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Abgr32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Abgr32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -166,7 +166,7 @@ public partial class PixelOperations<TPixel>
         ref Bgr24 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Bgr24 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -202,7 +202,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Bgr24 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Bgr24 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -238,7 +238,7 @@ public partial class PixelOperations<TPixel>
         ref Bgra32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Bgra32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -274,7 +274,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Bgra32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Bgra32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -310,7 +310,7 @@ public partial class PixelOperations<TPixel>
         ref L8 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref L8 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -346,7 +346,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref L8 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref L8 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -382,7 +382,7 @@ public partial class PixelOperations<TPixel>
         ref L16 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref L16 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -418,7 +418,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref L16 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref L16 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -454,7 +454,7 @@ public partial class PixelOperations<TPixel>
         ref La16 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref La16 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -490,7 +490,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref La16 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref La16 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -526,7 +526,7 @@ public partial class PixelOperations<TPixel>
         ref La32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref La32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -562,7 +562,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref La32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref La32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -598,7 +598,7 @@ public partial class PixelOperations<TPixel>
         ref Rgb24 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgb24 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -634,7 +634,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Rgb24 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Rgb24 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -670,7 +670,7 @@ public partial class PixelOperations<TPixel>
         ref Rgba32 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgba32 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -706,7 +706,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Rgba32 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Rgba32 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -742,7 +742,7 @@ public partial class PixelOperations<TPixel>
         ref Rgb48 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgb48 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -778,7 +778,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Rgb48 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Rgb48 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -814,7 +814,7 @@ public partial class PixelOperations<TPixel>
         ref Rgba64 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgba64 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -850,7 +850,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Rgba64 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Rgba64 dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -886,7 +886,7 @@ public partial class PixelOperations<TPixel>
         ref Bgra5551 sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Bgra5551 sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -922,7 +922,7 @@ public partial class PixelOperations<TPixel>
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref Bgra5551 destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref Bgra5551 dp = ref Unsafe.Add(ref destBaseRef, i);

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.Generated.tt
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.Generated.tt
@@ -28,7 +28,7 @@
         ref <#=pixelType#> sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref <#=pixelType#> sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -70,7 +70,7 @@
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref <#=pixelType#> destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (int i = 0; i < sourcePixels.Length; i++)
+        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref <#=pixelType#> dp = ref Unsafe.Add(ref destBaseRef, i);

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.Generated.tt
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.Generated.tt
@@ -28,7 +28,7 @@
         ref <#=pixelType#> sourceBaseRef = ref MemoryMarshal.GetReference(source);
         ref TPixel destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref <#=pixelType#> sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref TPixel dp = ref Unsafe.Add(ref destBaseRef, i);
@@ -70,7 +70,7 @@
         ref TPixel sourceBaseRef = ref MemoryMarshal.GetReference(sourcePixels);
         ref <#=pixelType#> destBaseRef = ref MemoryMarshal.GetReference(destinationPixels);
 
-        for (nint i = 0; i < (uint)sourcePixels.Length; i++)
+        for (nuint i = 0; i < (uint)sourcePixels.Length; i++)
         {
             ref TPixel sp = ref Unsafe.Add(ref sourceBaseRef, i);
             ref <#=pixelType#> dp = ref Unsafe.Add(ref destBaseRef, i);

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
@@ -187,7 +187,7 @@ public partial class PixelOperations<TPixel>
         ref byte b = ref MemoryMarshal.GetReference(blueChannel);
         ref TPixel d = ref MemoryMarshal.GetReference(destination);
 
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             rgb24.R = Unsafe.Add(ref r, i);
             rgb24.G = Unsafe.Add(ref g, i);
@@ -218,7 +218,7 @@ public partial class PixelOperations<TPixel>
         ref float g = ref MemoryMarshal.GetReference(greenChannel);
         ref float b = ref MemoryMarshal.GetReference(blueChannel);
         ref TPixel src = ref MemoryMarshal.GetReference(source);
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             Unsafe.Add(ref src, i).ToRgba32(ref rgba32);
             Unsafe.Add(ref r, i) = rgba32.R;

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
@@ -187,7 +187,7 @@ public partial class PixelOperations<TPixel>
         ref byte b = ref MemoryMarshal.GetReference(blueChannel);
         ref TPixel d = ref MemoryMarshal.GetReference(destination);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             rgb24.R = Unsafe.Add(ref r, i);
             rgb24.G = Unsafe.Add(ref g, i);
@@ -218,7 +218,7 @@ public partial class PixelOperations<TPixel>
         ref float g = ref MemoryMarshal.GetReference(greenChannel);
         ref float b = ref MemoryMarshal.GetReference(blueChannel);
         ref TPixel src = ref MemoryMarshal.GetReference(source);
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             Unsafe.Add(ref src, i).ToRgba32(ref rgba32);
             Unsafe.Add(ref r, i) = rgba32.R;

--- a/src/ImageSharp/PixelFormats/Utils/Vector4Converters.Default.cs
+++ b/src/ImageSharp/PixelFormats/Utils/Vector4Converters.Default.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 using System.Numerics;
@@ -88,7 +88,7 @@ internal static partial class Vector4Converters
             where TPixel : unmanaged, IPixel<TPixel>
         {
             ref Vector4 sourceStart = ref MemoryMarshal.GetReference(sourceVectors);
-            ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceStart, sourceVectors.Length);
+            ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceStart, (uint)sourceVectors.Length);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destPixels);
 
             while (Unsafe.IsAddressLessThan(ref sourceStart, ref sourceEnd))
@@ -107,7 +107,7 @@ internal static partial class Vector4Converters
             where TPixel : unmanaged, IPixel<TPixel>
         {
             ref TPixel sourceStart = ref MemoryMarshal.GetReference(sourcePixels);
-            ref TPixel sourceEnd = ref Unsafe.Add(ref sourceStart, sourcePixels.Length);
+            ref TPixel sourceEnd = ref Unsafe.Add(ref sourceStart, (uint)sourcePixels.Length);
             ref Vector4 destRef = ref MemoryMarshal.GetReference(destVectors);
 
             while (Unsafe.IsAddressLessThan(ref sourceStart, ref sourceEnd))
@@ -126,7 +126,7 @@ internal static partial class Vector4Converters
             where TPixel : unmanaged, IPixel<TPixel>
         {
             ref Vector4 sourceStart = ref MemoryMarshal.GetReference(sourceVectors);
-            ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceStart, sourceVectors.Length);
+            ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceStart, (uint)sourceVectors.Length);
             ref TPixel destRef = ref MemoryMarshal.GetReference(destinationColors);
 
             while (Unsafe.IsAddressLessThan(ref sourceStart, ref sourceEnd))
@@ -145,7 +145,7 @@ internal static partial class Vector4Converters
             where TPixel : unmanaged, IPixel<TPixel>
         {
             ref TPixel sourceStart = ref MemoryMarshal.GetReference(sourceColors);
-            ref TPixel sourceEnd = ref Unsafe.Add(ref sourceStart, sourceColors.Length);
+            ref TPixel sourceEnd = ref Unsafe.Add(ref sourceStart, (uint)sourceColors.Length);
             ref Vector4 destRef = ref MemoryMarshal.GetReference(destinationVectors);
 
             while (Unsafe.IsAddressLessThan(ref sourceStart, ref sourceEnd))

--- a/src/ImageSharp/Primitives/Rectangle.cs
+++ b/src/ImageSharp/Primitives/Rectangle.cs
@@ -195,7 +195,7 @@ public struct Rectangle : IEquatable<Rectangle>
     /// <param name="rectangle">The rectangle.</param>
     /// <returns>The <see cref="Point"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Point Center(Rectangle rectangle) => new(rectangle.Left + (rectangle.Width & 1), rectangle.Top + (rectangle.Height & 1));     // & 1 is bit-hack for / 2
+    public static Point Center(Rectangle rectangle) => new(rectangle.Left + (rectangle.Width >> 1), rectangle.Top + (rectangle.Height >> 1));     // >> 1 is bit-hack for / 2
 
     /// <summary>
     /// Creates a rectangle that represents the intersection between <paramref name="a"/> and

--- a/src/ImageSharp/Primitives/Rectangle.cs
+++ b/src/ImageSharp/Primitives/Rectangle.cs
@@ -195,7 +195,7 @@ public struct Rectangle : IEquatable<Rectangle>
     /// <param name="rectangle">The rectangle.</param>
     /// <returns>The <see cref="Point"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Point Center(Rectangle rectangle) => new(rectangle.Left + (rectangle.Width / 2), rectangle.Top + (rectangle.Height / 2));
+    public static Point Center(Rectangle rectangle) => new(rectangle.Left + (rectangle.Width & 1), rectangle.Top + (rectangle.Height & 1));     // & 1 is bit-hack for / 2
 
     /// <summary>
     /// Creates a rectangle that represents the intersection between <paramref name="a"/> and

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor{TPixel}.cs
@@ -132,7 +132,7 @@ internal class BinaryThresholdProcessor<TPixel> : ImageProcessor<TPixel>
 
                 case BinaryThresholdMode.MaxChroma:
                 {
-                    float threshold = this.threshold / 2F;
+                    float threshold = this.threshold * 0.5F;    // /2
                     for (int x = 0; x < rowSpan.Length; x++)
                     {
                         float chroma = GetMaxChroma(span[x]);
@@ -149,9 +149,10 @@ internal class BinaryThresholdProcessor<TPixel> : ImageProcessor<TPixel>
         private static float GetSaturation(Rgb24 rgb)
         {
             // Slimmed down RGB => HSL formula. See HslAndRgbConverter.
-            float r = rgb.R / 255F;
-            float g = rgb.G / 255F;
-            float b = rgb.B / 255F;
+            const float inv255 = 1 / 255F;
+            float r = rgb.R * inv255;
+            float g = rgb.G * inv255;
+            float b = rgb.B * inv255;
 
             float max = MathF.Max(r, MathF.Max(g, b));
             float min = MathF.Min(r, MathF.Min(g, b));
@@ -162,7 +163,7 @@ internal class BinaryThresholdProcessor<TPixel> : ImageProcessor<TPixel>
                 return 0F;
             }
 
-            float l = (max + min) / 2F;
+            float l = (max + min) * 0.5F;   // /2
 
             if (l <= .5F)
             {

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
@@ -128,19 +128,19 @@ public sealed class BokehBlurProcessor : IImageProcessor
             int boundsWidth = this.bounds.Width;
             int kernelSize = this.kernel.Length;
 
-            ref int sampleRowBase = ref Unsafe.Add(ref MemoryMarshal.GetReference(this.map.GetRowOffsetSpan()), (y - this.bounds.Y) * kernelSize);
+            ref int sampleRowBase = ref Unsafe.Add(ref MemoryMarshal.GetReference(this.map.GetRowOffsetSpan()), (uint)((y - this.bounds.Y) * kernelSize));
 
             // The target buffer is zeroed initially and then it accumulates the results
             // of each partial convolution, so we don't have to clear it here as well
             ref Vector4 targetBase = ref this.targetValues.GetElementUnsafe(boundsX, y);
             ref Complex64 kernelStart = ref this.kernel[0];
-            ref Complex64 kernelEnd = ref Unsafe.Add(ref kernelStart, kernelSize);
+            ref Complex64 kernelEnd = ref Unsafe.Add(ref kernelStart, (uint)kernelSize);
 
             while (Unsafe.IsAddressLessThan(ref kernelStart, ref kernelEnd))
             {
                 // Get the precalculated source sample row for this kernel row and copy to our buffer
                 ref ComplexVector4 sourceBase = ref this.sourceValues.GetElementUnsafe(0, sampleRowBase);
-                ref ComplexVector4 sourceEnd = ref Unsafe.Add(ref sourceBase, boundsWidth);
+                ref ComplexVector4 sourceEnd = ref Unsafe.Add(ref sourceBase, (uint)boundsWidth);
                 ref Vector4 targetStart = ref targetBase;
                 Complex64 factor = kernelStart;
 

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor.cs
@@ -133,7 +133,7 @@ public sealed class BokehBlurProcessor : IImageProcessor
             // The target buffer is zeroed initially and then it accumulates the results
             // of each partial convolution, so we don't have to clear it here as well
             ref Vector4 targetBase = ref this.targetValues.GetElementUnsafe(boundsX, y);
-            ref Complex64 kernelStart = ref this.kernel[0];
+            ref Complex64 kernelStart = ref MemoryMarshal.GetArrayDataReference(this.kernel);
             ref Complex64 kernelEnd = ref Unsafe.Add(ref kernelStart, (uint)kernelSize);
 
             while (Unsafe.IsAddressLessThan(ref kernelStart, ref kernelEnd))

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
@@ -244,7 +244,7 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
             ref Vector4 sourceBase = ref MemoryMarshal.GetReference(span);
             ref ComplexVector4 targetStart = ref MemoryMarshal.GetReference(targetBuffer);
             ref ComplexVector4 targetEnd = ref Unsafe.Add(ref targetStart, (uint)span.Length);
-            ref Complex64 kernelBase = ref this.kernel[0];
+            ref Complex64 kernelBase = ref MemoryMarshal.GetArrayDataReference(this.kernel);
             ref Complex64 kernelEnd = ref Unsafe.Add(ref kernelBase, (uint)kernelSize);
             ref int sampleColumnBase = ref MemoryMarshal.GetReference(this.map.GetColumnOffsetSpan());
 

--- a/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/BokehBlurProcessor{TPixel}.cs
@@ -157,8 +157,8 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
         for (int i = 0; i < this.kernels.Length; i++)
         {
             // Compute the resulting complex buffer for the current component
-            Complex64[] kernel = Unsafe.Add(ref baseRef, i);
-            Vector4 parameters = Unsafe.Add(ref paramsRef, i);
+            Complex64[] kernel = Unsafe.Add(ref baseRef, (uint)i);
+            Vector4 parameters = Unsafe.Add(ref paramsRef, (uint)i);
 
             // Horizontal convolution
             var horizontalOperation = new FirstPassConvolutionRowOperation(
@@ -243,9 +243,9 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
 
             ref Vector4 sourceBase = ref MemoryMarshal.GetReference(span);
             ref ComplexVector4 targetStart = ref MemoryMarshal.GetReference(targetBuffer);
-            ref ComplexVector4 targetEnd = ref Unsafe.Add(ref targetStart, span.Length);
+            ref ComplexVector4 targetEnd = ref Unsafe.Add(ref targetStart, (uint)span.Length);
             ref Complex64 kernelBase = ref this.kernel[0];
-            ref Complex64 kernelEnd = ref Unsafe.Add(ref kernelBase, kernelSize);
+            ref Complex64 kernelEnd = ref Unsafe.Add(ref kernelBase, (uint)kernelSize);
             ref int sampleColumnBase = ref MemoryMarshal.GetReference(this.map.GetColumnOffsetSpan());
 
             while (Unsafe.IsAddressLessThan(ref targetStart, ref targetEnd))
@@ -255,7 +255,7 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
 
                 while (Unsafe.IsAddressLessThan(ref kernelStart, ref kernelEnd))
                 {
-                    Vector4 sample = Unsafe.Add(ref sourceBase, sampleColumnStart - boundsX);
+                    Vector4 sample = Unsafe.Add(ref sourceBase, (uint)(sampleColumnStart - boundsX));
 
                     targetStart.Sum(kernelStart * sample);
 
@@ -265,7 +265,7 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
 
                 // Shift the base column sampling reference by one row at the end of each outer
                 // iteration so that the inner tight loop indexing can skip the multiplication
-                sampleColumnBase = ref Unsafe.Add(ref sampleColumnBase, kernelSize);
+                sampleColumnBase = ref Unsafe.Add(ref sampleColumnBase, (uint)kernelSize);
                 targetStart = ref Unsafe.Add(ref targetStart, 1);
             }
         }
@@ -309,7 +309,7 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
 
             for (int x = 0; x < this.bounds.Width; x++)
             {
-                ref Vector4 v = ref Unsafe.Add(ref baseRef, x);
+                ref Vector4 v = ref Unsafe.Add(ref baseRef, (uint)x);
                 v.X = MathF.Pow(v.X, this.gamma);
                 v.Y = MathF.Pow(v.Y, this.gamma);
                 v.Z = MathF.Pow(v.Z, this.gamma);
@@ -399,7 +399,7 @@ internal class BokehBlurProcessor<TPixel> : ImageProcessor<TPixel>
 
             for (int x = 0; x < this.bounds.Width; x++)
             {
-                ref Vector4 v = ref Unsafe.Add(ref sourceRef, x);
+                ref Vector4 v = ref Unsafe.Add(ref sourceRef, (uint)x);
                 Vector4 clamp = Numerics.Clamp(v, low, high);
                 v.X = MathF.Pow(clamp.X, this.inverseGamma);
                 v.Y = MathF.Pow(clamp.Y, this.inverseGamma);

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DRowOperation{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DRowOperation{TPixel}.cs
@@ -76,7 +76,7 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
         Span<Vector4> targetXBuffer = span.Slice(boundsWidth * 2, boundsWidth);
 
         var state = new Convolution2DState(in this.kernelMatrixY, in this.kernelMatrixX, this.map);
-        ref int sampleRowBase = ref state.GetSampleRow(y - this.bounds.Y);
+        ref int sampleRowBase = ref state.GetSampleRow((uint)(y - this.bounds.Y));
 
         // Clear the target buffers for each row run.
         targetYBuffer.Clear();
@@ -87,24 +87,24 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
         ReadOnlyKernel kernelY = state.KernelY;
         ReadOnlyKernel kernelX = state.KernelX;
         Span<TPixel> sourceRow;
-        for (int kY = 0; kY < kernelY.Rows; kY++)
+        for (uint kY = 0; kY < kernelY.Rows; kY++)
         {
             // Get the precalculated source sample row for this kernel row and copy to our buffer.
-            int sampleY = Unsafe.Add(ref sampleRowBase, (uint)kY);
+            int sampleY = Unsafe.Add(ref sampleRowBase, kY);
             sourceRow = this.sourcePixels.DangerousGetRowSpan(sampleY).Slice(boundsX, boundsWidth);
             PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
             ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
 
-            for (int x = 0; x < sourceBuffer.Length; x++)
+            for (uint x = 0; x < (uint)sourceBuffer.Length; x++)
             {
                 ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                ref Vector4 targetY = ref Unsafe.Add(ref targetBaseY, (uint)x);
-                ref Vector4 targetX = ref Unsafe.Add(ref targetBaseX, (uint)x);
+                ref Vector4 targetY = ref Unsafe.Add(ref targetBaseY, x);
+                ref Vector4 targetX = ref Unsafe.Add(ref targetBaseX, x);
 
-                for (int kX = 0; kX < kernelY.Columns; kX++)
+                for (uint kX = 0; kX < kernelY.Columns; kX++)
                 {
-                    int sampleX = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
+                    int sampleX = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
                     Vector4 sample = Unsafe.Add(ref sourceBase, (uint)sampleX);
                     targetY += kernelX[kY, kX] * sample;
                     targetX += kernelY[kY, kX] * sample;
@@ -117,14 +117,14 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
         sourceRow = this.sourcePixels.DangerousGetRowSpan(y).Slice(boundsX, boundsWidth);
         PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
-        for (int x = 0; x < sourceRow.Length; x++)
+        for (nuint x = 0; x < (uint)sourceRow.Length; x++)
         {
-            ref Vector4 target = ref Unsafe.Add(ref targetBaseY, (uint)x);
+            ref Vector4 target = ref Unsafe.Add(ref targetBaseY, x);
             Vector4 vectorY = target;
-            Vector4 vectorX = Unsafe.Add(ref targetBaseX, (uint)x);
+            Vector4 vectorX = Unsafe.Add(ref targetBaseX, x);
 
             target = Vector4.SquareRoot((vectorX * vectorX) + (vectorY * vectorY));
-            target.W = Unsafe.Add(ref MemoryMarshal.GetReference(sourceBuffer), (uint)x).W;
+            target.W = Unsafe.Add(ref MemoryMarshal.GetReference(sourceBuffer), x).W;
         }
 
         Span<TPixel> targetRowSpan = this.targetPixels.DangerousGetRowSpan(y).Slice(boundsX, boundsWidth);
@@ -142,7 +142,7 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
         Span<Vector4> targetXBuffer = span.Slice(boundsWidth * 2, boundsWidth);
 
         var state = new Convolution2DState(in this.kernelMatrixY, in this.kernelMatrixX, this.map);
-        ref int sampleRowBase = ref state.GetSampleRow(y - this.bounds.Y);
+        ref int sampleRowBase = ref state.GetSampleRow((uint)(y - this.bounds.Y));
 
         // Clear the target buffers for each row run.
         targetYBuffer.Clear();
@@ -152,26 +152,26 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
 
         ReadOnlyKernel kernelY = state.KernelY;
         ReadOnlyKernel kernelX = state.KernelX;
-        for (int kY = 0; kY < kernelY.Rows; kY++)
+        for (uint kY = 0; kY < kernelY.Rows; kY++)
         {
             // Get the precalculated source sample row for this kernel row and copy to our buffer.
-            int sampleY = Unsafe.Add(ref sampleRowBase, (uint)kY);
+            int sampleY = Unsafe.Add(ref sampleRowBase, kY);
             Span<TPixel> sourceRow = this.sourcePixels.DangerousGetRowSpan(sampleY).Slice(boundsX, boundsWidth);
             PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
             Numerics.Premultiply(sourceBuffer);
             ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
 
-            for (int x = 0; x < sourceBuffer.Length; x++)
+            for (uint x = 0; x < (uint)sourceBuffer.Length; x++)
             {
                 ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                ref Vector4 targetY = ref Unsafe.Add(ref targetBaseY, (uint)x);
-                ref Vector4 targetX = ref Unsafe.Add(ref targetBaseX, (uint)x);
+                ref Vector4 targetY = ref Unsafe.Add(ref targetBaseY, x);
+                ref Vector4 targetX = ref Unsafe.Add(ref targetBaseX, x);
 
-                for (int kX = 0; kX < kernelY.Columns; kX++)
+                for (uint kX = 0; kX < kernelY.Columns; kX++)
                 {
-                    int sampleX = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
-                    Vector4 sample = Unsafe.Add(ref sourceBase, (uint)sampleX);
+                    int sampleX = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
+                    Vector4 sample = Unsafe.Add(ref sourceBase, sampleX);
                     targetY += kernelX[kY, kX] * sample;
                     targetX += kernelY[kY, kX] * sample;
                 }
@@ -179,11 +179,11 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
         }
 
         // Now we need to combine the values
-        for (int x = 0; x < targetYBuffer.Length; x++)
+        for (nuint x = 0; x < (uint)targetYBuffer.Length; x++)
         {
-            ref Vector4 target = ref Unsafe.Add(ref targetBaseY, (uint)x);
+            ref Vector4 target = ref Unsafe.Add(ref targetBaseY, x);
             Vector4 vectorY = target;
-            Vector4 vectorX = Unsafe.Add(ref targetBaseX, (uint)x);
+            Vector4 vectorX = Unsafe.Add(ref targetBaseX, x);
 
             target = Vector4.SquareRoot((vectorX * vectorX) + (vectorY * vectorY));
         }

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DRowOperation{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DRowOperation{TPixel}.cs
@@ -90,7 +90,7 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
         for (int kY = 0; kY < kernelY.Rows; kY++)
         {
             // Get the precalculated source sample row for this kernel row and copy to our buffer.
-            int sampleY = Unsafe.Add(ref sampleRowBase, kY);
+            int sampleY = Unsafe.Add(ref sampleRowBase, (uint)kY);
             sourceRow = this.sourcePixels.DangerousGetRowSpan(sampleY).Slice(boundsX, boundsWidth);
             PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
@@ -99,13 +99,13 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
             for (int x = 0; x < sourceBuffer.Length; x++)
             {
                 ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                ref Vector4 targetY = ref Unsafe.Add(ref targetBaseY, x);
-                ref Vector4 targetX = ref Unsafe.Add(ref targetBaseX, x);
+                ref Vector4 targetY = ref Unsafe.Add(ref targetBaseY, (uint)x);
+                ref Vector4 targetX = ref Unsafe.Add(ref targetBaseX, (uint)x);
 
                 for (int kX = 0; kX < kernelY.Columns; kX++)
                 {
-                    int sampleX = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
-                    Vector4 sample = Unsafe.Add(ref sourceBase, sampleX);
+                    int sampleX = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
+                    Vector4 sample = Unsafe.Add(ref sourceBase, (uint)sampleX);
                     targetY += kernelX[kY, kX] * sample;
                     targetX += kernelY[kY, kX] * sample;
                 }
@@ -119,12 +119,12 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
 
         for (int x = 0; x < sourceRow.Length; x++)
         {
-            ref Vector4 target = ref Unsafe.Add(ref targetBaseY, x);
+            ref Vector4 target = ref Unsafe.Add(ref targetBaseY, (uint)x);
             Vector4 vectorY = target;
-            Vector4 vectorX = Unsafe.Add(ref targetBaseX, x);
+            Vector4 vectorX = Unsafe.Add(ref targetBaseX, (uint)x);
 
             target = Vector4.SquareRoot((vectorX * vectorX) + (vectorY * vectorY));
-            target.W = Unsafe.Add(ref MemoryMarshal.GetReference(sourceBuffer), x).W;
+            target.W = Unsafe.Add(ref MemoryMarshal.GetReference(sourceBuffer), (uint)x).W;
         }
 
         Span<TPixel> targetRowSpan = this.targetPixels.DangerousGetRowSpan(y).Slice(boundsX, boundsWidth);
@@ -155,7 +155,7 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
         for (int kY = 0; kY < kernelY.Rows; kY++)
         {
             // Get the precalculated source sample row for this kernel row and copy to our buffer.
-            int sampleY = Unsafe.Add(ref sampleRowBase, kY);
+            int sampleY = Unsafe.Add(ref sampleRowBase, (uint)kY);
             Span<TPixel> sourceRow = this.sourcePixels.DangerousGetRowSpan(sampleY).Slice(boundsX, boundsWidth);
             PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
@@ -165,13 +165,13 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
             for (int x = 0; x < sourceBuffer.Length; x++)
             {
                 ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                ref Vector4 targetY = ref Unsafe.Add(ref targetBaseY, x);
-                ref Vector4 targetX = ref Unsafe.Add(ref targetBaseX, x);
+                ref Vector4 targetY = ref Unsafe.Add(ref targetBaseY, (uint)x);
+                ref Vector4 targetX = ref Unsafe.Add(ref targetBaseX, (uint)x);
 
                 for (int kX = 0; kX < kernelY.Columns; kX++)
                 {
-                    int sampleX = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
-                    Vector4 sample = Unsafe.Add(ref sourceBase, sampleX);
+                    int sampleX = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
+                    Vector4 sample = Unsafe.Add(ref sourceBase, (uint)sampleX);
                     targetY += kernelX[kY, kX] * sample;
                     targetX += kernelY[kY, kX] * sample;
                 }
@@ -181,9 +181,9 @@ internal readonly struct Convolution2DRowOperation<TPixel> : IRowOperation<Vecto
         // Now we need to combine the values
         for (int x = 0; x < targetYBuffer.Length; x++)
         {
-            ref Vector4 target = ref Unsafe.Add(ref targetBaseY, x);
+            ref Vector4 target = ref Unsafe.Add(ref targetBaseY, (uint)x);
             Vector4 vectorY = target;
-            Vector4 vectorX = Unsafe.Add(ref targetBaseX, x);
+            Vector4 vectorX = Unsafe.Add(ref targetBaseX, (uint)x);
 
             target = Vector4.SquareRoot((vectorX * vectorX) + (vectorY * vectorY));
         }

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DState.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DState.cs
@@ -13,8 +13,8 @@ internal readonly ref struct Convolution2DState
 {
     private readonly Span<int> rowOffsetMap;
     private readonly Span<int> columnOffsetMap;
-    private readonly int kernelHeight;
-    private readonly int kernelWidth;
+    private readonly uint kernelHeight;
+    private readonly uint kernelWidth;
 
     public Convolution2DState(
         in DenseMatrix<float> kernelY,
@@ -24,8 +24,8 @@ internal readonly ref struct Convolution2DState
         // We check the kernels are the same size upstream.
         this.KernelY = new ReadOnlyKernel(kernelY);
         this.KernelX = new ReadOnlyKernel(kernelX);
-        this.kernelHeight = kernelY.Rows;
-        this.kernelWidth = kernelY.Columns;
+        this.kernelHeight = (uint)kernelY.Rows;
+        this.kernelWidth = (uint)kernelY.Columns;
         this.rowOffsetMap = map.GetRowOffsetSpan();
         this.columnOffsetMap = map.GetColumnOffsetSpan();
     }
@@ -43,10 +43,10 @@ internal readonly ref struct Convolution2DState
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly ref int GetSampleRow(int row)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), (uint)(row * this.kernelHeight));
+    public readonly ref int GetSampleRow(uint row)
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), row * this.kernelHeight);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly ref int GetSampleColumn(int column)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), (uint)(column * this.kernelWidth));
+    public readonly ref int GetSampleColumn(uint column)
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), column * this.kernelWidth);
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DState.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DState.cs
@@ -44,9 +44,9 @@ internal readonly ref struct Convolution2DState
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly ref int GetSampleRow(int row)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), row * this.kernelHeight);
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), (uint)(row * this.kernelHeight));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly ref int GetSampleColumn(int column)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), column * this.kernelWidth);
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), (uint)(column * this.kernelWidth));
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
@@ -179,7 +179,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
             ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
             ref Vector4 targetStart = ref MemoryMarshal.GetReference(targetBuffer);
             ref Vector4 targetEnd = ref Unsafe.Add(ref targetStart, (uint)sourceBuffer.Length);
-            ref float kernelBase = ref this.kernel[0];
+            ref float kernelBase = ref MemoryMarshal.GetArrayDataReference(this.kernel);
             ref float kernelEnd = ref Unsafe.Add(ref kernelBase, (uint)kernelSize);
             ref int sampleColumnBase = ref MemoryMarshal.GetReference(this.map.GetColumnOffsetSpan());
 
@@ -243,7 +243,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
             ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
             ref Vector4 targetStart = ref MemoryMarshal.GetReference(targetBuffer);
             ref Vector4 targetEnd = ref Unsafe.Add(ref targetStart, (uint)sourceBuffer.Length);
-            ref float kernelBase = ref this.kernel[0];
+            ref float kernelBase = ref MemoryMarshal.GetArrayDataReference(this.kernel);
             ref float kernelEnd = ref Unsafe.Add(ref kernelBase, (uint)kernelSize);
             ref int sampleColumnBase = ref MemoryMarshal.GetReference(this.map.GetColumnOffsetSpan());
 
@@ -341,7 +341,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
             targetBuffer.Clear();
 
             ref Vector4 targetBase = ref MemoryMarshal.GetReference(targetBuffer);
-            ref float kernelStart = ref this.kernel[0];
+            ref float kernelStart = ref MemoryMarshal.GetArrayDataReference(this.kernel);
             ref float kernelEnd = ref Unsafe.Add(ref kernelStart, (uint)kernelSize);
 
             Span<TPixel> sourceRow;
@@ -406,7 +406,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
             targetBuffer.Clear();
 
             ref Vector4 targetBase = ref MemoryMarshal.GetReference(targetBuffer);
-            ref float kernelStart = ref this.kernel[0];
+            ref float kernelStart = ref MemoryMarshal.GetArrayDataReference(this.kernel);
             ref float kernelEnd = ref Unsafe.Add(ref kernelStart, (uint)kernelSize);
 
             Span<TPixel> sourceRow;

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
@@ -178,9 +178,9 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
 
             ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
             ref Vector4 targetStart = ref MemoryMarshal.GetReference(targetBuffer);
-            ref Vector4 targetEnd = ref Unsafe.Add(ref targetStart, sourceBuffer.Length);
+            ref Vector4 targetEnd = ref Unsafe.Add(ref targetStart, (uint)sourceBuffer.Length);
             ref float kernelBase = ref this.kernel[0];
-            ref float kernelEnd = ref Unsafe.Add(ref kernelBase, kernelSize);
+            ref float kernelEnd = ref Unsafe.Add(ref kernelBase, (uint)kernelSize);
             ref int sampleColumnBase = ref MemoryMarshal.GetReference(this.map.GetColumnOffsetSpan());
 
             while (Unsafe.IsAddressLessThan(ref targetStart, ref targetEnd))
@@ -190,7 +190,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
 
                 while (Unsafe.IsAddressLessThan(ref kernelStart, ref kernelEnd))
                 {
-                    Vector4 sample = Unsafe.Add(ref sourceBase, sampleColumnStart - boundsX);
+                    Vector4 sample = Unsafe.Add(ref sourceBase, (uint)(sampleColumnStart - boundsX));
 
                     targetStart += kernelStart * sample;
 
@@ -199,7 +199,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
                 }
 
                 targetStart = ref Unsafe.Add(ref targetStart, 1);
-                sampleColumnBase = ref Unsafe.Add(ref sampleColumnBase, kernelSize);
+                sampleColumnBase = ref Unsafe.Add(ref sampleColumnBase, (uint)kernelSize);
             }
 
             // Now we need to copy the original alpha values from the source row.
@@ -242,9 +242,9 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
 
             ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
             ref Vector4 targetStart = ref MemoryMarshal.GetReference(targetBuffer);
-            ref Vector4 targetEnd = ref Unsafe.Add(ref targetStart, sourceBuffer.Length);
+            ref Vector4 targetEnd = ref Unsafe.Add(ref targetStart, (uint)sourceBuffer.Length);
             ref float kernelBase = ref this.kernel[0];
-            ref float kernelEnd = ref Unsafe.Add(ref kernelBase, kernelSize);
+            ref float kernelEnd = ref Unsafe.Add(ref kernelBase, (uint)kernelSize);
             ref int sampleColumnBase = ref MemoryMarshal.GetReference(this.map.GetColumnOffsetSpan());
 
             while (Unsafe.IsAddressLessThan(ref targetStart, ref targetEnd))
@@ -254,7 +254,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
 
                 while (Unsafe.IsAddressLessThan(ref kernelStart, ref kernelEnd))
                 {
-                    Vector4 sample = Unsafe.Add(ref sourceBase, sampleColumnStart - boundsX);
+                    Vector4 sample = Unsafe.Add(ref sourceBase, (uint)(sampleColumnStart - boundsX));
 
                     targetStart += kernelStart * sample;
 
@@ -263,7 +263,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
                 }
 
                 targetStart = ref Unsafe.Add(ref targetStart, 1);
-                sampleColumnBase = ref Unsafe.Add(ref sampleColumnBase, kernelSize);
+                sampleColumnBase = ref Unsafe.Add(ref sampleColumnBase, (uint)kernelSize);
             }
 
             Numerics.UnPremultiply(targetBuffer);
@@ -335,14 +335,14 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
             Span<Vector4> sourceBuffer = span[..this.bounds.Width];
             Span<Vector4> targetBuffer = span[this.bounds.Width..];
 
-            ref int sampleRowBase = ref Unsafe.Add(ref MemoryMarshal.GetReference(this.map.GetRowOffsetSpan()), (y - this.bounds.Y) * kernelSize);
+            ref int sampleRowBase = ref Unsafe.Add(ref MemoryMarshal.GetReference(this.map.GetRowOffsetSpan()), (uint)((y - this.bounds.Y) * kernelSize));
 
             // Clear the target buffer for each row run.
             targetBuffer.Clear();
 
             ref Vector4 targetBase = ref MemoryMarshal.GetReference(targetBuffer);
             ref float kernelStart = ref this.kernel[0];
-            ref float kernelEnd = ref Unsafe.Add(ref kernelStart, kernelSize);
+            ref float kernelEnd = ref Unsafe.Add(ref kernelStart, (uint)kernelSize);
 
             Span<TPixel> sourceRow;
             while (Unsafe.IsAddressLessThan(ref kernelStart, ref kernelEnd))
@@ -353,7 +353,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
                 PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
                 ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
-                ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceBase, sourceBuffer.Length);
+                ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceBase, (uint)sourceBuffer.Length);
                 ref Vector4 targetStart = ref targetBase;
                 float factor = kernelStart;
 
@@ -374,7 +374,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
             PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
             {
                 ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
-                ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceBase, sourceBuffer.Length);
+                ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceBase, (uint)sourceBuffer.Length);
 
                 while (Unsafe.IsAddressLessThan(ref sourceBase, ref sourceEnd))
                 {
@@ -400,14 +400,14 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
             Span<Vector4> sourceBuffer = span[..this.bounds.Width];
             Span<Vector4> targetBuffer = span[this.bounds.Width..];
 
-            ref int sampleRowBase = ref Unsafe.Add(ref MemoryMarshal.GetReference(this.map.GetRowOffsetSpan()), (y - this.bounds.Y) * kernelSize);
+            ref int sampleRowBase = ref Unsafe.Add(ref MemoryMarshal.GetReference(this.map.GetRowOffsetSpan()), (uint)((y - this.bounds.Y) * kernelSize));
 
             // Clear the target buffer for each row run.
             targetBuffer.Clear();
 
             ref Vector4 targetBase = ref MemoryMarshal.GetReference(targetBuffer);
             ref float kernelStart = ref this.kernel[0];
-            ref float kernelEnd = ref Unsafe.Add(ref kernelStart, kernelSize);
+            ref float kernelEnd = ref Unsafe.Add(ref kernelStart, (uint)kernelSize);
 
             Span<TPixel> sourceRow;
             while (Unsafe.IsAddressLessThan(ref kernelStart, ref kernelEnd))
@@ -420,7 +420,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
                 Numerics.Premultiply(sourceBuffer);
 
                 ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
-                ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceBase, sourceBuffer.Length);
+                ref Vector4 sourceEnd = ref Unsafe.Add(ref sourceBase, (uint)sourceBuffer.Length);
                 ref Vector4 targetStart = ref targetBase;
                 float factor = kernelStart;
 

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
@@ -123,7 +123,7 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
 
             var state = new ConvolutionState(in this.kernel, this.map);
             int row = y - this.bounds.Y;
-            ref int sampleRowBase = ref state.GetSampleRow(row);
+            ref int sampleRowBase = ref state.GetSampleRow((uint)row);
 
             if (this.preserveAlpha)
             {
@@ -132,23 +132,23 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
                 ref Vector4 targetBase = ref MemoryMarshal.GetReference(targetBuffer);
 
                 Span<TPixel> sourceRow;
-                for (int kY = 0; kY < state.Kernel.Rows; kY++)
+                for (uint kY = 0; kY < state.Kernel.Rows; kY++)
                 {
                     // Get the precalculated source sample row for this kernel row and copy to our buffer.
-                    int offsetY = Unsafe.Add(ref sampleRowBase, (uint)kY);
+                    int offsetY = Unsafe.Add(ref sampleRowBase, kY);
                     sourceRow = this.sourcePixels.DangerousGetRowSpan(offsetY).Slice(boundsX, boundsWidth);
                     PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
                     ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
 
-                    for (int x = 0; x < sourceBuffer.Length; x++)
+                    for (uint x = 0; x < (uint)sourceBuffer.Length; x++)
                     {
                         ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                        ref Vector4 target = ref Unsafe.Add(ref targetBase, (uint)x);
+                        ref Vector4 target = ref Unsafe.Add(ref targetBase, x);
 
-                        for (int kX = 0; kX < state.Kernel.Columns; kX++)
+                        for (uint kX = 0; kX < state.Kernel.Columns; kX++)
                         {
-                            int offsetX = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
+                            int offsetX = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
                             Vector4 sample = Unsafe.Add(ref sourceBase, (uint)offsetX);
                             target += state.Kernel[kY, kX] * sample;
                         }
@@ -159,10 +159,10 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
                 sourceRow = this.sourcePixels.DangerousGetRowSpan(y).Slice(boundsX, boundsWidth);
                 PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
-                for (int x = 0; x < sourceRow.Length; x++)
+                for (nuint x = 0; x < (uint)sourceRow.Length; x++)
                 {
-                    ref Vector4 target = ref Unsafe.Add(ref targetBase, (uint)x);
-                    target.W = Unsafe.Add(ref MemoryMarshal.GetReference(sourceBuffer), (uint)x).W;
+                    ref Vector4 target = ref Unsafe.Add(ref targetBase, x);
+                    target.W = Unsafe.Add(ref MemoryMarshal.GetReference(sourceBuffer), x).W;
                 }
             }
             else
@@ -171,24 +171,24 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
                 targetBuffer.Clear();
                 ref Vector4 targetBase = ref MemoryMarshal.GetReference(targetBuffer);
 
-                for (int kY = 0; kY < state.Kernel.Rows; kY++)
+                for (uint kY = 0; kY < state.Kernel.Rows; kY++)
                 {
                     // Get the precalculated source sample row for this kernel row and copy to our buffer.
-                    int offsetY = Unsafe.Add(ref sampleRowBase, (uint)kY);
+                    int offsetY = Unsafe.Add(ref sampleRowBase, kY);
                     Span<TPixel> sourceRow = this.sourcePixels.DangerousGetRowSpan(offsetY).Slice(boundsX, boundsWidth);
                     PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
                     Numerics.Premultiply(sourceBuffer);
                     ref Vector4 sourceBase = ref MemoryMarshal.GetReference(sourceBuffer);
 
-                    for (int x = 0; x < sourceBuffer.Length; x++)
+                    for (uint x = 0; x < (uint)sourceBuffer.Length; x++)
                     {
                         ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                        ref Vector4 target = ref Unsafe.Add(ref targetBase, (uint)x);
+                        ref Vector4 target = ref Unsafe.Add(ref targetBase, x);
 
-                        for (int kX = 0; kX < state.Kernel.Columns; kX++)
+                        for (uint kX = 0; kX < state.Kernel.Columns; kX++)
                         {
-                            int offsetX = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
+                            int offsetX = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
                             Vector4 sample = Unsafe.Add(ref sourceBase, (uint)offsetX);
                             target += state.Kernel[kY, kX] * sample;
                         }

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor{TPixel}.cs
@@ -135,7 +135,7 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
                 for (int kY = 0; kY < state.Kernel.Rows; kY++)
                 {
                     // Get the precalculated source sample row for this kernel row and copy to our buffer.
-                    int offsetY = Unsafe.Add(ref sampleRowBase, kY);
+                    int offsetY = Unsafe.Add(ref sampleRowBase, (uint)kY);
                     sourceRow = this.sourcePixels.DangerousGetRowSpan(offsetY).Slice(boundsX, boundsWidth);
                     PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
@@ -144,12 +144,12 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
                     for (int x = 0; x < sourceBuffer.Length; x++)
                     {
                         ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                        ref Vector4 target = ref Unsafe.Add(ref targetBase, x);
+                        ref Vector4 target = ref Unsafe.Add(ref targetBase, (uint)x);
 
                         for (int kX = 0; kX < state.Kernel.Columns; kX++)
                         {
-                            int offsetX = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
-                            Vector4 sample = Unsafe.Add(ref sourceBase, offsetX);
+                            int offsetX = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
+                            Vector4 sample = Unsafe.Add(ref sourceBase, (uint)offsetX);
                             target += state.Kernel[kY, kX] * sample;
                         }
                     }
@@ -161,8 +161,8 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
 
                 for (int x = 0; x < sourceRow.Length; x++)
                 {
-                    ref Vector4 target = ref Unsafe.Add(ref targetBase, x);
-                    target.W = Unsafe.Add(ref MemoryMarshal.GetReference(sourceBuffer), x).W;
+                    ref Vector4 target = ref Unsafe.Add(ref targetBase, (uint)x);
+                    target.W = Unsafe.Add(ref MemoryMarshal.GetReference(sourceBuffer), (uint)x).W;
                 }
             }
             else
@@ -174,7 +174,7 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
                 for (int kY = 0; kY < state.Kernel.Rows; kY++)
                 {
                     // Get the precalculated source sample row for this kernel row and copy to our buffer.
-                    int offsetY = Unsafe.Add(ref sampleRowBase, kY);
+                    int offsetY = Unsafe.Add(ref sampleRowBase, (uint)kY);
                     Span<TPixel> sourceRow = this.sourcePixels.DangerousGetRowSpan(offsetY).Slice(boundsX, boundsWidth);
                     PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceBuffer);
 
@@ -184,12 +184,12 @@ internal class ConvolutionProcessor<TPixel> : ImageProcessor<TPixel>
                     for (int x = 0; x < sourceBuffer.Length; x++)
                     {
                         ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                        ref Vector4 target = ref Unsafe.Add(ref targetBase, x);
+                        ref Vector4 target = ref Unsafe.Add(ref targetBase, (uint)x);
 
                         for (int kX = 0; kX < state.Kernel.Columns; kX++)
                         {
-                            int offsetX = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
-                            Vector4 sample = Unsafe.Add(ref sourceBase, offsetX);
+                            int offsetX = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
+                            Vector4 sample = Unsafe.Add(ref sourceBase, (uint)offsetX);
                             target += state.Kernel[kY, kX] * sample;
                         }
                     }

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionState.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionState.cs
@@ -35,9 +35,9 @@ internal readonly ref struct ConvolutionState
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly ref int GetSampleRow(int row)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), row * this.kernelHeight);
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), (uint)(row * this.kernelHeight));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly ref int GetSampleColumn(int column)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), column * this.kernelWidth);
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), (uint)(column * this.kernelWidth));
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionState.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionState.cs
@@ -13,16 +13,16 @@ internal readonly ref struct ConvolutionState
 {
     private readonly Span<int> rowOffsetMap;
     private readonly Span<int> columnOffsetMap;
-    private readonly int kernelHeight;
-    private readonly int kernelWidth;
+    private readonly uint kernelHeight;
+    private readonly uint kernelWidth;
 
     public ConvolutionState(
         in DenseMatrix<float> kernel,
         KernelSamplingMap map)
     {
         this.Kernel = new ReadOnlyKernel(kernel);
-        this.kernelHeight = kernel.Rows;
-        this.kernelWidth = kernel.Columns;
+        this.kernelHeight = (uint)kernel.Rows;
+        this.kernelWidth = (uint)kernel.Columns;
         this.rowOffsetMap = map.GetRowOffsetSpan();
         this.columnOffsetMap = map.GetColumnOffsetSpan();
     }
@@ -34,10 +34,10 @@ internal readonly ref struct ConvolutionState
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly ref int GetSampleRow(int row)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), (uint)(row * this.kernelHeight));
+    public readonly ref int GetSampleRow(uint row)
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), row * this.kernelHeight);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly ref int GetSampleColumn(int column)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), (uint)(column * this.kernelWidth));
+    public readonly ref int GetSampleColumn(uint column)
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), column * this.kernelWidth);
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
@@ -98,8 +98,8 @@ internal class EdgeDetectorCompassProcessor<TPixel> : ImageProcessor<TPixel>
     {
         private readonly Buffer2D<TPixel> targetPixels;
         private readonly Buffer2D<TPixel> passPixels;
-        private readonly int minX;
-        private readonly int maxX;
+        private readonly uint minX;
+        private readonly uint maxX;
 
         [MethodImpl(InliningOptions.ShortMethod)]
         public RowOperation(
@@ -109,8 +109,8 @@ internal class EdgeDetectorCompassProcessor<TPixel> : ImageProcessor<TPixel>
         {
             this.targetPixels = targetPixels;
             this.passPixels = passPixels;
-            this.minX = bounds.X;
-            this.maxX = bounds.Right;
+            this.minX = (uint)bounds.X;
+            this.maxX = (uint)bounds.Right;
         }
 
         /// <inheritdoc/>
@@ -120,11 +120,11 @@ internal class EdgeDetectorCompassProcessor<TPixel> : ImageProcessor<TPixel>
             ref TPixel passPixelsBase = ref MemoryMarshal.GetReference(this.passPixels.DangerousGetRowSpan(y));
             ref TPixel targetPixelsBase = ref MemoryMarshal.GetReference(this.targetPixels.DangerousGetRowSpan(y));
 
-            for (int x = this.minX; x < this.maxX; x++)
+            for (nuint x = this.minX; x < this.maxX; x++)
             {
                 // Grab the max components of the two pixels
-                ref TPixel currentPassPixel = ref Unsafe.Add(ref passPixelsBase, (uint)x);
-                ref TPixel currentTargetPixel = ref Unsafe.Add(ref targetPixelsBase, (uint)x);
+                ref TPixel currentPassPixel = ref Unsafe.Add(ref passPixelsBase, x);
+                ref TPixel currentTargetPixel = ref Unsafe.Add(ref targetPixelsBase, x);
 
                 var pixelValue = Vector4.Max(currentPassPixel.ToVector4(), currentTargetPixel.ToVector4());
 

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
@@ -123,8 +123,8 @@ internal class EdgeDetectorCompassProcessor<TPixel> : ImageProcessor<TPixel>
             for (int x = this.minX; x < this.maxX; x++)
             {
                 // Grab the max components of the two pixels
-                ref TPixel currentPassPixel = ref Unsafe.Add(ref passPixelsBase, x);
-                ref TPixel currentTargetPixel = ref Unsafe.Add(ref targetPixelsBase, x);
+                ref TPixel currentPassPixel = ref Unsafe.Add(ref passPixelsBase, (uint)x);
+                ref TPixel currentTargetPixel = ref Unsafe.Add(ref targetPixelsBase, (uint)x);
 
                 var pixelValue = Vector4.Max(currentPassPixel.ToVector4(), currentTargetPixel.ToVector4());
 

--- a/src/ImageSharp/Processing/Processors/Convolution/Kernel.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Kernel.cs
@@ -49,7 +49,7 @@ internal readonly ref struct Kernel<T>
         {
             this.CheckCoordinates(row, column);
             ref T vBase = ref MemoryMarshal.GetReference(this.values);
-            return Unsafe.Add(ref vBase, (row * this.Columns) + column);
+            return Unsafe.Add(ref vBase, (uint)((row * this.Columns) + column));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -57,7 +57,7 @@ internal readonly ref struct Kernel<T>
         {
             this.CheckCoordinates(row, column);
             ref T vBase = ref MemoryMarshal.GetReference(this.values);
-            Unsafe.Add(ref vBase, (row * this.Columns) + column) = value;
+            Unsafe.Add(ref vBase, (uint)((row * this.Columns) + column)) = value;
         }
     }
 
@@ -66,7 +66,7 @@ internal readonly ref struct Kernel<T>
     {
         this.CheckIndex(index);
         ref T vBase = ref MemoryMarshal.GetReference(this.values);
-        Unsafe.Add(ref vBase, index) = value;
+        Unsafe.Add(ref vBase, (uint)index) = value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ImageSharp/Processing/Processors/Convolution/KernelSamplingMap.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KernelSamplingMap.cs
@@ -92,7 +92,7 @@ internal sealed class KernelSamplingMap : IDisposable
             int chunkBase = chunk * kernelSize;
             for (int i = 0; i < kernelSize; i++)
             {
-                Unsafe.Add(ref spanBase, chunkBase + i) = chunk + i + min - radius;
+                Unsafe.Add(ref spanBase, (uint)(chunkBase + i)) = chunk + i + min - radius;
             }
         }
 

--- a/src/ImageSharp/Processing/Processors/Convolution/MedianConvolutionState.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/MedianConvolutionState.cs
@@ -36,9 +36,9 @@ internal readonly ref struct MedianConvolutionState
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly ref int GetSampleRow(int row)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), row * this.kernelHeight);
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.rowOffsetMap), (uint)(row * this.kernelHeight));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly ref int GetSampleColumn(int column)
-        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), column * this.kernelWidth);
+        => ref Unsafe.Add(ref MemoryMarshal.GetReference(this.columnOffsetMap), (uint)(column * this.kernelWidth));
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/MedianRowOperation{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/MedianRowOperation{TPixel}.cs
@@ -75,7 +75,7 @@ internal readonly struct MedianRowOperation<TPixel> : IRowOperation<Vector4>
         // First convert the required source rows to Vector4.
         for (int i = 0; i < this.kernelSize; i++)
         {
-            int currentYIndex = Unsafe.Add(ref sampleRowBase, i);
+            int currentYIndex = Unsafe.Add(ref sampleRowBase, (uint)i);
             Span<TPixel> sourceRow = this.sourcePixels.DangerousGetRowSpan(currentYIndex).Slice(boundsX, boundsWidth);
             Span<Vector4> sourceVectorRow = sourceVectorBuffer.Slice(i * boundsWidth, boundsWidth);
             PixelOperations<TPixel>.Instance.ToVector4(this.configuration, sourceRow, sourceVectorRow);
@@ -87,15 +87,15 @@ internal readonly struct MedianRowOperation<TPixel> : IRowOperation<Vector4>
             {
                 int index = 0;
                 ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                ref Vector4 target = ref Unsafe.Add(ref targetBase, x);
+                ref Vector4 target = ref Unsafe.Add(ref targetBase, (uint)x);
                 for (int kY = 0; kY < state.Kernel.Rows; kY++)
                 {
                     Span<Vector4> sourceRow = sourceVectorBuffer[(kY * boundsWidth)..];
                     ref Vector4 sourceRowBase = ref MemoryMarshal.GetReference(sourceRow);
                     for (int kX = 0; kX < state.Kernel.Columns; kX++)
                     {
-                        int currentXIndex = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
-                        Vector4 pixel = Unsafe.Add(ref sourceRowBase, currentXIndex);
+                        int currentXIndex = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
+                        Vector4 pixel = Unsafe.Add(ref sourceRowBase, (uint)currentXIndex);
                         state.Kernel.SetValue(index, pixel);
                         index++;
                     }
@@ -111,15 +111,15 @@ internal readonly struct MedianRowOperation<TPixel> : IRowOperation<Vector4>
             {
                 int index = 0;
                 ref int sampleColumnBase = ref state.GetSampleColumn(x);
-                ref Vector4 target = ref Unsafe.Add(ref targetBase, x);
+                ref Vector4 target = ref Unsafe.Add(ref targetBase, (uint)x);
                 for (int kY = 0; kY < state.Kernel.Rows; kY++)
                 {
                     Span<Vector4> sourceRow = sourceVectorBuffer[(kY * boundsWidth)..];
                     ref Vector4 sourceRowBase = ref MemoryMarshal.GetReference(sourceRow);
                     for (int kX = 0; kX < state.Kernel.Columns; kX++)
                     {
-                        int currentXIndex = Unsafe.Add(ref sampleColumnBase, kX) - boundsX;
-                        Vector4 pixel = Unsafe.Add(ref sourceRowBase, currentXIndex);
+                        int currentXIndex = Unsafe.Add(ref sampleColumnBase, (uint)kX) - boundsX;
+                        Vector4 pixel = Unsafe.Add(ref sourceRowBase, (uint)currentXIndex);
                         state.Kernel.SetValue(index, pixel);
                         index++;
                     }

--- a/src/ImageSharp/Processing/Processors/Convolution/Parameters/BokehBlurKernelDataProvider.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Parameters/BokehBlurKernelDataProvider.cs
@@ -134,7 +134,7 @@ internal static class BokehBlurKernelDataProvider
         ref Vector4 baseRef = ref MemoryMarshal.GetReference(kernelParameters.AsSpan());
         for (int i = 0; i < kernelParameters.Length; i++)
         {
-            ref Vector4 paramsRef = ref Unsafe.Add(ref baseRef, i);
+            ref Vector4 paramsRef = ref Unsafe.Add(ref baseRef, (uint)i);
             kernels[i] = CreateComplex1DKernel(radius, kernelSize, kernelsScale, paramsRef.X, paramsRef.Y);
         }
 
@@ -167,7 +167,7 @@ internal static class BokehBlurKernelDataProvider
             value *= value;
 
             // Fill in the complex kernel values
-            Unsafe.Add(ref baseRef, i) = new Complex64(
+            Unsafe.Add(ref baseRef, (uint)i) = new Complex64(
                 MathF.Exp(-a * value) * MathF.Cos(b * value),
                 MathF.Exp(-a * value) * MathF.Sin(b * value));
         }
@@ -190,17 +190,17 @@ internal static class BokehBlurKernelDataProvider
 
         for (int i = 0; i < kernelParameters.Length; i++)
         {
-            ref Complex64[] kernelRef = ref Unsafe.Add(ref baseKernelsRef, i);
+            ref Complex64[] kernelRef = ref Unsafe.Add(ref baseKernelsRef, (uint)i);
             int length = kernelRef.Length;
             ref Complex64 valueRef = ref kernelRef[0];
-            ref Vector4 paramsRef = ref Unsafe.Add(ref baseParamsRef, i);
+            ref Vector4 paramsRef = ref Unsafe.Add(ref baseParamsRef, (uint)i);
 
             for (int j = 0; j < length; j++)
             {
                 for (int k = 0; k < length; k++)
                 {
-                    ref Complex64 jRef = ref Unsafe.Add(ref valueRef, j);
-                    ref Complex64 kRef = ref Unsafe.Add(ref valueRef, k);
+                    ref Complex64 jRef = ref Unsafe.Add(ref valueRef, (uint)j);
+                    ref Complex64 kRef = ref Unsafe.Add(ref valueRef, (uint)k);
                     total +=
                         (paramsRef.Z * ((jRef.Real * kRef.Real) - (jRef.Imaginary * kRef.Imaginary)))
                         + (paramsRef.W * ((jRef.Real * kRef.Imaginary) + (jRef.Imaginary * kRef.Real)));
@@ -212,13 +212,13 @@ internal static class BokehBlurKernelDataProvider
         float scalar = 1f / MathF.Sqrt(total);
         for (int i = 0; i < kernelsSpan.Length; i++)
         {
-            ref Complex64[] kernelsRef = ref Unsafe.Add(ref baseKernelsRef, i);
+            ref Complex64[] kernelsRef = ref Unsafe.Add(ref baseKernelsRef, (uint)i);
             int length = kernelsRef.Length;
             ref Complex64 valueRef = ref kernelsRef[0];
 
             for (int j = 0; j < length; j++)
             {
-                Unsafe.Add(ref valueRef, j) *= scalar;
+                Unsafe.Add(ref valueRef, (uint)j) *= scalar;
             }
         }
     }

--- a/src/ImageSharp/Processing/Processors/Convolution/Parameters/BokehBlurKernelDataProvider.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Parameters/BokehBlurKernelDataProvider.cs
@@ -192,7 +192,7 @@ internal static class BokehBlurKernelDataProvider
         {
             ref Complex64[] kernelRef = ref Unsafe.Add(ref baseKernelsRef, (uint)i);
             int length = kernelRef.Length;
-            ref Complex64 valueRef = ref kernelRef[0];
+            ref Complex64 valueRef = ref MemoryMarshal.GetArrayDataReference(kernelRef);
             ref Vector4 paramsRef = ref Unsafe.Add(ref baseParamsRef, (uint)i);
 
             for (int j = 0; j < length; j++)
@@ -214,7 +214,7 @@ internal static class BokehBlurKernelDataProvider
         {
             ref Complex64[] kernelsRef = ref Unsafe.Add(ref baseKernelsRef, (uint)i);
             int length = kernelsRef.Length;
-            ref Complex64 valueRef = ref kernelsRef[0];
+            ref Complex64 valueRef = ref MemoryMarshal.GetArrayDataReference(kernelsRef);
 
             for (int j = 0; j < length; j++)
             {

--- a/src/ImageSharp/Processing/Processors/Convolution/ReadOnlyKernel.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ReadOnlyKernel.cs
@@ -17,43 +17,43 @@ internal readonly ref struct ReadOnlyKernel
 
     public ReadOnlyKernel(DenseMatrix<float> matrix)
     {
-        this.Columns = matrix.Columns;
-        this.Rows = matrix.Rows;
+        this.Columns = (uint)matrix.Columns;
+        this.Rows = (uint)matrix.Rows;
         this.values = matrix.Span;
     }
 
-    public int Columns
+    public uint Columns
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get;
     }
 
-    public int Rows
+    public uint Rows
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get;
     }
 
-    public float this[int row, int column]
+    public float this[uint row, uint column]
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
             this.CheckCoordinates(row, column);
             ref float vBase = ref MemoryMarshal.GetReference(this.values);
-            return Unsafe.Add(ref vBase, (uint)((row * this.Columns) + column));
+            return Unsafe.Add(ref vBase, (row * this.Columns) + column);
         }
     }
 
     [Conditional("DEBUG")]
-    private void CheckCoordinates(int row, int column)
+    private void CheckCoordinates(uint row, uint column)
     {
-        if (row < 0 || row >= this.Rows)
+        if (row >= this.Rows)
         {
             throw new ArgumentOutOfRangeException(nameof(row), row, $"{row} is outwith the matrix bounds.");
         }
 
-        if (column < 0 || column >= this.Columns)
+        if (column >= this.Columns)
         {
             throw new ArgumentOutOfRangeException(nameof(column), column, $"{column} is outwith the matrix bounds.");
         }

--- a/src/ImageSharp/Processing/Processors/Convolution/ReadOnlyKernel.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ReadOnlyKernel.cs
@@ -41,7 +41,7 @@ internal readonly ref struct ReadOnlyKernel
         {
             this.CheckCoordinates(row, column);
             ref float vBase = ref MemoryMarshal.GetReference(this.values);
-            return Unsafe.Add(ref vBase, (row * this.Columns) + column);
+            return Unsafe.Add(ref vBase, (uint)((row * this.Columns) + column));
         }
     }
 

--- a/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
@@ -114,8 +114,8 @@ public readonly partial struct ErrorDither : IDither, IEquatable<ErrorDither>, I
 
             for (int x = bounds.Left; x < bounds.Right; x++)
             {
-                TPixel sourcePixel = Unsafe.Add(ref sourceRowRef, x);
-                Unsafe.Add(ref destinationRowRef, x - offsetX) = quantizer.GetQuantizedColor(sourcePixel, out TPixel transformed);
+                TPixel sourcePixel = Unsafe.Add(ref sourceRowRef, (uint)x);
+                Unsafe.Add(ref destinationRowRef, (uint)(x - offsetX)) = quantizer.GetQuantizedColor(sourcePixel, out TPixel transformed);
                 this.Dither(source, bounds, sourcePixel, transformed, x, y, scale);
             }
         }
@@ -142,7 +142,7 @@ public readonly partial struct ErrorDither : IDither, IEquatable<ErrorDither>, I
             ref TPixel sourceRowRef = ref MemoryMarshal.GetReference(sourceBuffer.DangerousGetRowSpan(y));
             for (int x = bounds.Left; x < bounds.Right; x++)
             {
-                ref TPixel sourcePixel = ref Unsafe.Add(ref sourceRowRef, x);
+                ref TPixel sourcePixel = ref Unsafe.Add(ref sourceRowRef, (uint)x);
                 TPixel transformed = Unsafe.AsRef(processor).GetPaletteColor(sourcePixel);
                 this.Dither(source, bounds, sourcePixel, transformed, x, y, scale);
                 sourcePixel = transformed;

--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
@@ -107,9 +107,9 @@ internal class OilPaintingProcessor<TPixel> : ImageProcessor<TPixel>
 
             ref float binsRef = ref bins.GetReference();
             ref int intensityBinRef = ref Unsafe.As<float, int>(ref binsRef);
-            ref float redBinRef = ref Unsafe.Add(ref binsRef, this.levels);
-            ref float blueBinRef = ref Unsafe.Add(ref redBinRef, this.levels);
-            ref float greenBinRef = ref Unsafe.Add(ref blueBinRef, this.levels);
+            ref float redBinRef = ref Unsafe.Add(ref binsRef, (uint)this.levels);
+            ref float blueBinRef = ref Unsafe.Add(ref redBinRef, (uint)this.levels);
+            ref float greenBinRef = ref Unsafe.Add(ref blueBinRef, (uint)this.levels);
 
             for (int y = rows.Min; y < rows.Max; y++)
             {
@@ -148,21 +148,21 @@ internal class OilPaintingProcessor<TPixel> : ImageProcessor<TPixel>
 
                             int currentIntensity = (int)MathF.Round((sourceBlue + sourceGreen + sourceRed) / 3F * (this.levels - 1));
 
-                            Unsafe.Add(ref intensityBinRef, currentIntensity)++;
-                            Unsafe.Add(ref redBinRef, currentIntensity) += sourceRed;
-                            Unsafe.Add(ref blueBinRef, currentIntensity) += sourceBlue;
-                            Unsafe.Add(ref greenBinRef, currentIntensity) += sourceGreen;
+                            Unsafe.Add(ref intensityBinRef, (uint)currentIntensity)++;
+                            Unsafe.Add(ref redBinRef, (uint)currentIntensity) += sourceRed;
+                            Unsafe.Add(ref blueBinRef, (uint)currentIntensity) += sourceBlue;
+                            Unsafe.Add(ref greenBinRef, (uint)currentIntensity) += sourceGreen;
 
-                            if (Unsafe.Add(ref intensityBinRef, currentIntensity) > maxIntensity)
+                            if (Unsafe.Add(ref intensityBinRef, (uint)currentIntensity) > maxIntensity)
                             {
-                                maxIntensity = Unsafe.Add(ref intensityBinRef, currentIntensity);
+                                maxIntensity = Unsafe.Add(ref intensityBinRef, (uint)currentIntensity);
                                 maxIndex = currentIntensity;
                             }
                         }
 
-                        float red = MathF.Abs(Unsafe.Add(ref redBinRef, maxIndex) / maxIntensity);
-                        float blue = MathF.Abs(Unsafe.Add(ref blueBinRef, maxIndex) / maxIntensity);
-                        float green = MathF.Abs(Unsafe.Add(ref greenBinRef, maxIndex) / maxIntensity);
+                        float red = MathF.Abs(Unsafe.Add(ref redBinRef, (uint)maxIndex) / maxIntensity);
+                        float blue = MathF.Abs(Unsafe.Add(ref blueBinRef, (uint)maxIndex) / maxIntensity);
+                        float green = MathF.Abs(Unsafe.Add(ref greenBinRef, (uint)maxIndex) / maxIntensity);
                         float alpha = sourceRowVector4Span[x].W;
 
                         targetRowVector4Span[x] = new Vector4(red, green, blue, alpha);

--- a/src/ImageSharp/Processing/Processors/Filters/OpaqueProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Filters/OpaqueProcessor{TPixel}.cs
@@ -61,7 +61,7 @@ internal sealed class OpaqueProcessor<TPixel> : ImageProcessor<TPixel>
 
             for (int x = 0; x < this.bounds.Width; x++)
             {
-                ref Vector4 v = ref Unsafe.Add(ref baseRef, x);
+                ref Vector4 v = ref Unsafe.Add(ref baseRef, (uint)x);
                 v.W = 1F;
             }
 

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationProcessor{TPixel}.cs
@@ -59,8 +59,8 @@ internal class AdaptiveHistogramEqualizationProcessor<TPixel> : HistogramEqualiz
         int tileWidth = (int)MathF.Ceiling(sourceWidth / (float)this.Tiles);
         int tileHeight = (int)MathF.Ceiling(sourceHeight / (float)this.Tiles);
         int tileCount = this.Tiles;
-        int halfTileWidth = tileWidth / 2;
-        int halfTileHeight = tileHeight / 2;
+        int halfTileWidth = (int)((uint)tileWidth / 2);
+        int halfTileHeight = (int)((uint)tileHeight / 2);
         int luminanceLevels = this.LuminanceLevels;
 
         // The image is split up into tiles. For each tile the cumulative distribution function will be calculated.
@@ -176,7 +176,7 @@ internal class AdaptiveHistogramEqualizationProcessor<TPixel> : HistogramEqualiz
         int xEnd,
         int luminanceLevels)
     {
-        int halfTileHeight = tileHeight / 2;
+        int halfTileHeight = (int)((uint)tileHeight / 2);
 
         int cdfY = 0;
         int y = halfTileHeight;
@@ -228,7 +228,7 @@ internal class AdaptiveHistogramEqualizationProcessor<TPixel> : HistogramEqualiz
         int yEnd,
         int luminanceLevels)
     {
-        int halfTileWidth = tileWidth / 2;
+        int halfTileWidth = (int)((uint)tileWidth / 2);
 
         int cdfX = 0;
         int x = halfTileWidth;

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
@@ -254,9 +254,9 @@ internal class AdaptiveHistogramEqualizationSlidingWindowProcessor<TPixel> : His
     [MethodImpl(InliningOptions.ShortMethod)]
     private static void AddPixelsToHistogram(ref Vector4 greyValuesBase, ref int histogramBase, int luminanceLevels, int length)
     {
-        for (nint idx = 0; idx < length; idx++)
+        for (nuint idx = 0; idx < (uint)length; idx++)
         {
-            int luminance = ColorNumerics.GetBT709Luminance(ref Unsafe.Add(ref greyValuesBase, (uint)idx), luminanceLevels);
+            int luminance = ColorNumerics.GetBT709Luminance(ref Unsafe.Add(ref greyValuesBase, idx), luminanceLevels);
             Unsafe.Add(ref histogramBase, (uint)luminance)++;
         }
     }
@@ -271,9 +271,9 @@ internal class AdaptiveHistogramEqualizationSlidingWindowProcessor<TPixel> : His
     [MethodImpl(InliningOptions.ShortMethod)]
     private static void RemovePixelsFromHistogram(ref Vector4 greyValuesBase, ref int histogramBase, int luminanceLevels, int length)
     {
-        for (int idx = 0; idx < length; idx++)
+        for (nuint idx = 0; idx < (uint)length; idx++)
         {
-            int luminance = ColorNumerics.GetBT709Luminance(ref Unsafe.Add(ref greyValuesBase, (uint)idx), luminanceLevels);
+            int luminance = ColorNumerics.GetBT709Luminance(ref Unsafe.Add(ref greyValuesBase, idx), luminanceLevels);
             Unsafe.Add(ref histogramBase, (uint)luminance)--;
         }
     }

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
@@ -59,7 +59,7 @@ internal class AdaptiveHistogramEqualizationSlidingWindowProcessor<TPixel> : His
         int tileWidth = source.Width / this.Tiles;
         int tileHeight = tileWidth;
         int pixelInTile = tileWidth * tileHeight;
-        int halfTileHeight = tileHeight / 2;
+        int halfTileHeight = (int)((uint)tileHeight / 2);
         int halfTileWidth = halfTileHeight;
         SlidingWindowInfos slidingWindowInfos = new(tileWidth, tileHeight, halfTileWidth, halfTileHeight, pixelInTile);
 

--- a/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AdaptiveHistogramEqualizationSlidingWindowProcessor{TPixel}.cs
@@ -256,8 +256,8 @@ internal class AdaptiveHistogramEqualizationSlidingWindowProcessor<TPixel> : His
     {
         for (nint idx = 0; idx < length; idx++)
         {
-            int luminance = ColorNumerics.GetBT709Luminance(ref Unsafe.Add(ref greyValuesBase, idx), luminanceLevels);
-            Unsafe.Add(ref histogramBase, luminance)++;
+            int luminance = ColorNumerics.GetBT709Luminance(ref Unsafe.Add(ref greyValuesBase, (uint)idx), luminanceLevels);
+            Unsafe.Add(ref histogramBase, (uint)luminance)++;
         }
     }
 
@@ -273,8 +273,8 @@ internal class AdaptiveHistogramEqualizationSlidingWindowProcessor<TPixel> : His
     {
         for (int idx = 0; idx < length; idx++)
         {
-            int luminance = ColorNumerics.GetBT709Luminance(ref Unsafe.Add(ref greyValuesBase, idx), luminanceLevels);
-            Unsafe.Add(ref histogramBase, luminance)--;
+            int luminance = ColorNumerics.GetBT709Luminance(ref Unsafe.Add(ref greyValuesBase, (uint)idx), luminanceLevels);
+            Unsafe.Add(ref histogramBase, (uint)luminance)--;
         }
     }
 
@@ -382,7 +382,7 @@ internal class AdaptiveHistogramEqualizationSlidingWindowProcessor<TPixel> : His
 
                     // Map the current pixel to the new equalized value.
                     int luminance = GetLuminance(this.source[x, y], this.processor.LuminanceLevels);
-                    float luminanceEqualized = Unsafe.Add(ref cdfBase, luminance) / numberOfPixelsMinusCdfMin;
+                    float luminanceEqualized = Unsafe.Add(ref cdfBase, (uint)luminance) / numberOfPixelsMinusCdfMin;
                     this.targetPixels[x, y].FromVector4(new Vector4(luminanceEqualized, luminanceEqualized, luminanceEqualized, this.source[x, y].ToVector4().W));
 
                     // Remove top most row from the histogram, mirroring rows which exceeds the borders.

--- a/src/ImageSharp/Processing/Processors/Normalization/AutoLevelProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/AutoLevelProcessor{TPixel}.cs
@@ -148,12 +148,12 @@ internal class AutoLevelProcessor<TPixel> : HistogramEqualizationProcessor<TPixe
 
             for (int x = 0; x < this.bounds.Width; x++)
             {
-                var vector = Unsafe.Add(ref vectorRef, x);
+                var vector = Unsafe.Add(ref vectorRef, (uint)x);
                 int luminance = ColorNumerics.GetBT709Luminance(ref vector, levels);
-                float scaledLuminance = Unsafe.Add(ref cdfBase, luminance) / noOfPixelsMinusCdfMin;
+                float scaledLuminance = Unsafe.Add(ref cdfBase, (uint)luminance) / noOfPixelsMinusCdfMin;
                 float scalingFactor = scaledLuminance * levels / luminance;
                 Vector4 scaledVector = new Vector4(scalingFactor * vector.X, scalingFactor * vector.Y, scalingFactor * vector.Z, vector.W);
-                Unsafe.Add(ref vectorRef, x) = scaledVector;
+                Unsafe.Add(ref vectorRef, (uint)x) = scaledVector;
             }
 
             PixelOperations<TPixel>.Instance.FromVector4Destructive(this.configuration, vectorBuffer, pixelRow);
@@ -209,7 +209,7 @@ internal class AutoLevelProcessor<TPixel> : HistogramEqualizationProcessor<TPixe
 
             for (int x = 0; x < this.bounds.Width; x++)
             {
-                var vector = Unsafe.Add(ref vectorRef, x) * levelsMinusOne;
+                var vector = Unsafe.Add(ref vectorRef, (uint)x) * levelsMinusOne;
 
                 uint originalX = (uint)MathF.Round(vector.X);
                 float scaledX = Unsafe.Add(ref cdfBase, originalX) / noOfPixelsMinusCdfMin;
@@ -217,7 +217,7 @@ internal class AutoLevelProcessor<TPixel> : HistogramEqualizationProcessor<TPixe
                 float scaledY = Unsafe.Add(ref cdfBase, originalY) / noOfPixelsMinusCdfMin;
                 uint originalZ = (uint)MathF.Round(vector.Z);
                 float scaledZ = Unsafe.Add(ref cdfBase, originalZ) / noOfPixelsMinusCdfMin;
-                Unsafe.Add(ref vectorRef, x) = new Vector4(scaledX, scaledY, scaledZ, vector.W);
+                Unsafe.Add(ref vectorRef, (uint)x) = new Vector4(scaledX, scaledY, scaledZ, vector.W);
             }
 
             PixelOperations<TPixel>.Instance.FromVector4Destructive(this.configuration, vectorBuffer, pixelRow);

--- a/src/ImageSharp/Processing/Processors/Normalization/GlobalHistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/GlobalHistogramEqualizationProcessor{TPixel}.cs
@@ -129,10 +129,10 @@ internal class GlobalHistogramEqualizationProcessor<TPixel> : HistogramEqualizat
 
             for (int x = 0; x < this.bounds.Width; x++)
             {
-                var vector = Unsafe.Add(ref vectorRef, x);
+                var vector = Unsafe.Add(ref vectorRef, (uint)x);
                 int luminance = ColorNumerics.GetBT709Luminance(ref vector, levels);
-                float luminanceEqualized = Unsafe.Add(ref cdfBase, luminance) / noOfPixelsMinusCdfMin;
-                Unsafe.Add(ref vectorRef, x) = new Vector4(luminanceEqualized, luminanceEqualized, luminanceEqualized, vector.W);
+                float luminanceEqualized = Unsafe.Add(ref cdfBase, (uint)luminance) / noOfPixelsMinusCdfMin;
+                Unsafe.Add(ref vectorRef, (uint)x) = new Vector4(luminanceEqualized, luminanceEqualized, luminanceEqualized, vector.W);
             }
 
             PixelOperations<TPixel>.Instance.FromVector4Destructive(this.configuration, vectorBuffer, pixelRow);

--- a/src/ImageSharp/Processing/Processors/Normalization/GrayscaleLevelsRowOperation{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/GrayscaleLevelsRowOperation{TPixel}.cs
@@ -56,9 +56,9 @@ internal readonly struct GrayscaleLevelsRowOperation<TPixel> : IRowOperation<Vec
 
         for (int x = 0; x < this.bounds.Width; x++)
         {
-            var vector = Unsafe.Add(ref vectorRef, x);
+            var vector = Unsafe.Add(ref vectorRef, (uint)x);
             int luminance = ColorNumerics.GetBT709Luminance(ref vector, levels);
-            Interlocked.Increment(ref Unsafe.Add(ref histogramBase, luminance));
+            Interlocked.Increment(ref Unsafe.Add(ref histogramBase, (uint)luminance));
         }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor{TPixel}.cs
@@ -73,7 +73,7 @@ internal abstract class HistogramEqualizationProcessor<TPixel> : ImageProcessor<
         int cdfMin = 0;
         bool cdfMinFound = false;
 
-        for (nint i = 0; i <= (uint)maxIdx; i++)
+        for (nuint i = 0; i <= (uint)maxIdx; i++)
         {
             histSum += Unsafe.Add(ref histogramBase, i);
             if (!cdfMinFound && histSum != 0)
@@ -101,7 +101,7 @@ internal abstract class HistogramEqualizationProcessor<TPixel> : ImageProcessor<
         int sumOverClip = 0;
         ref int histogramBase = ref MemoryMarshal.GetReference(histogram);
 
-        for (nint i = 0; i < (uint)histogram.Length; i++)
+        for (nuint i = 0; i < (uint)histogram.Length; i++)
         {
             ref int histogramLevel = ref Unsafe.Add(ref histogramBase, i);
             if (histogramLevel > clipLimit)
@@ -115,7 +115,7 @@ internal abstract class HistogramEqualizationProcessor<TPixel> : ImageProcessor<
         int addToEachBin = sumOverClip > 0 ? (int)MathF.Floor(sumOverClip / this.luminanceLevelsFloat) : 0;
         if (addToEachBin > 0)
         {
-            for (nint i = 0; i < (uint)histogram.Length; i++)
+            for (nuint i = 0; i < (uint)histogram.Length; i++)
             {
                 Unsafe.Add(ref histogramBase, i) += addToEachBin;
             }
@@ -124,8 +124,8 @@ internal abstract class HistogramEqualizationProcessor<TPixel> : ImageProcessor<
         int residual = sumOverClip - (addToEachBin * this.LuminanceLevels);
         if (residual != 0)
         {
-            int residualStep = Math.Max(this.LuminanceLevels / residual, 1);
-            for (nint i = 0; i < (uint)this.LuminanceLevels && residual > 0; i += residualStep, residual--)
+            uint residualStep = (uint)Math.Max(this.LuminanceLevels / residual, 1);
+            for (nuint i = 0; i < (uint)this.LuminanceLevels && residual > 0; i += residualStep, residual--)
             {
                 ref int histogramLevel = ref Unsafe.Add(ref histogramBase, i);
                 histogramLevel++;

--- a/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Normalization/HistogramEqualizationProcessor{TPixel}.cs
@@ -73,7 +73,7 @@ internal abstract class HistogramEqualizationProcessor<TPixel> : ImageProcessor<
         int cdfMin = 0;
         bool cdfMinFound = false;
 
-        for (int i = 0; i <= maxIdx; i++)
+        for (nint i = 0; i <= (uint)maxIdx; i++)
         {
             histSum += Unsafe.Add(ref histogramBase, i);
             if (!cdfMinFound && histSum != 0)
@@ -101,7 +101,7 @@ internal abstract class HistogramEqualizationProcessor<TPixel> : ImageProcessor<
         int sumOverClip = 0;
         ref int histogramBase = ref MemoryMarshal.GetReference(histogram);
 
-        for (int i = 0; i < histogram.Length; i++)
+        for (nint i = 0; i < (uint)histogram.Length; i++)
         {
             ref int histogramLevel = ref Unsafe.Add(ref histogramBase, i);
             if (histogramLevel > clipLimit)
@@ -115,7 +115,7 @@ internal abstract class HistogramEqualizationProcessor<TPixel> : ImageProcessor<
         int addToEachBin = sumOverClip > 0 ? (int)MathF.Floor(sumOverClip / this.luminanceLevelsFloat) : 0;
         if (addToEachBin > 0)
         {
-            for (int i = 0; i < histogram.Length; i++)
+            for (nint i = 0; i < (uint)histogram.Length; i++)
             {
                 Unsafe.Add(ref histogramBase, i) += addToEachBin;
             }
@@ -125,7 +125,7 @@ internal abstract class HistogramEqualizationProcessor<TPixel> : ImageProcessor<
         if (residual != 0)
         {
             int residualStep = Math.Max(this.LuminanceLevels / residual, 1);
-            for (int i = 0; i < this.LuminanceLevels && residual > 0; i += residualStep, residual--)
+            for (nint i = 0; i < (uint)this.LuminanceLevels && residual > 0; i += residualStep, residual--)
             {
                 ref int histogramLevel = ref Unsafe.Add(ref histogramBase, i);
                 histogramLevel++;

--- a/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/EuclideanPixelMap{TPixel}.cs
@@ -75,7 +75,7 @@ internal sealed class EuclideanPixelMap<TPixel> : IDisposable
             return this.GetClosestColorSlow(rgba, ref paletteRef, out match);
         }
 
-        match = Unsafe.Add(ref paletteRef, index);
+        match = Unsafe.Add(ref paletteRef, (ushort)index);
         return index;
     }
 
@@ -119,7 +119,7 @@ internal sealed class EuclideanPixelMap<TPixel> : IDisposable
 
         // Now I have the index, pop it into the cache for next time
         this.cache.Add(rgba, (byte)index);
-        match = Unsafe.Add(ref paletteRef, index);
+        match = Unsafe.Add(ref paletteRef, (uint)index);
         return index;
     }
 

--- a/src/ImageSharp/Processing/Processors/Quantization/WuQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/WuQuantizer{TPixel}.cs
@@ -684,7 +684,7 @@ internal struct WuQuantizer<TPixel> : IQuantizer<TPixel>
         using IMemoryOwner<double> vvOwner = this.Configuration.MemoryAllocator.Allocate<double>(this.maxColors);
         Span<double> vv = vvOwner.GetSpan();
 
-        ref Box cube = ref this.colorCube[0];
+        ref Box cube = ref MemoryMarshal.GetArrayDataReference(this.colorCube);
         cube.RMin = cube.GMin = cube.BMin = cube.AMin = 0;
         cube.RMax = cube.GMax = cube.BMax = IndexCount - 1;
         cube.AMax = IndexAlphaCount - 1;

--- a/src/ImageSharp/Processing/Processors/Transforms/Linear/FlipProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Linear/FlipProcessor{TPixel}.cs
@@ -54,7 +54,7 @@ internal class FlipProcessor<TPixel> : ImageProcessor<TPixel>
         using IMemoryOwner<TPixel> tempBuffer = configuration.MemoryAllocator.Allocate<TPixel>(source.Width);
         Span<TPixel> temp = tempBuffer.Memory.Span;
 
-        for (int yTop = 0; yTop < height / 2; yTop++)
+        for (int yTop = 0; yTop < (int)((uint)height / 2); yTop++)
         {
             int yBottom = height - yTop - 1;
             Span<TPixel> topRow = source.DangerousGetRowSpan(yBottom);

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeHelper.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeHelper.cs
@@ -105,11 +105,11 @@ internal static class ResizeHelper
             switch (options.Position)
             {
                 case AnchorPositionMode.Left:
-                    targetY = (height - sourceHeight) / 2;
+                    targetY = (int)((uint)(height - sourceHeight) / 2);
                     targetX = 0;
                     break;
                 case AnchorPositionMode.Right:
-                    targetY = (height - sourceHeight) / 2;
+                    targetY = (int)((uint)(height - sourceHeight) / 2);
                     targetX = width - sourceWidth;
                     break;
                 case AnchorPositionMode.TopRight:
@@ -118,7 +118,7 @@ internal static class ResizeHelper
                     break;
                 case AnchorPositionMode.Top:
                     targetY = 0;
-                    targetX = (width - sourceWidth) / 2;
+                    targetX = (int)((uint)(width - sourceWidth) / 2);
                     break;
                 case AnchorPositionMode.TopLeft:
                     targetY = 0;
@@ -130,15 +130,15 @@ internal static class ResizeHelper
                     break;
                 case AnchorPositionMode.Bottom:
                     targetY = height - sourceHeight;
-                    targetX = (width - sourceWidth) / 2;
+                    targetX = (int)((uint)(width - sourceWidth) / 2);
                     break;
                 case AnchorPositionMode.BottomLeft:
                     targetY = height - sourceHeight;
                     targetX = 0;
                     break;
                 default:
-                    targetY = (height - sourceHeight) / 2;
-                    targetX = (width - sourceWidth) / 2;
+                    targetY = (int)((uint)(height - sourceHeight) / 2);
+                    targetX = (int)((uint)(width - sourceWidth) / 2);
                     break;
             }
 

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
@@ -100,7 +100,7 @@ internal partial class ResizeKernelMap : IDisposable
     /// Returns a <see cref="ResizeKernel"/> for an index value between 0 and DestinationSize - 1.
     /// </summary>
     [MethodImpl(InliningOptions.ShortMethod)]
-    internal ref ResizeKernel GetKernel(nint destIdx) => ref this.kernels[destIdx];
+    internal ref ResizeKernel GetKernel(nuint destIdx) => ref this.kernels[(int)destIdx];
 
     /// <summary>
     /// Computes the weights to apply at each pixel when resizing.

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
@@ -134,7 +134,7 @@ internal sealed class ResizeWorker<TPixel> : IDisposable
 
             for (nint x = 0; x < (right - left); x++)
             {
-                ref Vector4 firstPassColumnBase = ref Unsafe.Add(ref fpBase, x * this.workerHeight);
+                ref Vector4 firstPassColumnBase = ref Unsafe.Add(ref fpBase, x * (nint)(uint)this.workerHeight);
 
                 // Destination color components
                 Unsafe.Add(ref tempRowBase, x) = kernel.ConvolveCore(ref firstPassColumnBase);
@@ -186,13 +186,13 @@ internal sealed class ResizeWorker<TPixel> : IDisposable
             // Span<Vector4> firstPassSpan = transposedFirstPassBufferSpan.Slice(y - this.currentWindow.Min);
             ref Vector4 firstPassBaseRef = ref transposedFirstPassBufferSpan[y - this.currentWindow.Min];
 
-            for (nint x = left, z = 0; x < right; x++, z++)
+            for (nint x = left, z = 0; x < (nint)(uint)right; x++, z++)
             {
                 ResizeKernel kernel = this.horizontalKernelMap.GetKernel(x - targetOriginX);
 
                 // optimization for:
                 // firstPassSpan[x * this.workerHeight] = kernel.Convolve(tempRowSpan);
-                Unsafe.Add(ref firstPassBaseRef, z * this.workerHeight) = kernel.Convolve(tempRowSpan);
+                Unsafe.Add(ref firstPassBaseRef, z * (nint)(uint)this.workerHeight) = kernel.Convolve(tempRowSpan);
             }
         }
     }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
@@ -119,7 +119,7 @@ internal sealed class ResizeWorker<TPixel> : IDisposable
         for (int y = rowInterval.Min; y < rowInterval.Max; y++)
         {
             // Ensure offsets are normalized for cropping and padding.
-            ResizeKernel kernel = this.verticalKernelMap.GetKernel(y - this.targetOrigin.Y);
+            ResizeKernel kernel = this.verticalKernelMap.GetKernel((uint)(y - this.targetOrigin.Y));
 
             while (kernel.StartIndex + kernel.Length > this.currentWindow.Max)
             {
@@ -132,9 +132,9 @@ internal sealed class ResizeWorker<TPixel> : IDisposable
 
             ref Vector4 fpBase = ref transposedFirstPassBufferSpan[top];
 
-            for (nint x = 0; x < (right - left); x++)
+            for (nuint x = 0; x < (uint)(right - left); x++)
             {
-                ref Vector4 firstPassColumnBase = ref Unsafe.Add(ref fpBase, x * (nint)(uint)this.workerHeight);
+                ref Vector4 firstPassColumnBase = ref Unsafe.Add(ref fpBase, x * (uint)this.workerHeight);
 
                 // Destination color components
                 Unsafe.Add(ref tempRowBase, x) = kernel.ConvolveCore(ref firstPassColumnBase);
@@ -169,9 +169,9 @@ internal sealed class ResizeWorker<TPixel> : IDisposable
         Span<Vector4> tempRowSpan = this.tempRowBuffer.GetSpan();
         Span<Vector4> transposedFirstPassBufferSpan = this.transposedFirstPassBuffer.DangerousGetSingleSpan();
 
-        int left = this.targetWorkingRect.Left;
-        int right = this.targetWorkingRect.Right;
-        int targetOriginX = this.targetOrigin.X;
+        nuint left = (uint)this.targetWorkingRect.Left;
+        nuint right = (uint)this.targetWorkingRect.Right;
+        nuint targetOriginX = (uint)this.targetOrigin.X;
         for (int y = calculationInterval.Min; y < calculationInterval.Max; y++)
         {
             Span<TPixel> sourceRow = this.source.DangerousGetRowSpan(y);
@@ -186,13 +186,13 @@ internal sealed class ResizeWorker<TPixel> : IDisposable
             // Span<Vector4> firstPassSpan = transposedFirstPassBufferSpan.Slice(y - this.currentWindow.Min);
             ref Vector4 firstPassBaseRef = ref transposedFirstPassBufferSpan[y - this.currentWindow.Min];
 
-            for (nint x = left, z = 0; x < (nint)(uint)right; x++, z++)
+            for (nuint x = left, z = 0; x < right; x++, z++)
             {
                 ResizeKernel kernel = this.horizontalKernelMap.GetKernel(x - targetOriginX);
 
                 // optimization for:
                 // firstPassSpan[x * this.workerHeight] = kernel.Convolve(tempRowSpan);
-                Unsafe.Add(ref firstPassBaseRef, z * (nint)(uint)this.workerHeight) = kernel.Convolve(tempRowSpan);
+                Unsafe.Add(ref firstPassBaseRef, z * (uint)this.workerHeight) = kernel.Convolve(tempRowSpan);
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Bulk/FromVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/FromVector4.cs
@@ -103,10 +103,9 @@ public class FromVector4Rgba32 : FromVector4<Rgba32>
         Span<float> src = MemoryMarshal.Cast<Vector4, float>(this.source.GetSpan());
         Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(this.destination.GetSpan());
 
-        nuint n = (uint)(dest.Length / Vector<byte>.Count);
+        nuint n = (uint)dest.Length / (uint)Vector<byte>.Count;
 
-        ref Vector256<float> sourceBase =
-            ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(src));
+        ref Vector256<float> sourceBase = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(src));
         ref Vector256<byte> destBase = ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(dest));
 
         ref byte maskBase = ref MemoryMarshal.GetReference(PermuteMaskDeinterleave8x32);

--- a/tests/ImageSharp.Benchmarks/Bulk/FromVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/FromVector4.cs
@@ -103,7 +103,7 @@ public class FromVector4Rgba32 : FromVector4<Rgba32>
         Span<float> src = MemoryMarshal.Cast<Vector4, float>(this.source.GetSpan());
         Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(this.destination.GetSpan());
 
-        int n = dest.Length / Vector<byte>.Count;
+        nint n = (nint)(uint)dest.Length / Vector<byte>.Count;
 
         ref Vector256<float> sourceBase =
             ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(src));
@@ -114,7 +114,7 @@ public class FromVector4Rgba32 : FromVector4<Rgba32>
 
         var maxBytes = Vector256.Create(255f);
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             ref Vector256<float> s = ref Unsafe.Add(ref sourceBase, i * 4);
 

--- a/tests/ImageSharp.Benchmarks/Bulk/FromVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/FromVector4.cs
@@ -47,7 +47,7 @@ public abstract class FromVector4<TPixel>
     {
         ref Vector4 s = ref MemoryMarshal.GetReference(this.source.GetSpan());
         ref TPixel d = ref MemoryMarshal.GetReference(this.destination.GetSpan());
-        for (nint i = 0; i < (uint)this.Count; i++)
+        for (nuint i = 0; i < (uint)this.Count; i++)
         {
             Unsafe.Add(ref d, i).FromVector4(Unsafe.Add(ref s, i));
         }
@@ -103,7 +103,7 @@ public class FromVector4Rgba32 : FromVector4<Rgba32>
         Span<float> src = MemoryMarshal.Cast<Vector4, float>(this.source.GetSpan());
         Span<byte> dest = MemoryMarshal.Cast<Rgba32, byte>(this.destination.GetSpan());
 
-        nint n = (nint)(uint)dest.Length / Vector<byte>.Count;
+        nuint n = (uint)(dest.Length / Vector<byte>.Count);
 
         ref Vector256<float> sourceBase =
             ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(src));
@@ -114,7 +114,7 @@ public class FromVector4Rgba32 : FromVector4<Rgba32>
 
         var maxBytes = Vector256.Create(255f);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             ref Vector256<float> s = ref Unsafe.Add(ref sourceBase, i * 4);
 

--- a/tests/ImageSharp.Benchmarks/Bulk/FromVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/FromVector4.cs
@@ -47,7 +47,7 @@ public abstract class FromVector4<TPixel>
     {
         ref Vector4 s = ref MemoryMarshal.GetReference(this.source.GetSpan());
         ref TPixel d = ref MemoryMarshal.GetReference(this.destination.GetSpan());
-        for (int i = 0; i < this.Count; i++)
+        for (nint i = 0; i < (uint)this.Count; i++)
         {
             Unsafe.Add(ref d, i).FromVector4(Unsafe.Add(ref s, i));
         }

--- a/tests/ImageSharp.Benchmarks/Bulk/PremultiplyVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/PremultiplyVector4.cs
@@ -17,7 +17,7 @@ public class PremultiplyVector4
     {
         ref Vector4 baseRef = ref MemoryMarshal.GetReference<Vector4>(Vectors);
 
-        for (nint i = 0; i < (uint)Vectors.Length; i++)
+        for (nuint i = 0; i < (uint)Vectors.Length; i++)
         {
             ref Vector4 v = ref Unsafe.Add(ref baseRef, i);
             Premultiply(ref v);
@@ -29,7 +29,7 @@ public class PremultiplyVector4
     {
         ref Vector4 baseRef = ref MemoryMarshal.GetReference<Vector4>(Vectors);
 
-        for (nint i = 0; i < (uint)Vectors.Length; i++)
+        for (nuint i = 0; i < (uint)Vectors.Length; i++)
         {
             ref Vector4 v = ref Unsafe.Add(ref baseRef, i);
             Numerics.Premultiply(ref v);

--- a/tests/ImageSharp.Benchmarks/Bulk/PremultiplyVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/PremultiplyVector4.cs
@@ -17,7 +17,7 @@ public class PremultiplyVector4
     {
         ref Vector4 baseRef = ref MemoryMarshal.GetReference<Vector4>(Vectors);
 
-        for (int i = 0; i < Vectors.Length; i++)
+        for (nint i = 0; i < (uint)Vectors.Length; i++)
         {
             ref Vector4 v = ref Unsafe.Add(ref baseRef, i);
             Premultiply(ref v);
@@ -29,7 +29,7 @@ public class PremultiplyVector4
     {
         ref Vector4 baseRef = ref MemoryMarshal.GetReference<Vector4>(Vectors);
 
-        for (int i = 0; i < Vectors.Length; i++)
+        for (nint i = 0; i < (uint)Vectors.Length; i++)
         {
             ref Vector4 v = ref Unsafe.Add(ref baseRef, i);
             Numerics.Premultiply(ref v);

--- a/tests/ImageSharp.Benchmarks/Bulk/ToVector4_Rgba32.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/ToVector4_Rgba32.cs
@@ -54,13 +54,13 @@ public class ToVector4_Rgba32 : ToVector4<Rgba32>
         Span<byte> sBytes = MemoryMarshal.Cast<Rgba32, byte>(this.source.GetSpan());
         Span<float> dFloats = MemoryMarshal.Cast<Vector4, float>(this.destination.GetSpan());
 
-        int n = dFloats.Length / Vector<byte>.Count;
+        nint n = (nint)(uint)dFloats.Length / Vector<byte>.Count;
 
         ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference((ReadOnlySpan<byte>)sBytes));
         ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dFloats));
         ref Vector<uint> destBaseU = ref Unsafe.As<Vector<float>, Vector<uint>>(ref destBase);
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             Vector<byte> b = Unsafe.Add(ref sourceBase, i);
 
@@ -75,10 +75,10 @@ public class ToVector4_Rgba32 : ToVector4<Rgba32>
             Unsafe.Add(ref d, 3) = w3;
         }
 
-        n = dFloats.Length / Vector<float>.Count;
+        n = (nint)(uint)dFloats.Length / Vector<float>.Count;
         var scale = new Vector<float>(1f / 255f);
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             ref Vector<float> dRef = ref Unsafe.Add(ref destBase, i);
 
@@ -96,13 +96,13 @@ public class ToVector4_Rgba32 : ToVector4<Rgba32>
         Span<byte> sBytes = MemoryMarshal.Cast<Rgba32, byte>(this.source.GetSpan());
         Span<float> dFloats = MemoryMarshal.Cast<Vector4, float>(this.destination.GetSpan());
 
-        int n = dFloats.Length / Vector<byte>.Count;
+        nint n = (nint)(uint)dFloats.Length / Vector<byte>.Count;
 
         ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference((ReadOnlySpan<byte>)sBytes));
         ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dFloats));
         var scale = new Vector<float>(1f / 255f);
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             Vector<byte> b = Unsafe.Add(ref sourceBase, i);
 

--- a/tests/ImageSharp.Benchmarks/Bulk/ToVector4_Rgba32.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/ToVector4_Rgba32.cs
@@ -54,13 +54,13 @@ public class ToVector4_Rgba32 : ToVector4<Rgba32>
         Span<byte> sBytes = MemoryMarshal.Cast<Rgba32, byte>(this.source.GetSpan());
         Span<float> dFloats = MemoryMarshal.Cast<Vector4, float>(this.destination.GetSpan());
 
-        nint n = (nint)(uint)dFloats.Length / Vector<byte>.Count;
+        nuint n = (uint)(dFloats.Length / Vector<byte>.Count);
 
         ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference((ReadOnlySpan<byte>)sBytes));
         ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dFloats));
         ref Vector<uint> destBaseU = ref Unsafe.As<Vector<float>, Vector<uint>>(ref destBase);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             Vector<byte> b = Unsafe.Add(ref sourceBase, i);
 
@@ -75,10 +75,10 @@ public class ToVector4_Rgba32 : ToVector4<Rgba32>
             Unsafe.Add(ref d, 3) = w3;
         }
 
-        n = (nint)(uint)dFloats.Length / Vector<float>.Count;
+        n = (uint)(dFloats.Length / Vector<float>.Count);
         var scale = new Vector<float>(1f / 255f);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             ref Vector<float> dRef = ref Unsafe.Add(ref destBase, i);
 
@@ -96,13 +96,13 @@ public class ToVector4_Rgba32 : ToVector4<Rgba32>
         Span<byte> sBytes = MemoryMarshal.Cast<Rgba32, byte>(this.source.GetSpan());
         Span<float> dFloats = MemoryMarshal.Cast<Vector4, float>(this.destination.GetSpan());
 
-        nint n = (nint)(uint)dFloats.Length / Vector<byte>.Count;
+        nuint n = (uint)(dFloats.Length / Vector<byte>.Count);
 
         ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference((ReadOnlySpan<byte>)sBytes));
         ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dFloats));
         var scale = new Vector<float>(1f / 255f);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             Vector<byte> b = Unsafe.Add(ref sourceBase, i);
 

--- a/tests/ImageSharp.Benchmarks/Bulk/ToVector4_Rgba32.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/ToVector4_Rgba32.cs
@@ -54,7 +54,7 @@ public class ToVector4_Rgba32 : ToVector4<Rgba32>
         Span<byte> sBytes = MemoryMarshal.Cast<Rgba32, byte>(this.source.GetSpan());
         Span<float> dFloats = MemoryMarshal.Cast<Vector4, float>(this.destination.GetSpan());
 
-        nuint n = (uint)(dFloats.Length / Vector<byte>.Count);
+        nuint n = (uint)dFloats.Length / (uint)Vector<byte>.Count;
 
         ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference((ReadOnlySpan<byte>)sBytes));
         ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dFloats));
@@ -96,7 +96,7 @@ public class ToVector4_Rgba32 : ToVector4<Rgba32>
         Span<byte> sBytes = MemoryMarshal.Cast<Rgba32, byte>(this.source.GetSpan());
         Span<float> dFloats = MemoryMarshal.Cast<Vector4, float>(this.destination.GetSpan());
 
-        nuint n = (uint)(dFloats.Length / Vector<byte>.Count);
+        nuint n = (uint)dFloats.Length / (uint)Vector<byte>.Count;
 
         ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference((ReadOnlySpan<byte>)sBytes));
         ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dFloats));

--- a/tests/ImageSharp.Benchmarks/Bulk/UnPremultiplyVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/UnPremultiplyVector4.cs
@@ -17,7 +17,7 @@ public class UnPremultiplyVector4
     {
         ref Vector4 baseRef = ref MemoryMarshal.GetReference<Vector4>(Vectors);
 
-        for (int i = 0; i < Vectors.Length; i++)
+        for (nint i = 0; i < (uint)Vectors.Length; i++)
         {
             ref Vector4 v = ref Unsafe.Add(ref baseRef, i);
 
@@ -30,7 +30,7 @@ public class UnPremultiplyVector4
     {
         ref Vector4 baseRef = ref MemoryMarshal.GetReference<Vector4>(Vectors);
 
-        for (int i = 0; i < Vectors.Length; i++)
+        for (nint i = 0; i < (uint)Vectors.Length; i++)
         {
             ref Vector4 v = ref Unsafe.Add(ref baseRef, i);
             Numerics.UnPremultiply(ref v);

--- a/tests/ImageSharp.Benchmarks/Bulk/UnPremultiplyVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Bulk/UnPremultiplyVector4.cs
@@ -17,7 +17,7 @@ public class UnPremultiplyVector4
     {
         ref Vector4 baseRef = ref MemoryMarshal.GetReference<Vector4>(Vectors);
 
-        for (nint i = 0; i < (uint)Vectors.Length; i++)
+        for (nuint i = 0; i < (uint)Vectors.Length; i++)
         {
             ref Vector4 v = ref Unsafe.Add(ref baseRef, i);
 
@@ -30,7 +30,7 @@ public class UnPremultiplyVector4
     {
         ref Vector4 baseRef = ref MemoryMarshal.GetReference<Vector4>(Vectors);
 
-        for (nint i = 0; i < (uint)Vectors.Length; i++)
+        for (nuint i = 0; i < (uint)Vectors.Length; i++)
         {
             ref Vector4 v = ref Unsafe.Add(ref baseRef, i);
             Numerics.UnPremultiply(ref v);

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_CopyTo1x1.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_CopyTo1x1.cs
@@ -72,8 +72,8 @@ public unsafe class Block8x8F_CopyTo1x1
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void CopyRowImpl(ref byte selfBase, ref byte destBase, int destStride, int row)
     {
-        ref byte s = ref Unsafe.Add(ref selfBase, row * 8 * sizeof(float));
-        ref byte d = ref Unsafe.Add(ref destBase, row * destStride);
+        ref byte s = ref Unsafe.Add(ref selfBase, (uint)row * 8 * sizeof(float));
+        ref byte d = ref Unsafe.Add(ref destBase, (uint)(row * destStride));
         Unsafe.CopyBlock(ref d, ref s, 8 * sizeof(float));
     }
 
@@ -82,7 +82,7 @@ public unsafe class Block8x8F_CopyTo1x1
     {
         ref Block8x8F s = ref this.block;
         ref float origin = ref Unsafe.AsRef<float>(this.bufferPtr);
-        int stride = Width;
+        nint stride = (nint)(uint)Width;
 
         ref Vector<float> d0 = ref Unsafe.As<float, Vector<float>>(ref origin);
         ref Vector<float> d1 = ref Unsafe.As<float, Vector<float>>(ref Unsafe.Add(ref origin, stride));
@@ -117,7 +117,7 @@ public unsafe class Block8x8F_CopyTo1x1
     {
         ref Block8x8F s = ref this.block;
         ref float origin = ref Unsafe.AsRef<float>(this.bufferPtr);
-        int stride = Width;
+        nint stride = (nint)(uint)Width;
 
         ref Vector<float> d0 = ref Unsafe.As<float, Vector<float>>(ref origin);
         ref Vector<float> d1 = ref Unsafe.As<float, Vector<float>>(ref Unsafe.Add(ref origin, stride));
@@ -141,29 +141,29 @@ public unsafe class Block8x8F_CopyTo1x1
     [Benchmark]
     public void UseVector8_V3()
     {
-        int stride = Width * sizeof(float);
+        nint stride = (nint)(uint)Width * sizeof(float);
         ref float d = ref this.unpinnedBuffer[0];
         ref Vector<float> s = ref Unsafe.As<Block8x8F, Vector<float>>(ref this.block);
 
         Vector<float> v0 = s;
-        Vector<float> v1 = Unsafe.AddByteOffset(ref s, (IntPtr)1);
-        Vector<float> v2 = Unsafe.AddByteOffset(ref s, (IntPtr)2);
-        Vector<float> v3 = Unsafe.AddByteOffset(ref s, (IntPtr)3);
+        Vector<float> v1 = Unsafe.AddByteOffset(ref s, 1);
+        Vector<float> v2 = Unsafe.AddByteOffset(ref s, 2);
+        Vector<float> v3 = Unsafe.AddByteOffset(ref s, 3);
 
         Unsafe.As<float, Vector<float>>(ref d) = v0;
-        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)stride)) = v1;
-        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 2))) = v2;
-        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 3))) = v3;
+        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, stride)) = v1;
+        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, stride * 2)) = v2;
+        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, stride * 3)) = v3;
 
-        v0 = Unsafe.AddByteOffset(ref s, (IntPtr)4);
-        v1 = Unsafe.AddByteOffset(ref s, (IntPtr)5);
-        v2 = Unsafe.AddByteOffset(ref s, (IntPtr)6);
-        v3 = Unsafe.AddByteOffset(ref s, (IntPtr)7);
+        v0 = Unsafe.AddByteOffset(ref s, 4);
+        v1 = Unsafe.AddByteOffset(ref s, 5);
+        v2 = Unsafe.AddByteOffset(ref s, 6);
+        v3 = Unsafe.AddByteOffset(ref s, 7);
 
-        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 4))) = v0;
-        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 5))) = v1;
-        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 6))) = v2;
-        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 7))) = v3;
+        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, stride * 4)) = v0;
+        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, stride * 5)) = v1;
+        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, stride * 6)) = v2;
+        Unsafe.As<float, Vector<float>>(ref Unsafe.AddByteOffset(ref d, stride * 7)) = v3;
     }
 
     [Benchmark]
@@ -254,7 +254,7 @@ public unsafe class Block8x8F_CopyTo1x1
     [Benchmark]
     public void UseVector256_Avx2_Variant3_RefCast()
     {
-        int stride = Width;
+        nint stride = (nint)(uint)Width;
         ref float d = ref this.unpinnedBuffer[0];
         ref Vector256<float> s = ref Unsafe.As<Block8x8F, Vector256<float>>(ref this.block);
 
@@ -282,29 +282,29 @@ public unsafe class Block8x8F_CopyTo1x1
     [Benchmark]
     public void UseVector256_Avx2_Variant3_RefCast_Mod()
     {
-        int stride = Width * sizeof(float);
+        nint stride = (nint)(uint)Width * sizeof(float);
         ref float d = ref this.unpinnedBuffer[0];
         ref Vector256<float> s = ref Unsafe.As<Block8x8F, Vector256<float>>(ref this.block);
 
         Vector256<float> v0 = s;
-        Vector256<float> v1 = Unsafe.AddByteOffset(ref s, (IntPtr)1);
-        Vector256<float> v2 = Unsafe.AddByteOffset(ref s, (IntPtr)2);
-        Vector256<float> v3 = Unsafe.AddByteOffset(ref s, (IntPtr)3);
+        Vector256<float> v1 = Unsafe.AddByteOffset(ref s, 1);
+        Vector256<float> v2 = Unsafe.AddByteOffset(ref s, 2);
+        Vector256<float> v3 = Unsafe.AddByteOffset(ref s, 3);
 
         Unsafe.As<float, Vector256<float>>(ref d) = v0;
-        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)stride)) = v1;
-        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 2))) = v2;
-        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 3))) = v3;
+        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, stride)) = v1;
+        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, stride * 2)) = v2;
+        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, stride * 3)) = v3;
 
-        v0 = Unsafe.AddByteOffset(ref s, (IntPtr)4);
-        v1 = Unsafe.AddByteOffset(ref s, (IntPtr)5);
-        v2 = Unsafe.AddByteOffset(ref s, (IntPtr)6);
-        v3 = Unsafe.AddByteOffset(ref s, (IntPtr)7);
+        v0 = Unsafe.AddByteOffset(ref s, 4);
+        v1 = Unsafe.AddByteOffset(ref s, 5);
+        v2 = Unsafe.AddByteOffset(ref s, 6);
+        v3 = Unsafe.AddByteOffset(ref s, 7);
 
-        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 4))) = v0;
-        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 5))) = v1;
-        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 6))) = v2;
-        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, (IntPtr)(stride * 7))) = v3;
+        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, stride * 4)) = v0;
+        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, stride * 5)) = v1;
+        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, stride * 6)) = v2;
+        Unsafe.As<float, Vector256<float>>(ref Unsafe.AddByteOffset(ref d, stride * 7)) = v3;
     }
 
     // [Benchmark]

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_CopyTo1x1.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_CopyTo1x1.cs
@@ -82,7 +82,7 @@ public unsafe class Block8x8F_CopyTo1x1
     {
         ref Block8x8F s = ref this.block;
         ref float origin = ref Unsafe.AsRef<float>(this.bufferPtr);
-        nint stride = (nint)(uint)Width;
+        nuint stride = (uint)Width;
 
         ref Vector<float> d0 = ref Unsafe.As<float, Vector<float>>(ref origin);
         ref Vector<float> d1 = ref Unsafe.As<float, Vector<float>>(ref Unsafe.Add(ref origin, stride));
@@ -117,7 +117,7 @@ public unsafe class Block8x8F_CopyTo1x1
     {
         ref Block8x8F s = ref this.block;
         ref float origin = ref Unsafe.AsRef<float>(this.bufferPtr);
-        nint stride = (nint)(uint)Width;
+        nuint stride = (uint)Width;
 
         ref Vector<float> d0 = ref Unsafe.As<float, Vector<float>>(ref origin);
         ref Vector<float> d1 = ref Unsafe.As<float, Vector<float>>(ref Unsafe.Add(ref origin, stride));
@@ -141,7 +141,7 @@ public unsafe class Block8x8F_CopyTo1x1
     [Benchmark]
     public void UseVector8_V3()
     {
-        nint stride = (nint)(uint)Width * sizeof(float);
+        nuint stride = (uint)Width * sizeof(float);
         ref float d = ref this.unpinnedBuffer[0];
         ref Vector<float> s = ref Unsafe.As<Block8x8F, Vector<float>>(ref this.block);
 
@@ -254,7 +254,7 @@ public unsafe class Block8x8F_CopyTo1x1
     [Benchmark]
     public void UseVector256_Avx2_Variant3_RefCast()
     {
-        nint stride = (nint)(uint)Width;
+        nuint stride = (uint)Width;
         ref float d = ref this.unpinnedBuffer[0];
         ref Vector256<float> s = ref Unsafe.As<Block8x8F, Vector256<float>>(ref this.block);
 
@@ -282,7 +282,7 @@ public unsafe class Block8x8F_CopyTo1x1
     [Benchmark]
     public void UseVector256_Avx2_Variant3_RefCast_Mod()
     {
-        nint stride = (nint)(uint)Width * sizeof(float);
+        nuint stride = (uint)Width * sizeof(float);
         ref float d = ref this.unpinnedBuffer[0];
         ref Vector256<float> s = ref Unsafe.As<Block8x8F, Vector256<float>>(ref this.block);
 

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_CopyTo2x2.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_CopyTo2x2.cs
@@ -47,9 +47,9 @@ public class Block8x8F_CopyTo2x2
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void WidenCopyImpl2x2(ref Block8x8F src, ref float destBase, int row, int destStride)
     {
-        ref Vector4 selfLeft = ref Unsafe.Add(ref src.V0L, 2 * row);
+        ref Vector4 selfLeft = ref Unsafe.Add(ref src.V0L, 2 * (uint)row);
         ref Vector4 selfRight = ref Unsafe.Add(ref selfLeft, 1);
-        ref float destLocalOrigo = ref Unsafe.Add(ref destBase, row * 2 * destStride);
+        ref float destLocalOrigo = ref Unsafe.Add(ref destBase, (uint)(row * 2 * destStride));
 
         Unsafe.Add(ref destLocalOrigo, 0) = selfLeft.X;
         Unsafe.Add(ref destLocalOrigo, 1) = selfLeft.X;
@@ -69,23 +69,23 @@ public class Block8x8F_CopyTo2x2
         Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, 8), 6) = selfRight.W;
         Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, 8), 7) = selfRight.W;
 
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride), 0) = selfLeft.X;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride), 1) = selfLeft.X;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride), 2) = selfLeft.Y;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride), 3) = selfLeft.Y;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride), 4) = selfLeft.Z;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride), 5) = selfLeft.Z;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride), 6) = selfLeft.W;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride), 7) = selfLeft.W;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride), 0) = selfLeft.X;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride), 1) = selfLeft.X;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride), 2) = selfLeft.Y;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride), 3) = selfLeft.Y;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride), 4) = selfLeft.Z;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride), 5) = selfLeft.Z;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride), 6) = selfLeft.W;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride), 7) = selfLeft.W;
 
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride + 8), 0) = selfRight.X;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride + 8), 1) = selfRight.X;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride + 8), 2) = selfRight.Y;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride + 8), 3) = selfRight.Y;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride + 8), 4) = selfRight.Z;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride + 8), 5) = selfRight.Z;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride + 8), 6) = selfRight.W;
-        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, destStride + 8), 7) = selfRight.W;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride + 8), 0) = selfRight.X;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride + 8), 1) = selfRight.X;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride + 8), 2) = selfRight.Y;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride + 8), 3) = selfRight.Y;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride + 8), 4) = selfRight.Z;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride + 8), 5) = selfRight.Z;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride + 8), 6) = selfRight.W;
+        Unsafe.Add(ref Unsafe.Add(ref destLocalOrigo, (uint)destStride + 8), 7) = selfRight.W;
     }
 
     [Benchmark]
@@ -109,9 +109,9 @@ public class Block8x8F_CopyTo2x2
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void WidenCopyImpl2x2_V2(ref Block8x8F src, ref float destBase, int row, int destStride)
     {
-        ref Vector4 selfLeft = ref Unsafe.Add(ref src.V0L, 2 * row);
+        ref Vector4 selfLeft = ref Unsafe.Add(ref src.V0L, 2 * (uint)row);
         ref Vector4 selfRight = ref Unsafe.Add(ref selfLeft, 1);
-        ref float dest0 = ref Unsafe.Add(ref destBase, row * 2 * destStride);
+        ref float dest0 = ref Unsafe.Add(ref destBase, (uint)(row * 2 * destStride));
 
         Unsafe.Add(ref dest0, 0) = selfLeft.X;
         Unsafe.Add(ref dest0, 1) = selfLeft.X;
@@ -133,7 +133,7 @@ public class Block8x8F_CopyTo2x2
         Unsafe.Add(ref dest1, 6) = selfRight.W;
         Unsafe.Add(ref dest1, 7) = selfRight.W;
 
-        ref float dest2 = ref Unsafe.Add(ref dest0, destStride);
+        ref float dest2 = ref Unsafe.Add(ref dest0, (uint)destStride);
 
         Unsafe.Add(ref dest2, 0) = selfLeft.X;
         Unsafe.Add(ref dest2, 1) = selfLeft.X;
@@ -177,12 +177,12 @@ public class Block8x8F_CopyTo2x2
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void WidenCopyImpl2x2_Vector2(ref Block8x8F src, ref Vector2 destBase, int row, int destStride)
     {
-        ref Vector4 sLeft = ref Unsafe.Add(ref src.V0L, 2 * row);
+        ref Vector4 sLeft = ref Unsafe.Add(ref src.V0L, 2 * (uint)row);
         ref Vector4 sRight = ref Unsafe.Add(ref sLeft, 1);
 
-        ref Vector2 dTopLeft = ref Unsafe.Add(ref destBase, 2 * row * destStride);
+        ref Vector2 dTopLeft = ref Unsafe.Add(ref destBase, (uint)(2 * row * destStride));
         ref Vector2 dTopRight = ref Unsafe.Add(ref dTopLeft, 4);
-        ref Vector2 dBottomLeft = ref Unsafe.Add(ref dTopLeft, destStride);
+        ref Vector2 dBottomLeft = ref Unsafe.Add(ref dTopLeft, (uint)destStride);
         ref Vector2 dBottomRight = ref Unsafe.Add(ref dBottomLeft, 4);
 
         var xLeft = new Vector2(sLeft.X);
@@ -237,12 +237,12 @@ public class Block8x8F_CopyTo2x2
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void WidenCopyImpl2x2_Vector4(ref Block8x8F src, ref Vector2 destBase, int row, int destStride)
     {
-        ref Vector4 sLeft = ref Unsafe.Add(ref src.V0L, 2 * row);
+        ref Vector4 sLeft = ref Unsafe.Add(ref src.V0L, 2 * (uint)row);
         ref Vector4 sRight = ref Unsafe.Add(ref sLeft, 1);
 
-        ref Vector2 dTopLeft = ref Unsafe.Add(ref destBase, 2 * row * destStride);
+        ref Vector2 dTopLeft = ref Unsafe.Add(ref destBase, (uint)(2 * row * destStride));
         ref Vector2 dTopRight = ref Unsafe.Add(ref dTopLeft, 4);
-        ref Vector2 dBottomLeft = ref Unsafe.Add(ref dTopLeft, destStride);
+        ref Vector2 dBottomLeft = ref Unsafe.Add(ref dTopLeft, (uint)destStride);
         ref Vector2 dBottomRight = ref Unsafe.Add(ref dBottomLeft, 4);
 
         var xLeft = new Vector4(sLeft.X);
@@ -297,11 +297,11 @@ public class Block8x8F_CopyTo2x2
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void WidenCopyImpl2x2_Vector4_SafeRightCorner(ref Block8x8F src, ref Vector2 destBase, int row, int destStride)
     {
-        ref Vector4 sLeft = ref Unsafe.Add(ref src.V0L, 2 * row);
+        ref Vector4 sLeft = ref Unsafe.Add(ref src.V0L, 2 * (uint)row);
         ref Vector4 sRight = ref Unsafe.Add(ref sLeft, 1);
 
-        ref Vector2 dTopLeft = ref Unsafe.Add(ref destBase, 2 * row * destStride);
-        ref Vector2 dBottomLeft = ref Unsafe.Add(ref dTopLeft, destStride);
+        ref Vector2 dTopLeft = ref Unsafe.Add(ref destBase, (uint)(2 * row * destStride));
+        ref Vector2 dBottomLeft = ref Unsafe.Add(ref dTopLeft, (uint)destStride);
 
         var xLeft = new Vector4(sLeft.X);
         var yLeft = new Vector4(sLeft.Y);
@@ -355,12 +355,12 @@ public class Block8x8F_CopyTo2x2
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void WidenCopyImpl2x2_Vector4_V2(ref Block8x8F src, ref Vector2 destBase, int row, int destStride)
     {
-        ref Vector4 sLeft = ref Unsafe.Add(ref src.V0L, 2 * row);
+        ref Vector4 sLeft = ref Unsafe.Add(ref src.V0L, 2 * (uint)row);
         ref Vector4 sRight = ref Unsafe.Add(ref sLeft, 1);
 
         int offset = 2 * row * destStride;
-        ref Vector4 dTopLeft = ref Unsafe.As<Vector2, Vector4>(ref Unsafe.Add(ref destBase, offset));
-        ref Vector4 dBottomLeft = ref Unsafe.As<Vector2, Vector4>(ref Unsafe.Add(ref destBase, offset + destStride));
+        ref Vector4 dTopLeft = ref Unsafe.As<Vector2, Vector4>(ref Unsafe.Add(ref destBase, (uint)offset));
+        ref Vector4 dBottomLeft = ref Unsafe.As<Vector2, Vector4>(ref Unsafe.Add(ref destBase, (uint)(offset + destStride)));
 
         var xyLeft = new Vector4(sLeft.X)
         {

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_Round.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_Round.cs
@@ -54,7 +54,7 @@ public unsafe class Block8x8F_Round
     {
         ref float b = ref Unsafe.As<Block8x8F, float>(ref this.block);
 
-        for (int i = 0; i < Block8x8F.Size; i++)
+        for (nint i = 0; i < Block8x8F.Size; i++)
         {
             ref float v = ref Unsafe.Add(ref b, i);
             v = (float)Math.Round(v);
@@ -178,7 +178,7 @@ public unsafe class Block8x8F_Round
     {
         ref Vector128<float> p = ref Unsafe.As<Block8x8F, Vector128<float>>(ref this.block);
         p = Sse41.RoundToNearestInteger(p);
-        var offset = (IntPtr)sizeof(Vector128<float>);
+        nint offset = sizeof(Vector128<float>);
         p = Sse41.RoundToNearestInteger(p);
 
         p = ref Unsafe.AddByteOffset(ref p, offset);
@@ -218,7 +218,7 @@ public unsafe class Block8x8F_Round
     {
         ref Vector128<float> p = ref Unsafe.As<Block8x8F, Vector128<float>>(ref this.block);
         p = Sse41.RoundToNearestInteger(p);
-        var offset = (IntPtr)sizeof(Vector128<float>);
+        nint offset = sizeof(Vector128<float>);
 
         for (int i = 0; i < 15; i++)
         {
@@ -231,7 +231,7 @@ public unsafe class Block8x8F_Round
     public unsafe void Sse41_V4()
     {
         ref Vector128<float> p = ref Unsafe.As<Block8x8F, Vector128<float>>(ref this.block);
-        var offset = (IntPtr)sizeof(Vector128<float>);
+        nint offset = sizeof(Vector128<float>);
 
         ref Vector128<float> a = ref p;
         ref Vector128<float> b = ref Unsafe.AddByteOffset(ref a, offset);

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_Round.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/BlockOperations/Block8x8F_Round.cs
@@ -54,7 +54,7 @@ public unsafe class Block8x8F_Round
     {
         ref float b = ref Unsafe.As<Block8x8F, float>(ref this.block);
 
-        for (nint i = 0; i < Block8x8F.Size; i++)
+        for (nuint i = 0; i < Block8x8F.Size; i++)
         {
             ref float v = ref Unsafe.Add(ref b, i);
             v = (float)Math.Round(v);
@@ -178,7 +178,7 @@ public unsafe class Block8x8F_Round
     {
         ref Vector128<float> p = ref Unsafe.As<Block8x8F, Vector128<float>>(ref this.block);
         p = Sse41.RoundToNearestInteger(p);
-        nint offset = sizeof(Vector128<float>);
+        nuint offset = (uint)sizeof(Vector128<float>);
         p = Sse41.RoundToNearestInteger(p);
 
         p = ref Unsafe.AddByteOffset(ref p, offset);
@@ -218,7 +218,7 @@ public unsafe class Block8x8F_Round
     {
         ref Vector128<float> p = ref Unsafe.As<Block8x8F, Vector128<float>>(ref this.block);
         p = Sse41.RoundToNearestInteger(p);
-        nint offset = sizeof(Vector128<float>);
+        nuint offset = (uint)sizeof(Vector128<float>);
 
         for (int i = 0; i < 15; i++)
         {
@@ -231,7 +231,7 @@ public unsafe class Block8x8F_Round
     public unsafe void Sse41_V4()
     {
         ref Vector128<float> p = ref Unsafe.As<Block8x8F, Vector128<float>>(ref this.block);
-        nint offset = sizeof(Vector128<float>);
+        nuint offset = (uint)sizeof(Vector128<float>);
 
         ref Vector128<float> a = ref p;
         ref Vector128<float> b = ref Unsafe.AddByteOffset(ref a, offset);

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromRgba32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromRgba32.cs
@@ -34,7 +34,7 @@ public abstract class PixelConversion_ConvertFromRgba32
             ref T destBaseRef = ref this.Dest[0];
             ref Rgba32 sourceBaseRef = ref this.Source[0];
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i).FromRgba32(ref Unsafe.Add(ref sourceBaseRef, i));
             }
@@ -48,7 +48,7 @@ public abstract class PixelConversion_ConvertFromRgba32
             ref T destBaseRef = ref this.Dest[0];
             ref Rgba32 sourceBaseRef = ref this.Source[0];
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i).FromRgba32(Unsafe.Add(ref sourceBaseRef, i));
             }
@@ -62,7 +62,7 @@ public abstract class PixelConversion_ConvertFromRgba32
             ref T destBaseRef = ref this.Dest[0];
             ref Rgba32 sourceBaseRef = ref this.Source[0];
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 ref Rgba32 s = ref Unsafe.Add(ref sourceBaseRef, i);
                 Unsafe.Add(ref destBaseRef, i).FromBytes(s.R, s.G, s.B, s.A);
@@ -111,7 +111,7 @@ public class PixelConversion_ConvertFromRgba32_Compatible : PixelConversion_Conv
         ref Rgba32 sBase = ref this.CompatibleMemLayoutRunner.Source[0];
         ref Rgba32 dBase = ref Unsafe.As<TestRgba, Rgba32>(ref this.CompatibleMemLayoutRunner.Dest[0]);
 
-        for (nint i = 0; i < (uint)this.Count; i++)
+        for (nuint i = 0; i < (uint)this.Count; i++)
         {
             Unsafe.Add(ref dBase, i) = Unsafe.Add(ref sBase, i);
         }
@@ -151,7 +151,7 @@ public class PixelConversion_ConvertFromRgba32_Permuted_RgbaToArgb : PixelConver
         ref Rgba32 sBase = ref this.PermutedRunnerRgbaToArgb.Source[0];
         ref TestArgb dBase = ref this.PermutedRunnerRgbaToArgb.Dest[0];
 
-        for (nint i = 0; i < (uint)this.Count; i++)
+        for (nuint i = 0; i < (uint)this.Count; i++)
         {
             Rgba32 s = Unsafe.Add(ref sBase, i);
             ref TestArgb d = ref Unsafe.Add(ref dBase, i);

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromRgba32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromRgba32.cs
@@ -34,7 +34,7 @@ public abstract class PixelConversion_ConvertFromRgba32
             ref T destBaseRef = ref this.Dest[0];
             ref Rgba32 sourceBaseRef = ref this.Source[0];
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i).FromRgba32(ref Unsafe.Add(ref sourceBaseRef, i));
             }
@@ -48,7 +48,7 @@ public abstract class PixelConversion_ConvertFromRgba32
             ref T destBaseRef = ref this.Dest[0];
             ref Rgba32 sourceBaseRef = ref this.Source[0];
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i).FromRgba32(Unsafe.Add(ref sourceBaseRef, i));
             }
@@ -62,7 +62,7 @@ public abstract class PixelConversion_ConvertFromRgba32
             ref T destBaseRef = ref this.Dest[0];
             ref Rgba32 sourceBaseRef = ref this.Source[0];
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 ref Rgba32 s = ref Unsafe.Add(ref sourceBaseRef, i);
                 Unsafe.Add(ref destBaseRef, i).FromBytes(s.R, s.G, s.B, s.A);
@@ -111,7 +111,7 @@ public class PixelConversion_ConvertFromRgba32_Compatible : PixelConversion_Conv
         ref Rgba32 sBase = ref this.CompatibleMemLayoutRunner.Source[0];
         ref Rgba32 dBase = ref Unsafe.As<TestRgba, Rgba32>(ref this.CompatibleMemLayoutRunner.Dest[0]);
 
-        for (int i = 0; i < this.Count; i++)
+        for (nint i = 0; i < (uint)this.Count; i++)
         {
             Unsafe.Add(ref dBase, i) = Unsafe.Add(ref sBase, i);
         }
@@ -151,7 +151,7 @@ public class PixelConversion_ConvertFromRgba32_Permuted_RgbaToArgb : PixelConver
         ref Rgba32 sBase = ref this.PermutedRunnerRgbaToArgb.Source[0];
         ref TestArgb dBase = ref this.PermutedRunnerRgbaToArgb.Dest[0];
 
-        for (int i = 0; i < this.Count; i++)
+        for (nint i = 0; i < (uint)this.Count; i++)
         {
             Rgba32 s = Unsafe.Add(ref sBase, i);
             ref TestArgb d = ref Unsafe.Add(ref dBase, i);

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromVector4.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromVector4.cs
@@ -71,7 +71,7 @@ public class PixelConversion_ConvertFromVector4
             ref T destBaseRef = ref this.dest[0];
             ref Vector4 sourceBaseRef = ref this.source[0];
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i).FromVector4(ref Unsafe.Add(ref sourceBaseRef, i));
             }
@@ -85,7 +85,7 @@ public class PixelConversion_ConvertFromVector4
             ref T destBaseRef = ref this.dest[0];
             ref Vector4 sourceBaseRef = ref this.source[0];
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i).FromVector4(Unsafe.Add(ref sourceBaseRef, i));
             }

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromVector4.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertFromVector4.cs
@@ -71,7 +71,7 @@ public class PixelConversion_ConvertFromVector4
             ref T destBaseRef = ref this.dest[0];
             ref Vector4 sourceBaseRef = ref this.source[0];
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i).FromVector4(ref Unsafe.Add(ref sourceBaseRef, i));
             }
@@ -85,7 +85,7 @@ public class PixelConversion_ConvertFromVector4
             ref T destBaseRef = ref this.dest[0];
             ref Vector4 sourceBaseRef = ref this.source[0];
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i).FromVector4(Unsafe.Add(ref sourceBaseRef, i));
             }

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToRgba32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToRgba32.cs
@@ -38,7 +38,7 @@ public class PixelConversion_ConvertToRgba32
             ref T sourceBaseRef = ref this.source[0];
             ref Rgba32 destBaseRef = ref this.dest[0];
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i) = Unsafe.Add(ref sourceBaseRef, i).ToRgba32();
             }
@@ -52,7 +52,7 @@ public class PixelConversion_ConvertToRgba32
             ref T sourceBaseRef = ref this.source[0];
             ref Rgba32 destBaseRef = ref this.dest[0];
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref sourceBaseRef, i).CopyToRgba32(ref Unsafe.Add(ref destBaseRef, i));
             }

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToRgba32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToRgba32.cs
@@ -38,7 +38,7 @@ public class PixelConversion_ConvertToRgba32
             ref T sourceBaseRef = ref this.source[0];
             ref Rgba32 destBaseRef = ref this.dest[0];
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i) = Unsafe.Add(ref sourceBaseRef, i).ToRgba32();
             }
@@ -52,7 +52,7 @@ public class PixelConversion_ConvertToRgba32
             ref T sourceBaseRef = ref this.source[0];
             ref Rgba32 destBaseRef = ref this.dest[0];
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref sourceBaseRef, i).CopyToRgba32(ref Unsafe.Add(ref destBaseRef, i));
             }

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToRgba32_AsPartOfCompositeOperation.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToRgba32_AsPartOfCompositeOperation.cs
@@ -33,7 +33,7 @@ public class PixelConversion_ConvertToRgba32_AsPartOfCompositeOperation
 
             Rgba32 temp;
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 temp = Unsafe.Add(ref sourceBaseRef, i).ToRgba32();
 
@@ -54,7 +54,7 @@ public class PixelConversion_ConvertToRgba32_AsPartOfCompositeOperation
 
             Rgba32 temp = default;
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref sourceBaseRef, i).CopyToRgba32(ref temp);
 

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToRgba32_AsPartOfCompositeOperation.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToRgba32_AsPartOfCompositeOperation.cs
@@ -33,7 +33,7 @@ public class PixelConversion_ConvertToRgba32_AsPartOfCompositeOperation
 
             Rgba32 temp;
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 temp = Unsafe.Add(ref sourceBaseRef, i).ToRgba32();
 
@@ -54,7 +54,7 @@ public class PixelConversion_ConvertToRgba32_AsPartOfCompositeOperation
 
             Rgba32 temp = default;
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref sourceBaseRef, i).CopyToRgba32(ref temp);
 

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToVector4.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToVector4.cs
@@ -30,7 +30,7 @@ public class PixelConversion_ConvertToVector4
             ref T sourceBaseRef = ref this.source[0];
             ref Vector4 destBaseRef = ref this.dest[0];
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i) = Unsafe.Add(ref sourceBaseRef, i).ToVector4();
             }
@@ -44,7 +44,7 @@ public class PixelConversion_ConvertToVector4
             ref T sourceBaseRef = ref this.source[0];
             ref Vector4 destBaseRef = ref this.dest[0];
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref sourceBaseRef, i).CopyToVector4(ref Unsafe.Add(ref destBaseRef, i));
             }

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToVector4.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToVector4.cs
@@ -30,7 +30,7 @@ public class PixelConversion_ConvertToVector4
             ref T sourceBaseRef = ref this.source[0];
             ref Vector4 destBaseRef = ref this.dest[0];
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref destBaseRef, i) = Unsafe.Add(ref sourceBaseRef, i).ToVector4();
             }
@@ -44,7 +44,7 @@ public class PixelConversion_ConvertToVector4
             ref T sourceBaseRef = ref this.source[0];
             ref Vector4 destBaseRef = ref this.dest[0];
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref sourceBaseRef, i).CopyToVector4(ref Unsafe.Add(ref destBaseRef, i));
             }

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToVector4_AsPartOfCompositeOperation.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToVector4_AsPartOfCompositeOperation.cs
@@ -32,7 +32,7 @@ public class PixelConversion_ConvertToVector4_AsPartOfCompositeOperation
 
             Vector4 temp;
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 temp = Unsafe.Add(ref sourceBaseRef, i).ToVector4();
 
@@ -53,7 +53,7 @@ public class PixelConversion_ConvertToVector4_AsPartOfCompositeOperation
 
             Vector4 temp = default;
 
-            for (nint i = 0; i < (uint)count; i++)
+            for (nuint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref sourceBaseRef, i).CopyToVector4(ref temp);
 

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToVector4_AsPartOfCompositeOperation.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_ConvertToVector4_AsPartOfCompositeOperation.cs
@@ -32,7 +32,7 @@ public class PixelConversion_ConvertToVector4_AsPartOfCompositeOperation
 
             Vector4 temp;
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 temp = Unsafe.Add(ref sourceBaseRef, i).ToVector4();
 
@@ -53,7 +53,7 @@ public class PixelConversion_ConvertToVector4_AsPartOfCompositeOperation
 
             Vector4 temp = default;
 
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 Unsafe.Add(ref sourceBaseRef, i).CopyToVector4(ref temp);
 

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_PackFromRgbPlanes.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_PackFromRgbPlanes.cs
@@ -92,7 +92,7 @@ public unsafe class PixelConversion_PackFromRgbPlanes
         ref byte b = ref this.rBuf[0];
         ref Rgb24 rgb = ref this.rgbBuf[0];
 
-        for (nint i = 0; i < (uint)this.Count; i++)
+        for (nuint i = 0; i < (uint)this.Count; i++)
         {
             ref Rgb24 d = ref Unsafe.Add(ref rgb, i);
             d.R = Unsafe.Add(ref r, i);
@@ -110,7 +110,7 @@ public unsafe class PixelConversion_PackFromRgbPlanes
         ref Rgb24 rgb = ref this.rgbBuf[0];
 
         int count = this.Count / 8;
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb24 d0 = ref Unsafe.Add(ref rgb, i * 8);
             ref Rgb24 d1 = ref Unsafe.Add(ref d0, 1);
@@ -168,7 +168,7 @@ public unsafe class PixelConversion_PackFromRgbPlanes
         ref Rgb24 rgb = ref this.rgbBuf[0];
 
         int count = this.Count / 4;
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             ref Rgb24 d0 = ref Unsafe.Add(ref rgb, i * 4);
             ref Rgb24 d1 = ref Unsafe.Add(ref d0, 1);
@@ -205,14 +205,14 @@ public unsafe class PixelConversion_PackFromRgbPlanes
         ref Vector256<float> bBase = ref Unsafe.As<float, Vector256<float>>(ref this.bFloat[0]);
         ref Vector256<float> resultBase = ref Unsafe.As<float, Vector256<float>>(ref this.rgbaFloat[0]);
 
-        nint count = (nint)(uint)this.Count / Vector256<float>.Count;
+        nuint count = (uint)(this.Count / Vector256<float>.Count);
 
         ref byte control = ref MemoryMarshal.GetReference(SimdUtils.HwIntrinsics.PermuteMaskEvenOdd8x32);
         Vector256<int> vcontrol = Unsafe.As<byte, Vector256<int>>(ref control);
 
         var va = Vector256.Create(1F);
 
-        for (nint i = 0; i < count; i++)
+        for (nuint i = 0; i < count; i++)
         {
             Vector256<float> r = Unsafe.Add(ref rBase, i);
             Vector256<float> g = Unsafe.Add(ref gBase, i);

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_PackFromRgbPlanes.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_PackFromRgbPlanes.cs
@@ -205,7 +205,7 @@ public unsafe class PixelConversion_PackFromRgbPlanes
         ref Vector256<float> bBase = ref Unsafe.As<float, Vector256<float>>(ref this.bFloat[0]);
         ref Vector256<float> resultBase = ref Unsafe.As<float, Vector256<float>>(ref this.rgbaFloat[0]);
 
-        nuint count = (uint)(this.Count / Vector256<float>.Count);
+        nuint count = (uint)this.Count / (uint)Vector256<float>.Count;
 
         ref byte control = ref MemoryMarshal.GetReference(SimdUtils.HwIntrinsics.PermuteMaskEvenOdd8x32);
         Vector256<int> vcontrol = Unsafe.As<byte, Vector256<int>>(ref control);

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_PackFromRgbPlanes.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_PackFromRgbPlanes.cs
@@ -92,7 +92,7 @@ public unsafe class PixelConversion_PackFromRgbPlanes
         ref byte b = ref this.rBuf[0];
         ref Rgb24 rgb = ref this.rgbBuf[0];
 
-        for (int i = 0; i < this.Count; i++)
+        for (nint i = 0; i < (uint)this.Count; i++)
         {
             ref Rgb24 d = ref Unsafe.Add(ref rgb, i);
             d.R = Unsafe.Add(ref r, i);
@@ -110,7 +110,7 @@ public unsafe class PixelConversion_PackFromRgbPlanes
         ref Rgb24 rgb = ref this.rgbBuf[0];
 
         int count = this.Count / 8;
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb24 d0 = ref Unsafe.Add(ref rgb, i * 8);
             ref Rgb24 d1 = ref Unsafe.Add(ref d0, 1);
@@ -168,7 +168,7 @@ public unsafe class PixelConversion_PackFromRgbPlanes
         ref Rgb24 rgb = ref this.rgbBuf[0];
 
         int count = this.Count / 4;
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             ref Rgb24 d0 = ref Unsafe.Add(ref rgb, i * 4);
             ref Rgb24 d1 = ref Unsafe.Add(ref d0, 1);

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_PackFromRgbPlanes.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_PackFromRgbPlanes.cs
@@ -205,14 +205,14 @@ public unsafe class PixelConversion_PackFromRgbPlanes
         ref Vector256<float> bBase = ref Unsafe.As<float, Vector256<float>>(ref this.bFloat[0]);
         ref Vector256<float> resultBase = ref Unsafe.As<float, Vector256<float>>(ref this.rgbaFloat[0]);
 
-        int count = this.Count / Vector256<float>.Count;
+        nint count = (nint)(uint)this.Count / Vector256<float>.Count;
 
         ref byte control = ref MemoryMarshal.GetReference(SimdUtils.HwIntrinsics.PermuteMaskEvenOdd8x32);
         Vector256<int> vcontrol = Unsafe.As<byte, Vector256<int>>(ref control);
 
         var va = Vector256.Create(1F);
 
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < count; i++)
         {
             Vector256<float> r = Unsafe.Add(ref rBase, i);
             Vector256<float> g = Unsafe.Add(ref gBase, i);

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Argb32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Argb32.cs
@@ -31,7 +31,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref Rgba32 sBase = ref this.source[0];
         ref Argb32 dBase = ref this.dest[0];
 
-        for (int i = 0; i < this.Count; i++)
+        for (nint i = 0; i < (uint)this.Count; i++)
         {
             Rgba32 s = Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i).FromRgba32(s);
@@ -45,7 +45,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref Rgba32 sBase = ref MemoryMarshal.GetReference(source);
         ref TPixel dBase = ref MemoryMarshal.GetReference(dest);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             Rgba32 s = Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i).FromRgba32(s);
@@ -64,7 +64,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref Rgba32 sBase = ref this.source[0];
         ref Argb32 dBase = ref this.dest[0];
 
-        for (int i = 0; i < this.Count; i += 2)
+        for (nint i = 0; i < (uint)this.Count; i += 2)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             Rgba32 s1 = Unsafe.Add(ref s0, 1);
@@ -81,7 +81,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref Rgba32 sBase = ref this.source[0];
         ref Argb32 dBase = ref this.dest[0];
 
-        for (int i = 0; i < this.Count; i += 4)
+        for (nint i = 0; i < (uint)this.Count; i += 4)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             ref Rgba32 s1 = ref Unsafe.Add(ref s0, 1);
@@ -105,7 +105,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref uint sBase = ref Unsafe.As<Rgba32, uint>(ref this.source[0]);
         ref uint dBase = ref Unsafe.As<Argb32, uint>(ref this.dest[0]);
 
-        for (int i = 0; i < this.Count; i++)
+        for (nint i = 0; i < (uint)this.Count; i++)
         {
             uint s = Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i) = FromRgba32.ToArgb32(s);
@@ -118,7 +118,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref ulong sBase = ref Unsafe.As<Rgba32, ulong>(ref this.source[0]);
         ref ulong dBase = ref Unsafe.As<Argb32, ulong>(ref this.dest[0]);
 
-        for (int i = 0; i < this.Count / 2; i++)
+        for (nint i = 0; i < (uint)this.Count / 2; i++)
         {
             ulong s = Unsafe.Add(ref sBase, i);
             uint lo = (uint)s;

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Argb32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Argb32.cs
@@ -31,7 +31,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref Rgba32 sBase = ref this.source[0];
         ref Argb32 dBase = ref this.dest[0];
 
-        for (nint i = 0; i < (uint)this.Count; i++)
+        for (nuint i = 0; i < (uint)this.Count; i++)
         {
             Rgba32 s = Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i).FromRgba32(s);
@@ -45,7 +45,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref Rgba32 sBase = ref MemoryMarshal.GetReference(source);
         ref TPixel dBase = ref MemoryMarshal.GetReference(dest);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             Rgba32 s = Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i).FromRgba32(s);
@@ -64,7 +64,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref Rgba32 sBase = ref this.source[0];
         ref Argb32 dBase = ref this.dest[0];
 
-        for (nint i = 0; i < (uint)this.Count; i += 2)
+        for (nuint i = 0; i < (uint)this.Count; i += 2)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             Rgba32 s1 = Unsafe.Add(ref s0, 1);
@@ -81,7 +81,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref Rgba32 sBase = ref this.source[0];
         ref Argb32 dBase = ref this.dest[0];
 
-        for (nint i = 0; i < (uint)this.Count; i += 4)
+        for (nuint i = 0; i < (uint)this.Count; i += 4)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             ref Rgba32 s1 = ref Unsafe.Add(ref s0, 1);
@@ -105,7 +105,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref uint sBase = ref Unsafe.As<Rgba32, uint>(ref this.source[0]);
         ref uint dBase = ref Unsafe.As<Argb32, uint>(ref this.dest[0]);
 
-        for (nint i = 0; i < (uint)this.Count; i++)
+        for (nuint i = 0; i < (uint)this.Count; i++)
         {
             uint s = Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i) = FromRgba32.ToArgb32(s);
@@ -118,7 +118,7 @@ public class PixelConversion_Rgba32_To_Argb32
         ref ulong sBase = ref Unsafe.As<Rgba32, ulong>(ref this.source[0]);
         ref ulong dBase = ref Unsafe.As<Argb32, ulong>(ref this.dest[0]);
 
-        for (nint i = 0; i < (uint)this.Count / 2; i++)
+        for (nuint i = 0; i < (uint)this.Count / 2; i++)
         {
             ulong s = Unsafe.Add(ref sBase, i);
             uint lo = (uint)s;

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Bgra32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Bgra32.cs
@@ -52,7 +52,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref this.source[0];
         ref Bgra32 dBase = ref this.dest[0];
 
-        for (int i = 0; i < this.Count; i++)
+        for (nint i = 0; i < (uint)this.Count; i++)
         {
             ref Rgba32 s = ref Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i).FromRgba32(s);
@@ -66,7 +66,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref MemoryMarshal.GetReference(source);
         ref TPixel dBase = ref MemoryMarshal.GetReference(dest);
 
-        for (int i = 0; i < source.Length; i++)
+        for (nint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgba32 s = ref Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i).FromRgba32(s);
@@ -85,7 +85,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref this.source[0];
         ref Bgra32 dBase = ref this.dest[0];
 
-        for (int i = 0; i < this.Count; i += 2)
+        for (nint i = 0; i < (uint)this.Count; i += 2)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             Rgba32 s1 = Unsafe.Add(ref s0, 1);
@@ -102,7 +102,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref this.source[0];
         ref Bgra32 dBase = ref this.dest[0];
 
-        for (int i = 0; i < this.Count; i += 4)
+        for (nint i = 0; i < (uint)this.Count; i += 4)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             ref Rgba32 s1 = ref Unsafe.Add(ref s0, 1);
@@ -127,7 +127,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref MemoryMarshal.GetReference(source);
         ref TPixel dBase = ref MemoryMarshal.GetReference(dest);
 
-        for (int i = 0; i < source.Length; i += 4)
+        for (nint i = 0; i < (uint)source.Length; i += 4)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             ref Rgba32 s1 = ref Unsafe.Add(ref s0, 1);
@@ -157,7 +157,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref this.source[0];
         ref Bgra32 dBase = ref this.dest[0];
 
-        for (int i = 0; i < this.Count / 4; i += 4)
+        for (nint i = 0; i < (uint)this.Count / 4; i += 4)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             ref Rgba32 s1 = ref Unsafe.Add(ref s0, 1);
@@ -196,7 +196,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref uint sBase = ref Unsafe.As<Rgba32, uint>(ref this.source[0]);
         ref uint dBase = ref Unsafe.As<Bgra32, uint>(ref this.dest[0]);
 
-        for (int i = 0; i < this.Count; i++)
+        for (nint i = 0; i < (uint)this.Count; i++)
         {
             uint s = Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i) = FromRgba32.ToBgra32(s);
@@ -209,7 +209,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Tuple4OfUInt32 sBase = ref Unsafe.As<Rgba32, Tuple4OfUInt32>(ref this.source[0]);
         ref Tuple4OfUInt32 dBase = ref Unsafe.As<Bgra32, Tuple4OfUInt32>(ref this.dest[0]);
 
-        for (int i = 0; i < this.Count / 4; i++)
+        for (nint i = 0; i < (uint)this.Count / 4; i++)
         {
             ref Tuple4OfUInt32 d = ref Unsafe.Add(ref dBase, i);
             d = Unsafe.Add(ref sBase, i);
@@ -222,7 +222,7 @@ public class PixelConversion_Rgba32_To_Bgra32
     {
         ref Tuple4OfUInt32 sBase = ref Unsafe.As<Rgba32, Tuple4OfUInt32>(ref this.source[0]);
 
-        for (int i = 0; i < this.Count / 4; i++)
+        for (nint i = 0; i < (uint)this.Count / 4; i++)
         {
             Unsafe.Add(ref sBase, i).ConvertMe();
         }
@@ -234,7 +234,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Octet<uint> sBase = ref Unsafe.As<Rgba32, Octet<uint>>(ref this.source[0]);
         ref Octet<uint> dBase = ref Unsafe.As<Bgra32, Octet<uint>>(ref this.dest[0]);
 
-        for (int i = 0; i < this.Count / 8; i++)
+        for (nint i = 0; i < (uint)this.Count / 8; i++)
         {
             BitopsSimdImpl(ref Unsafe.Add(ref sBase, i), ref Unsafe.Add(ref dBase, i));
         }
@@ -289,7 +289,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref uint sBase = ref Unsafe.As<Rgba32, uint>(ref this.source[0]);
         ref uint dBase = ref Unsafe.As<Bgra32, uint>(ref this.dest[0]);
 
-        for (int i = 0; i < this.Count; i++)
+        for (nint i = 0; i < (uint)this.Count; i++)
         {
             ref uint s0 = ref Unsafe.Add(ref sBase, i);
             uint s1 = Unsafe.Add(ref s0, 1);
@@ -306,7 +306,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref ulong sBase = ref Unsafe.As<Rgba32, ulong>(ref this.source[0]);
         ref ulong dBase = ref Unsafe.As<Bgra32, ulong>(ref this.dest[0]);
 
-        for (int i = 0; i < this.Count / 2; i++)
+        for (nint i = 0; i < (uint)this.Count / 2; i++)
         {
             ulong s = Unsafe.Add(ref sBase, i);
             uint lo = (uint)s;
@@ -326,7 +326,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref ulong sBase = ref Unsafe.As<Rgba32, ulong>(ref this.source[0]);
         ref ulong dBase = ref Unsafe.As<Bgra32, ulong>(ref this.dest[0]);
 
-        for (int i = 0; i < this.Count / 2; i++)
+        for (nint i = 0; i < (uint)this.Count / 2; i++)
         {
             ulong s = Unsafe.Add(ref sBase, i);
             uint lo = (uint)s;

--- a/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Bgra32.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelConversion/PixelConversion_Rgba32_To_Bgra32.cs
@@ -52,7 +52,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref this.source[0];
         ref Bgra32 dBase = ref this.dest[0];
 
-        for (nint i = 0; i < (uint)this.Count; i++)
+        for (nuint i = 0; i < (uint)this.Count; i++)
         {
             ref Rgba32 s = ref Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i).FromRgba32(s);
@@ -66,7 +66,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref MemoryMarshal.GetReference(source);
         ref TPixel dBase = ref MemoryMarshal.GetReference(dest);
 
-        for (nint i = 0; i < (uint)source.Length; i++)
+        for (nuint i = 0; i < (uint)source.Length; i++)
         {
             ref Rgba32 s = ref Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i).FromRgba32(s);
@@ -85,7 +85,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref this.source[0];
         ref Bgra32 dBase = ref this.dest[0];
 
-        for (nint i = 0; i < (uint)this.Count; i += 2)
+        for (nuint i = 0; i < (uint)this.Count; i += 2)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             Rgba32 s1 = Unsafe.Add(ref s0, 1);
@@ -102,7 +102,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref this.source[0];
         ref Bgra32 dBase = ref this.dest[0];
 
-        for (nint i = 0; i < (uint)this.Count; i += 4)
+        for (nuint i = 0; i < (uint)this.Count; i += 4)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             ref Rgba32 s1 = ref Unsafe.Add(ref s0, 1);
@@ -127,7 +127,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref MemoryMarshal.GetReference(source);
         ref TPixel dBase = ref MemoryMarshal.GetReference(dest);
 
-        for (nint i = 0; i < (uint)source.Length; i += 4)
+        for (nuint i = 0; i < (uint)source.Length; i += 4)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             ref Rgba32 s1 = ref Unsafe.Add(ref s0, 1);
@@ -157,7 +157,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Rgba32 sBase = ref this.source[0];
         ref Bgra32 dBase = ref this.dest[0];
 
-        for (nint i = 0; i < (uint)this.Count / 4; i += 4)
+        for (nuint i = 0; i < (uint)this.Count / 4; i += 4)
         {
             ref Rgba32 s0 = ref Unsafe.Add(ref sBase, i);
             ref Rgba32 s1 = ref Unsafe.Add(ref s0, 1);
@@ -196,7 +196,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref uint sBase = ref Unsafe.As<Rgba32, uint>(ref this.source[0]);
         ref uint dBase = ref Unsafe.As<Bgra32, uint>(ref this.dest[0]);
 
-        for (nint i = 0; i < (uint)this.Count; i++)
+        for (nuint i = 0; i < (uint)this.Count; i++)
         {
             uint s = Unsafe.Add(ref sBase, i);
             Unsafe.Add(ref dBase, i) = FromRgba32.ToBgra32(s);
@@ -209,7 +209,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Tuple4OfUInt32 sBase = ref Unsafe.As<Rgba32, Tuple4OfUInt32>(ref this.source[0]);
         ref Tuple4OfUInt32 dBase = ref Unsafe.As<Bgra32, Tuple4OfUInt32>(ref this.dest[0]);
 
-        for (nint i = 0; i < (uint)this.Count / 4; i++)
+        for (nuint i = 0; i < (uint)this.Count / 4; i++)
         {
             ref Tuple4OfUInt32 d = ref Unsafe.Add(ref dBase, i);
             d = Unsafe.Add(ref sBase, i);
@@ -222,7 +222,7 @@ public class PixelConversion_Rgba32_To_Bgra32
     {
         ref Tuple4OfUInt32 sBase = ref Unsafe.As<Rgba32, Tuple4OfUInt32>(ref this.source[0]);
 
-        for (nint i = 0; i < (uint)this.Count / 4; i++)
+        for (nuint i = 0; i < (uint)this.Count / 4; i++)
         {
             Unsafe.Add(ref sBase, i).ConvertMe();
         }
@@ -234,7 +234,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref Octet<uint> sBase = ref Unsafe.As<Rgba32, Octet<uint>>(ref this.source[0]);
         ref Octet<uint> dBase = ref Unsafe.As<Bgra32, Octet<uint>>(ref this.dest[0]);
 
-        for (nint i = 0; i < (uint)this.Count / 8; i++)
+        for (nuint i = 0; i < (uint)this.Count / 8; i++)
         {
             BitopsSimdImpl(ref Unsafe.Add(ref sBase, i), ref Unsafe.Add(ref dBase, i));
         }
@@ -289,7 +289,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref uint sBase = ref Unsafe.As<Rgba32, uint>(ref this.source[0]);
         ref uint dBase = ref Unsafe.As<Bgra32, uint>(ref this.dest[0]);
 
-        for (nint i = 0; i < (uint)this.Count; i++)
+        for (nuint i = 0; i < (uint)this.Count; i++)
         {
             ref uint s0 = ref Unsafe.Add(ref sBase, i);
             uint s1 = Unsafe.Add(ref s0, 1);
@@ -306,7 +306,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref ulong sBase = ref Unsafe.As<Rgba32, ulong>(ref this.source[0]);
         ref ulong dBase = ref Unsafe.As<Bgra32, ulong>(ref this.dest[0]);
 
-        for (nint i = 0; i < (uint)this.Count / 2; i++)
+        for (nuint i = 0; i < (uint)this.Count / 2; i++)
         {
             ulong s = Unsafe.Add(ref sBase, i);
             uint lo = (uint)s;
@@ -326,7 +326,7 @@ public class PixelConversion_Rgba32_To_Bgra32
         ref ulong sBase = ref Unsafe.As<Rgba32, ulong>(ref this.source[0]);
         ref ulong dBase = ref Unsafe.As<Bgra32, ulong>(ref this.dest[0]);
 
-        for (nint i = 0; i < (uint)this.Count / 2; i++)
+        for (nuint i = 0; i < (uint)this.Count / 2; i++)
         {
             ulong s = Unsafe.Add(ref sBase, i);
             uint lo = (uint)s;

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/UInt32ToSingle.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/UInt32ToSingle.cs
@@ -12,7 +12,7 @@ public class UInt32ToSingle
 {
     private float[] data;
 
-    private const int Count = 32;
+    private const uint Count = 32;
 
     [GlobalSetup]
     public void Setup()
@@ -25,7 +25,7 @@ public class UInt32ToSingle
     {
         ref Vector<float> b = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
 
-        nuint n = (uint)(Count / Vector<float>.Count);
+        nuint n = Count / (uint)Vector<float>.Count;
 
         var bVec = new Vector<float>(256.0f / 255.0f);
         var magicFloat = new Vector<float>(32768.0f);
@@ -50,7 +50,7 @@ public class UInt32ToSingle
     [Benchmark]
     public void StandardSimd()
     {
-        nuint n = (uint)(Count / Vector<float>.Count);
+        nuint n = Count / (uint)Vector<float>.Count;
 
         ref Vector<float> bf = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
         ref Vector<uint> bu = ref Unsafe.As<Vector<float>, Vector<uint>>(ref bf);
@@ -69,7 +69,7 @@ public class UInt32ToSingle
     [Benchmark]
     public void StandardSimdFromInt()
     {
-        nuint n = (uint)(Count / Vector<float>.Count);
+        nuint n = Count / (uint)Vector<float>.Count;
 
         ref Vector<float> bf = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
         ref Vector<int> bu = ref Unsafe.As<Vector<float>, Vector<int>>(ref bf);
@@ -88,7 +88,7 @@ public class UInt32ToSingle
     [Benchmark]
     public void StandardSimdFromInt_RefCast()
     {
-        nuint n = (uint)(Count / Vector<float>.Count);
+        nuint n = Count / (uint)Vector<float>.Count;
 
         ref Vector<float> bf = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
         var scale = new Vector<float>(1f / 255f);

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/UInt32ToSingle.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/UInt32ToSingle.cs
@@ -25,14 +25,14 @@ public class UInt32ToSingle
     {
         ref Vector<float> b = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
 
-        nint n = Count / Vector<float>.Count;
+        nuint n = (uint)(Count / Vector<float>.Count);
 
         var bVec = new Vector<float>(256.0f / 255.0f);
         var magicFloat = new Vector<float>(32768.0f);
         var magicInt = new Vector<uint>(1191182336); // reinterpreted value of 32768.0f
         var mask = new Vector<uint>(255);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             ref Vector<float> df = ref Unsafe.Add(ref b, i);
 
@@ -50,14 +50,14 @@ public class UInt32ToSingle
     [Benchmark]
     public void StandardSimd()
     {
-        nint n = Count / Vector<float>.Count;
+        nuint n = (uint)(Count / Vector<float>.Count);
 
         ref Vector<float> bf = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
         ref Vector<uint> bu = ref Unsafe.As<Vector<float>, Vector<uint>>(ref bf);
 
         var scale = new Vector<float>(1f / 255f);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             Vector<uint> u = Unsafe.Add(ref bu, i);
             Vector<float> v = Vector.ConvertToSingle(u);
@@ -69,14 +69,14 @@ public class UInt32ToSingle
     [Benchmark]
     public void StandardSimdFromInt()
     {
-        nint n = Count / Vector<float>.Count;
+        nuint n = (uint)(Count / Vector<float>.Count);
 
         ref Vector<float> bf = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
         ref Vector<int> bu = ref Unsafe.As<Vector<float>, Vector<int>>(ref bf);
 
         var scale = new Vector<float>(1f / 255f);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             Vector<int> u = Unsafe.Add(ref bu, i);
             Vector<float> v = Vector.ConvertToSingle(u);
@@ -88,12 +88,12 @@ public class UInt32ToSingle
     [Benchmark]
     public void StandardSimdFromInt_RefCast()
     {
-        nint n = Count / Vector<float>.Count;
+        nuint n = (uint)(Count / Vector<float>.Count);
 
         ref Vector<float> bf = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
         var scale = new Vector<float>(1f / 255f);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             ref Vector<float> fRef = ref Unsafe.Add(ref bf, i);
 

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/UInt32ToSingle.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/UInt32ToSingle.cs
@@ -25,14 +25,14 @@ public class UInt32ToSingle
     {
         ref Vector<float> b = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
 
-        int n = Count / Vector<float>.Count;
+        nint n = Count / Vector<float>.Count;
 
         var bVec = new Vector<float>(256.0f / 255.0f);
         var magicFloat = new Vector<float>(32768.0f);
         var magicInt = new Vector<uint>(1191182336); // reinterpreted value of 32768.0f
         var mask = new Vector<uint>(255);
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             ref Vector<float> df = ref Unsafe.Add(ref b, i);
 
@@ -50,14 +50,14 @@ public class UInt32ToSingle
     [Benchmark]
     public void StandardSimd()
     {
-        int n = Count / Vector<float>.Count;
+        nint n = Count / Vector<float>.Count;
 
         ref Vector<float> bf = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
         ref Vector<uint> bu = ref Unsafe.As<Vector<float>, Vector<uint>>(ref bf);
 
         var scale = new Vector<float>(1f / 255f);
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             Vector<uint> u = Unsafe.Add(ref bu, i);
             Vector<float> v = Vector.ConvertToSingle(u);
@@ -69,14 +69,14 @@ public class UInt32ToSingle
     [Benchmark]
     public void StandardSimdFromInt()
     {
-        int n = Count / Vector<float>.Count;
+        nint n = Count / Vector<float>.Count;
 
         ref Vector<float> bf = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
         ref Vector<int> bu = ref Unsafe.As<Vector<float>, Vector<int>>(ref bf);
 
         var scale = new Vector<float>(1f / 255f);
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             Vector<int> u = Unsafe.Add(ref bu, i);
             Vector<float> v = Vector.ConvertToSingle(u);
@@ -88,12 +88,12 @@ public class UInt32ToSingle
     [Benchmark]
     public void StandardSimdFromInt_RefCast()
     {
-        int n = Count / Vector<float>.Count;
+        nint n = Count / Vector<float>.Count;
 
         ref Vector<float> bf = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
         var scale = new Vector<float>(1f / 255f);
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             ref Vector<float> fRef = ref Unsafe.Add(ref bf, i);
 

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/VectorFetching.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/VectorFetching.cs
@@ -63,7 +63,7 @@ public class VectorFetching
         var v = new Vector<float>(this.testValue);
         ref Vector<float> start = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
 
-        nuint n = (uint)(this.InputSize / Vector<uint>.Count);
+        nuint n = (uint)this.InputSize / (uint)Vector<uint>.Count;
 
         for (nuint i = 0; i < n; i++)
         {
@@ -82,7 +82,7 @@ public class VectorFetching
         var v = new Vector<float>(this.testValue);
         ref Vector<float> start = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
 
-        nuint n = (uint)(this.InputSize / Vector<uint>.Count);
+        nuint n = (uint)this.InputSize / (uint)Vector<uint>.Count;
 
         for (nuint i = 0; i < n; i++)
         {
@@ -100,7 +100,7 @@ public class VectorFetching
 
         ref Vector<float> start = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(span));
 
-        nuint n = (uint)(this.InputSize / Vector<uint>.Count);
+        nuint n = (uint)this.InputSize / (uint)Vector<uint>.Count;
 
         for (nuint i = 0; i < n; i++)
         {

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/VectorFetching.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/VectorFetching.cs
@@ -63,9 +63,9 @@ public class VectorFetching
         var v = new Vector<float>(this.testValue);
         ref Vector<float> start = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
 
-        nint n = (nint)(uint)this.InputSize / Vector<uint>.Count;
+        nuint n = (uint)(this.InputSize / Vector<uint>.Count);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             ref Vector<float> p = ref Unsafe.Add(ref start, i);
 
@@ -82,9 +82,9 @@ public class VectorFetching
         var v = new Vector<float>(this.testValue);
         ref Vector<float> start = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
 
-        nint n = (nint)(uint)this.InputSize / Vector<uint>.Count;
+        nuint n = (uint)(this.InputSize / Vector<uint>.Count);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             ref Vector<float> a = ref Unsafe.Add(ref start, i);
             a *= v;
@@ -100,9 +100,9 @@ public class VectorFetching
 
         ref Vector<float> start = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(span));
 
-        nint n = (nint)(uint)this.InputSize / Vector<uint>.Count;
+        nuint n = (uint)(this.InputSize / Vector<uint>.Count);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             ref Vector<float> a = ref Unsafe.Add(ref start, i);
             a *= v;

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/VectorFetching.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/VectorFetching.cs
@@ -63,14 +63,14 @@ public class VectorFetching
         var v = new Vector<float>(this.testValue);
         ref Vector<float> start = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
 
-        int n = this.InputSize / Vector<uint>.Count;
+        nint n = (nint)(uint)this.InputSize / Vector<uint>.Count;
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             ref Vector<float> p = ref Unsafe.Add(ref start, i);
 
             Vector<float> a = p;
-            a = a * v;
+            a *= v;
 
             p = a;
         }
@@ -82,12 +82,12 @@ public class VectorFetching
         var v = new Vector<float>(this.testValue);
         ref Vector<float> start = ref Unsafe.As<float, Vector<float>>(ref this.data[0]);
 
-        int n = this.InputSize / Vector<uint>.Count;
+        nint n = (nint)(uint)this.InputSize / Vector<uint>.Count;
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             ref Vector<float> a = ref Unsafe.Add(ref start, i);
-            a = a * v;
+            a *= v;
         }
     }
 
@@ -100,12 +100,12 @@ public class VectorFetching
 
         ref Vector<float> start = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(span));
 
-        int n = this.InputSize / Vector<uint>.Count;
+        nint n = (nint)(uint)this.InputSize / Vector<uint>.Count;
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             ref Vector<float> a = ref Unsafe.Add(ref start, i);
-            a = a * v;
+            a *= v;
         }
     }
 }

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/WidenBytesToUInt32.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/WidenBytesToUInt32.cs
@@ -33,7 +33,7 @@ public class WidenBytesToUInt32
         ref Octet<byte> sBase = ref Unsafe.As<byte, Octet<byte>>(ref this.source[0]);
         ref Octet<uint> dBase = ref Unsafe.As<uint, Octet<uint>>(ref this.dest[0]);
 
-        for (int i = 0; i < N; i++)
+        for (nint i = 0; i < N; i++)
         {
             Unsafe.Add(ref dBase, i).LoadFrom(ref Unsafe.Add(ref sBase, i));
         }

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/WidenBytesToUInt32.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/WidenBytesToUInt32.cs
@@ -33,7 +33,7 @@ public class WidenBytesToUInt32
         ref Octet<byte> sBase = ref Unsafe.As<byte, Octet<byte>>(ref this.source[0]);
         ref Octet<uint> dBase = ref Unsafe.As<uint, Octet<uint>>(ref this.dest[0]);
 
-        for (nint i = 0; i < N; i++)
+        for (nuint i = 0; i < N; i++)
         {
             Unsafe.Add(ref dBase, i).LoadFrom(ref Unsafe.Add(ref sBase, i));
         }
@@ -42,12 +42,12 @@ public class WidenBytesToUInt32
     [Benchmark]
     public void Simd()
     {
-        nint n = Count / Vector<byte>.Count;
+        nuint n = (uint)(Count / Vector<byte>.Count);
 
         ref Vector<byte> sBase = ref Unsafe.As<byte, Vector<byte>>(ref this.source[0]);
         ref Vector<uint> dBase = ref Unsafe.As<uint, Vector<uint>>(ref this.dest[0]);
 
-        for (nint i = 0; i < n; i++)
+        for (nuint i = 0; i < n; i++)
         {
             Vector<byte> b = Unsafe.Add(ref sBase, i);
 

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/WidenBytesToUInt32.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/WidenBytesToUInt32.cs
@@ -42,7 +42,7 @@ public class WidenBytesToUInt32
     [Benchmark]
     public void Simd()
     {
-        nuint n = (uint)(Count / Vector<byte>.Count);
+        nuint n = Count / (uint)Vector<byte>.Count;
 
         ref Vector<byte> sBase = ref Unsafe.As<byte, Vector<byte>>(ref this.source[0]);
         ref Vector<uint> dBase = ref Unsafe.As<uint, Vector<uint>>(ref this.dest[0]);

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/WidenBytesToUInt32.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/WidenBytesToUInt32.cs
@@ -42,12 +42,12 @@ public class WidenBytesToUInt32
     [Benchmark]
     public void Simd()
     {
-        int n = Count / Vector<byte>.Count;
+        nint n = Count / Vector<byte>.Count;
 
         ref Vector<byte> sBase = ref Unsafe.As<byte, Vector<byte>>(ref this.source[0]);
         ref Vector<uint> dBase = ref Unsafe.As<uint, Vector<uint>>(ref this.dest[0]);
 
-        for (int i = 0; i < n; i++)
+        for (nint i = 0; i < n; i++)
         {
             Vector<byte> b = Unsafe.Add(ref sBase, i);
 

--- a/tests/ImageSharp.Benchmarks/PixelBlenders/PorterDuffBulkVsSingleVector.cs
+++ b/tests/ImageSharp.Benchmarks/PixelBlenders/PorterDuffBulkVsSingleVector.cs
@@ -58,7 +58,7 @@ public class PorterDuffBulkVsSingleVector
         Vector256<float> result = default;
         Vector256<float> opacity = Vector256.Create(.5F);
         int count = this.backdrop.Length / 2;
-        for (nint i = 0; i < (uint)count; i++)
+        for (nuint i = 0; i < (uint)count; i++)
         {
             result = PorterDuffFunctions.NormalSrcOver(Unsafe.Add(ref backdrop, i), Unsafe.Add(ref source, i), opacity);
         }

--- a/tests/ImageSharp.Benchmarks/PixelBlenders/PorterDuffBulkVsSingleVector.cs
+++ b/tests/ImageSharp.Benchmarks/PixelBlenders/PorterDuffBulkVsSingleVector.cs
@@ -58,7 +58,7 @@ public class PorterDuffBulkVsSingleVector
         Vector256<float> result = default;
         Vector256<float> opacity = Vector256.Create(.5F);
         int count = this.backdrop.Length / 2;
-        for (int i = 0; i < count; i++)
+        for (nint i = 0; i < (uint)count; i++)
         {
             result = PorterDuffFunctions.NormalSrcOver(Unsafe.Add(ref backdrop, i), Unsafe.Add(ref source, i), opacity);
         }

--- a/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
+++ b/tests/ImageSharp.Tests/Common/SimdUtilsTests.Shuffle.cs
@@ -493,10 +493,10 @@ public partial class SimdUtilsTests
 
         SimdUtils.Shuffle.InverseMMShuffle(
             control,
-            out int p3,
-            out int p2,
-            out int p1,
-            out int p0);
+            out uint p3,
+            out uint p2,
+            out uint p1,
+            out uint p0);
 
         for (int i = 0; i < expected.Length; i += 4)
         {
@@ -524,10 +524,10 @@ public partial class SimdUtilsTests
 
         SimdUtils.Shuffle.InverseMMShuffle(
             control,
-            out int p3,
-            out int p2,
-            out int p1,
-            out int p0);
+            out uint p3,
+            out uint p2,
+            out uint p1,
+            out uint p0);
 
         for (int i = 0; i < expected.Length; i += 4)
         {
@@ -555,10 +555,10 @@ public partial class SimdUtilsTests
 
         SimdUtils.Shuffle.InverseMMShuffle(
             control,
-            out int _,
-            out int p2,
-            out int p1,
-            out int p0);
+            out uint _,
+            out uint p2,
+            out uint p1,
+            out uint p0);
 
         for (int i = 0; i < expected.Length; i += 3)
         {
@@ -586,10 +586,10 @@ public partial class SimdUtilsTests
 
         SimdUtils.Shuffle.InverseMMShuffle(
             control,
-            out int p3,
-            out int p2,
-            out int p1,
-            out int p0);
+            out uint p3,
+            out uint p2,
+            out uint p1,
+            out uint p0);
 
         for (int i = 0, j = 0; i < expected.Length; i += 4, j += 3)
         {
@@ -607,10 +607,10 @@ public partial class SimdUtilsTests
             temp[2] = source[j + 2];
             temp[3] = byte.MaxValue;
 
-            expected[i] = temp[p0];
-            expected[i + 1] = temp[p1];
-            expected[i + 2] = temp[p2];
-            expected[i + 3] = temp[p3];
+            expected[i] = temp[(int)p0];
+            expected[i + 1] = temp[(int)p1];
+            expected[i + 2] = temp[(int)p2];
+            expected[i + 3] = temp[(int)p3];
         }
 
         convert(source, result);
@@ -637,10 +637,10 @@ public partial class SimdUtilsTests
 
         SimdUtils.Shuffle.InverseMMShuffle(
             control,
-            out int _,
-            out int p2,
-            out int p1,
-            out int p0);
+            out uint _,
+            out uint p2,
+            out uint p1,
+            out uint p0);
 
         for (int i = 0, j = 0; i < expected.Length; i += 3, j += 4)
         {

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderFilterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderFilterTests.cs
@@ -287,7 +287,7 @@ public class PngEncoderFilterTests : MeasureFixture
                     break;
 
                 case PngFilterMethod.Average:
-                    AverageFilter.Encode(this.previousScanline, this.scanline, this.resultBuffer, this.bpp, out sum);
+                    AverageFilter.Encode(this.previousScanline, this.scanline, this.resultBuffer, (uint)this.bpp, out sum);
                     break;
 
                 case PngFilterMethod.Paeth:

--- a/tests/ImageSharp.Tests/Formats/Png/ReferenceImplementations.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/ReferenceImplementations.cs
@@ -34,8 +34,8 @@ internal static partial class ReferenceImplementations
         // Paeth(x) = Raw(x) - PaethPredictor(Raw(x-bpp), Prior(x), Prior(x - bpp))
         resultBaseRef = 4;
 
-        int x = 0;
-        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        nint x = 0;
+        for (; x < (nint)(uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -45,7 +45,7 @@ internal static partial class ReferenceImplementations
             sum += Numerics.Abs(unchecked((sbyte)res));
         }
 
-        for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (nint)(uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, xLeft);
@@ -77,8 +77,8 @@ internal static partial class ReferenceImplementations
         // Sub(x) = Raw(x) - Raw(x-bpp)
         resultBaseRef = 1;
 
-        int x = 0;
-        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        nint x = 0;
+        for (; x < (nint)(uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             ++x;
@@ -87,7 +87,7 @@ internal static partial class ReferenceImplementations
             sum += Numerics.Abs(unchecked((sbyte)res));
         }
 
-        for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (nint)(uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte prev = Unsafe.Add(ref scanBaseRef, xLeft);
@@ -119,9 +119,9 @@ internal static partial class ReferenceImplementations
         // Up(x) = Raw(x) - Prior(x)
         resultBaseRef = 2;
 
-        int x = 0;
+        nint x = 0;
 
-        for (; x < scanline.Length; /* Note: ++x happens in the body to avoid one add operation */)
+        for (; x < (nint)(uint)scanline.Length; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -154,8 +154,8 @@ internal static partial class ReferenceImplementations
         // Average(x) = Raw(x) - floor((Raw(x-bpp)+Prior(x))/2)
         resultBaseRef = 3;
 
-        int x = 0;
-        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        nint x = 0;
+        for (; x < (nint)(uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -165,7 +165,7 @@ internal static partial class ReferenceImplementations
             sum += Numerics.Abs(unchecked((sbyte)res));
         }
 
-        for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (nint)(uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, xLeft);

--- a/tests/ImageSharp.Tests/Formats/Png/ReferenceImplementations.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/ReferenceImplementations.cs
@@ -34,8 +34,8 @@ internal static partial class ReferenceImplementations
         // Paeth(x) = Raw(x) - PaethPredictor(Raw(x-bpp), Prior(x), Prior(x - bpp))
         resultBaseRef = 4;
 
-        nint x = 0;
-        for (; x < (nint)(uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        int x = 0;
+        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -45,7 +45,7 @@ internal static partial class ReferenceImplementations
             sum += Numerics.Abs(unchecked((sbyte)res));
         }
 
-        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (nint)(uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, xLeft);
@@ -77,8 +77,8 @@ internal static partial class ReferenceImplementations
         // Sub(x) = Raw(x) - Raw(x-bpp)
         resultBaseRef = 1;
 
-        nint x = 0;
-        for (; x < (nint)(uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        int x = 0;
+        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             ++x;
@@ -87,7 +87,7 @@ internal static partial class ReferenceImplementations
             sum += Numerics.Abs(unchecked((sbyte)res));
         }
 
-        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (nint)(uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte prev = Unsafe.Add(ref scanBaseRef, xLeft);
@@ -119,9 +119,9 @@ internal static partial class ReferenceImplementations
         // Up(x) = Raw(x) - Prior(x)
         resultBaseRef = 2;
 
-        nint x = 0;
+        int x = 0;
 
-        for (; x < (nint)(uint)scanline.Length; /* Note: ++x happens in the body to avoid one add operation */)
+        for (; x < scanline.Length; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -154,8 +154,8 @@ internal static partial class ReferenceImplementations
         // Average(x) = Raw(x) - floor((Raw(x-bpp)+Prior(x))/2)
         resultBaseRef = 3;
 
-        nint x = 0;
-        for (; x < (nint)(uint)bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
+        int x = 0;
+        for (; x < bytesPerPixel; /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -165,7 +165,7 @@ internal static partial class ReferenceImplementations
             sum += Numerics.Abs(unchecked((sbyte)res));
         }
 
-        for (nint xLeft = x - (nint)(uint)bytesPerPixel; x < (nint)(uint)scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
+        for (int xLeft = x - bytesPerPixel; x < scanline.Length; ++xLeft /* Note: ++x happens in the body to avoid one add operation */)
         {
             byte scan = Unsafe.Add(ref scanBaseRef, x);
             byte left = Unsafe.Add(ref scanBaseRef, xLeft);

--- a/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
@@ -100,7 +100,7 @@ public abstract partial class PixelConverterTests
             if (typeof(TDestinationPixel) == typeof(L16))
             {
                 ref L16 l16Ref = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<TDestinationPixel, L16>(destinationPixels));
-                for (nint i = 0; i < (uint)count; i++)
+                for (int i = 0; i < count; i++)
                 {
                     ref TSourcePixel sp = ref Unsafe.Add(ref sourceRef, i);
                     ref L16 dp = ref Unsafe.Add(ref l16Ref, i);
@@ -113,7 +113,7 @@ public abstract partial class PixelConverterTests
             if (typeof(TDestinationPixel) == typeof(L8))
             {
                 ref L8 l8Ref = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<TDestinationPixel, L8>(destinationPixels));
-                for (nint i = 0; i < (uint)count; i++)
+                for (int i = 0; i < count; i++)
                 {
                     ref TSourcePixel sp = ref Unsafe.Add(ref sourceRef, i);
                     ref L8 dp = ref Unsafe.Add(ref l8Ref, i);
@@ -125,7 +125,7 @@ public abstract partial class PixelConverterTests
 
             // Normal conversion
             ref TDestinationPixel destRef = ref MemoryMarshal.GetReference(destinationPixels);
-            for (nint i = 0; i < (uint)count; i++)
+            for (int i = 0; i < count; i++)
             {
                 ref TSourcePixel sp = ref Unsafe.Add(ref sourceRef, i);
                 ref TDestinationPixel dp = ref Unsafe.Add(ref destRef, i);

--- a/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelConverterTests.ReferenceImplementations.cs
@@ -100,7 +100,7 @@ public abstract partial class PixelConverterTests
             if (typeof(TDestinationPixel) == typeof(L16))
             {
                 ref L16 l16Ref = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<TDestinationPixel, L16>(destinationPixels));
-                for (int i = 0; i < count; i++)
+                for (nint i = 0; i < (uint)count; i++)
                 {
                     ref TSourcePixel sp = ref Unsafe.Add(ref sourceRef, i);
                     ref L16 dp = ref Unsafe.Add(ref l16Ref, i);
@@ -113,7 +113,7 @@ public abstract partial class PixelConverterTests
             if (typeof(TDestinationPixel) == typeof(L8))
             {
                 ref L8 l8Ref = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<TDestinationPixel, L8>(destinationPixels));
-                for (int i = 0; i < count; i++)
+                for (nint i = 0; i < (uint)count; i++)
                 {
                     ref TSourcePixel sp = ref Unsafe.Add(ref sourceRef, i);
                     ref L8 dp = ref Unsafe.Add(ref l8Ref, i);
@@ -125,7 +125,7 @@ public abstract partial class PixelConverterTests
 
             // Normal conversion
             ref TDestinationPixel destRef = ref MemoryMarshal.GetReference(destinationPixels);
-            for (int i = 0; i < count; i++)
+            for (nint i = 0; i < (uint)count; i++)
             {
                 ref TSourcePixel sp = ref Unsafe.Add(ref sourceRef, i);
                 ref TDestinationPixel dp = ref Unsafe.Add(ref destRef, i);

--- a/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.cs
@@ -1184,7 +1184,7 @@ public abstract class PixelOperationsTests<TPixel> : MeasureFixture
             get
             {
                 ref byte self = ref Unsafe.As<OctetBytes, byte>(ref this);
-                return Unsafe.Add(ref self, idx);
+                return Unsafe.Add(ref self, (uint)idx);
             }
         }
     }

--- a/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/PixelOperations/PixelOperationsTests.cs
@@ -1184,7 +1184,7 @@ public abstract class PixelOperationsTests<TPixel> : MeasureFixture
             get
             {
                 ref byte self = ref Unsafe.As<OctetBytes, byte>(ref this);
-                return Unsafe.Add(ref self, (uint)idx);
+                return Unsafe.Add(ref self, idx);
             }
         }
     }

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeKernelMapTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeKernelMapTests.cs
@@ -128,7 +128,7 @@ public partial class ResizeKernelMapTests
 
         for (int i = 0; i < kernelMap.DestinationLength; i++)
         {
-            ResizeKernel kernel = kernelMap.GetKernel(i);
+            ResizeKernel kernel = kernelMap.GetKernel((uint)i);
 
             ReferenceKernel referenceKernel = referenceMap.GetKernel(i);
 
@@ -153,7 +153,7 @@ public partial class ResizeKernelMapTests
     }
 
     private static string PrintKernelMap(ResizeKernelMap kernelMap)
-        => PrintKernelMap(kernelMap, km => km.DestinationLength, (km, i) => km.GetKernel(i));
+        => PrintKernelMap(kernelMap, km => km.DestinationLength, (km, i) => km.GetKernel((uint)i));
 
     private static string PrintKernelMap(ReferenceKernelMap kernelMap)
         => PrintKernelMap(kernelMap, km => km.DestinationSize, (km, i) => km.GetKernel(i));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Scanned through the code-base (Regex based search) and did some low-hanging fruit optimizations.
* optimized [division by constants](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgCUBXAOwwEt8YLAJI8ovLrl5hcAbho1iAZiakGAYQYBvGg11NlXcRgYBZcgAojDADYwuAcwwALAJQMAvAD4bdx04YA9AwAajBgGNDkpAAcADwAZtYQ2BieLGoQ3Bhy1Hr6DIY8pqSWRbYOzm5eDOaFGC7mHEYu5X6BIWERUFFxicmp6Zk8OQC+QA=)
* for `Unsafe.Add`-usage tweaked the code / loops to don't emit sign extending movs (`movsxd` -> `mov` or `movzx`)

Sorry for touching so many files...
Cf. https://github.com/SixLabors/ImageSharp/pull/2397#discussion_r1133733625