### PR TITLE
Port GrayscalConverter to Arm

### DIFF
--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -580,7 +580,7 @@ internal static partial class SimdUtils
                 return AdvSimd.Add(AdvSimd.Multiply(vm0, vm1), va);
             }
 
-            return Avx.Add(Avx.Multiply(vm0, vm1), va);
+            return Sse.Add(Sse.Multiply(vm0, vm1), va);
         }
 
         /// <summary>

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -4,6 +4,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -549,6 +550,34 @@ internal static partial class SimdUtils
             if (Fma.IsSupported)
             {
                 return Fma.MultiplyAdd(vm1, vm0, va);
+            }
+
+            return Avx.Add(Avx.Multiply(vm0, vm1), va);
+        }
+
+        /// <summary>
+        /// Performs a multiplication and an addition of the <see cref="Vector128{Single}"/>.
+        /// TODO: Fix. The arguments are in a different order to the FMA intrinsic.
+        /// </summary>
+        /// <remarks>ret = (vm0 * vm1) + va</remarks>
+        /// <param name="va">The vector to add to the intermediate result.</param>
+        /// <param name="vm0">The first vector to multiply.</param>
+        /// <param name="vm1">The second vector to multiply.</param>
+        /// <returns>The <see cref="Vector256{T}"/>.</returns>
+        [MethodImpl(InliningOptions.AlwaysInline)]
+        public static Vector128<float> MultiplyAdd(
+            in Vector128<float> va,
+            in Vector128<float> vm0,
+            in Vector128<float> vm1)
+        {
+            if (Fma.IsSupported)
+            {
+                return Fma.MultiplyAdd(vm1, vm0, va);
+            }
+
+            if (AdvSimd.IsSupported)
+            {
+                return AdvSimd.Add(AdvSimd.Multiply(vm0, vm1), va);
             }
 
             return Avx.Add(Avx.Multiply(vm0, vm1), va);

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -566,9 +566,9 @@ internal static partial class SimdUtils
         /// <returns>The <see cref="Vector256{T}"/>.</returns>
         [MethodImpl(InliningOptions.AlwaysInline)]
         public static Vector128<float> MultiplyAdd(
-            in Vector128<float> va,
-            in Vector128<float> vm0,
-            in Vector128<float> vm1)
+            Vector128<float> va,
+            Vector128<float> vm0,
+            Vector128<float> vm1)
         {
             if (Fma.IsSupported)
             {

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleArm.cs
@@ -27,8 +27,8 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector128.Create(1 / this.MaximumValue);
 
-            nint n = values.Component0.Length / Vector128<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector128<float> c0 = ref Unsafe.Add(ref c0Base, i);
                 c0 = AdvSimd.Multiply(c0, scale);
@@ -53,8 +53,8 @@ internal abstract partial class JpegColorConverterBase
             var f0587 = Vector128.Create(0.587f);
             var f0114 = Vector128.Create(0.114f);
 
-            nint n = values.Component0.Length / Vector128<float>.Count;
-            for (nint i = 0; i < n; i++)
+            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
+            for (nuint i = 0; i < n; i++)
             {
                 ref Vector128<float> r = ref Unsafe.Add(ref srcRed, i);
                 ref Vector128<float> g = ref Unsafe.Add(ref srcGreen, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleArm.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using static SixLabors.ImageSharp.SimdUtils;
+
+namespace SixLabors.ImageSharp.Formats.Jpeg.Components;
+
+internal abstract partial class JpegColorConverterBase
+{
+    internal sealed class GrayscaleArm : JpegColorConverterArm
+    {
+        public GrayscaleArm(int precision)
+            : base(JpegColorSpace.Grayscale, precision)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void ConvertToRgbInplace(in ComponentValues values)
+        {
+            ref Vector128<float> c0Base =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component0));
+
+            // Used for the color conversion
+            var scale = Vector128.Create(1 / this.MaximumValue);
+
+            nint n = values.Component0.Length / Vector128<float>.Count;
+            for (nint i = 0; i < n; i++)
+            {
+                ref Vector128<float> c0 = ref Unsafe.Add(ref c0Base, i);
+                c0 = AdvSimd.Multiply(c0, scale);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void ConvertFromRgb(in ComponentValues values, Span<float> rLane, Span<float> gLane, Span<float> bLane)
+        {
+            ref Vector128<float> destLuminance =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component0));
+
+            ref Vector128<float> srcRed =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(rLane));
+            ref Vector128<float> srcGreen =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(gLane));
+            ref Vector128<float> srcBlue =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(bLane));
+
+            // Used for the color conversion
+            var f0299 = Vector128.Create(0.299f);
+            var f0587 = Vector128.Create(0.587f);
+            var f0114 = Vector128.Create(0.114f);
+
+            nint n = values.Component0.Length / Vector128<float>.Count;
+            for (nint i = 0; i < n; i++)
+            {
+                ref Vector128<float> r = ref Unsafe.Add(ref srcRed, i);
+                ref Vector128<float> g = ref Unsafe.Add(ref srcGreen, i);
+                ref Vector128<float> b = ref Unsafe.Add(ref srcBlue, i);
+
+                // luminocity = (0.299 * r) + (0.587 * g) + (0.114 * b)
+                Unsafe.Add(ref destLuminance, i) = HwIntrinsics.MultiplyAdd(HwIntrinsics.MultiplyAdd(AdvSimd.Multiply(f0114, b), f0587, g), f0299, r);
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
@@ -200,6 +200,11 @@ internal abstract partial class JpegColorConverterBase
             return new GrayscaleAvx(precision);
         }
 
+        if (JpegColorConverterArm.IsSupported)
+        {
+            return new GrayscaleArm(precision);
+        }
+
         if (JpegColorConverterVector.IsSupported)
         {
             return new GrayScaleVector(precision);

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/ColorConversion/GrayscaleColorConversion.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/ColorConversion/GrayscaleColorConversion.cs
@@ -29,4 +29,12 @@ public class GrayscaleColorConversion : ColorConversionBenchmark
 
         new JpegColorConverterBase.GrayscaleAvx(8).ConvertToRgbInplace(values);
     }
+
+    [Benchmark]
+    public void SimdVectorArm()
+    {
+        var values = new JpegColorConverterBase.ComponentValues(this.Input, 0);
+
+        new JpegColorConverterBase.GrayscaleArm(8).ConvertToRgbInplace(values);
+    }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -309,6 +309,23 @@ public class JpegColorConverterTests
 
     [Theory]
     [MemberData(nameof(Seeds))]
+    public void FromGrayscaleArm(int seed) =>
+        this.TestConversionToRgb(new JpegColorConverterBase.GrayscaleArm(8),
+            1,
+            seed,
+            new JpegColorConverterBase.GrayscaleScalar(8));
+
+    [Theory]
+    [MemberData(nameof(Seeds))]
+    public void FromRgbToGrayscaleArm(int seed) =>
+        this.TestConversionFromRgb(new JpegColorConverterBase.GrayscaleArm(8),
+            1,
+            seed,
+            new JpegColorConverterBase.GrayscaleScalar(8),
+            precísion: 3);
+
+    [Theory]
+    [MemberData(nameof(Seeds))]
     public void FromRgbAvx2(int seed) =>
         this.TestConversionToRgb(new JpegColorConverterBase.RgbAvx(8),
             3,
@@ -480,7 +497,7 @@ public class JpegColorConverterTests
         JpegColorConverterBase baseLineConverter,
         int precision = 4)
     {
-        // arrange 
+        // arrange
         JpegColorConverterBase.ComponentValues actual = CreateRandomValues(TestBufferLength, componentCount, seed);
         JpegColorConverterBase.ComponentValues expected = CreateRandomValues(TestBufferLength, componentCount, seed);
         Random rnd = new(seed);


### PR DESCRIPTION
Port Grayscaleconverter to ARM


Benchmarks:

```md
|        Method |      Mean |    Error |   StdDev | Ratio | RatioSD |
|-------------- |----------:|---------:|---------:|------:|--------:|
|        Scalar | 118.76 ns | 0.499 ns | 0.443 ns |  1.00 |    0.00 |
| SimdVectorAvx |        NA |       NA |       NA |     ? |       ? |
| SimdVectorArm |  53.57 ns | 0.410 ns | 0.364 ns |  0.45 |    0.00 |

```