### PR TITLE
Webp: Dont use using statement for encodedAlphaData

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
@@ -345,30 +345,6 @@ internal class Vp8Encoder : IDisposable
         int expectedSize = this.Mbw * this.Mbh * averageBytesPerMacroBlock;
         this.bitWriter = new Vp8BitWriter(expectedSize, this);
 
-        // Extract and encode alpha channel data, if present.
-        int alphaDataSize = 0;
-        bool alphaCompressionSucceeded = false;
-        Span<byte> alphaData = Span<byte>.Empty;
-        IMemoryOwner<byte> encodedAlphaData = null;
-        if (hasAlpha)
-        {
-            // TODO: This can potentially run in an separate task.
-            encodedAlphaData = AlphaEncoder.EncodeAlpha(
-                image,
-                this.configuration,
-                this.memoryAllocator,
-                this.skipMetadata,
-                this.alphaCompression,
-                out alphaDataSize);
-
-            alphaData = encodedAlphaData.GetSpan();
-            if (alphaDataSize < pixelCount)
-            {
-                // Only use compressed data, if the compressed data is actually smaller then the uncompressed data.
-                alphaCompressionSucceeded = true;
-            }
-        }
-
         // Stats-collection loop.
         this.StatLoop(width, height, yStride, uvStride);
         it.Init();
@@ -406,8 +382,32 @@ internal class Vp8Encoder : IDisposable
         ExifProfile exifProfile = this.skipMetadata ? null : metadata.ExifProfile;
         XmpProfile xmpProfile = this.skipMetadata ? null : metadata.XmpProfile;
 
+        // Extract and encode alpha channel data, if present.
+        int alphaDataSize = 0;
+        bool alphaCompressionSucceeded = false;
+        Span<byte> alphaData = Span<byte>.Empty;
+        IMemoryOwner<byte> encodedAlphaData = null;
         try
         {
+            if (hasAlpha)
+            {
+                // TODO: This can potentially run in an separate task.
+                encodedAlphaData = AlphaEncoder.EncodeAlpha(
+                    image,
+                    this.configuration,
+                    this.memoryAllocator,
+                    this.skipMetadata,
+                    this.alphaCompression,
+                    out alphaDataSize);
+
+                alphaData = encodedAlphaData.GetSpan();
+                if (alphaDataSize < pixelCount)
+                {
+                    // Only use compressed data, if the compressed data is actually smaller then the uncompressed data.
+                    alphaCompressionSucceeded = true;
+                }
+            }
+
             this.bitWriter.WriteEncodedImageToStream(
                 stream,
                 exifProfile,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable) Not sure howto provide a test for this issue.

### Description

This PR changes the disposing of the encodedAlphaData to be in a try/finally block instead of using statement.
This is related to Issue #2411
