### PR TITLE
Fixed wrong division hack

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
@@ -1456,7 +1456,7 @@ internal static unsafe class LosslessUtils
     }
 
     [MethodImpl(InliningOptions.ShortMethod)]
-    private static int AddSubtractComponentHalf(int a, int b) => (int)Clip255((uint)(a + ((a - b) >> 1)));  // >> 1 is bit-hack for / 2
+    private static int AddSubtractComponentHalf(int a, int b) => (int)Clip255((uint)(a + ((a - b) / 2)));
 
     [MethodImpl(InliningOptions.ShortMethod)]
     private static int AddSubtractComponentFull(int a, int b, int c) => (int)Clip255((uint)(a + b - c));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

In https://github.com/SixLabors/ImageSharp/pull/2401 I introduced a bug (sorry for that) -- this PR fixes that.
The bit-hack for divison by powers of two is only valid for positive numerators, and in the failed testcase (cf. https://github.com/SixLabors/ImageSharp/pull/2409#issuecomment-1482798035) it was negative. As showcase see [this sharplab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEUCuA7AHwAEAmARgFgAoayPAZwwAIBLPZgExgBsMBDJgF4mcAMwB2ANzVqRMgE4AFF14CA9ExIBKaVTlKV/JgD5jTMjqA===).

**Note to maintainers**: please run CI on ARM too (as I understand that's not on by default, so that bug even came into main-branch)