### PR TITLE
Fix RgbScalar

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
@@ -229,7 +229,7 @@ internal abstract partial class JpegColorConverterBase
             return new RgbScalar(precision);
         }
 
-        return new GrayscaleScalar(precision);
+        return new RgbScalar(precision);
     }
 
     /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
@@ -226,7 +226,7 @@ internal abstract partial class JpegColorConverterBase
 
         if (JpegColorConverterVector.IsSupported)
         {
-            return new RgbScalar(precision);
+            return new RgbVector(precision);
         }
 
         return new RgbScalar(precision);

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -72,7 +72,7 @@ public class JpegColorConverterTests
     }
 
     [Fact]
-    public void GetConverterReturnsValidConverterWithRgbColorSpace()
+    public void GetConverterReturnsCorrectConverterWithRgbColorSpace()
     {
         FeatureTestRunner.RunWithHwIntrinsicsFeature(
             RunTest,
@@ -97,6 +97,39 @@ public class JpegColorConverterTests
 
             // act
             JpegColorConverterBase converter = JpegColorConverterBase.GetConverter(JpegColorSpace.RGB, 8);
+            Type actualType = converter.GetType();
+
+            // assert
+            Assert.Equal(expectedType, actualType);
+        }
+    }
+
+    [Fact]
+    public void GetConverterReturnsCorrectConverterWithCmykColorSpace()
+    {
+        FeatureTestRunner.RunWithHwIntrinsicsFeature(
+            RunTest,
+            HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE2 | HwIntrinsics.DisableHWIntrinsic);
+
+        static void RunTest(string arg)
+        {
+            // arrange
+            Type expectedType = typeof(JpegColorConverterBase.CmykScalar);
+            if (Avx.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.CmykAvx);
+            }
+            else if (Sse2.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.CmykVector);
+            }
+            else if (AdvSimd.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.CmykArm64);
+            }
+
+            // act
+            JpegColorConverterBase converter = JpegColorConverterBase.GetConverter(JpegColorSpace.Cmyk, 8);
             Type actualType = converter.GetType();
 
             // assert

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -222,6 +222,10 @@ public class JpegColorConverterTests
             {
                 expectedType = typeof(JpegColorConverterBase.YccKVector);
             }
+            else if (AdvSimd.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.YccKVector);
+            }
 
             // act
             JpegColorConverterBase converter = JpegColorConverterBase.GetConverter(JpegColorSpace.Ycck, 8);

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -277,7 +277,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromYCbCrAvx2(int seed) =>
-        this.TestConversionToRgb(new JpegColorConverterBase.YCbCrAvx(8),
+        this.TestConversionToRgb(
+            new JpegColorConverterBase.YCbCrAvx(8),
             3,
             seed,
             new JpegColorConverterBase.YCbCrScalar(8));
@@ -285,7 +286,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromRgbToYCbCrAvx2(int seed) =>
-        this.TestConversionFromRgb(new JpegColorConverterBase.YCbCrAvx(8),
+        this.TestConversionFromRgb(
+            new JpegColorConverterBase.YCbCrAvx(8),
             3,
             seed,
             new JpegColorConverterBase.YCbCrScalar(8),
@@ -294,7 +296,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromCmykAvx2(int seed) =>
-        this.TestConversionToRgb(new JpegColorConverterBase.CmykAvx(8),
+        this.TestConversionToRgb(
+            new JpegColorConverterBase.CmykAvx(8),
             4,
             seed,
             new JpegColorConverterBase.CmykScalar(8));
@@ -302,7 +305,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromRgbToCmykAvx2(int seed) =>
-        this.TestConversionFromRgb(new JpegColorConverterBase.CmykAvx(8),
+        this.TestConversionFromRgb(
+            new JpegColorConverterBase.CmykAvx(8),
             4,
             seed,
             new JpegColorConverterBase.CmykScalar(8),
@@ -311,7 +315,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromCmykArm(int seed) =>
-        this.TestConversionToRgb( new JpegColorConverterBase.CmykArm64(8),
+        this.TestConversionToRgb(
+            new JpegColorConverterBase.CmykArm64(8),
             4,
             seed,
             new JpegColorConverterBase.CmykScalar(8));
@@ -319,7 +324,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromRgbToCmykArm(int seed) =>
-        this.TestConversionFromRgb(new JpegColorConverterBase.CmykArm64(8),
+        this.TestConversionFromRgb(
+            new JpegColorConverterBase.CmykArm64(8),
             4,
             seed,
             new JpegColorConverterBase.CmykScalar(8),
@@ -328,7 +334,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromGrayscaleAvx2(int seed) =>
-        this.TestConversionToRgb(new JpegColorConverterBase.GrayscaleAvx(8),
+        this.TestConversionToRgb(
+            new JpegColorConverterBase.GrayscaleAvx(8),
             1,
             seed,
             new JpegColorConverterBase.GrayscaleScalar(8));
@@ -336,7 +343,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromRgbToGrayscaleAvx2(int seed) =>
-        this.TestConversionFromRgb(new JpegColorConverterBase.GrayscaleAvx(8),
+        this.TestConversionFromRgb(
+            new JpegColorConverterBase.GrayscaleAvx(8),
             1,
             seed,
             new JpegColorConverterBase.GrayscaleScalar(8),
@@ -345,7 +353,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromRgbAvx2(int seed) =>
-        this.TestConversionToRgb(new JpegColorConverterBase.RgbAvx(8),
+        this.TestConversionToRgb(
+            new JpegColorConverterBase.RgbAvx(8),
             3,
             seed,
             new JpegColorConverterBase.RgbScalar(8));
@@ -353,7 +362,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromRgbArm(int seed) =>
-        this.TestConversionToRgb(new JpegColorConverterBase.RgbArm(8),
+        this.TestConversionToRgb(
+            new JpegColorConverterBase.RgbArm(8),
             3,
             seed,
             new JpegColorConverterBase.RgbScalar(8));
@@ -361,7 +371,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromYccKAvx2(int seed) =>
-        this.TestConversionToRgb( new JpegColorConverterBase.YccKAvx(8),
+        this.TestConversionToRgb(
+            new JpegColorConverterBase.YccKAvx(8),
             4,
             seed,
             new JpegColorConverterBase.YccKScalar(8));
@@ -369,7 +380,8 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromRgbToYccKAvx2(int seed) =>
-        this.TestConversionFromRgb(new JpegColorConverterBase.YccKAvx(8),
+        this.TestConversionFromRgb(
+            new JpegColorConverterBase.YccKAvx(8),
             4,
             seed,
             new JpegColorConverterBase.YccKScalar(8),
@@ -515,7 +527,7 @@ public class JpegColorConverterTests
         JpegColorConverterBase baseLineConverter,
         int precision = 4)
     {
-        // arrange 
+        // arrange
         JpegColorConverterBase.ComponentValues actual = CreateRandomValues(TestBufferLength, componentCount, seed);
         JpegColorConverterBase.ComponentValues expected = CreateRandomValues(TestBufferLength, componentCount, seed);
         Random rnd = new(seed);

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -105,6 +105,35 @@ public class JpegColorConverterTests
     }
 
     [Fact]
+    public void GetConverterReturnsCorrectConverterWithGrayScaleColorSpace()
+    {
+        FeatureTestRunner.RunWithHwIntrinsicsFeature(
+            RunTest,
+            HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE2 | HwIntrinsics.DisableHWIntrinsic);
+
+        static void RunTest(string arg)
+        {
+            // arrange
+            Type expectedType = typeof(JpegColorConverterBase.GrayscaleScalar);
+            if (Avx.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.GrayscaleAvx);
+            }
+            else if (Sse2.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.GrayScaleVector);
+            }
+
+            // act
+            JpegColorConverterBase converter = JpegColorConverterBase.GetConverter(JpegColorSpace.Grayscale, 8);
+            Type actualType = converter.GetType();
+
+            // assert
+            Assert.Equal(expectedType, actualType);
+        }
+    }
+
+    [Fact]
     public void GetConverterReturnsCorrectConverterWithCmykColorSpace()
     {
         FeatureTestRunner.RunWithHwIntrinsicsFeature(

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -189,6 +189,10 @@ public class JpegColorConverterTests
             {
                 expectedType = typeof(JpegColorConverterBase.YCbCrVector);
             }
+            else if (AdvSimd.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.YCbCrVector);
+            }
 
             // act
             JpegColorConverterBase converter = JpegColorConverterBase.GetConverter(JpegColorSpace.YCbCr, 8);

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -137,6 +137,35 @@ public class JpegColorConverterTests
         }
     }
 
+    [Fact]
+    public void GetConverterReturnsCorrectConverterWithYCbCrColorSpace()
+    {
+        FeatureTestRunner.RunWithHwIntrinsicsFeature(
+            RunTest,
+            HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE2 | HwIntrinsics.DisableHWIntrinsic);
+
+        static void RunTest(string arg)
+        {
+            // arrange
+            Type expectedType = typeof(JpegColorConverterBase.YCbCrScalar);
+            if (Avx.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.YCbCrAvx);
+            }
+            else if (Sse2.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.YCbCrVector);
+            }
+
+            // act
+            JpegColorConverterBase converter = JpegColorConverterBase.GetConverter(JpegColorSpace.YCbCr, 8);
+            Type actualType = converter.GetType();
+
+            // assert
+            Assert.Equal(expectedType, actualType);
+        }
+    }
+
     [Theory]
     [InlineData(JpegColorSpace.Grayscale, 1)]
     [InlineData(JpegColorSpace.Ycck, 4)]

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -166,6 +166,35 @@ public class JpegColorConverterTests
         }
     }
 
+    [Fact]
+    public void GetConverterReturnsCorrectConverterWithYcckColorSpace()
+    {
+        FeatureTestRunner.RunWithHwIntrinsicsFeature(
+            RunTest,
+            HwIntrinsics.AllowAll | HwIntrinsics.DisableAVX2 | HwIntrinsics.DisableSSE2 | HwIntrinsics.DisableHWIntrinsic);
+
+        static void RunTest(string arg)
+        {
+            // arrange
+            Type expectedType = typeof(JpegColorConverterBase.YccKScalar);
+            if (Avx.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.YccKAvx);
+            }
+            else if (Sse2.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.YccKVector);
+            }
+
+            // act
+            JpegColorConverterBase converter = JpegColorConverterBase.GetConverter(JpegColorSpace.Ycck, 8);
+            Type actualType = converter.GetType();
+
+            // assert
+            Assert.Equal(expectedType, actualType);
+        }
+    }
+
     [Theory]
     [InlineData(JpegColorSpace.Grayscale, 1)]
     [InlineData(JpegColorSpace.Ycck, 4)]

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -123,6 +123,10 @@ public class JpegColorConverterTests
             {
                 expectedType = typeof(JpegColorConverterBase.GrayScaleVector);
             }
+            else if (AdvSimd.IsSupported)
+            {
+                expectedType = typeof(JpegColorConverterBase.GrayscaleArm);
+            }
 
             // act
             JpegColorConverterBase converter = JpegColorConverterBase.GetConverter(JpegColorSpace.Grayscale, 8);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I ran the tests with SSE Disabled. And I found this bug... 

Before fixing it I had 151 failing tests after it only 53 tests are failing. On a quick check all other failures are 'Image difference is over threshold!' 