### PR TITLE
Port colorconverter YCbCr and YCCk  to arm

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrArm.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+using static SixLabors.ImageSharp.SimdUtils;
+
+// ReSharper disable ImpureMethodCallOnReadonlyValueField
+namespace SixLabors.ImageSharp.Formats.Jpeg.Components;
+
+internal abstract partial class JpegColorConverterBase
+{
+    internal sealed class YCbCrArm : JpegColorConverterArm
+    {
+        public YCbCrArm(int precision)
+            : base(JpegColorSpace.YCbCr, precision)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void ConvertToRgbInplace(in ComponentValues values)
+        {
+            ref Vector128<float> c0Base =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component0));
+            ref Vector128<float> c1Base =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component1));
+            ref Vector128<float> c2Base =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component2));
+
+            // Used for the color conversion
+            var chromaOffset = Vector128.Create(-this.HalfValue);
+            var scale = Vector128.Create(1 / this.MaximumValue);
+            var rCrMult = Vector128.Create(YCbCrScalar.RCrMult);
+            var gCbMult = Vector128.Create(-YCbCrScalar.GCbMult);
+            var gCrMult = Vector128.Create(-YCbCrScalar.GCrMult);
+            var bCbMult = Vector128.Create(YCbCrScalar.BCbMult);
+
+            // Walking 8 elements at one step:
+            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
+            for (nuint i = 0; i < n; i++)
+            {
+                // y = yVals[i];
+                // cb = cbVals[i] - 128F;
+                // cr = crVals[i] - 128F;
+                ref Vector128<float> c0 = ref Unsafe.Add(ref c0Base, i);
+                ref Vector128<float> c1 = ref Unsafe.Add(ref c1Base, i);
+                ref Vector128<float> c2 = ref Unsafe.Add(ref c2Base, i);
+
+                Vector128<float> y = c0;
+                Vector128<float> cb = AdvSimd.Add(c1, chromaOffset);
+                Vector128<float> cr = AdvSimd.Add(c2, chromaOffset);
+
+                // r = y + (1.402F * cr);
+                // g = y - (0.344136F * cb) - (0.714136F * cr);
+                // b = y + (1.772F * cb);
+                Vector128<float> r = HwIntrinsics.MultiplyAdd(y, cr, rCrMult);
+                Vector128<float> g = HwIntrinsics.MultiplyAdd(HwIntrinsics.MultiplyAdd(y, cb, gCbMult), cr, gCrMult);
+                Vector128<float> b = HwIntrinsics.MultiplyAdd(y, cb, bCbMult);
+
+                r = AdvSimd.Multiply(AdvSimd.RoundToNearest(r), scale);
+                g = AdvSimd.Multiply(AdvSimd.RoundToNearest(g), scale);
+                b = AdvSimd.Multiply(AdvSimd.RoundToNearest(b), scale);
+
+                c0 = r;
+                c1 = g;
+                c2 = b;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void ConvertFromRgb(in ComponentValues values, Span<float> rLane, Span<float> gLane, Span<float> bLane)
+        {
+            ref Vector128<float> destY =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component0));
+            ref Vector128<float> destCb =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component1));
+            ref Vector128<float> destCr =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component2));
+
+            ref Vector128<float> srcR =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(rLane));
+            ref Vector128<float> srcG =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(gLane));
+            ref Vector128<float> srcB =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(bLane));
+
+            // Used for the color conversion
+            var chromaOffset = Vector128.Create(this.HalfValue);
+
+            var f0299 = Vector128.Create(0.299f);
+            var f0587 = Vector128.Create(0.587f);
+            var f0114 = Vector128.Create(0.114f);
+            var fn0168736 = Vector128.Create(-0.168736f);
+            var fn0331264 = Vector128.Create(-0.331264f);
+            var fn0418688 = Vector128.Create(-0.418688f);
+            var fn0081312F = Vector128.Create(-0.081312F);
+            var f05 = Vector128.Create(0.5f);
+
+            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
+            for (nuint i = 0; i < n; i++)
+            {
+                Vector128<float> r = Unsafe.Add(ref srcR, i);
+                Vector128<float> g = Unsafe.Add(ref srcG, i);
+                Vector128<float> b = Unsafe.Add(ref srcB, i);
+
+                // y  =   0 + (0.299 * r) + (0.587 * g) + (0.114 * b)
+                // cb = 128 - (0.168736 * r) - (0.331264 * g) + (0.5 * b)
+                // cr = 128 + (0.5 * r) - (0.418688 * g) - (0.081312 * b)
+                Vector128<float> y = HwIntrinsics.MultiplyAdd(HwIntrinsics.MultiplyAdd(AdvSimd.Multiply(f0114, b), f0587, g), f0299, r);
+                Vector128<float> cb = AdvSimd.Add(chromaOffset, HwIntrinsics.MultiplyAdd(HwIntrinsics.MultiplyAdd(AdvSimd.Multiply(f05, b), fn0331264, g), fn0168736, r));
+                Vector128<float> cr = AdvSimd.Add(chromaOffset, HwIntrinsics.MultiplyAdd(HwIntrinsics.MultiplyAdd(AdvSimd.Multiply(fn0081312F, b), fn0418688, g), f05, r));
+
+                Unsafe.Add(ref destY, i) = y;
+                Unsafe.Add(ref destCb, i) = cb;
+                Unsafe.Add(ref destCr, i) = cr;
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKArm64.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKArm64.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+using static SixLabors.ImageSharp.SimdUtils;
+
+namespace SixLabors.ImageSharp.Formats.Jpeg.Components;
+
+internal abstract partial class JpegColorConverterBase
+{
+    internal sealed class YccKArm64 : JpegColorConverterArm64
+    {
+        public YccKArm64(int precision)
+            : base(JpegColorSpace.Ycck, precision)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void ConvertToRgbInplace(in ComponentValues values)
+        {
+            ref Vector128<float> c0Base =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component0));
+            ref Vector128<float> c1Base =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component1));
+            ref Vector128<float> c2Base =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component2));
+            ref Vector128<float> kBase =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component3));
+
+            // Used for the color conversion
+            var chromaOffset = Vector128.Create(-this.HalfValue);
+            var scale = Vector128.Create(1 / (this.MaximumValue * this.MaximumValue));
+            var max = Vector128.Create(this.MaximumValue);
+            var rCrMult = Vector128.Create(YCbCrScalar.RCrMult);
+            var gCbMult = Vector128.Create(-YCbCrScalar.GCbMult);
+            var gCrMult = Vector128.Create(-YCbCrScalar.GCrMult);
+            var bCbMult = Vector128.Create(YCbCrScalar.BCbMult);
+
+            // Walking 8 elements at one step:
+            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
+            for (nuint i = 0; i < n; i++)
+            {
+                // y = yVals[i];
+                // cb = cbVals[i] - 128F;
+                // cr = crVals[i] - 128F;
+                // k = kVals[i] / 256F;
+                ref Vector128<float> c0 = ref Unsafe.Add(ref c0Base, i);
+                ref Vector128<float> c1 = ref Unsafe.Add(ref c1Base, i);
+                ref Vector128<float> c2 = ref Unsafe.Add(ref c2Base, i);
+                Vector128<float> y = c0;
+                Vector128<float> cb = AdvSimd.Add(c1, chromaOffset);
+                Vector128<float> cr = AdvSimd.Add(c2, chromaOffset);
+                Vector128<float> scaledK = AdvSimd.Multiply(Unsafe.Add(ref kBase, i), scale);
+
+                // r = y + (1.402F * cr);
+                // g = y - (0.344136F * cb) - (0.714136F * cr);
+                // b = y + (1.772F * cb);
+                Vector128<float> r = HwIntrinsics.MultiplyAdd(y, cr, rCrMult);
+                Vector128<float> g =
+                    HwIntrinsics.MultiplyAdd(HwIntrinsics.MultiplyAdd(y, cb, gCbMult), cr, gCrMult);
+                Vector128<float> b = HwIntrinsics.MultiplyAdd(y, cb, bCbMult);
+
+                r = AdvSimd.Subtract(max, AdvSimd.RoundToNearest(r));
+                g = AdvSimd.Subtract(max, AdvSimd.RoundToNearest(g));
+                b = AdvSimd.Subtract(max, AdvSimd.RoundToNearest(b));
+
+                r = AdvSimd.Multiply(r, scaledK);
+                g = AdvSimd.Multiply(g, scaledK);
+                b = AdvSimd.Multiply(b, scaledK);
+
+                c0 = r;
+                c1 = g;
+                c2 = b;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void ConvertFromRgb(in ComponentValues values, Span<float> rLane, Span<float> gLane, Span<float> bLane)
+        {
+            // rgb -> cmyk
+            CmykArm64.ConvertFromRgb(in values, this.MaximumValue, rLane, gLane, bLane);
+
+            // cmyk -> ycck
+            ref Vector128<float> destY =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component0));
+            ref Vector128<float> destCb =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component1));
+            ref Vector128<float> destCr =
+                ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(values.Component2));
+
+            ref Vector128<float> srcR = ref destY;
+            ref Vector128<float> srcG = ref destCb;
+            ref Vector128<float> srcB = ref destCr;
+
+            // Used for the color conversion
+            var maxSampleValue = Vector128.Create(this.MaximumValue);
+
+            var chromaOffset = Vector128.Create(this.HalfValue);
+
+            var f0299 = Vector128.Create(0.299f);
+            var f0587 = Vector128.Create(0.587f);
+            var f0114 = Vector128.Create(0.114f);
+            var fn0168736 = Vector128.Create(-0.168736f);
+            var fn0331264 = Vector128.Create(-0.331264f);
+            var fn0418688 = Vector128.Create(-0.418688f);
+            var fn0081312F = Vector128.Create(-0.081312F);
+            var f05 = Vector128.Create(0.5f);
+
+            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
+            for (nuint i = 0; i < n; i++)
+            {
+                Vector128<float> r = AdvSimd.Subtract(maxSampleValue, Unsafe.Add(ref srcR, i));
+                Vector128<float> g = AdvSimd.Subtract(maxSampleValue, Unsafe.Add(ref srcG, i));
+                Vector128<float> b = AdvSimd.Subtract(maxSampleValue, Unsafe.Add(ref srcB, i));
+
+                // y  =   0 + (0.299 * r) + (0.587 * g) + (0.114 * b)
+                // cb = 128 - (0.168736 * r) - (0.331264 * g) + (0.5 * b)
+                // cr = 128 + (0.5 * r) - (0.418688 * g) - (0.081312 * b)
+                Vector128<float> y = HwIntrinsics.MultiplyAdd(HwIntrinsics.MultiplyAdd(AdvSimd.Multiply(f0114, b), f0587, g), f0299, r);
+                Vector128<float> cb = AdvSimd.Add(chromaOffset, HwIntrinsics.MultiplyAdd(HwIntrinsics.MultiplyAdd(AdvSimd.Multiply(f05, b), fn0331264, g), fn0168736, r));
+                Vector128<float> cr = AdvSimd.Add(chromaOffset, HwIntrinsics.MultiplyAdd(HwIntrinsics.MultiplyAdd(AdvSimd.Multiply(fn0081312F, b), fn0418688, g), f05, r));
+
+                Unsafe.Add(ref destY, i) = y;
+                Unsafe.Add(ref destCb, i) = cb;
+                Unsafe.Add(ref destCr, i) = cr;
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
@@ -167,6 +167,11 @@ internal abstract partial class JpegColorConverterBase
             return new YccKVector(precision);
         }
 
+        if (JpegColorConverterArm64.IsSupported)
+        {
+            return new YccKArm64(precision);
+        }
+
         return new YccKScalar(precision);
     }
 

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
@@ -162,14 +162,14 @@ internal abstract partial class JpegColorConverterBase
             return new YccKAvx(precision);
         }
 
-        if (JpegColorConverterVector.IsSupported)
-        {
-            return new YccKVector(precision);
-        }
-
         if (JpegColorConverterArm64.IsSupported)
         {
             return new YccKArm64(precision);
+        }
+
+        if (JpegColorConverterVector.IsSupported)
+        {
+            return new YccKVector(precision);
         }
 
         return new YccKScalar(precision);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverterBase.cs
@@ -138,6 +138,11 @@ internal abstract partial class JpegColorConverterBase
             return new YCbCrAvx(precision);
         }
 
+        if (JpegColorConverterArm.IsSupported)
+        {
+            return new YCbCrArm(precision);
+        }
+
         if (JpegColorConverterVector.IsSupported)
         {
             return new YCbCrVector(precision);

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/ColorConversion/YCbCrColorConversion.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/ColorConversion/YCbCrColorConversion.cs
@@ -37,4 +37,12 @@ public class YCbCrColorConversion : ColorConversionBenchmark
 
         new JpegColorConverterBase.YCbCrAvx(8).ConvertToRgbInplace(values);
     }
+
+    [Benchmark]
+    public void SimdVectorArm()
+    {
+        var values = new JpegColorConverterBase.ComponentValues(this.Input, 0);
+
+        new JpegColorConverterBase.YCbCrArm(8).ConvertToRgbInplace(values);
+    }
 }

--- a/tests/ImageSharp.Benchmarks/Codecs/Jpeg/ColorConversion/YccKColorConverter.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Jpeg/ColorConversion/YccKColorConverter.cs
@@ -37,4 +37,12 @@ public class YccKColorConverter : ColorConversionBenchmark
 
         new JpegColorConverterBase.YccKAvx(8).ConvertToRgbInplace(values);
     }
+
+    [Benchmark]
+    public void SimdVectorArm64()
+    {
+        var values = new JpegColorConverterBase.ComponentValues(this.Input, 0);
+
+        new JpegColorConverterBase.YccKArm64(8).ConvertToRgbInplace(values);
+    }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -156,7 +156,7 @@ public class JpegColorConverterTests
             {
                 expectedType = typeof(JpegColorConverterBase.CmykVector);
             }
-            else if (AdvSimd.IsSupported)
+            else if (AdvSimd.Arm64.IsSupported)
             {
                 expectedType = typeof(JpegColorConverterBase.CmykArm64);
             }
@@ -222,7 +222,7 @@ public class JpegColorConverterTests
             {
                 expectedType = typeof(JpegColorConverterBase.YccKVector);
             }
-            else if (AdvSimd.IsSupported)
+            else if (AdvSimd.Arm64.IsSupported)
             {
                 expectedType = typeof(JpegColorConverterBase.YccKArm64);
             }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -258,6 +258,23 @@ public class JpegColorConverterTests
 
     [Theory]
     [MemberData(nameof(Seeds))]
+    public void FromYCbCrArm(int seed) =>
+        this.TestConversionToRgb(new JpegColorConverterBase.YCbCrArm(8),
+            3,
+            seed,
+            new JpegColorConverterBase.YCbCrScalar(8));
+
+    [Theory]
+    [MemberData(nameof(Seeds))]
+    public void FromRgbToYCbCrArm(int seed) =>
+        this.TestConversionFromRgb(new JpegColorConverterBase.YCbCrArm(8),
+            3,
+            seed,
+            new JpegColorConverterBase.YCbCrScalar(8),
+            precísion: 2);
+
+    [Theory]
+    [MemberData(nameof(Seeds))]
     public void FromCmykAvx2(int seed) =>
         this.TestConversionToRgb(new JpegColorConverterBase.CmykAvx(8),
             4,

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -374,6 +374,23 @@ public class JpegColorConverterTests
             new JpegColorConverterBase.YccKScalar(8),
             precísion: 4);
 
+    [Theory]
+    [MemberData(nameof(Seeds))]
+    public void FromYccKArm64(int seed) =>
+        this.TestConversionToRgb( new JpegColorConverterBase.YccKArm64(8),
+            4,
+            seed,
+            new JpegColorConverterBase.YccKScalar(8));
+
+    [Theory]
+    [MemberData(nameof(Seeds))]
+    public void FromRgbToYccKArm64(int seed) =>
+        this.TestConversionFromRgb(new JpegColorConverterBase.YccKArm64(8),
+            4,
+            seed,
+            new JpegColorConverterBase.YccKScalar(8),
+            precísion: 4);
+
     private void TestConversionToRgb(
         JpegColorConverterBase converter,
         int componentCount,

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -556,7 +556,7 @@ public class JpegColorConverterTests
     [Theory]
     [MemberData(nameof(Seeds))]
     public void FromYccKArm64(int seed) =>
-        this.TestConversionToRgb( new JpegColorConverterBase.YccKArm64(8),
+        this.TestConversionToRgb(new JpegColorConverterBase.YccKArm64(8),
             4,
             seed,
             new JpegColorConverterBase.YccKScalar(8));

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegColorConverterTests.cs
@@ -191,7 +191,7 @@ public class JpegColorConverterTests
             }
             else if (AdvSimd.IsSupported)
             {
-                expectedType = typeof(JpegColorConverterBase.YCbCrVector);
+                expectedType = typeof(JpegColorConverterBase.YCbCrArm);
             }
 
             // act
@@ -224,7 +224,7 @@ public class JpegColorConverterTests
             }
             else if (AdvSimd.IsSupported)
             {
-                expectedType = typeof(JpegColorConverterBase.YccKVector);
+                expectedType = typeof(JpegColorConverterBase.YccKArm64);
             }
 
             // act


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Benchmark:
YCbCr
|        Method |       Mean |    Error |   StdDev |
|-------------- |-----------:|---------:|---------:|
|        Scalar | 4,777.9 ns | 15.98 ns | 14.95 ns |
|   SimdVector8 |   295.5 ns |  1.07 ns |  1.00 ns |
| SimdVectorAvx |         NA |       NA |       NA |
| SimdVectorArm |   188.3 ns |  0.87 ns |  0.77 ns |

YCCk
|          Method |       Mean |    Error |   StdDev | Ratio | RatioSD |
|---------------- |-----------:|---------:|---------:|------:|--------:|
|          Scalar | 5,934.5 ns | 12.66 ns | 11.22 ns |  1.00 |    0.00 |
|     SimdVector8 |   327.8 ns |  0.74 ns |  0.70 ns |  0.06 |    0.00 |
|  SimdVectorAvx2 |         NA |       NA |       NA |     ? |       ? |
| SimdVectorArm64 |   228.3 ns |  0.47 ns |  0.42 ns |  0.04 |    0.00 |
