### PR TITLE
Added and used Numerics.Vector{128|256}Count extension

### DIFF
--- a/src/ImageSharp/Common/Helpers/Numerics.cs
+++ b/src/ImageSharp/Common/Helpers/Numerics.cs
@@ -949,4 +949,94 @@ internal static class Numerics
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsOutOfRange(int value, int min, int max)
         => (uint)(value - min) > (uint)(max - min);
+
+    /// <summary>
+    /// Gets the count of vectors that safely fit into the given span.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="span">The given span.</param>
+    /// <returns>Count of vectors that safely fit into the span.</returns>
+    public static nuint VectorCount<TVector>(this Span<byte> span)
+        where TVector : struct
+        => (uint)span.Length / (uint)Vector<TVector>.Count;
+
+    /// <summary>
+    /// Gets the count of vectors that safely fit into the given span.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="span">The given span.</param>
+    /// <returns>Count of vectors that safely fit into the span.</returns>
+    public static nuint Vector128Count<TVector>(this Span<byte> span)
+        where TVector : struct
+        => (uint)span.Length / (uint)Vector128<TVector>.Count;
+
+    /// <summary>
+    /// Gets the count of vectors that safely fit into the given span.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="span">The given span.</param>
+    /// <returns>Count of vectors that safely fit into the span.</returns>
+    public static nuint Vector128Count<TVector>(this ReadOnlySpan<byte> span)
+        where TVector : struct
+        => (uint)span.Length / (uint)Vector128<TVector>.Count;
+
+    /// <summary>
+    /// Gets the count of vectors that safely fit into the given span.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="span">The given span.</param>
+    /// <returns>Count of vectors that safely fit into the span.</returns>
+    public static nuint Vector256Count<TVector>(this Span<byte> span)
+        where TVector : struct
+        => (uint)span.Length / (uint)Vector256<TVector>.Count;
+
+    /// <summary>
+    /// Gets the count of vectors that safely fit into the given span.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="span">The given span.</param>
+    /// <returns>Count of vectors that safely fit into the span.</returns>
+    public static nuint Vector256Count<TVector>(this ReadOnlySpan<byte> span)
+        where TVector : struct
+        => (uint)span.Length / (uint)Vector256<TVector>.Count;
+
+    /// <summary>
+    /// Gets the count of vectors that safely fit into the given span.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="span">The given span.</param>
+    /// <returns>Count of vectors that safely fit into the span.</returns>
+    public static nuint VectorCount<TVector>(this Span<float> span)
+        where TVector : struct
+        => (uint)span.Length / (uint)Vector<TVector>.Count;
+
+    /// <summary>
+    /// Gets the count of vectors that safely fit into the given span.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="span">The given span.</param>
+    /// <returns>Count of vectors that safely fit into the span.</returns>
+    public static nuint Vector128Count<TVector>(this Span<float> span)
+        where TVector : struct
+        => (uint)span.Length / (uint)Vector128<TVector>.Count;
+
+    /// <summary>
+    /// Gets the count of vectors that safely fit into the given span.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="span">The given span.</param>
+    /// <returns>Count of vectors that safely fit into the span.</returns>
+    public static nuint Vector256Count<TVector>(this Span<float> span)
+        where TVector : struct
+        => (uint)span.Length / (uint)Vector256<TVector>.Count;
+
+    /// <summary>
+    /// Gets the count of vectors that safely fit into length.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="length">The given length.</param>
+    /// <returns>Count of vectors that safely fit into the length.</returns>
+    public static nuint Vector256Count<TVector>(int length)
+        where TVector : struct
+        => (uint)length / (uint)Vector256<TVector>.Count;
 }

--- a/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.ExtendedIntrinsics.cs
@@ -97,7 +97,7 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, Vector<byte>.Count);
 
-            nuint n = (uint)dest.Length / (uint)Vector<byte>.Count;
+            nuint n = dest.VectorCount<byte>();
 
             ref Vector<byte> sourceBase = ref Unsafe.As<byte, Vector<byte>>(ref MemoryMarshal.GetReference(source));
             ref Vector<float> destBase = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(dest));
@@ -132,7 +132,7 @@ internal static partial class SimdUtils
         {
             VerifySpanInput(source, dest, Vector<byte>.Count);
 
-            nuint n = (uint)dest.Length / (uint)Vector<byte>.Count;
+            nuint n = dest.VectorCount<byte>();
 
             ref Vector<float> sourceBase =
                 ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(source));

--- a/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
+++ b/src/ImageSharp/Common/Helpers/SimdUtils.HwIntrinsics.cs
@@ -222,7 +222,7 @@ internal static partial class SimdUtils
                 ref Vector256<float> destBase =
                     ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(dest));
 
-                nint n = (nint)(uint)(dest.Length / Vector256<float>.Count);
+                nint n = (nint)dest.Vector256Count<float>();
                 nint m = Numerics.Modulo4(n);
                 nint u = n - m;
 
@@ -392,7 +392,7 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                nuint n = (uint)source.Length / (uint)Vector128<byte>.Count;
+                nuint n = source.Vector128Count<byte>();
 
                 for (nuint i = 0; i < n; i += 3)
                 {
@@ -455,7 +455,7 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                nuint n = (uint)source.Length / (uint)Vector128<byte>.Count;
+                nuint n = source.Vector128Count<byte>();
 
                 for (nuint i = 0, j = 0; i < n; i += 3, j += 4)
                 {
@@ -499,7 +499,7 @@ internal static partial class SimdUtils
                 ref Vector128<byte> destBase =
                     ref Unsafe.As<byte, Vector128<byte>>(ref MemoryMarshal.GetReference(dest));
 
-                nuint n = (uint)source.Length / (uint)Vector128<byte>.Count;
+                nuint n = source.Vector128Count<byte>();
 
                 for (nuint i = 0, j = 0; i < n; i += 4, j += 3)
                 {
@@ -679,7 +679,7 @@ internal static partial class SimdUtils
                 {
                     VerifySpanInput(source, dest, Vector256<byte>.Count);
 
-                    nuint n = (uint)dest.Length / (uint)Vector256<byte>.Count;
+                    nuint n = dest.Vector256Count<byte>();
 
                     ref Vector256<float> destBase =
                         ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(dest));
@@ -712,7 +712,7 @@ internal static partial class SimdUtils
                     // Sse
                     VerifySpanInput(source, dest, Vector128<byte>.Count);
 
-                    nuint n = (uint)dest.Length / (uint)Vector128<byte>.Count;
+                    nuint n = dest.Vector128Count<byte>();
 
                     ref Vector128<float> destBase =
                         ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(dest));
@@ -811,7 +811,7 @@ internal static partial class SimdUtils
             {
                 VerifySpanInput(source, dest, Vector256<byte>.Count);
 
-                nuint n = (uint)dest.Length / (uint)Vector256<byte>.Count;
+                nuint n = dest.Vector256Count<byte>();
 
                 ref Vector256<float> sourceBase =
                     ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(source));
@@ -850,7 +850,7 @@ internal static partial class SimdUtils
                 // Sse
                 VerifySpanInput(source, dest, Vector128<byte>.Count);
 
-                nuint n = (uint)dest.Length / (uint)Vector128<byte>.Count;
+                nuint n = dest.Vector128Count<byte>();
 
                 ref Vector128<float> sourceBase =
                     ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(source));
@@ -893,7 +893,7 @@ internal static partial class SimdUtils
             ref Vector256<byte> bBase = ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(blueChannel));
             ref byte dBase = ref Unsafe.As<Rgb24, byte>(ref MemoryMarshal.GetReference(destination));
 
-            nuint count = (uint)redChannel.Length / (uint)Vector256<byte>.Count;
+            nuint count = redChannel.Vector256Count<byte>();
 
             ref byte control1Bytes = ref MemoryMarshal.GetReference(PermuteMaskEvenOdd8x32);
             Vector256<uint> control1 = Unsafe.As<byte, Vector256<uint>>(ref control1Bytes);
@@ -965,7 +965,7 @@ internal static partial class SimdUtils
             ref Vector256<byte> bBase = ref Unsafe.As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(blueChannel));
             ref Vector256<byte> dBase = ref Unsafe.As<Rgba32, Vector256<byte>>(ref MemoryMarshal.GetReference(destination));
 
-            nuint count = (uint)redChannel.Length / (uint)Vector256<byte>.Count;
+            nuint count = redChannel.Vector256Count<byte>();
             ref byte control1Bytes = ref MemoryMarshal.GetReference(PermuteMaskEvenOdd8x32);
             Vector256<uint> control1 = Unsafe.As<byte, Vector256<uint>>(ref control1Bytes);
             var a = Vector256.Create((byte)255);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykAvx.cs
@@ -32,7 +32,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector256.Create(1 / (this.MaximumValue * this.MaximumValue));
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
+            nuint n = values.Component0.Vector256Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> c = ref Unsafe.Add(ref c0Base, i);
@@ -71,7 +71,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = Vector256.Create(maxValue);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
+            nuint n = values.Component0.Vector256Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 Vector256<float> ctmp = Avx.Subtract(scale, Unsafe.Add(ref srcR, i));

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.CmykVector.cs
@@ -30,7 +30,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / (this.MaximumValue * this.MaximumValue));
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
+            nuint n = values.Component0.VectorCount<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> c = ref Unsafe.Add(ref cBase, i);
@@ -78,7 +78,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = new Vector<float>(maxValue);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
+            nuint n = values.Component0.VectorCount<float>();
             for (nuint i = 0; i < n; i++)
             {
                 Vector<float> ctmp = scale - Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleArm.cs
@@ -27,7 +27,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector128.Create(1 / this.MaximumValue);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
+            nuint n = values.Component0.Vector128Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector128<float> c0 = ref Unsafe.Add(ref c0Base, i);
@@ -53,7 +53,7 @@ internal abstract partial class JpegColorConverterBase
             var f0587 = Vector128.Create(0.587f);
             var f0114 = Vector128.Create(0.114f);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
+            nuint n = values.Component0.Vector128Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector128<float> r = ref Unsafe.Add(ref srcRed, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleAvx.cs
@@ -27,7 +27,7 @@ internal abstract partial class JpegColorConverterBase
             // Used for the color conversion
             var scale = Vector256.Create(1 / this.MaximumValue);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
+            nuint n = values.Component0.Vector256Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> c0 = ref Unsafe.Add(ref c0Base, i);
@@ -53,7 +53,7 @@ internal abstract partial class JpegColorConverterBase
             var f0587 = Vector256.Create(0.587f);
             var f0114 = Vector256.Create(0.114f);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
+            nuint n = values.Component0.Vector256Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> r = ref Unsafe.Add(ref srcRed, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.GrayScaleVector.cs
@@ -24,7 +24,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / this.MaximumValue);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
+            nuint n = values.Component0.VectorCount<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> c0 = ref Unsafe.Add(ref cBase, i);
@@ -53,7 +53,7 @@ internal abstract partial class JpegColorConverterBase
             var gMult = new Vector<float>(0.587f);
             var bMult = new Vector<float>(0.114f);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
+            nuint n = values.Component0.VectorCount<float>();
             for (nuint i = 0; i < n; i++)
             {
                 Vector<float> r = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbArm.cs
@@ -30,7 +30,7 @@ internal abstract partial class JpegColorConverterBase
 
             // Used for the color conversion
             var scale = Vector128.Create(1 / this.MaximumValue);
-            nuint n = (uint)values.Component0.Length / (uint)Vector128<float>.Count;
+            nuint n = values.Component0.Vector128Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector128<float> r = ref Unsafe.Add(ref rBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbAvx.cs
@@ -29,7 +29,7 @@ internal abstract partial class JpegColorConverterBase
 
             // Used for the color conversion
             var scale = Vector256.Create(1 / this.MaximumValue);
-            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
+            nuint n = values.Component0.Vector256Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector256<float> r = ref Unsafe.Add(ref rBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.RgbVector.cs
@@ -28,7 +28,7 @@ internal abstract partial class JpegColorConverterBase
 
             var scale = new Vector<float>(1 / this.MaximumValue);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
+            nuint n = values.Component0.VectorCount<float>();
             for (nuint i = 0; i < n; i++)
             {
                 ref Vector<float> r = ref Unsafe.Add(ref rBase, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrAvx.cs
@@ -38,7 +38,7 @@ internal abstract partial class JpegColorConverterBase
             var bCbMult = Vector256.Create(YCbCrScalar.BCbMult);
 
             // Walking 8 elements at one step:
-            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
+            nuint n = values.Component0.Vector256Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -98,7 +98,7 @@ internal abstract partial class JpegColorConverterBase
             var fn0081312F = Vector256.Create(-0.081312F);
             var f05 = Vector256.Create(0.5f);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
+            nuint n = values.Component0.Vector256Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 Vector256<float> r = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YCbCrVector.cs
@@ -35,7 +35,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(-YCbCrScalar.GCrMult);
             var bCbMult = new Vector<float>(YCbCrScalar.BCbMult);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
+            nuint n = values.Component0.VectorCount<float>();
             for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -103,7 +103,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(0.418688f);
             var bCrMult = new Vector<float>(0.081312f);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
+            nuint n = values.Component0.VectorCount<float>();
             for (nuint i = 0; i < n; i++)
             {
                 Vector<float> r = Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKAvx.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKAvx.cs
@@ -40,7 +40,7 @@ internal abstract partial class JpegColorConverterBase
             var bCbMult = Vector256.Create(YCbCrScalar.BCbMult);
 
             // Walking 8 elements at one step:
-            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
+            nuint n = values.Component0.Vector256Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -109,7 +109,7 @@ internal abstract partial class JpegColorConverterBase
             var fn0081312F = Vector256.Create(-0.081312F);
             var f05 = Vector256.Create(0.5f);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector256<float>.Count;
+            nuint n = values.Component0.Vector256Count<float>();
             for (nuint i = 0; i < n; i++)
             {
                 Vector256<float> r = Avx.Subtract(maxSampleValue, Unsafe.Add(ref srcR, i));

--- a/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKVector.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/ColorConverters/JpegColorConverter.YccKVector.cs
@@ -36,7 +36,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(-YCbCrScalar.GCrMult);
             var bCbMult = new Vector<float>(YCbCrScalar.BCbMult);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
+            nuint n = values.Component0.VectorCount<float>();
             for (nuint i = 0; i < n; i++)
             {
                 // y = yVals[i];
@@ -107,7 +107,7 @@ internal abstract partial class JpegColorConverterBase
             var gCrMult = new Vector<float>(0.418688f);
             var bCrMult = new Vector<float>(0.081312f);
 
-            nuint n = (uint)values.Component0.Length / (uint)Vector<float>.Count;
+            nuint n = values.Component0.VectorCount<float>();
             for (nuint i = 0; i < n; i++)
             {
                 Vector<float> r = maxSampleValue - Unsafe.Add(ref srcR, i);

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
@@ -122,7 +122,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> sourceVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(source));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
-                nuint count = (uint)source.Length / (uint)Vector256<float>.Count;
+                nuint count = source.Vector256Count<float>();
                 for (nuint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) = Avx.Add(Unsafe.Add(ref targetVectorRef, i), Unsafe.Add(ref sourceVectorRef, i));
@@ -133,7 +133,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector<float> targetVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(target));
                 ref Vector<float> sourceVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(source));
 
-                nuint count = (uint)source.Length / (uint)Vector<float>.Count;
+                nuint count = source.VectorCount<float>();
                 for (nuint i = 0; i < count; i++)
                 {
                     Unsafe.Add(ref targetVectorRef, i) += Unsafe.Add(ref sourceVectorRef, i);
@@ -166,7 +166,7 @@ internal class ComponentProcessor : IDisposable
                 source = source.Slice(touchedCount);
                 target = target.Slice(touchedCount / factor);
 
-                nuint length = (uint)touchedCount / (uint)Vector256<float>.Count;
+                nuint length = Numerics.Vector256Count<float>(touchedCount);
 
                 for (uint i = 0; i < haddIterationsCount; i++)
                 {
@@ -200,7 +200,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> targetVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(target));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
-                nuint count = (uint)target.Length / (uint)Vector256<float>.Count;
+                nuint count = target.Vector256Count<float>();
                 var multiplierVector = Vector256.Create(multiplier);
                 for (nuint i = 0; i < count; i++)
                 {
@@ -211,7 +211,7 @@ internal class ComponentProcessor : IDisposable
             {
                 ref Vector<float> targetVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(target));
 
-                nuint count = (uint)target.Length / (uint)Vector<float>.Count;
+                nuint count = target.VectorCount<float>();
                 var multiplierVector = new Vector<float>(multiplier);
                 for (nuint i = 0; i < count; i++)
                 {

--- a/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/FeatureTesting/FeatureTestRunner.cs
@@ -62,7 +62,7 @@ public static class FeatureTestRunner
             ProcessStartInfo processStartInfo = new();
             if (intrinsic.Key != HwIntrinsics.AllowAll)
             {
-                processStartInfo.Environment[$"COMPlus_{intrinsic.Value}"] = "0";
+                processStartInfo.Environment[$"DOTNET_{intrinsic.Value}"] = "0";
 
                 RemoteExecutor.Invoke(
                     action,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Instead of typing 
```c#
nuint n = (uint)dest.Length / (uint)Vector256<float>.Count;
```
everytime, there's now a helper that shortens this to
```c#
nuint n = dest.Vector256Count<float>();
```
Cf. https://github.com/SixLabors/ImageSharp/pull/2419#discussion_r1149799246