### PR TITLE
Add AdvSimd in ComponentProcessor

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
@@ -129,6 +129,18 @@ internal class ComponentProcessor : IDisposable
                     Unsafe.Add(ref targetVectorRef, i) = Avx.Add(Unsafe.Add(ref targetVectorRef, i), Unsafe.Add(ref sourceVectorRef, i));
                 }
             }
+            else if (AdvSimd.IsSupported)
+            {
+                ref Vector128<float> targetVectorRef = ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(target));
+                ref Vector128<float> sourceVectorRef = ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(source));
+
+                // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
+                nuint count = source.Vector128Count<float>();
+                for (nuint i = 0; i < count; i++)
+                {
+                    Unsafe.Add(ref targetVectorRef, i) = AdvSimd.Add(Unsafe.Add(ref targetVectorRef, i), Unsafe.Add(ref sourceVectorRef, i));
+                }
+            }
             else
             {
                 ref Vector<float> targetVectorRef = ref Unsafe.As<float, Vector<float>>(ref MemoryMarshal.GetReference(target));

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
@@ -123,6 +123,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> sourceVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(source));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
+                DebugGuard.IsTrue(source.Length % 8 == 0, "source must be multiple of 8");
                 nuint count = source.Vector256Count<float>();
                 for (nuint i = 0; i < count; i++)
                 {
@@ -135,6 +136,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector128<float> sourceVectorRef = ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(source));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
+                DebugGuard.IsTrue(source.Length % 8 == 0, "source must be multiple of 8");
                 nuint count = source.Vector128Count<float>();
                 for (nuint i = 0; i < count; i++)
                 {
@@ -213,6 +215,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector256<float> targetVectorRef = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(target));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
+                DebugGuard.IsTrue(target.Length % 8 == 0, "target must be multiple of 8");
                 nuint count = target.Vector256Count<float>();
                 Vector256<float> multiplierVector = Vector256.Create(multiplier);
                 for (nuint i = 0; i < count; i++)
@@ -225,6 +228,7 @@ internal class ComponentProcessor : IDisposable
                 ref Vector128<float> targetVectorRef = ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(target));
 
                 // Spans are guaranteed to be multiple of 8 so no extra 'remainder' steps are needed
+                DebugGuard.IsTrue(target.Length % 8 == 0, "target must be multiple of 8");
                 nuint count = target.Vector128Count<float>();
                 Vector128<float> multiplierVector = Vector128.Create(multiplier);
                 for (nuint i = 0; i < count; i++)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Added Arm intrinsics in the ComponentProcessor. 

Only SumHorizontal is not ported to Arm.
