### PR TITLE
Fix decoding tiled tiff with unequal tile width and height

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -344,7 +344,7 @@ internal class TiffDecoderCore : IImageDecoderInternals
             ArgumentNullException.ThrowIfNull(valueWidth);
         }
 
-        if (!tags.TryGetValue(ExifTag.TileWidth, out IExifValue<Number> valueLength))
+        if (!tags.TryGetValue(ExifTag.TileLength, out IExifValue<Number> valueLength))
         {
             ArgumentNullException.ThrowIfNull(valueLength);
         }

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -200,11 +200,7 @@ public class TiffDecoderTests : TiffDecoderBaseTester
     [Theory]
     [WithFile(Rgba3BitAssociatedAlpha, PixelTypes.Rgba32)]
     public void TiffDecoder_CanDecode_12Bit_WithAssociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
-        where TPixel : unmanaged, IPixel<TPixel>
-    {
-
-        TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.264F);
-    }
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.264F);
 
     [Theory]
     [WithFile(Flower14BitGray, PixelTypes.Rgba32)]
@@ -249,11 +245,7 @@ public class TiffDecoderTests : TiffDecoderBaseTester
     [WithFile(Rgba5BitAssociatedAlpha, PixelTypes.Rgba32)]
     public void TiffDecoder_CanDecode_20Bit_WithAssociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
 
-        where TPixel : unmanaged, IPixel<TPixel>
-    {
-
-        TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.376F);
-    }
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.376F);
 
     [Theory]
     [WithFile(FlowerRgb888Contiguous, PixelTypes.Rgba32)]
@@ -268,11 +260,7 @@ public class TiffDecoderTests : TiffDecoderBaseTester
     [Theory]
     [WithFile(Rgba6BitAssociatedAlpha, PixelTypes.Rgba32)]
     public void TiffDecoder_CanDecode_24Bit_WithAssociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
-        where TPixel : unmanaged, IPixel<TPixel>
-    {
-
-        TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.405F);
-    }
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.405F);
 
     [Theory]
     [WithFile(Flower24BitGray, PixelTypes.Rgba32)]
@@ -362,12 +350,8 @@ public class TiffDecoderTests : TiffDecoderBaseTester
     [Theory]
     [WithFile(Rgba8BitAssociatedAlpha, PixelTypes.Rgba32)]
     public void TiffDecoder_CanDecode_32Bit_WithAssociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
-        where TPixel : unmanaged, IPixel<TPixel>
-    {
-
         // Note: Using tolerant comparer here, because there is a small difference to the reference decoder probably due to floating point rounding issues.
-        TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.004F);
-    }
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.004F);
 
     [Theory]
     [WithFile(Flower32BitGrayPredictorBigEndian, PixelTypes.Rgba32)]
@@ -395,11 +379,7 @@ public class TiffDecoderTests : TiffDecoderBaseTester
     [WithFile(Rgba10BitAssociatedAlphaBigEndian, PixelTypes.Rgba32)]
     [WithFile(Rgba10BitAssociatedAlphaLittleEndian, PixelTypes.Rgba32)]
     public void TiffDecoder_CanDecode_40Bit_WithAssociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
-        where TPixel : unmanaged, IPixel<TPixel>
-    {
-
-        TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.247F);
-    }
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.247F);
 
     [Theory]
     [WithFile(FlowerRgb141414Contiguous, PixelTypes.Rgba32)]
@@ -426,11 +406,7 @@ public class TiffDecoderTests : TiffDecoderBaseTester
     [WithFile(Rgba12BitAssociatedAlphaBigEndian, PixelTypes.Rgba32)]
     [WithFile(Rgba12BitAssociatedAlphaLittleEndian, PixelTypes.Rgba32)]
     public void TiffDecoder_CanDecode_48Bit_WithAssociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
-        where TPixel : unmanaged, IPixel<TPixel>
-    {
-
-        TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.118F);
-    }
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.118F);
 
     [Theory]
     [WithFile(FlowerRgb161616PredictorBigEndian, PixelTypes.Rgba32)]
@@ -448,11 +424,7 @@ public class TiffDecoderTests : TiffDecoderBaseTester
     [WithFile(Rgba14BitAssociatedAlphaBigEndian, PixelTypes.Rgba32)]
     [WithFile(Rgba14BitAssociatedAlphaLittleEndian, PixelTypes.Rgba32)]
     public void TiffDecoder_CanDecode_56Bit_WithAssociatedAlpha<TPixel>(TestImageProvider<TPixel> provider)
-        where TPixel : unmanaged, IPixel<TPixel>
-    {
-
-        TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.075F);
-    }
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider, useExactComparer: false, compareTolerance: 0.075F);
 
     [Theory]
     [WithFile(FlowerRgb242424Contiguous, PixelTypes.Rgba32)]
@@ -684,6 +656,12 @@ public class TiffDecoderTests : TiffDecoderBaseTester
     [Theory]
     [WithFile(Issues2149, PixelTypes.Rgba32)]
     public void TiffDecoder_CanDecode_Fax4CompressedWithStrips<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
+
+    // https://github.com/SixLabors/ImageSharp/issues/2435
+    [Theory]
+    [WithFile(Issues2435, PixelTypes.Rgba32)]
+    public void TiffDecoder_CanDecode_TiledWithNonEqualWidthAndHeight<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
     [Theory]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -964,6 +964,7 @@ public static class TestImages
         public const string Issues2123 = "Tiff/Issues/Issue2123.tiff";
         public const string Issues2149 = "Tiff/Issues/Group4CompressionWithStrips.tiff";
         public const string Issues2255 = "Tiff/Issues/Issue2255.png";
+        public const string Issues2435 = "Tiff/Issues/Issue2435.tiff";
 
         public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
         public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/Images/Input/Tiff/Issues/Issue2435.tiff
+++ b/tests/Images/Input/Tiff/Issues/Issue2435.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5c90d6d90f1cf090562d7d70df858b83513e5d7d78fb7b7c4d7992cb620030e
+size 258540


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This PR fixes an issue when decoding tiled tiff images. The tile height was not correctly determined.

Fixes #2435