### PR TITLE
bugfix in Rational.cs, when both Nominator and Denominator equals to 0

### DIFF
--- a/src/ImageSharp/Primitives/LongRational.cs
+++ b/src/ImageSharp/Primitives/LongRational.cs
@@ -131,6 +131,11 @@ internal readonly struct LongRational : IEquatable<LongRational>
     /// <param name="bestPrecision">Whether to use the best possible precision when parsing the value.</param>
     public static LongRational FromDouble(double value, bool bestPrecision)
     {
+        if (value == 0.0)
+        {
+            return new LongRational(0, 1);
+        }
+
         if (double.IsNaN(value))
         {
             return new LongRational(0, 0);
@@ -152,10 +157,6 @@ internal readonly struct LongRational : IEquatable<LongRational>
         double val = Math.Abs(value);
         double df = numerator / (double)denominator;
         double epsilon = bestPrecision ? double.Epsilon : .000001;
-
-        if(val < epsilon) {
-            return new LongRational(0, 1);
-        }
 
         while (Math.Abs(df - val) > epsilon)
         {

--- a/src/ImageSharp/Primitives/LongRational.cs
+++ b/src/ImageSharp/Primitives/LongRational.cs
@@ -203,7 +203,7 @@ internal readonly struct LongRational : IEquatable<LongRational>
 
         if (this.Numerator == 0)
         {
-            return new LongRational(0, 0);
+            return new LongRational(0, 1);
         }
 
         if (this.Numerator == this.Denominator)

--- a/src/ImageSharp/Primitives/LongRational.cs
+++ b/src/ImageSharp/Primitives/LongRational.cs
@@ -153,6 +153,10 @@ internal readonly struct LongRational : IEquatable<LongRational>
         double df = numerator / (double)denominator;
         double epsilon = bestPrecision ? double.Epsilon : .000001;
 
+        if(val < epsilon) {
+            return new LongRational(0, 1);
+        }
+
         while (Math.Abs(df - val) > epsilon)
         {
             if (df < val)
@@ -199,11 +203,6 @@ internal readonly struct LongRational : IEquatable<LongRational>
             this.IsZero)
         {
             return this;
-        }
-
-        if (this.Numerator == 0)
-        {
-            return new LongRational(0, 1);
         }
 
         if (this.Numerator == this.Denominator)

--- a/src/ImageSharp/Primitives/Rational.cs
+++ b/src/ImageSharp/Primitives/Rational.cs
@@ -74,6 +74,11 @@ public readonly struct Rational : IEquatable<Rational>
 
         this.Numerator = (uint)rational.Numerator;
         this.Denominator = (uint)rational.Denominator;
+        
+        if(this.Numerator == 0 && this.Denominator == 0) 
+        {
+            this.Denominator = 1;
+        }
     }
 
     /// <summary>

--- a/src/ImageSharp/Primitives/Rational.cs
+++ b/src/ImageSharp/Primitives/Rational.cs
@@ -74,11 +74,6 @@ public readonly struct Rational : IEquatable<Rational>
 
         this.Numerator = (uint)rational.Numerator;
         this.Denominator = (uint)rational.Denominator;
-        
-        if(this.Numerator == 0 && this.Denominator == 0) 
-        {
-            this.Denominator = 1;
-        }
     }
 
     /// <summary>

--- a/tests/ImageSharp.Tests/Numerics/RationalTests.cs
+++ b/tests/ImageSharp.Tests/Numerics/RationalTests.cs
@@ -42,6 +42,18 @@ public class RationalTests
     }
 
     /// <summary>
+    /// Tests the correct FromDouble(0).
+    /// </summary>
+    [Fact]
+    public void FromDouble0Non0Denominator()
+    {
+        var r = Rational.FromDouble(0);
+
+        Assert.Equal(0, r.Numerator);
+        Assert.Equal(1, r.Denominator);
+    }
+
+    /// <summary>
     /// Tests whether the Rational constructor correctly assign properties.
     /// </summary>
     [Fact]

--- a/tests/ImageSharp.Tests/Numerics/RationalTests.cs
+++ b/tests/ImageSharp.Tests/Numerics/RationalTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 namespace SixLabors.ImageSharp.Tests;
@@ -14,15 +14,15 @@ public class RationalTests
     [Fact]
     public void AreEqual()
     {
-        var r1 = new Rational(3, 2);
-        var r2 = new Rational(3, 2);
+        Rational r1 = new(3, 2);
+        Rational r2 = new(3, 2);
 
         Assert.Equal(r1, r2);
         Assert.True(r1 == r2);
 
-        var r3 = new Rational(7.55);
-        var r4 = new Rational(755, 100);
-        var r5 = new Rational(151, 20);
+        Rational r3 = new(7.55);
+        Rational r4 = new(755, 100);
+        Rational r5 = new(151, 20);
 
         Assert.Equal(r3, r4);
         Assert.Equal(r4, r5);
@@ -34,23 +34,30 @@ public class RationalTests
     [Fact]
     public void AreNotEqual()
     {
-        var first = new Rational(0, 100);
-        var second = new Rational(100, 100);
+        Rational first = new(0, 100);
+        Rational second = new(100, 100);
 
         Assert.NotEqual(first, second);
         Assert.True(first != second);
     }
 
     /// <summary>
-    /// Tests the correct FromDouble(0).
+    /// Tests known out-of-range values.
     /// </summary>
-    [Fact]
-    public void FromDouble0Non0Denominator()
+    /// <param name="value">The input value.</param>
+    /// <param name="numerator">The expected numerator.</param>
+    /// <param name="denominator">The expected denominator.</param>
+    [Theory]
+    [InlineData(0, 0, 1)]
+    [InlineData(double.NaN, 0, 0)]
+    [InlineData(double.PositiveInfinity, 1, 0)]
+    [InlineData(double.NegativeInfinity, 1, 0)]
+    public void FromDoubleOutOfRange(double value, uint numerator, uint denominator)
     {
-        var r = Rational.FromDouble(0);
+        Rational r = Rational.FromDouble(value);
 
-        Assert.Equal(0, r.Numerator);
-        Assert.Equal(1, r.Denominator);
+        Assert.Equal(numerator, r.Numerator);
+        Assert.Equal(denominator, r.Denominator);
     }
 
     /// <summary>
@@ -59,7 +66,7 @@ public class RationalTests
     [Fact]
     public void ConstructorAssignsProperties()
     {
-        var rational = new Rational(7, 55);
+        Rational rational = new(7, 55);
         Assert.Equal(7U, rational.Numerator);
         Assert.Equal(55U, rational.Denominator);
 
@@ -83,15 +90,15 @@ public class RationalTests
     [Fact]
     public void Fraction()
     {
-        var first = new Rational(1.0 / 1600);
-        var second = new Rational(1.0 / 1600, true);
+        Rational first = new(1.0 / 1600);
+        Rational second = new(1.0 / 1600, true);
         Assert.False(first.Equals(second));
     }
 
     [Fact]
     public void ToDouble()
     {
-        var rational = new Rational(0, 0);
+        Rational rational = new(0, 0);
         Assert.Equal(double.NaN, rational.ToDouble());
 
         rational = new Rational(2, 0);
@@ -101,7 +108,7 @@ public class RationalTests
     [Fact]
     public void ToStringRepresentation()
     {
-        var rational = new Rational(0, 0);
+        Rational rational = new(0, 0);
         Assert.Equal("[ Indeterminate ]", rational.ToString());
 
         rational = new Rational(double.PositiveInfinity);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
In cases, when you're trying to create Rational.FromDouble(0) it generates an invalid Rational item.

<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
