### PR TITLE
Tiff: Undo horizontal predictor for cmyk images

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Compression/HorizontalPredictor.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/HorizontalPredictor.cs
@@ -44,6 +44,7 @@ internal static class HorizontalPredictor
                 UndoRgb24Bit(pixelBytes, width);
                 break;
             case TiffColorType.Rgba8888:
+            case TiffColorType.Cmyk:
                 UndoRgba32Bit(pixelBytes, width);
                 break;
             case TiffColorType.Rgb161616:

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -308,6 +308,7 @@ public class TiffDecoderTests : TiffDecoderBaseTester
 
     [Theory]
     [WithFile(Cmyk, PixelTypes.Rgba32)]
+    [WithFile(CmykLzwPredictor, PixelTypes.Rgba32)]
     public void TiffDecoder_CanDecode_Cmyk<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
     {

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -958,6 +958,7 @@ public static class TestImages
 
         public const string Cmyk = "Tiff/Cmyk.tiff";
         public const string Cmyk64BitDeflate = "Tiff/cmyk_deflate_64bit.tiff";
+        public const string CmykLzwPredictor = "Tiff/Cmyk-lzw-predictor.tiff";
 
         public const string Issues1716Rgb161616BitLittleEndian = "Tiff/Issues/Issue1716.tiff";
         public const string Issues1891 = "Tiff/Issues/Issue1891.tiff";

--- a/tests/Images/External/ReferenceOutput/TiffDecoderTests/TiffDecoder_CanDecode_Cmyk_Rgba32_Cmyk-lzw-predictor.png
+++ b/tests/Images/External/ReferenceOutput/TiffDecoderTests/TiffDecoder_CanDecode_Cmyk_Rgba32_Cmyk-lzw-predictor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db076491d7afc78cb5de99cb1e7a9c53f891157bf064994c60d453aec75b9c90
+size 512

--- a/tests/Images/Input/Tiff/Cmyk-lzw-predictor.tiff
+++ b/tests/Images/Input/Tiff/Cmyk-lzw-predictor.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d322e42dd61c528e91ba9d16310248a4b9a77094a22761dcb9e6f132fc16fe1b
+size 1080


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix for Issue #2456: Horizontal predictor was not reverted correctly when decoding cmyk images.