### PR TITLE
fix a typo in XML comment for struct `Rgb48`

### DIFF
--- a/src/ImageSharp/PixelFormats/PixelImplementations/Rgb48.cs
+++ b/src/ImageSharp/PixelFormats/PixelImplementations/Rgb48.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 namespace SixLabors.ImageSharp.PixelFormats;
 
 /// <summary>
-/// Packed pixel type containing three 16-bit unsigned normalized values ranging from 0 to 635535.
+/// Packed pixel type containing three 16-bit unsigned normalized values ranging from 0 to 65535.
 /// <para>
 /// Ranges from [0, 0, 0, 1] to [1, 1, 1, 1] in vector form.
 /// </para>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
