### PR TITLE
Adding support for `MutateAsync()`

### DIFF
--- a/src/ImageSharp/Processing/Extensions/ProcessingExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/ProcessingExtensions.cs
@@ -21,6 +21,83 @@ public static partial class ProcessingExtensions
     /// <exception cref="ArgumentNullException">The operation is null.</exception>
     /// <exception cref="ObjectDisposedException">The source has been disposed.</exception>
     /// <exception cref="ImageProcessingException">The processing operation failed.</exception>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static Task MutateAsync(this Image source, Func<IImageProcessingContext, Task> operation)
+        => MutateAsync(source, source.GetConfiguration(), operation);
+
+    /// <summary>
+    /// Mutates the source image by applying the image operation to it.
+    /// </summary>
+    /// <param name="source">The image to mutate.</param>
+    /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+    /// <param name="operation">The operation to perform on the source.</param>
+    /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+    /// <exception cref="ArgumentNullException">The source is null.</exception>
+    /// <exception cref="ArgumentNullException">The operation is null.</exception>
+    /// <exception cref="ObjectDisposedException">The source has been disposed.</exception>
+    /// <exception cref="ImageProcessingException">The processing operation failed.</exception>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static Task MutateAsync(this Image source, Configuration configuration, Func<IImageProcessingContext, Task> operation)
+    {
+        Guard.NotNull(configuration, nameof(configuration));
+        Guard.NotNull(source, nameof(source));
+        Guard.NotNull(operation, nameof(operation));
+        source.EnsureNotDisposed();
+
+        return source.AcceptVisitorAsync(new AsyncProcessingVisitor(configuration, operation, true));
+    }
+
+    /// <summary>
+    /// Mutates the source image by applying the image operation to it.
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format.</typeparam>
+    /// <param name="source">The image to mutate.</param>
+    /// <param name="operation">The operation to perform on the source.</param>
+    /// <exception cref="ArgumentNullException">The source is null.</exception>
+    /// <exception cref="ArgumentNullException">The operation is null.</exception>
+    /// <exception cref="ObjectDisposedException">The source has been disposed.</exception>
+    /// <exception cref="ImageProcessingException">The processing operation failed.</exception>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static Task MutateAsync<TPixel>(this Image<TPixel> source, Func<IImageProcessingContext, Task> operation)
+        where TPixel : unmanaged, IPixel<TPixel>
+        => MutateAsync(source, source.GetConfiguration(), operation);
+
+    /// <summary>
+    /// Mutates the source image by applying the image operation to it.
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format.</typeparam>
+    /// <param name="source">The image to mutate.</param>
+    /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+    /// <param name="operation">The operation to perform on the source.</param>
+    /// <exception cref="ArgumentNullException">The configuration is null.</exception>
+    /// <exception cref="ArgumentNullException">The source is null.</exception>
+    /// <exception cref="ArgumentNullException">The operation is null.</exception>
+    /// <exception cref="ObjectDisposedException">The source has been disposed.</exception>
+    /// <exception cref="ImageProcessingException">The processing operation failed.</exception>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static Task MutateAsync<TPixel>(this Image<TPixel> source, Configuration configuration, Func<IImageProcessingContext, Task> operation)
+    where TPixel : unmanaged, IPixel<TPixel>
+    {
+        Guard.NotNull(configuration, nameof(configuration));
+        Guard.NotNull(source, nameof(source));
+        Guard.NotNull(operation, nameof(operation));
+        source.EnsureNotDisposed();
+
+        IInternalImageProcessingContext<TPixel> operationsRunner
+            = configuration.ImageOperationsProvider.CreateImageProcessingContext(configuration, source, true);
+
+        return operation(operationsRunner);
+    }
+
+    /// <summary>
+    /// Mutates the source image by applying the image operation to it.
+    /// </summary>
+    /// <param name="source">The image to mutate.</param>
+    /// <param name="operation">The operation to perform on the source.</param>
+    /// <exception cref="ArgumentNullException">The source is null.</exception>
+    /// <exception cref="ArgumentNullException">The operation is null.</exception>
+    /// <exception cref="ObjectDisposedException">The source has been disposed.</exception>
+    /// <exception cref="ImageProcessingException">The processing operation failed.</exception>
     public static void Mutate(this Image source, Action<IImageProcessingContext> operation)
         => Mutate(source, source.GetConfiguration(), operation);
 
@@ -264,6 +341,36 @@ public static partial class ProcessingExtensions
         }
 
         return source;
+    }
+
+    private class AsyncProcessingVisitor : IImageVisitorAsync
+    {
+        private readonly Configuration configuration;
+
+        private readonly Func<IImageProcessingContext, Task> operation;
+
+        private readonly bool mutate;
+
+        private Image? resultImage;
+
+        public AsyncProcessingVisitor(Configuration configuration, Func<IImageProcessingContext, Task> operation, bool mutate)
+        {
+            this.configuration = configuration;
+            this.operation = operation;
+            this.mutate = mutate;
+        }
+
+        public Image GetResultImage() => this.resultImage!;
+
+        public async Task VisitAsync<TPixel>(Image<TPixel> image, CancellationToken cancellationToken)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            IInternalImageProcessingContext<TPixel> operationsRunner =
+                this.configuration.ImageOperationsProvider.CreateImageProcessingContext(this.configuration, image, this.mutate);
+
+            await this.operation(operationsRunner).ConfigureAwait(false);
+            this.resultImage = operationsRunner.GetResultImage();
+        }
     }
 
     private class ProcessingVisitor : IImageVisitor


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
Adding additional support for `MutateAsync()` and friends, no additional or changed functionality

<!-- Thanks for contributing to ImageSharp! -->
