### PR TITLE
Update Directory.Build.targets

### DIFF
--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -30,7 +30,7 @@
     <PackageReference Update="PhotoSauce.MagicScaler" Version="0.12.1" />
     <PackageReference Update="Pfim" Version="0.9.1" />
     <PackageReference Update="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" Condition="'$(IsOSX)'=='true'" />
-    <PackageReference Update="SharpZipLib" Version="1.3.2" />
+    <PackageReference Update="SharpZipLib" Version="1.4.2" />
     <PackageReference Update="SkiaSharp" Version="2.80.2" />
     <PackageReference Update="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />


### PR DESCRIPTION
Updated SharpZip package version to  1.4.2

There is malware

SharpZipLib (or #ziplib) is a Zip, GZip, Tar and BZip2 library. Prior to version 1.3.3, a TAR file entry `../evil.txt` may be extracted in the parent directory of `destFolder`. This leads to arbitrary file write that may lead to code execution. The vulnerability was patched in version 1.3.3.