### PR TITLE
Fix #2467 bmp encoding issue for BMP with 1 bit per pixel and more pixels per row than divisible by 8.

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -668,7 +668,7 @@ internal sealed class BmpEncoderCore : IImageEncoderInternals
 
             if (quantizedPixelRow.Length % 8 != 0)
             {
-                int startIdx = quantizedPixelRow.Length - 7;
+                int startIdx = quantizedPixelRow.Length - (quantizedPixelRow.Length % 8);
                 endIdx = quantizedPixelRow.Length;
                 Write1BitPalette(stream, startIdx, endIdx, quantizedPixelRow);
             }

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -370,6 +370,30 @@ public class BmpEncoderTests
         TestBmpEncoderCore(provider, bitsPerPixel);
     }
 
+    [Theory]
+    [WithFile(BlackWhitePalletDataMatrix, PixelTypes.Rgb24, BmpBitsPerPixel.Pixel1)]
+    public void Encode_Issue2467<TPixel>(TestImageProvider<TPixel> provider, BmpBitsPerPixel bitsPerPixel)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage();
+
+        using var reencodedStream = new MemoryStream();
+        var encoder = new BmpEncoder
+        {
+            BitsPerPixel = bitsPerPixel,
+            SupportTransparency = false,
+            Quantizer = KnownQuantizers.Octree
+        };
+        image.SaveAsBmp(reencodedStream, encoder);
+        reencodedStream.Seek(0, SeekOrigin.Begin);
+
+        using Image<TPixel> reencodedImage = Image.Load<TPixel>(reencodedStream);
+
+        reencodedImage.DebugSave(provider);
+
+        reencodedImage.CompareToOriginal(provider);
+    }
+
     private static void TestBmpEncoderCore<TPixel>(
         TestImageProvider<TPixel> provider,
         BmpBitsPerPixel bitsPerPixel,

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -407,6 +407,8 @@ public static class TestImages
         public const string Rgba321010102 = "Bmp/rgba32-1010102.bmp";
         public const string RgbaAlphaBitfields = "Bmp/rgba32abf.bmp";
 
+        public const string BlackWhitePalletDataMatrix = "Bmp/bit1datamatrix.bmp";
+
         public static readonly string[] BitFields =
         {
               Rgb32bfdef,

--- a/tests/Images/Input/Bmp/bit1datamatrix.bmp
+++ b/tests/Images/Input/Bmp/bit1datamatrix.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b2288e2a059b15c7855eb141c05e3ce69431e7c3ddef851033f7fd9ca39a2d4
+size 102


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
Fix for issue #2467.

If you have a BMP with 1 bit per pixel, and more pixels per row than divisible by 8, the last byte of the row will need to be padded with extra zeros.

So if you have a black/white image of 10 pixels in a row, and the row looks like: 
`bwwbbbwbww`
The bytes should look like:"
`0x01100010 0x11000000`

However, the current implementation of Write1BitPixelData will when it reaches the last byte looks like:
```C#
if (quantizedPixelRow.Length % 8 != 0)
{
    int startIdx = quantizedPixelRow.Length - 7;
    endIdx = quantizedPixelRow.Length;
    Write1BitPalette(stream, startIdx, endIdx, quantizedPixelRow);
}
```
So `quantizedPixelRow.Length` will be 10, resulting in a `startIdx` of 10-7 = 3
It will then write pixels to the byte starting at index 3 again, meaning that the last bytes looks like:
`0x00010110`, **the last byte will always contain the last 7 pixels, instead of the amount of pixels remaining**.

This results in that when the image in opened again, the row bytes looks like:
`0x01100010 0x00010110`

If you check the images in #2467, you can see that the corrupted image shows column 4 & 5 again in column 9 & 10.

### The fix
The fix is to read the last X pixels from the `quantizedPixelRow` when X equals the remaining pixels instead of always the last 7 pixels. So the `startIdx` needs to be adjusted:
From:
`int startIdx = quantizedPixelRow.Length - 7;`
To: 
`int startIdx = quantizedPixelRow.Length - (quantizedPixelRow.Length % 8);`

### Small note
I am unsure of my test name, so I named it after my issue. I hope this is fine.