### PR TITLE
Fix for B&W pbm images with width not dividable by 8

### DIFF
--- a/src/ImageSharp/Formats/Pbm/BinaryDecoder.cs
+++ b/src/ImageSharp/Formats/Pbm/BinaryDecoder.cs
@@ -152,7 +152,6 @@ internal class BinaryDecoder
     {
         int width = pixels.Width;
         int height = pixels.Height;
-        int startBit = 0;
         MemoryAllocator allocator = configuration.MemoryAllocator;
         using IMemoryOwner<L8> row = allocator.Allocate<L8>(width);
         Span<L8> rowSpan = row.GetSpan();
@@ -162,23 +161,11 @@ internal class BinaryDecoder
             for (int x = 0; x < width;)
             {
                 int raw = stream.ReadByte();
-                int bit = startBit;
-                startBit = 0;
-                for (; bit < 8; bit++)
+                for (int bit = 0; bit < 8; bit++)
                 {
                     bool bitValue = (raw & (0x80 >> bit)) != 0;
                     rowSpan[x] = bitValue ? black : white;
                     x++;
-                    if (x == width)
-                    {
-                        startBit = (bit + 1) & 7; // Round off to below 8.
-                        if (startBit != 0)
-                        {
-                            stream.Seek(-1, System.IO.SeekOrigin.Current);
-                        }
-
-                        break;
-                    }
                 }
             }
 

--- a/src/ImageSharp/Formats/Pbm/BinaryDecoder.cs
+++ b/src/ImageSharp/Formats/Pbm/BinaryDecoder.cs
@@ -161,7 +161,8 @@ internal class BinaryDecoder
             for (int x = 0; x < width;)
             {
                 int raw = stream.ReadByte();
-                for (int bit = 0; bit < 8; bit++)
+                int stopBit = Math.Min(8, width - x);
+                for (int bit = 0; bit < stopBit; bit++)
                 {
                     bool bitValue = (raw & (0x80 >> bit)) != 0;
                     rowSpan[x] = bitValue ? black : white;

--- a/src/ImageSharp/Formats/Pbm/BinaryEncoder.cs
+++ b/src/ImageSharp/Formats/Pbm/BinaryEncoder.cs
@@ -192,7 +192,8 @@ internal class BinaryEncoder
             for (int x = 0; x < width;)
             {
                 int value = previousValue;
-                for (int i = 0; i < 8; i++)
+                int stopBit = Math.Min(8, width - x);
+                for (int i = 0; i < stopBit; i++)
                 {
                     if (rowSpan[x].PackedValue < 128)
                     {

--- a/src/ImageSharp/Formats/Pbm/BinaryEncoder.cs
+++ b/src/ImageSharp/Formats/Pbm/BinaryEncoder.cs
@@ -201,6 +201,7 @@ internal class BinaryEncoder
                     }
 
                     x++;
+
                     // End each row on a byte boundary.
                     if (x == width)
                     {

--- a/src/ImageSharp/Formats/Pbm/BinaryEncoder.cs
+++ b/src/ImageSharp/Formats/Pbm/BinaryEncoder.cs
@@ -179,7 +179,6 @@ internal class BinaryEncoder
         using IMemoryOwner<L8> row = allocator.Allocate<L8>(width);
         Span<L8> rowSpan = row.GetSpan();
 
-        int previousValue = 0;
         for (int y = 0; y < height; y++)
         {
             Span<TPixel> pixelSpan = pixelBuffer.DangerousGetRowSpan(y);
@@ -191,7 +190,7 @@ internal class BinaryEncoder
 
             for (int x = 0; x < width;)
             {
-                int value = previousValue;
+                int value = 0;
                 int stopBit = Math.Min(8, width - x);
                 for (int i = 0; i < stopBit; i++)
                 {
@@ -201,16 +200,9 @@ internal class BinaryEncoder
                     }
 
                     x++;
-
-                    // End each row on a byte boundary.
-                    if (x == width)
-                    {
-                        break;
-                    }
                 }
 
                 stream.WriteByte((byte)value);
-                previousValue = 0;
             }
         }
     }

--- a/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
@@ -81,6 +81,7 @@ public class PbmDecoderTests
     [Theory]
     [WithFile(BlackAndWhitePlain, PixelTypes.L8, "pbm")]
     [WithFile(BlackAndWhiteBinary, PixelTypes.L8, "pbm")]
+    [WithFile(Issue2477, PixelTypes.L8, "pbm")]
     [WithFile(GrayscalePlain, PixelTypes.L8, "pgm")]
     [WithFile(GrayscalePlainNormalized, PixelTypes.L8, "pgm")]
     [WithFile(GrayscaleBinary, PixelTypes.L8, "pgm")]

--- a/tests/ImageSharp.Tests/Formats/Pbm/PbmEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/PbmEncoderTests.cs
@@ -26,6 +26,7 @@ public class PbmEncoderTests
         {
             { BlackAndWhiteBinary, PbmColorType.BlackAndWhite },
             { BlackAndWhitePlain, PbmColorType.BlackAndWhite },
+            { Issue2477, PbmColorType.BlackAndWhite },
             { GrayscaleBinary, PbmColorType.Grayscale },
             { GrayscaleBinaryWide, PbmColorType.Grayscale },
             { GrayscalePlain, PbmColorType.Grayscale },
@@ -94,6 +95,11 @@ public class PbmEncoderTests
     [Theory]
     [WithFile(BlackAndWhiteBinary, PixelTypes.Rgb24)]
     public void PbmEncoder_P4_Works<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel> => TestPbmEncoderCore(provider, PbmColorType.BlackAndWhite, PbmEncoding.Binary);
+
+    [Theory]
+    [WithFile(Issue2477, PixelTypes.Rgb24)]
+    public void PbmEncoder_P4_Irregular_Works<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel> => TestPbmEncoderCore(provider, PbmColorType.BlackAndWhite, PbmEncoding.Binary);
 
     [Theory]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -1038,5 +1038,6 @@ public static class TestImages
         public const string RgbPlain = "Pbm/rgb_plain.ppm";
         public const string RgbPlainNormalized = "Pbm/rgb_plain_normalized.ppm";
         public const string RgbPlainMagick = "Pbm/rgb_plain_magick.ppm";
+        public const string Issue2477 = "Pbm/issue2477.pbm";
     }
 }

--- a/tests/Images/External/ReferenceOutput/PbmDecoderTests/DecodeReferenceImage_L8_issue2477.png
+++ b/tests/Images/External/ReferenceOutput/PbmDecoderTests/DecodeReferenceImage_L8_issue2477.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:670bc844ba878afa0f03574dea23ab774ac0cc5aa371d0f4b4dff7da4d32f916
+size 2912

--- a/tests/Images/Input/Pbm/issue2477.pbm
+++ b/tests/Images/Input/Pbm/issue2477.pbm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d625635f7be760fbea935056c0f6d046832dd74bba33a1597b52ab3dfe0c5e4e
+size 4956


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This fixes #2477 by handling Black & White binary images with a width not dividable by 8 correctly. The handling of the padding bits was incorrect and not according to the specification.

Thanks for reporting this bug !