### PR TITLE
Allow JFXX as an App0 marker header

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JFifMarker.cs
@@ -71,7 +71,9 @@ internal readonly struct JFifMarker : IEquatable<JFifMarker>
     /// <param name="marker">The marker to return.</param>
     public static bool TryParse(ReadOnlySpan<byte> bytes, out JFifMarker marker)
     {
-        if (ProfileResolver.IsProfile(bytes, ProfileResolver.JFifMarker))
+        // Some images incorrectly use JFXX as the App0 marker (Issue 2478)
+        if (ProfileResolver.IsProfile(bytes, ProfileResolver.JFifMarker)
+            || ProfileResolver.IsProfile(bytes, ProfileResolver.JFxxMarker))
         {
             byte majorVersion = bytes[5];
             byte minorVersion = bytes[6];

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ProfileResolver.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ProfileResolver.cs
@@ -17,6 +17,14 @@ internal static class ProfileResolver
     };
 
     /// <summary>
+    /// Gets the JFXX specific markers.
+    /// </summary>
+    public static ReadOnlySpan<byte> JFxxMarker => new[]
+    {
+        (byte)'J', (byte)'F', (byte)'X', (byte)'X', (byte)'\0'
+    };
+
+    /// <summary>
     /// Gets the ICC specific markers.
     /// </summary>
     public static ReadOnlySpan<byte> IccMarker => new[]

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -314,4 +314,15 @@ public partial class JpegDecoderTests
         image.DebugSave(provider);
         image.CompareToOriginal(provider);
     }
+
+    // https://github.com/SixLabors/ImageSharp/issues/2478
+    [Theory]
+    [WithFile(TestImages.Jpeg.Issues.Issue2478_JFXX, PixelTypes.Rgba32)]
+    public void Issue2478_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
+        image.DebugSave(provider);
+        image.CompareToOriginal(provider);
+    }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -290,6 +290,7 @@ public static class TestImages
             public const string Issue2315_NotEnoughBytes = "Jpg/issues/issue-2315.jpg";
             public const string Issue2334_NotEnoughBytesA = "Jpg/issues/issue-2334-a.jpg";
             public const string Issue2334_NotEnoughBytesB = "Jpg/issues/issue-2334-b.jpg";
+            public const string Issue2478_JFXX = "Jpg/issues/issue-2478-jfxx.jpg";
 
             public static class Fuzz
             {

--- a/tests/Images/Input/Jpg/issues/issue-2478-jfxx.jpg
+++ b/tests/Images/Input/Jpg/issues/issue-2478-jfxx.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bd5d14cbbead348404511801d7a2bacab19174e9f4063b5d2cec96f28fd578e
+size 300170


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #2479 

<!-- Thanks for contributing to ImageSharp! -->
