### PR TITLE
Tiff: ccitt compression, fix for issue #2451

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
@@ -127,7 +127,7 @@ internal sealed class T6BitReader : T4BitReader
                         this.Code = Len7Code0000000;
 
                         // We do not support Extensions1D codes, but some encoders (scanner from epson) write a premature EOL code,
-                        // which at this point cannot be distinguished from a distinguish, because we read the data bit by bit.
+                        // which at this point cannot be distinguished from the marker, because we read the data bit by bit.
                         // Read the next 5 bit, if its a EOL code return true, indicating its the end of the image.
                         if (this.ReadValue(5) == 1)
                         {

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6BitReader.cs
@@ -125,13 +125,29 @@ internal sealed class T6BitReader : T4BitReader
                     if (value == Len7Code0000000.Code)
                     {
                         this.Code = Len7Code0000000;
-                        return false;
+
+                        // We do not support Extensions1D codes, but some encoders (scanner from epson) write a premature EOL code,
+                        // which at this point cannot be distinguished from a distinguish, because we read the data bit by bit.
+                        // Read the next 5 bit, if its a EOL code return true, indicating its the end of the image.
+                        if (this.ReadValue(5) == 1)
+                        {
+                            return true;
+                        }
+
+                        throw new NotSupportedException("ccitt extensions 1D codes are not supported.");
                     }
 
                     if (value == Len7Code0000001.Code)
                     {
                         this.Code = Len7Code0000001;
-                        return false;
+
+                        // Same as above, we do not support Extensions2D codes, but it could be a EOL instead.
+                        if (this.ReadValue(5) == 1)
+                        {
+                            return true;
+                        }
+
+                        throw new NotSupportedException("ccitt extensions 2D codes are not supported.");
                     }
 
                     if (value == Len7Code0000011.Code)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable) (no test image available, which can be used publicly)

### Description

This PR fixes #2541 as discussed [here](https://github.com/SixLabors/ImageSharp/issues/2451#issuecomment-1544618277):
If we encounter a Extensions1D or 2D code, we read the next 5 bits and if it turns out to be a EOL and not a Extensions1D or 2D, we return that. Otherwise throw a NotSupported Exception for the Extension1D/2D code.
