### PR TITLE
Use `FileOptions.Asynchronous` when doing async IO

### DIFF
--- a/src/ImageSharp/IO/IFileSystem.cs
+++ b/src/ImageSharp/IO/IFileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 namespace SixLabors.ImageSharp.IO;
@@ -9,16 +9,32 @@ namespace SixLabors.ImageSharp.IO;
 internal interface IFileSystem
 {
     /// <summary>
-    /// Returns a readable stream as defined by the path.
+    /// Opens a file as defined by the path and returns it as a readable stream.
     /// </summary>
     /// <param name="path">Path to the file to open.</param>
-    /// <returns>A stream representing the file to open.</returns>
+    /// <returns>A stream representing the opened file.</returns>
     Stream OpenRead(string path);
 
     /// <summary>
-    /// Creates or opens a file and returns it as a writable stream as defined by the path.
+    /// Opens a file as defined by the path and returns it as a readable stream
+    /// that can be used for asynchronous reading.
     /// </summary>
     /// <param name="path">Path to the file to open.</param>
-    /// <returns>A stream representing the file to open.</returns>
+    /// <returns>A stream representing the opened file.</returns>
+    Stream OpenReadAsynchronous(string path);
+
+    /// <summary>
+    /// Creates or opens a file as defined by the path and returns it as a writable stream.
+    /// </summary>
+    /// <param name="path">Path to the file to open.</param>
+    /// <returns>A stream representing the opened file.</returns>
     Stream Create(string path);
+
+    /// <summary>
+    /// Creates or opens a file as defined by the path and returns it as a writable stream
+    /// that can be used for asynchronous reading and writing.
+    /// </summary>
+    /// <param name="path">Path to the file to open.</param>
+    /// <returns>A stream representing the opened file.</returns>
+    Stream CreateAsynchronous(string path);
 }

--- a/src/ImageSharp/IO/LocalFileSystem.cs
+++ b/src/ImageSharp/IO/LocalFileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 namespace SixLabors.ImageSharp.IO;
@@ -12,5 +12,23 @@ internal sealed class LocalFileSystem : IFileSystem
     public Stream OpenRead(string path) => File.OpenRead(path);
 
     /// <inheritdoc/>
+    public Stream OpenReadAsynchronous(string path) => File.Open(path, new FileStreamOptions
+    {
+        Mode = FileMode.Open,
+        Access = FileAccess.Read,
+        Share = FileShare.Read,
+        Options = FileOptions.Asynchronous,
+    });
+
+    /// <inheritdoc/>
     public Stream Create(string path) => File.Create(path);
+
+    /// <inheritdoc/>
+    public Stream CreateAsynchronous(string path) => File.Open(path, new FileStreamOptions
+    {
+        Mode = FileMode.Create,
+        Access = FileAccess.ReadWrite,
+        Share = FileShare.None,
+        Options = FileOptions.Asynchronous,
+    });
 }

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -72,7 +72,7 @@ public abstract partial class Image
     {
         Guard.NotNull(options, nameof(options));
 
-        using Stream stream = options.Configuration.FileSystem.OpenRead(path);
+        await using Stream stream = options.Configuration.FileSystem.OpenReadAsynchronous(path);
         return await DetectFormatAsync(options, stream, cancellationToken).ConfigureAwait(false);
     }
 
@@ -144,7 +144,7 @@ public abstract partial class Image
         CancellationToken cancellationToken = default)
     {
         Guard.NotNull(options, nameof(options));
-        using Stream stream = options.Configuration.FileSystem.OpenRead(path);
+        await using Stream stream = options.Configuration.FileSystem.OpenReadAsynchronous(path);
         return await IdentifyAsync(options, stream, cancellationToken).ConfigureAwait(false);
     }
 
@@ -214,7 +214,7 @@ public abstract partial class Image
         string path,
         CancellationToken cancellationToken = default)
     {
-        using Stream stream = options.Configuration.FileSystem.OpenRead(path);
+        await using Stream stream = options.Configuration.FileSystem.OpenReadAsynchronous(path);
         return await LoadAsync(options, stream, cancellationToken).ConfigureAwait(false);
     }
 
@@ -291,7 +291,7 @@ public abstract partial class Image
         Guard.NotNull(options, nameof(options));
         Guard.NotNull(path, nameof(path));
 
-        using Stream stream = options.Configuration.FileSystem.OpenRead(path);
+        await using Stream stream = options.Configuration.FileSystem.OpenReadAsynchronous(path);
         return await LoadAsync<TPixel>(options, stream, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/ImageSharp/ImageExtensions.cs
+++ b/src/ImageSharp/ImageExtensions.cs
@@ -70,7 +70,7 @@ public static partial class ImageExtensions
         Guard.NotNull(path, nameof(path));
         Guard.NotNull(encoder, nameof(encoder));
 
-        using Stream fs = source.GetConfiguration().FileSystem.Create(path);
+        await using Stream fs = source.GetConfiguration().FileSystem.CreateAsynchronous(path);
         await source.SaveAsync(fs, encoder, cancellationToken).ConfigureAwait(false);
     }
 

--- a/tests/ImageSharp.Tests/IO/LocalFileSystemTests.cs
+++ b/tests/ImageSharp.Tests/IO/LocalFileSystemTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 using SixLabors.ImageSharp.IO;
@@ -11,36 +11,97 @@ public class LocalFileSystemTests
     public void OpenRead()
     {
         string path = Path.GetTempFileName();
-        string testData = Guid.NewGuid().ToString();
-        File.WriteAllText(path, testData);
-
-        var fs = new LocalFileSystem();
-
-        using (var r = new StreamReader(fs.OpenRead(path)))
+        try
         {
-            string data = r.ReadToEnd();
+            string testData = Guid.NewGuid().ToString();
+            File.WriteAllText(path, testData);
 
-            Assert.Equal(testData, data);
+            LocalFileSystem fs = new();
+
+            using (Stream stream = fs.OpenRead(path))
+            using (StreamReader reader = new(stream))
+            {
+                string data = reader.ReadToEnd();
+
+                Assert.Equal(testData, data);
+            }
         }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 
-        File.Delete(path);
+    [Fact]
+    public async Task OpenReadAsynchronous()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            string testData = Guid.NewGuid().ToString();
+            File.WriteAllText(path, testData);
+
+            LocalFileSystem fs = new();
+
+            await using (Stream stream = fs.OpenReadAsynchronous(path))
+            using (StreamReader reader = new(stream))
+            {
+                string data = await reader.ReadToEndAsync();
+
+                Assert.Equal(testData, data);
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     [Fact]
     public void Create()
     {
         string path = Path.GetTempFileName();
-        string testData = Guid.NewGuid().ToString();
-        var fs = new LocalFileSystem();
-
-        using (var r = new StreamWriter(fs.Create(path)))
+        try
         {
-            r.Write(testData);
+            string testData = Guid.NewGuid().ToString();
+            LocalFileSystem fs = new();
+
+            using (Stream stream = fs.Create(path))
+            using (StreamWriter writer = new(stream))
+            {
+                writer.Write(testData);
+            }
+
+            string data = File.ReadAllText(path);
+            Assert.Equal(testData, data);
         }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 
-        string data = File.ReadAllText(path);
-        Assert.Equal(testData, data);
+    [Fact]
+    public async Task CreateAsynchronous()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            string testData = Guid.NewGuid().ToString();
+            LocalFileSystem fs = new();
 
-        File.Delete(path);
+            await using (Stream stream = fs.CreateAsynchronous(path))
+            using (StreamWriter writer = new(stream))
+            {
+                await writer.WriteAsync(testData);
+            }
+
+            string data = File.ReadAllText(path);
+            Assert.Equal(testData, data);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 }

--- a/tests/ImageSharp.Tests/IO/LocalFileSystemTests.cs
+++ b/tests/ImageSharp.Tests/IO/LocalFileSystemTests.cs
@@ -18,9 +18,13 @@ public class LocalFileSystemTests
 
             LocalFileSystem fs = new();
 
-            using (Stream stream = fs.OpenRead(path))
+            using (FileStream stream = (FileStream)fs.OpenRead(path))
             using (StreamReader reader = new(stream))
             {
+                Assert.False(stream.IsAsync);
+                Assert.True(stream.CanRead);
+                Assert.False(stream.CanWrite);
+
                 string data = reader.ReadToEnd();
 
                 Assert.Equal(testData, data);
@@ -43,9 +47,13 @@ public class LocalFileSystemTests
 
             LocalFileSystem fs = new();
 
-            await using (Stream stream = fs.OpenReadAsynchronous(path))
+            await using (FileStream stream = (FileStream)fs.OpenReadAsynchronous(path))
             using (StreamReader reader = new(stream))
             {
+                Assert.True(stream.IsAsync);
+                Assert.True(stream.CanRead);
+                Assert.False(stream.CanWrite);
+
                 string data = await reader.ReadToEndAsync();
 
                 Assert.Equal(testData, data);
@@ -66,9 +74,13 @@ public class LocalFileSystemTests
             string testData = Guid.NewGuid().ToString();
             LocalFileSystem fs = new();
 
-            using (Stream stream = fs.Create(path))
+            using (FileStream stream = (FileStream)fs.Create(path))
             using (StreamWriter writer = new(stream))
             {
+                Assert.False(stream.IsAsync);
+                Assert.True(stream.CanRead);
+                Assert.True(stream.CanWrite);
+
                 writer.Write(testData);
             }
 
@@ -90,9 +102,13 @@ public class LocalFileSystemTests
             string testData = Guid.NewGuid().ToString();
             LocalFileSystem fs = new();
 
-            await using (Stream stream = fs.CreateAsynchronous(path))
+            await using (FileStream stream = (FileStream)fs.CreateAsynchronous(path))
             await using (StreamWriter writer = new(stream))
             {
+                Assert.True(stream.IsAsync);
+                Assert.True(stream.CanRead);
+                Assert.True(stream.CanWrite);
+
                 await writer.WriteAsync(testData);
             }
 

--- a/tests/ImageSharp.Tests/IO/LocalFileSystemTests.cs
+++ b/tests/ImageSharp.Tests/IO/LocalFileSystemTests.cs
@@ -91,7 +91,7 @@ public class LocalFileSystemTests
             LocalFileSystem fs = new();
 
             await using (Stream stream = fs.CreateAsynchronous(path))
-            using (StreamWriter writer = new(stream))
+            await using (StreamWriter writer = new(stream))
             {
                 await writer.WriteAsync(testData);
             }

--- a/tests/ImageSharp.Tests/Image/ImageSaveTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageSaveTests.cs
@@ -44,7 +44,7 @@ public class ImageSaveTests : IDisposable
     [Fact]
     public void SavePath()
     {
-        var stream = new MemoryStream();
+        using MemoryStream stream = new();
         this.fileSystem.Setup(x => x.Create("path.png")).Returns(stream);
         this.image.Save("path.png");
 
@@ -54,7 +54,7 @@ public class ImageSaveTests : IDisposable
     [Fact]
     public void SavePathWithEncoder()
     {
-        var stream = new MemoryStream();
+        using MemoryStream stream = new();
         this.fileSystem.Setup(x => x.Create("path.jpg")).Returns(stream);
 
         this.image.Save("path.jpg", this.encoderNotInFormat.Object);
@@ -73,7 +73,7 @@ public class ImageSaveTests : IDisposable
     [Fact]
     public void SaveStreamWithMime()
     {
-        var stream = new MemoryStream();
+        using MemoryStream stream = new();
         this.image.Save(stream, this.localImageFormat.Object);
 
         this.encoder.Verify(x => x.Encode(this.image, stream));
@@ -82,7 +82,7 @@ public class ImageSaveTests : IDisposable
     [Fact]
     public void SaveStreamWithEncoder()
     {
-        var stream = new MemoryStream();
+        using MemoryStream stream = new();
 
         this.image.Save(stream, this.encoderNotInFormat.Object);
 

--- a/tests/ImageSharp.Tests/Image/ImageTests.ImageLoadTestBase.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.ImageLoadTestBase.cs
@@ -122,6 +122,7 @@ public partial class ImageTests
             Stream StreamFactory() => this.DataStream;
 
             this.LocalFileSystemMock.Setup(x => x.OpenRead(this.MockFilePath)).Returns(StreamFactory);
+            this.LocalFileSystemMock.Setup(x => x.OpenReadAsynchronous(this.MockFilePath)).Returns(StreamFactory);
             this.topLevelFileSystem.AddFile(this.MockFilePath, StreamFactory);
             this.LocalConfiguration.FileSystem = this.LocalFileSystemMock.Object;
             this.TopLevelConfiguration.FileSystem = this.topLevelFileSystem;
@@ -132,6 +133,11 @@ public partial class ImageTests
             // Clean up the global object;
             this.localStreamReturnImageRgba32?.Dispose();
             this.localStreamReturnImageAgnostic?.Dispose();
+
+            if (this.dataStreamLazy.IsValueCreated)
+            {
+                this.dataStreamLazy.Value.Dispose();
+            }
         }
 
         protected virtual Stream CreateStream() => this.TestFormat.CreateStream(this.Marker);

--- a/tests/ImageSharp.Tests/TestFileSystem.cs
+++ b/tests/ImageSharp.Tests/TestFileSystem.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
+
+#nullable enable
 
 namespace SixLabors.ImageSharp.Tests;
 
@@ -8,7 +10,7 @@ namespace SixLabors.ImageSharp.Tests;
 /// </summary>
 public class TestFileSystem : ImageSharp.IO.IFileSystem
 {
-    private readonly Dictionary<string, Func<Stream>> fileSystem = new Dictionary<string, Func<Stream>>(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Func<Stream>> fileSystem = new(StringComparer.OrdinalIgnoreCase);
 
     public void AddFile(string path, Func<Stream> data)
     {
@@ -18,35 +20,39 @@ public class TestFileSystem : ImageSharp.IO.IFileSystem
         }
     }
 
-    public Stream Create(string path)
+    public Stream Create(string path) => this.GetStream(path) ?? File.Create(path);
+
+    public Stream CreateAsynchronous(string path) => this.GetStream(path) ?? File.Open(path, new FileStreamOptions
+    {
+        Mode = FileMode.Create,
+        Access = FileAccess.ReadWrite,
+        Share = FileShare.None,
+        Options = FileOptions.Asynchronous,
+    });
+
+    public Stream OpenRead(string path) => this.GetStream(path) ?? File.OpenRead(path);
+
+    public Stream OpenReadAsynchronous(string path) => this.GetStream(path) ?? File.Open(path, new FileStreamOptions
+    {
+        Mode = FileMode.Open,
+        Access = FileAccess.Read,
+        Share = FileShare.Read,
+        Options = FileOptions.Asynchronous,
+    });
+
+    private Stream? GetStream(string path)
     {
         // if we have injected a fake file use it instead
         lock (this.fileSystem)
         {
-            if (this.fileSystem.ContainsKey(path))
+            if (this.fileSystem.TryGetValue(path, out Func<Stream>? streamFactory))
             {
-                Stream stream = this.fileSystem[path]();
+                Stream stream = streamFactory();
                 stream.Position = 0;
                 return stream;
             }
         }
 
-        return File.Create(path);
-    }
-
-    public Stream OpenRead(string path)
-    {
-        // if we have injected a fake file use it instead
-        lock (this.fileSystem)
-        {
-            if (this.fileSystem.ContainsKey(path))
-            {
-                Stream stream = this.fileSystem[path]();
-                stream.Position = 0;
-                return stream;
-            }
-        }
-
-        return File.OpenRead(path);
+        return null;
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/SingleStreamFileSystem.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/SingleStreamFileSystem.cs
@@ -13,5 +13,9 @@ internal class SingleStreamFileSystem : IFileSystem
 
     Stream IFileSystem.Create(string path) => this.stream;
 
+    Stream IFileSystem.CreateAsynchronous(string path) => this.stream;
+
     Stream IFileSystem.OpenRead(string path) => this.stream;
+
+    Stream IFileSystem.OpenReadAsynchronous(string path) => this.stream;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #2487