### PR TITLE
Vectorize TrimTransparentPixels in GifEncoderCore

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -435,11 +435,11 @@ internal sealed class GifEncoderCore : IImageEncoderInternals
                     {
                         Vector256<byte> vec = Vector256.LoadUnsafe(ref rowPtr, (nuint)x);
                         Vector256<byte> notEquals = ~Vector256.Equals(vec, trimmableVec256);
+                        uint mask = notEquals.ExtractMostSignificantBits();
 
-                        if (notEquals != Vector256<byte>.Zero)
+                        if (mask != 0)
                         {
                             isTransparentRow = false;
-                            uint mask = notEquals.ExtractMostSignificantBits();
                             nint start = x + (nint)uint.TrailingZeroCount(mask);
                             nint end = (nint)uint.LeadingZeroCount(mask);
 
@@ -463,11 +463,11 @@ internal sealed class GifEncoderCore : IImageEncoderInternals
                 {
                     Vector128<byte> vec = Vector128.LoadUnsafe(ref rowPtr, (nuint)x);
                     Vector128<byte> notEquals = ~Vector128.Equals(vec, trimmableVec);
+                    uint mask = notEquals.ExtractMostSignificantBits();
 
-                    if (notEquals != Vector128<byte>.Zero)
+                    if (mask != 0)
                     {
                         isTransparentRow = false;
-                        uint mask = notEquals.ExtractMostSignificantBits();
                         nint start = x + (nint)uint.TrailingZeroCount(mask);
                         nint end = (nint)uint.LeadingZeroCount(mask) - Vector128<byte>.Count;
 
@@ -493,11 +493,11 @@ internal sealed class GifEncoderCore : IImageEncoderInternals
                         Vector256<byte> vec = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.Add(ref rowPtr, x));
                         Vector256<byte> notEquals = Avx2.CompareEqual(vec, trimmableVec256);
                         notEquals = Avx2.Xor(notEquals, Vector256<byte>.AllBitsSet);
+                        int mask = Avx2.MoveMask(notEquals);
 
-                        if (!Avx.TestZ(notEquals, notEquals))
+                        if (mask != 0)
                         {
                             isTransparentRow = false;
-                            int mask = Avx2.MoveMask(notEquals);
                             nint start = x + (nint)(uint)BitOperations.TrailingZeroCount(mask);
                             nint end = (nint)(uint)BitOperations.LeadingZeroCount((uint)mask);
 
@@ -522,11 +522,11 @@ internal sealed class GifEncoderCore : IImageEncoderInternals
                     Vector128<byte> vec = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.Add(ref rowPtr, x));
                     Vector128<byte> notEquals = Sse2.CompareEqual(vec, trimmableVec);
                     notEquals = Sse2.Xor(notEquals, Vector128<byte>.AllBitsSet);
+                    int mask = Sse2.MoveMask(notEquals);
 
-                    if (!Sse41.TestZ(notEquals, notEquals))
+                    if (mask != 0)
                     {
                         isTransparentRow = false;
-                        int mask = Sse2.MoveMask(notEquals);
                         nint start = x + (nint)(uint)BitOperations.TrailingZeroCount(mask);
                         nint end = (nint)(uint)BitOperations.LeadingZeroCount((uint)mask) - Vector128<byte>.Count;
 

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -412,23 +412,142 @@ internal sealed class GifEncoderCore : IImageEncoderInternals
         int bottom = int.MaxValue;
         int left = int.MaxValue;
         int right = int.MinValue;
-
-        // Run through th buffer in a single pass. Use variables to track the min/max values.
         int minY = -1;
         bool isTransparentRow = true;
+
+        // Run through the buffer in a single pass. Use variables to track the min/max values.
         for (int y = 0; y < buffer.Height; y++)
         {
             isTransparentRow = true;
             Span<byte> rowSpan = buffer.DangerousGetRowSpan(y);
+            ref byte rowPtr = ref MemoryMarshal.GetReference(rowSpan);
+            nint rowLength = (nint)(uint)rowSpan.Length;
+            nint x = 0;
 
-            // TODO: It may be possible to optimize this inner loop using SIMD.
-            for (int x = 0; x < rowSpan.Length; x++)
+#if NET7_0_OR_GREATER
+            if (Vector128.IsHardwareAccelerated && rowLength >= Vector128<byte>.Count)
             {
-                if (rowSpan[x] != trimmableIndex)
+                Vector256<byte> trimmableVec256 = Vector256.Create(trimmableIndex);
+
+                if (Vector256.IsHardwareAccelerated && rowLength >= Vector256<byte>.Count)
+                {
+                    do
+                    {
+                        Vector256<byte> vec = Vector256.LoadUnsafe(ref rowPtr, (nuint)x);
+                        Vector256<byte> notEquals = ~Vector256.Equals(vec, trimmableVec256);
+
+                        if (notEquals != Vector256<byte>.Zero)
+                        {
+                            isTransparentRow = false;
+                            uint mask = notEquals.ExtractMostSignificantBits();
+                            nint start = x + (nint)uint.TrailingZeroCount(mask);
+                            nint end = (nint)uint.LeadingZeroCount(mask);
+
+                            // end is from the end, but we need the index from the beginning
+                            end = x + Vector256<byte>.Count - 1 - end;
+
+                            left = Math.Min(left, (int)start);
+                            right = Math.Max(right, (int)end);
+                        }
+
+                        x += Vector256<byte>.Count;
+                    }
+                    while (x <= rowLength - Vector256<byte>.Count);
+                }
+
+                Vector128<byte> trimmableVec = Vector256.IsHardwareAccelerated
+                    ? trimmableVec256.GetLower()
+                    : Vector128.Create(trimmableIndex);
+
+                while (x <= rowLength - Vector128<byte>.Count)
+                {
+                    Vector128<byte> vec = Vector128.LoadUnsafe(ref rowPtr, (nuint)x);
+                    Vector128<byte> notEquals = ~Vector128.Equals(vec, trimmableVec);
+
+                    if (notEquals != Vector128<byte>.Zero)
+                    {
+                        isTransparentRow = false;
+                        uint mask = notEquals.ExtractMostSignificantBits();
+                        nint start = x + (nint)uint.TrailingZeroCount(mask);
+                        nint end = (nint)uint.LeadingZeroCount(mask) - Vector128<byte>.Count;
+
+                        // end is from the end, but we need the index from the beginning
+                        end = x + Vector128<byte>.Count - 1 - end;
+
+                        left = Math.Min(left, (int)start);
+                        right = Math.Max(right, (int)end);
+                    }
+
+                    x += Vector128<byte>.Count;
+                }
+            }
+#else
+            if (Sse41.IsSupported && rowLength >= Vector128<byte>.Count)
+            {
+                Vector256<byte> trimmableVec256 = Vector256.Create(trimmableIndex);
+
+                if (Avx2.IsSupported && rowLength >= Vector256<byte>.Count)
+                {
+                    do
+                    {
+                        Vector256<byte> vec = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.Add(ref rowPtr, x));
+                        Vector256<byte> notEquals = Avx2.CompareEqual(vec, trimmableVec256);
+                        notEquals = Avx2.Xor(notEquals, Vector256<byte>.AllBitsSet);
+
+                        if (!Avx.TestZ(notEquals, notEquals))
+                        {
+                            isTransparentRow = false;
+                            int mask = Avx2.MoveMask(notEquals);
+                            nint start = x + (nint)(uint)BitOperations.TrailingZeroCount(mask);
+                            nint end = (nint)(uint)BitOperations.LeadingZeroCount((uint)mask);
+
+                            // end is from the end, but we need the index from the beginning
+                            end = x + Vector256<byte>.Count - 1 - end;
+
+                            left = Math.Min(left, (int)start);
+                            right = Math.Max(right, (int)end);
+                        }
+
+                        x += Vector256<byte>.Count;
+                    }
+                    while (x <= rowLength - Vector256<byte>.Count);
+                }
+
+                Vector128<byte> trimmableVec = Sse41.IsSupported
+                    ? trimmableVec256.GetLower()
+                    : Vector128.Create(trimmableIndex);
+
+                while (x <= rowLength - Vector128<byte>.Count)
+                {
+                    Vector128<byte> vec = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.Add(ref rowPtr, x));
+                    Vector128<byte> notEquals = Sse2.CompareEqual(vec, trimmableVec);
+                    notEquals = Sse2.Xor(notEquals, Vector128<byte>.AllBitsSet);
+
+                    if (!Sse41.TestZ(notEquals, notEquals))
+                    {
+                        isTransparentRow = false;
+                        int mask = Sse2.MoveMask(notEquals);
+                        nint start = x + (nint)(uint)BitOperations.TrailingZeroCount(mask);
+                        nint end = (nint)(uint)BitOperations.LeadingZeroCount((uint)mask) - Vector128<byte>.Count;
+
+                        // end is from the end, but we need the index from the beginning
+                        end = x + Vector128<byte>.Count - 1 - end;
+
+                        left = Math.Min(left, (int)start);
+                        right = Math.Max(right, (int)end);
+                    }
+
+                    x += Vector128<byte>.Count;
+                }
+            }
+#endif
+            for (; x < rowLength; ++x)
+            {
+                if (Unsafe.Add(ref rowPtr, x) != trimmableIndex)
                 {
                     isTransparentRow = false;
-                    left = Math.Min(left, x);
-                    right = Math.Max(right, x);
+                    left = Math.Min(left, (int)x);
+                    right = Math.Max(right, (int)x);
                 }
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

See https://github.com/SixLabors/ImageSharp/pull/2455#issuecomment-1613901985

A simple benchmark -- just for the inner loop -- yields:
```
|     Method |      Mean |    Error |   StdDev | Ratio |
|----------- |----------:|---------:|---------:|------:|
|    Default | 102.33 ns | 2.073 ns | 2.973 ns |  1.00 |
| Vectorized |  16.53 ns | 0.065 ns | 0.055 ns |  0.16 |
```
This is measured with .NET 7, but the codegen for .NET 6 is very similar.

<details>
  <summary>benchmark code</summary>

```c#
using System.Runtime.CompilerServices;
using System.Runtime.InteropServices;
using System.Runtime.Intrinsics;
using BenchmarkDotNet.Attributes;

Bench bench = new();
bench.Setup();
Console.WriteLine(bench.Default());
Console.WriteLine(bench.Vectorized());

#if !DEBUG
BenchmarkDotNet.Running.BenchmarkRunner.Run<Bench>();
#endif

public class Bench
{
    private byte[] _rowSpan = null!;
    private byte _trimmableIndex;

    [GlobalSetup]
    public void Setup()
    {
        _rowSpan = new byte[100];
        _rowSpan.AsSpan().Fill(42);
        _rowSpan.AsSpan(25, 9).Clear();

        _trimmableIndex = 42;
    }

    [Benchmark(Baseline = true)]
    public (int left, int right, bool isTransparentRow) Default()
    {
        Span<byte> rowSpan = _rowSpan;
        byte trimmableIndex = _trimmableIndex;

        int left = int.MaxValue;
        int right = int.MinValue;
        bool isTransparentRow = true;

        for (int x = 0; x < rowSpan.Length; ++x)
        {
            if (rowSpan[x] != trimmableIndex)
            {
                isTransparentRow = false;
                left = Math.Min(left, x);
                right = Math.Max(right, x);
            }
        }

        if (left == int.MaxValue)
        {
            left = 0;
        }

        if (right == int.MinValue)
        {
            right = rowSpan.Length;
        }

        return (left, right, isTransparentRow);
    }

    [Benchmark]
    public (int left, int right, bool isTransparentRow) Vectorized()
    {
        Span<byte> rowSpan = _rowSpan;
        byte trimmableIndex = _trimmableIndex;

        int left = int.MaxValue;
        int right = int.MinValue;
        bool isTransparentRow = true;

        ref byte rowPtr = ref MemoryMarshal.GetReference(rowSpan);
        nint rowLength = (nint)(uint)rowSpan.Length;
        nint x = 0;

        if (Vector128.IsHardwareAccelerated && rowLength >= Vector128<byte>.Count)
        {
            Vector256<byte> trimmableVec256 = Vector256.Create(trimmableIndex);

            if (Vector256.IsHardwareAccelerated && rowLength >= Vector256<byte>.Count)
            {
                do
                {
                    Vector256<byte> vec = Vector256.LoadUnsafe(ref rowPtr, (nuint)x);
                    Vector256<byte> notEquals = ~Vector256.Equals(vec, trimmableVec256);

                    if (notEquals != Vector256<byte>.Zero)
                    {
                        isTransparentRow = false;
                        uint mask = notEquals.ExtractMostSignificantBits();
                        nint start = x + (nint)uint.TrailingZeroCount(mask);

                        nint end = (nint)uint.LeadingZeroCount(mask);
                        // end is from the end, but we need the index from the beginning
                        end = x + Vector256<byte>.Count - 1 - end;

                        left = Math.Min(left, (int)start);
                        right = Math.Max(right, (int)end);
                    }

                    x += Vector256<byte>.Count;
                }
                while (x <= rowLength - Vector256<byte>.Count);
            }

            Vector128<byte> trimmableVec = Vector256.IsHardwareAccelerated
                ? trimmableVec256.GetLower()
                : Vector128.Create(trimmableIndex);

            while (x <= rowLength - Vector128<byte>.Count)
            {
                Vector128<byte> vec = Vector128.LoadUnsafe(ref rowPtr, (nuint)x);
                Vector128<byte> notEquals = ~Vector128.Equals(vec, trimmableVec);

                if (notEquals != Vector128<byte>.Zero)
                {
                    isTransparentRow = false;
                    uint mask = notEquals.ExtractMostSignificantBits();
                    nint start = x + (nint)uint.TrailingZeroCount(mask);

                    nint end = (nint)uint.LeadingZeroCount(mask) - Vector128<byte>.Count;
                    // end is from the end, but we need the index from the beginning
                    end = x + Vector128<byte>.Count - 1 - end;

                    left = Math.Min(left, (int)start);
                    right = Math.Max(right, (int)end);
                }

                x += Vector128<byte>.Count;
            }
        }

        for (; x < rowLength; ++x)
        {
            if (Unsafe.Add(ref rowPtr, x) != trimmableIndex)
            {
                isTransparentRow = false;
                left = Math.Min(left, (int)x);
                right = Math.Max(right, (int)x);
            }
        }

        if (left == int.MaxValue)
        {
            left = 0;
        }

        if (right == int.MinValue)
        {
            right = (int)rowLength;
        }

        return (left, right, isTransparentRow);
    }
}
```
</details>