### PR TITLE
Prevent crafted DOS attack.

### DIFF
--- a/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
+++ b/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
@@ -28,7 +28,7 @@ internal static class BufferedReadStreamExtensions
                 {
                     innerValue = stream.ReadByte();
                 }
-                while (innerValue != 0x0a);
+                while (innerValue is not 0x0a and not -0x1);
 
                 // Continue searching for whitespace.
                 val = innerValue;

--- a/tests/ImageSharp.Tests/Formats/Pbm/PbmMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/PbmMetadataTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Pbm;
 using static SixLabors.ImageSharp.Tests.TestImages.Pbm;
 
@@ -79,5 +80,15 @@ public class PbmMetadataTests
         PbmMetadata bitmapMetadata = imageInfo.Metadata.GetPbmMetadata();
         Assert.NotNull(bitmapMetadata);
         Assert.Equal(expectedComponentType, bitmapMetadata.ComponentType);
+    }
+
+    [Fact]
+    public void Identify_HandlesCraftedDenialOfServiceString()
+    {
+        byte[] bytes = Convert.FromBase64String("UDEjWAAACQAAAAA=");
+        ImageInfo info = Image.Identify(bytes);
+        Assert.Equal(default, info.Size);
+        Configuration.Default.ImageFormatsManager.TryFindFormatByFileExtension("pbm", out IImageFormat format);
+        Assert.Equal(format!, info.Metadata.DecodedImageFormat);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
It's possible to cause the library to hang with a crafted byte array targetting the PBM decoder. This PR fixes that vulnarability. All other formats correctly test for the end of the stream. 

<!-- Thanks for contributing to ImageSharp! -->
