### PR TITLE
Backport #2501

### DIFF
--- a/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
+++ b/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
@@ -29,7 +29,7 @@ namespace SixLabors.ImageSharp.Formats.Pbm
                     {
                         innerValue = stream.ReadByte();
                     }
-                    while (innerValue != 0x0a);
+                    while (innerValue is not 0x0a and not -0x1);
 
                     // Continue searching for whitespace.
                     val = innerValue;

--- a/tests/ImageSharp.Tests/Formats/Pbm/PbmMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/PbmMetadataTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.IO;
+using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Pbm;
 
 using Xunit;
@@ -81,6 +83,16 @@ namespace SixLabors.ImageSharp.Tests.Formats.Pbm
             PbmMetadata bitmapMetadata = imageInfo.Metadata.GetPbmMetadata();
             Assert.NotNull(bitmapMetadata);
             Assert.Equal(expectedComponentType, bitmapMetadata.ComponentType);
+        }
+
+        [Fact]
+        public void Identify_HandlesCraftedDenialOfServiceString()
+        {
+            byte[] bytes = Convert.FromBase64String("UDEjWAAACQAAAAA=");
+            IImageInfo info = Image.Identify(bytes);
+            Assert.Equal(default, info.Size());
+            IImageFormat format = Configuration.Default.ImageFormatsManager.FindFormatByFileExtension("pbm");
+            Assert.Equal("PBM", format.Name);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backports #2501 to 2.1.X

<!-- Thanks for contributing to ImageSharp! -->
