### PR TITLE
Handle EOF in Jpeg bit reader when data is bad to prevent DOS attack.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+      - release/*
     types: [ labeled, opened, synchronize, reopened ]
 jobs:
   Build:

--- a/src/ImageSharp/Advanced/ParallelRowIterator.cs
+++ b/src/ImageSharp/Advanced/ParallelRowIterator.cs
@@ -115,7 +115,7 @@ public static partial class ParallelRowIterator
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
         int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
         MemoryAllocator allocator = parallelSettings.MemoryAllocator;
         int bufferLength = Unsafe.AsRef(operation).GetRequiredBufferLength(rectangle);
@@ -180,7 +180,7 @@ public static partial class ParallelRowIterator
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
         int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
 
         // Avoid TPL overhead in this trivial case:
@@ -242,7 +242,7 @@ public static partial class ParallelRowIterator
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
         int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
         MemoryAllocator allocator = parallelSettings.MemoryAllocator;
         int bufferLength = Unsafe.AsRef(operation).GetRequiredBufferLength(rectangle);

--- a/src/ImageSharp/Advanced/ParallelRowIterator.cs
+++ b/src/ImageSharp/Advanced/ParallelRowIterator.cs
@@ -50,7 +50,7 @@ public static partial class ParallelRowIterator
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
         int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
 
         // Avoid TPL overhead in this trivial case:
@@ -270,7 +270,7 @@ public static partial class ParallelRowIterator
     }
 
     [MethodImpl(InliningOptions.ShortMethod)]
-    private static int DivideCeil(int dividend, int divisor) => 1 + ((dividend - 1) / divisor);
+    private static int DivideCeil(long dividend, int divisor) => (int)Math.Min(1 + ((dividend - 1) / divisor), int.MaxValue);
 
     private static void ValidateRectangle(Rectangle rectangle)
     {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
@@ -212,7 +212,7 @@ internal struct JpegBitReader
     private int ReadStream()
     {
         int value = this.badData ? 0 : this.stream.ReadByte();
-        if (value == -1 || this.stream.Position == this.stream.Length)
+        if (value == -1 || this.stream.Position >= this.stream.Length)
         {
             // We've encountered the end of the file stream which means there's no EOI marker
             // in the image or the SOS marker has the wrong dimensions set.

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
@@ -212,6 +212,11 @@ internal struct JpegBitReader
     private int ReadStream()
     {
         int value = this.badData ? 0 : this.stream.ReadByte();
+
+        // We've encountered the end of the file stream which means there's no EOI marker or the marker has been read
+        // during decoding of the SOS marker.
+        // When reading individual bits 'badData' simply means we have hit a marker, When data is '0' and the stream is exhausted
+        // we know we have hit the EOI and completed decoding the scan buffer.
         if (value == -1 || (this.badData && this.data == 0 && this.stream.Position >= this.stream.Length))
         {
             // We've encountered the end of the file stream which means there's no EOI marker

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
@@ -212,7 +212,7 @@ internal struct JpegBitReader
     private int ReadStream()
     {
         int value = this.badData ? 0 : this.stream.ReadByte();
-        if (value == -1 || this.stream.Position >= this.stream.Length)
+        if (value == -1 || (this.badData && this.data == 0 && this.stream.Position >= this.stream.Length))
         {
             // We've encountered the end of the file stream which means there's no EOI marker
             // in the image or the SOS marker has the wrong dimensions set.

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
@@ -212,7 +212,7 @@ internal struct JpegBitReader
     private int ReadStream()
     {
         int value = this.badData ? 0 : this.stream.ReadByte();
-        if (value == -1)
+        if (value == -1 || this.stream.Position == this.stream.Length)
         {
             // We've encountered the end of the file stream which means there's no EOI marker
             // in the image or the SOS marker has the wrong dimensions set.

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -314,4 +314,14 @@ public partial class JpegDecoderTests
         image.DebugSave(provider);
         image.CompareToOriginal(provider);
     }
+
+    [Theory]
+    [WithFile(TestImages.Jpeg.Issues.HangBadScan, PixelTypes.L8)]
+    public void DecodeHang<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
+        Assert.Equal(65503, image.Width);
+        Assert.Equal(65503, image.Height);
+    }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -320,6 +320,14 @@ public partial class JpegDecoderTests
     public void DecodeHang<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
     {
+        if (TestEnvironment.IsWindows &&
+            TestEnvironment.RunsOnCI &&
+            TestEnvironment.NetCoreVersion.Major == 6)
+        {
+            // Windows CI runs on .NET 6 consistently fail with OOM.
+            return;
+        }
+
         using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
         Assert.Equal(65503, image.Width);
         Assert.Equal(65503, image.Height);

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -321,10 +321,9 @@ public partial class JpegDecoderTests
         where TPixel : unmanaged, IPixel<TPixel>
     {
         if (TestEnvironment.IsWindows &&
-            TestEnvironment.RunsOnCI &&
-            TestEnvironment.NetCoreVersion.Major == 6)
+            TestEnvironment.RunsOnCI)
         {
-            // Windows CI runs on .NET 6 consistently fail with OOM.
+            // Windows CI runs consistently fail with OOM.
             return;
         }
 

--- a/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
+++ b/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Six Labors Split License.
 
 using System.Numerics;
+using Castle.Core.Configuration;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
@@ -404,6 +405,32 @@ public class ParallelRowIteratorTests
             () => ParallelRowIterator.IterateRowIntervals<TestRowIntervalOperation<Rgba32>, Rgba32>(rect, in parallelSettings, in operation));
 
         Assert.Contains(width <= 0 ? "Width" : "Height", ex.Message);
+    }
+
+    [Fact]
+    public void CanIterateWithoutIntOverflow()
+    {
+        ParallelExecutionSettings parallelSettings = ParallelExecutionSettings.FromConfiguration(Configuration.Default);
+
+        Rectangle rect = new(0, 0, 65535, 65535);
+
+        static void RowAction(RowInterval rows, Span<Rgba32> memory)
+        {
+        }
+
+        TestRowOperation operation = default;
+        TestRowIntervalOperation<Rgba32> intervalOperation = new(RowAction);
+
+        ParallelRowIterator.IterateRows(Configuration.Default, rect, in operation);
+
+        ParallelRowIterator.IterateRowIntervals<TestRowIntervalOperation<Rgba32>, Rgba32>(rect, in parallelSettings, in intervalOperation);
+    }
+
+    private readonly struct TestRowOperation : IRowOperation
+    {
+        public void Invoke(int y)
+        {
+        }
     }
 
     private readonly struct TestRowIntervalOperation : IRowIntervalOperation

--- a/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
+++ b/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Six Labors Split License.
 
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using Castle.Core.Configuration;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Memory;
@@ -411,25 +412,36 @@ public class ParallelRowIteratorTests
     public void CanIterateWithoutIntOverflow()
     {
         ParallelExecutionSettings parallelSettings = ParallelExecutionSettings.FromConfiguration(Configuration.Default);
+        const int max = 100_000;
 
-        Rectangle rect = new(0, 0, 65535, 65535);
+        Rectangle rect = new(0, 0, max, max);
+        int intervalMaxY = 0;
+        void RowAction(RowInterval rows, Span<Rgba32> memory) => intervalMaxY = Math.Max(rows.Max, intervalMaxY);
 
-        static void RowAction(RowInterval rows, Span<Rgba32> memory)
-        {
-        }
-
-        TestRowOperation operation = default;
+        TestRowOperation operation = new();
         TestRowIntervalOperation<Rgba32> intervalOperation = new(RowAction);
 
         ParallelRowIterator.IterateRows(Configuration.Default, rect, in operation);
+        Assert.Equal(max - 1, operation.MaxY.Value);
 
         ParallelRowIterator.IterateRowIntervals<TestRowIntervalOperation<Rgba32>, Rgba32>(rect, in parallelSettings, in intervalOperation);
+        Assert.Equal(max, intervalMaxY);
     }
 
     private readonly struct TestRowOperation : IRowOperation
     {
+        public TestRowOperation()
+        {
+        }
+
+        public StrongBox<int> MaxY { get; } = new StrongBox<int>();
+
         public void Invoke(int y)
         {
+            lock (this.MaxY)
+            {
+                this.MaxY.Value = Math.Max(y, this.MaxY.Value);
+            }
         }
     }
 

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -284,6 +284,7 @@ public static class TestImages
             public const string Issue2315_NotEnoughBytes = "Jpg/issues/issue-2315.jpg";
             public const string Issue2334_NotEnoughBytesA = "Jpg/issues/issue-2334-a.jpg";
             public const string Issue2334_NotEnoughBytesB = "Jpg/issues/issue-2334-b.jpg";
+            public const string HangBadScan = "Jpg/issues/Hang_C438A851.jpg";
 
             public static class Fuzz
             {

--- a/tests/Images/Input/Jpg/issues/Hang_C438A851.jpg
+++ b/tests/Images/Input/Jpg/issues/Hang_C438A851.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:580760756f2e7e3ed0752a4ec53d6b6786a4f005606f3a50878f732b3b2a1bcb
+size 413


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This specially crafted file has had the start of frame marker altered to change the dimensions to values (_65503x65503_) that far exceed the encoded data. Nothing seems to be able to open this but with a very small change we actually can and quickly too. 

It's better that we allow decoding than explicitly throwing because there is no way to tell the difference between a maliciously crafted file with complete data from a damaged file with limited data and we already work very hard to enable decoding the latter.

I've also added a fix to allow us to actually parallel process images of this size. I discovered the iterator suffered from an overflow issue during attempts to determine what the maximum dimensions of a file Windows can handle (_65500x65500_) as it cannot decode a reencoded of the full dimensions with any built in applications.

I've created a branch (release/v3.0.2) based of the v3.0.1 tagged commit and cherry-picked #2501. Once merged I'll publish a release based upon that branch I'll backport this fix into release/v2.x for publishing.

<!-- Thanks for contributing to ImageSharp! -->
