### PR TITLE
Fix #2518

### DIFF
--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
@@ -43,10 +43,17 @@ internal class OilPaintingProcessor<TPixel> : ImageProcessor<TPixel>
         source.CopyTo(targetPixels);
 
         RowIntervalOperation operation = new(this.SourceRectangle, targetPixels, source.PixelBuffer, this.Configuration, brushSize >> 1, levels);
-        ParallelRowIterator.IterateRowIntervals(
+        try
+        {
+            ParallelRowIterator.IterateRowIntervals(
             this.Configuration,
             this.SourceRectangle,
             in operation);
+        }
+        catch (Exception ex)
+        {
+            throw new ImageProcessingException("The OilPaintProcessor failed. The most likely reason is that a pixel component was outside of its' allowed range.", ex);
+        }
 
         Buffer2D<TPixel>.SwapOrCopyContent(source.PixelBuffer, targetPixels);
     }
@@ -142,7 +149,7 @@ internal class OilPaintingProcessor<TPixel> : ImageProcessor<TPixel>
                             int offsetX = x + fxr;
                             offsetX = Numerics.Clamp(offsetX, 0, maxX);
 
-                            Vector4 vector = Vector4.Clamp(sourceOffsetRow[offsetX].ToScaledVector4(), Vector4.Zero, Vector4.One);
+                            Vector4 vector = sourceOffsetRow[offsetX].ToScaledVector4();
 
                             float sourceRed = vector.X;
                             float sourceBlue = vector.Z;

--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor{TPixel}.cs
@@ -99,7 +99,7 @@ internal class OilPaintingProcessor<TPixel> : ImageProcessor<TPixel>
              * are cleared for each loop iteration, to avoid the repeated allocation for each processed pixel. */
             using IMemoryOwner<Vector4> sourceRowBuffer = this.configuration.MemoryAllocator.Allocate<Vector4>(this.source.Width);
             using IMemoryOwner<Vector4> targetRowBuffer = this.configuration.MemoryAllocator.Allocate<Vector4>(this.source.Width);
-            using IMemoryOwner<float> bins = this.configuration.MemoryAllocator.Allocate<float>(this.levels * 256 * 4);
+            using IMemoryOwner<float> bins = this.configuration.MemoryAllocator.Allocate<float>(this.levels * 4);
 
             Span<Vector4> sourceRowVector4Span = sourceRowBuffer.Memory.Span;
             Span<Vector4> sourceRowAreaVector4Span = sourceRowVector4Span.Slice(this.bounds.X, this.bounds.Width);
@@ -142,7 +142,7 @@ internal class OilPaintingProcessor<TPixel> : ImageProcessor<TPixel>
                             int offsetX = x + fxr;
                             offsetX = Numerics.Clamp(offsetX, 0, maxX);
 
-                            Vector4 vector = sourceOffsetRow[offsetX].ToScaledVector4();
+                            Vector4 vector = Vector4.Clamp(sourceOffsetRow[offsetX].ToScaledVector4(), Vector4.Zero, Vector4.One);
 
                             float sourceRed = vector.X;
                             float sourceBlue = vector.Z;

--- a/tests/ImageSharp.Benchmarks/Processing/OilPaint.cs
+++ b/tests/ImageSharp.Benchmarks/Processing/OilPaint.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using BenchmarkDotNet.Attributes;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace SixLabors.ImageSharp.Benchmarks.Processing;
+
+[Config(typeof(Config.MultiFramework))]
+public class OilPaint
+{
+    [Benchmark]
+    public void DoOilPaint()
+    {
+        using Image<RgbaVector> image = new Image<RgbaVector>(1920, 1200, new(127, 191, 255));
+        image.Mutate(ctx => ctx.OilPaint());
+    }
+}

--- a/tests/ImageSharp.Tests/Processing/Processors/Effects/OilPaintTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Effects/OilPaintTest.cs
@@ -27,8 +27,7 @@ public class OilPaintTest
     [WithFileCollection(nameof(InputImages), nameof(OilPaintValues), PixelTypes.Rgba32)]
     public void FullImage<TPixel>(TestImageProvider<TPixel> provider, int levels, int brushSize)
         where TPixel : unmanaged, IPixel<TPixel>
-    {
-        provider.RunValidatingProcessorTest(
+        => provider.RunValidatingProcessorTest(
             x =>
             {
                 x.OilPaint(levels, brushSize);
@@ -36,24 +35,21 @@ public class OilPaintTest
             },
             ImageComparer.TolerantPercentage(0.01F),
             appendPixelTypeToFileName: false);
-    }
 
     [Theory]
     [WithFileCollection(nameof(InputImages), nameof(OilPaintValues), PixelTypes.Rgba32)]
     [WithTestPatternImages(nameof(OilPaintValues), 100, 100, PixelTypes.Rgba32)]
     public void InBox<TPixel>(TestImageProvider<TPixel> provider, int levels, int brushSize)
         where TPixel : unmanaged, IPixel<TPixel>
-    {
-        provider.RunRectangleConstrainedValidatingProcessorTest(
+        => provider.RunRectangleConstrainedValidatingProcessorTest(
             (x, rect) => x.OilPaint(levels, brushSize, rect),
             $"{levels}-{brushSize}",
             ImageComparer.TolerantPercentage(0.01F));
-    }
 
     [Fact]
-    public void Issue2518()
+    public void Issue2518_PixelComponentOutsideOfRange_ThrowsImageProcessingException()
     {
-        using Image<RgbaVector> image = new Image<RgbaVector>(1920, 1200, new(127, 191, 255));
-        image.Mutate(ctx => ctx.OilPaint());
+        using Image<RgbaVector> image = new(10, 10, new RgbaVector(1, 1, 100));
+        Assert.Throws<ImageProcessingException>(() => image.Mutate(ctx => ctx.OilPaint()));
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Effects/OilPaintTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Effects/OilPaintTest.cs
@@ -49,4 +49,11 @@ public class OilPaintTest
             $"{levels}-{brushSize}",
             ImageComparer.TolerantPercentage(0.01F));
     }
+
+    [Fact]
+    public void Issue2518()
+    {
+        using Image<RgbaVector> image = new Image<RgbaVector>(1920, 1200, new(127, 191, 255));
+        image.Mutate(ctx => ctx.OilPaint());
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Applying a (hopefully correct) bin buffer size, and eliminating `Unsafe` usage in a less critical processor we did not attempt to optimize with other safer techniques.

### Benchmarks

#### main
```
|     Method |     Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |---------:|--------:|--------:|------:|------:|------:|----------:|
| DoOilPaint | 201.7 ms | 4.01 ms | 5.07 ms |     - |     - |     - |     18 KB |
```

#### PR
```
|     Method |     Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |---------:|--------:|--------:|------:|------:|------:|----------:|
| DoOilPaint | 214.5 ms | 3.61 ms | 3.20 ms |     - |     - |     - |     18 KB |
```

I believe the 6% cost is worth the readability and memory safety benefits. We should keep `Unsafe` for the hot path in critical stuff (codecs, resize etc.). If we want to optimize this processor, we can try other techniques first, eg. vectorization.