### PR TITLE
Handle EOF in Jpeg bit reader when data is bad to prevent DOS attack.…

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+      - release/*
     types: [ labeled, opened, synchronize, reopened ]
 jobs:
   Build:

--- a/src/ImageSharp/Advanced/ParallelRowIterator.cs
+++ b/src/ImageSharp/Advanced/ParallelRowIterator.cs
@@ -50,7 +50,7 @@ public static partial class ParallelRowIterator
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
         int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
 
         // Avoid TPL overhead in this trivial case:
@@ -115,7 +115,7 @@ public static partial class ParallelRowIterator
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
         int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
         MemoryAllocator allocator = parallelSettings.MemoryAllocator;
         int bufferLength = Unsafe.AsRef(operation).GetRequiredBufferLength(rectangle);
@@ -180,7 +180,7 @@ public static partial class ParallelRowIterator
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
         int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
 
         // Avoid TPL overhead in this trivial case:
@@ -242,7 +242,7 @@ public static partial class ParallelRowIterator
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
         int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
         MemoryAllocator allocator = parallelSettings.MemoryAllocator;
         int bufferLength = Unsafe.AsRef(operation).GetRequiredBufferLength(rectangle);
@@ -270,7 +270,7 @@ public static partial class ParallelRowIterator
     }
 
     [MethodImpl(InliningOptions.ShortMethod)]
-    private static int DivideCeil(int dividend, int divisor) => 1 + ((dividend - 1) / divisor);
+    private static int DivideCeil(long dividend, int divisor) => (int)Math.Min(1 + ((dividend - 1) / divisor), int.MaxValue);
 
     private static void ValidateRectangle(Rectangle rectangle)
     {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
@@ -212,7 +212,12 @@ internal struct JpegBitReader
     private int ReadStream()
     {
         int value = this.badData ? 0 : this.stream.ReadByte();
-        if (value == -1)
+
+        // We've encountered the end of the file stream which means there's no EOI marker or the marker has been read
+        // during decoding of the SOS marker.
+        // When reading individual bits 'badData' simply means we have hit a marker, When data is '0' and the stream is exhausted
+        // we know we have hit the EOI and completed decoding the scan buffer.
+        if (value == -1 || (this.badData && this.data == 0 && this.stream.Position >= this.stream.Length))
         {
             // We've encountered the end of the file stream which means there's no EOI marker
             // in the image or the SOS marker has the wrong dimensions set.

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -325,4 +325,21 @@ public partial class JpegDecoderTests
         image.DebugSave(provider);
         image.CompareToOriginal(provider);
     }
+
+    [Theory]
+    [WithFile(TestImages.Jpeg.Issues.HangBadScan, PixelTypes.L8)]
+    public void DecodeHang<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        if (TestEnvironment.IsWindows &&
+            TestEnvironment.RunsOnCI)
+        {
+            // Windows CI runs consistently fail with OOM.
+            return;
+        }
+
+        using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
+        Assert.Equal(65503, image.Width);
+        Assert.Equal(65503, image.Height);
+    }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -291,6 +291,7 @@ public static class TestImages
             public const string Issue2334_NotEnoughBytesA = "Jpg/issues/issue-2334-a.jpg";
             public const string Issue2334_NotEnoughBytesB = "Jpg/issues/issue-2334-b.jpg";
             public const string Issue2478_JFXX = "Jpg/issues/issue-2478-jfxx.jpg";
+            public const string HangBadScan = "Jpg/issues/Hang_C438A851.jpg";
 
             public static class Fuzz
             {

--- a/tests/Images/Input/Jpg/issues/Hang_C438A851.jpg
+++ b/tests/Images/Input/Jpg/issues/Hang_C438A851.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:580760756f2e7e3ed0752a4ec53d6b6786a4f005606f3a50878f732b3b2a1bcb
+size 413


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Cherry picked commit of #2516 so we can merge into main.
<!-- Thanks for contributing to ImageSharp! -->
