### PR TITLE
Backport - Handle EOF in Jpeg bit reader when data is bad to prevent DOS attack.

### DIFF
--- a/src/ImageSharp/Advanced/ParallelRowIterator.cs
+++ b/src/ImageSharp/Advanced/ParallelRowIterator.cs
@@ -52,7 +52,7 @@ namespace SixLabors.ImageSharp.Advanced
             int width = rectangle.Width;
             int height = rectangle.Height;
 
-            int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+            int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
             int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
 
             // Avoid TPL overhead in this trivial case:
@@ -117,7 +117,7 @@ namespace SixLabors.ImageSharp.Advanced
             int width = rectangle.Width;
             int height = rectangle.Height;
 
-            int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+            int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
             int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
             MemoryAllocator allocator = parallelSettings.MemoryAllocator;
 
@@ -181,7 +181,7 @@ namespace SixLabors.ImageSharp.Advanced
             int width = rectangle.Width;
             int height = rectangle.Height;
 
-            int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+            int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
             int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
 
             // Avoid TPL overhead in this trivial case:
@@ -243,7 +243,7 @@ namespace SixLabors.ImageSharp.Advanced
             int width = rectangle.Width;
             int height = rectangle.Height;
 
-            int maxSteps = DivideCeil(width * height, parallelSettings.MinimumPixelsProcessedPerTask);
+            int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
             int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
             MemoryAllocator allocator = parallelSettings.MemoryAllocator;
 
@@ -270,7 +270,7 @@ namespace SixLabors.ImageSharp.Advanced
         }
 
         [MethodImpl(InliningOptions.ShortMethod)]
-        private static int DivideCeil(int dividend, int divisor) => 1 + ((dividend - 1) / divisor);
+        private static int DivideCeil(long dividend, int divisor) => (int)Math.Min(1 + ((dividend - 1) / divisor), int.MaxValue);
 
         private static void ValidateRectangle(Rectangle rectangle)
         {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/HuffmanScanBuffer.cs
@@ -211,7 +211,12 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder
         private int ReadStream()
         {
             int value = this.badData ? 0 : this.stream.ReadByte();
-            if (value == -1)
+
+            // We've encountered the end of the file stream which means there's no EOI marker or the marker has been read
+            // during decoding of the SOS marker.
+            // When reading individual bits 'badData' simply means we have hit a marker, When data is '0' and the stream is exhausted
+            // we know we have hit the EOI and completed decoding the scan buffer.
+            if (value == -1 || (this.badData && this.data == 0 && this.stream.Position >= this.stream.Length))
             {
                 // We've encountered the end of the file stream which means there's no EOI marker
                 // in the image or the SOS marker has the wrong dimensions set.

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -261,5 +261,22 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
                 this.Output.WriteLine($"Difference for PORT: {portReport.DifferencePercentageString}");
             }
         }
+
+        [Theory]
+        [WithFile(TestImages.Jpeg.Issues.HangBadScan, PixelTypes.L8)]
+        public void DecodeHang<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+        {
+            if (TestEnvironment.IsWindows &&
+                TestEnvironment.RunsOnCI)
+            {
+                // Windows CI runs consistently fail with OOM.
+                return;
+            }
+
+            using Image<TPixel> image = provider.GetImage(JpegDecoder);
+            Assert.Equal(65503, image.Width);
+            Assert.Equal(65503, image.Height);
+        }
     }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -266,6 +266,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string ExifNullArrayTag = "Jpg/issues/issue-2056-exif-null-array.jpg";
                 public const string ValidExifArgumentNullExceptionOnEncode = "Jpg/issues/Issue2087-exif-null-reference-on-encode.jpg";
                 public const string Issue2133DeduceColorSpace = "Jpg/issues/Issue2133.jpg";
+                public const string HangBadScan = "Jpg/issues/Hang_C438A851.jpg";
 
                 public static class Fuzz
                 {

--- a/tests/Images/Input/Jpg/issues/Hang_C438A851.jpg
+++ b/tests/Images/Input/Jpg/issues/Hang_C438A851.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:580760756f2e7e3ed0752a4ec53d6b6786a4f005606f3a50878f732b3b2a1bcb
+size 413


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backport of #2516 for v2.x

<!-- Thanks for contributing to ImageSharp! -->
