### PR TITLE
Fix for issue 2504 - IPTC and ICC profile information being lost during TIFF file save

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -157,6 +157,7 @@ internal sealed class TiffEncoderCore : IImageEncoderInternals
         long ifdMarker = WriteHeader(writer, buffer);
 
         Image<TPixel> metadataImage = image;
+
         foreach (ImageFrame<TPixel> frame in image.Frames)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -235,8 +236,12 @@ internal sealed class TiffEncoderCore : IImageEncoderInternals
 
         if (image != null)
         {
+            // Write the metadata for the root image
             entriesCollector.ProcessMetadata(image, this.skipMetadata);
         }
+
+        // Write the metadata for the frame
+        entriesCollector.ProcessMetadata(frame, this.skipMetadata);
 
         entriesCollector.ProcessFrameInfo(frame, imageMetadata);
         entriesCollector.ProcessImageFormat(this);

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
@@ -7,6 +7,7 @@ using SixLabors.ImageSharp.Formats.Tiff;
 using SixLabors.ImageSharp.Formats.Tiff.Constants;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using SixLabors.ImageSharp.Metadata.Profiles.Iptc;
 using SixLabors.ImageSharp.Metadata.Profiles.Xmp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -317,5 +318,95 @@ public class TiffMetadataTests
 
         Assert.Equal((ushort)TiffPlanarConfiguration.Chunky, encodedImageExifProfile.GetValue(ExifTag.PlanarConfiguration)?.Value);
         Assert.Equal(exifProfileInput.Values.Count, encodedImageExifProfile.Values.Count);
+    }
+
+    [Theory]
+    [WithFile(SampleMetadata, PixelTypes.Rgba32)]
+    public void Encode_PreservesMetadata_IptcAndIcc<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        // Load Tiff image
+        DecoderOptions options = new() { SkipMetadata = false };
+        using Image<TPixel> image = provider.GetImage(TiffDecoder.Instance, options);
+
+        ImageMetadata inputMetaData = image.Metadata;
+        ImageFrame<TPixel> rootFrameInput = image.Frames.RootFrame;
+
+        IptcProfile iptcProfile = new();
+        iptcProfile.SetValue(IptcTag.Name, "Test name");
+        rootFrameInput.Metadata.IptcProfile = iptcProfile;
+
+        IccProfileHeader iccProfileHeader = new IccProfileHeader();
+        iccProfileHeader.Class = IccProfileClass.ColorSpace;
+        IccProfile iccProfile = new();
+        rootFrameInput.Metadata.IccProfile = iccProfile;
+
+        TiffFrameMetadata frameMetaInput = rootFrameInput.Metadata.GetTiffMetadata();
+        XmpProfile xmpProfileInput = rootFrameInput.Metadata.XmpProfile;
+        ExifProfile exifProfileInput = rootFrameInput.Metadata.ExifProfile;
+        IptcProfile iptcProfileInput = rootFrameInput.Metadata.IptcProfile;
+        IccProfile iccProfileInput = rootFrameInput.Metadata.IccProfile;
+
+        Assert.Equal(TiffCompression.Lzw, frameMetaInput.Compression);
+        Assert.Equal(TiffBitsPerPixel.Bit4, frameMetaInput.BitsPerPixel);
+
+        // Save to Tiff
+        TiffEncoder tiffEncoder = new() { PhotometricInterpretation = TiffPhotometricInterpretation.Rgb };
+        using MemoryStream ms = new();
+        image.Save(ms, tiffEncoder);
+
+        // Assert
+        ms.Position = 0;
+        using Image<Rgba32> encodedImage = Image.Load<Rgba32>(ms);
+
+        ImageMetadata encodedImageMetaData = encodedImage.Metadata;
+        ImageFrame<Rgba32> rootFrameEncodedImage = encodedImage.Frames.RootFrame;
+        TiffFrameMetadata tiffMetaDataEncodedRootFrame = rootFrameEncodedImage.Metadata.GetTiffMetadata();
+        ExifProfile encodedImageExifProfile = rootFrameEncodedImage.Metadata.ExifProfile;
+        XmpProfile encodedImageXmpProfile = rootFrameEncodedImage.Metadata.XmpProfile;
+        IptcProfile encodedImageIptcProfile = rootFrameEncodedImage.Metadata.IptcProfile;
+        IccProfile encodedImageIccProfile = rootFrameEncodedImage.Metadata.IccProfile;
+
+        Assert.Equal(TiffBitsPerPixel.Bit4, tiffMetaDataEncodedRootFrame.BitsPerPixel);
+        Assert.Equal(TiffCompression.Lzw, tiffMetaDataEncodedRootFrame.Compression);
+
+        Assert.Equal(inputMetaData.HorizontalResolution, encodedImageMetaData.HorizontalResolution);
+        Assert.Equal(inputMetaData.VerticalResolution, encodedImageMetaData.VerticalResolution);
+        Assert.Equal(inputMetaData.ResolutionUnits, encodedImageMetaData.ResolutionUnits);
+
+        Assert.Equal(rootFrameInput.Width, rootFrameEncodedImage.Width);
+        Assert.Equal(rootFrameInput.Height, rootFrameEncodedImage.Height);
+
+        PixelResolutionUnit resolutionUnitInput = UnitConverter.ExifProfileToResolutionUnit(exifProfileInput);
+        PixelResolutionUnit resolutionUnitEncoded = UnitConverter.ExifProfileToResolutionUnit(encodedImageExifProfile);
+        Assert.Equal(resolutionUnitInput, resolutionUnitEncoded);
+        Assert.Equal(exifProfileInput.GetValue(ExifTag.XResolution).Value.ToDouble(), encodedImageExifProfile.GetValue(ExifTag.XResolution).Value.ToDouble());
+        Assert.Equal(exifProfileInput.GetValue(ExifTag.YResolution).Value.ToDouble(), encodedImageExifProfile.GetValue(ExifTag.YResolution).Value.ToDouble());
+
+        Assert.NotNull(xmpProfileInput);
+        Assert.NotNull(encodedImageXmpProfile);
+        Assert.Equal(xmpProfileInput.Data, encodedImageXmpProfile.Data);
+
+        Assert.NotNull(iptcProfileInput);
+        Assert.NotNull(encodedImageIptcProfile);
+        Assert.Equal(iptcProfileInput.Data, encodedImageIptcProfile.Data);
+        Assert.Equal(iptcProfileInput.GetValues(IptcTag.Name)[0].Value, encodedImageIptcProfile.GetValues(IptcTag.Name)[0].Value);
+
+        Assert.NotNull(iccProfileInput);
+        Assert.NotNull(encodedImageIccProfile);
+        Assert.Equal(iccProfileInput.Entries.Length, encodedImageIccProfile.Entries.Length);
+        Assert.Equal(iccProfileInput.Header.Class, encodedImageIccProfile.Header.Class);
+
+        Assert.Equal(exifProfileInput.GetValue(ExifTag.Software).Value, encodedImageExifProfile.GetValue(ExifTag.Software).Value);
+        Assert.Equal(exifProfileInput.GetValue(ExifTag.ImageDescription).Value, encodedImageExifProfile.GetValue(ExifTag.ImageDescription).Value);
+        Assert.Equal(exifProfileInput.GetValue(ExifTag.Make).Value, encodedImageExifProfile.GetValue(ExifTag.Make).Value);
+        Assert.Equal(exifProfileInput.GetValue(ExifTag.Copyright).Value, encodedImageExifProfile.GetValue(ExifTag.Copyright).Value);
+        Assert.Equal(exifProfileInput.GetValue(ExifTag.Artist).Value, encodedImageExifProfile.GetValue(ExifTag.Artist).Value);
+        Assert.Equal(exifProfileInput.GetValue(ExifTag.Orientation).Value, encodedImageExifProfile.GetValue(ExifTag.Orientation).Value);
+        Assert.Equal(exifProfileInput.GetValue(ExifTag.Model).Value, encodedImageExifProfile.GetValue(ExifTag.Model).Value);
+
+        Assert.Equal((ushort)TiffPlanarConfiguration.Chunky, encodedImageExifProfile.GetValue(ExifTag.PlanarConfiguration)?.Value);
+        // Adding the IPTC and ICC profiles dynamically increments the number of values in the original EXIF profile by 2
+        Assert.Equal(exifProfileInput.Values.Count + 2, encodedImageExifProfile.Values.Count);
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffMetadataTests.cs
@@ -336,8 +336,7 @@ public class TiffMetadataTests
         iptcProfile.SetValue(IptcTag.Name, "Test name");
         rootFrameInput.Metadata.IptcProfile = iptcProfile;
 
-        IccProfileHeader iccProfileHeader = new IccProfileHeader();
-        iccProfileHeader.Class = IccProfileClass.ColorSpace;
+        IccProfileHeader iccProfileHeader = new() { Class = IccProfileClass.ColorSpace };
         IccProfile iccProfile = new();
         rootFrameInput.Metadata.IccProfile = iccProfile;
 
@@ -406,6 +405,7 @@ public class TiffMetadataTests
         Assert.Equal(exifProfileInput.GetValue(ExifTag.Model).Value, encodedImageExifProfile.GetValue(ExifTag.Model).Value);
 
         Assert.Equal((ushort)TiffPlanarConfiguration.Chunky, encodedImageExifProfile.GetValue(ExifTag.PlanarConfiguration)?.Value);
+
         // Adding the IPTC and ICC profiles dynamically increments the number of values in the original EXIF profile by 2
         Assert.Equal(exifProfileInput.Values.Count + 2, encodedImageExifProfile.Values.Count);
     }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
When testing adding and writing out IPTC tag data, it was found that the data was being lost during the save process for TIFF files.  It was also determined that the ICC profile data was also being lost.

During debugging, it was found that the Exif and XMP profiles were coming from the root frame only, and the IPTC and ICC profiles were coming from the image and not the root frame.

The changes introduced by this pull request split the writing of the image's metadata from each frame's metadata.  Also, rather than only using the profile data from the root frame, the metadata for each frame is written instead.  If multiple frames in the TIFF file have different metadata settings, that should preserve the data for each frame.

A new unit test was added to store and retrieve IPTC and ICC profile data, to verify that they were being saved and loaded correctly.