### PR TITLE
Change ExifTag TimeZoneOffset to Signed Short

### DIFF
--- a/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTag.LongArray.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTag.LongArray.cs
@@ -57,11 +57,6 @@ public abstract partial class ExifTag
     public static ExifTag<uint[]> IntergraphRegisters { get; } = new ExifTag<uint[]>(ExifTagValue.IntergraphRegisters);
 
     /// <summary>
-    /// Gets the TimeZoneOffset exif tag.
-    /// </summary>
-    public static ExifTag<uint[]> TimeZoneOffset { get; } = new ExifTag<uint[]>(ExifTagValue.TimeZoneOffset);
-
-    /// <summary>
     /// Gets the offset to child IFDs exif tag.
     /// </summary>
     public static ExifTag<uint[]> SubIFDs { get; } = new ExifTag<uint[]>(ExifTagValue.SubIFDs);

--- a/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTag.SignedShortArray.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTag.SignedShortArray.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.ImageSharp.Metadata.Profiles.Exif;
+
+/// <content/>
+public abstract partial class ExifTag
+{
+    /// <summary>
+    /// Gets the TimeZoneOffset exif tag.
+    /// </summary>
+    public static ExifTag<short[]> TimeZoneOffset { get; } = new ExifTag<short[]>(ExifTagValue.TimeZoneOffset);
+}

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifSignedShortArray.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifSignedShortArray.cs
@@ -5,6 +5,11 @@ namespace SixLabors.ImageSharp.Metadata.Profiles.Exif;
 
 internal sealed class ExifSignedShortArray : ExifArrayValue<short>
 {
+    public ExifSignedShortArray(ExifTag<short[]> tag)
+        : base(tag)
+    {
+    }
+
     public ExifSignedShortArray(ExifTagValue tag)
         : base(tag)
     {

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValues.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValues.cs
@@ -144,8 +144,6 @@ internal static partial class ExifValues
                 return new ExifLongArray(ExifTag.StripRowCounts);
             case ExifTagValue.IntergraphRegisters:
                 return new ExifLongArray(ExifTag.IntergraphRegisters);
-            case ExifTagValue.TimeZoneOffset:
-                return new ExifLongArray(ExifTag.TimeZoneOffset);
             case ExifTagValue.SubIFDs:
                 return new ExifLongArray(ExifTag.SubIFDs);
 
@@ -416,6 +414,9 @@ internal static partial class ExifValues
 
             case ExifTagValue.Decode:
                 return new ExifSignedRationalArray(ExifTag.Decode);
+
+            case ExifTagValue.TimeZoneOffset:
+                return new ExifSignedShortArray(ExifTag.TimeZoneOffset);
 
             case ExifTagValue.ImageDescription:
                 return new ExifString(ExifTag.ImageDescription);

--- a/tests/ImageSharp.Tests/Metadata/Profiles/Exif/Values/ExifValuesTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/Exif/Values/ExifValuesTests.cs
@@ -70,8 +70,7 @@ public class ExifValuesTests
         { ExifTag.JPEGDCTables },
         { ExifTag.JPEGACTables },
         { ExifTag.StripRowCounts },
-        { ExifTag.IntergraphRegisters },
-        { ExifTag.TimeZoneOffset }
+        { ExifTag.IntergraphRegisters }
     };
 
     public static TheoryData<ExifTag> NumberTags => new TheoryData<ExifTag>
@@ -233,6 +232,11 @@ public class ExifValuesTests
     public static TheoryData<ExifTag> SignedRationalArrayTags => new TheoryData<ExifTag>
     {
         { ExifTag.Decode }
+    };
+
+    public static TheoryData<ExifTag> SignedShortArrayTags => new TheoryData<ExifTag>
+    {
+        { ExifTag.TimeZoneOffset }
     };
 
     public static TheoryData<ExifTag> StringTags => new TheoryData<ExifTag>
@@ -556,6 +560,21 @@ public class ExifValuesTests
         Assert.True(value.TrySetValue(expected));
 
         var typed = (ExifSignedRationalArray)value;
+        Assert.Equal(expected, typed.Value);
+    }
+
+
+    [Theory]
+    [MemberData(nameof(SignedShortArrayTags))]
+    public void ExifSignedShortArrayTests(ExifTag tag)
+    {
+        short[] expected = new short[] { 21, 42 };
+        ExifValue value = ExifValues.Create(tag);
+
+        Assert.False(value.TrySetValue(expected.ToString()));
+        Assert.True(value.TrySetValue(expected));
+
+        var typed = (ExifSignedShortArray)value;
         Assert.Equal(expected, typed.Value);
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Fixes #2437 

As per the linked issue. TimeZoneOffset is a signed short array. However, currently in ImageSharp it is treated as a unsigned short array.

Changing the type to match the spec.

<!-- Thanks for contributing to ImageSharp! -->
