### PR TITLE
Add GPSHPositioningError exif tag

### DIFF
--- a/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTag.Rational.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTag.Rational.cs
@@ -165,4 +165,9 @@ public abstract partial class ExifTag
     /// Gets the GPSDestDistance exif tag.
     /// </summary>
     public static ExifTag<Rational> GPSDestDistance { get; } = new ExifTag<Rational>(ExifTagValue.GPSDestDistance);
+
+    /// <summary>
+    /// Gets the GPSHPositioningError exif tag.
+    /// </summary>
+    public static ExifTag<Rational> GPSHPositioningError { get; } = new ExifTag<Rational>(ExifTagValue.GPSHPositioningError);
 }

--- a/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTagValue.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTagValue.cs
@@ -1692,6 +1692,11 @@ internal enum ExifTagValue
     GPSDifferential = 0x001E,
 
     /// <summary>
+    /// GPSHPositioningError
+    /// </summary>
+    GPSHPositioningError = 0x001F,
+
+    /// <summary>
     /// Used in the Oce scanning process.
     /// Identifies the scanticket used in the scanning process.
     /// Includes a trailing zero.

--- a/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValues.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Values/ExifValues.cs
@@ -241,6 +241,8 @@ internal static partial class ExifValues
                 return new ExifRational(ExifTag.GPSDestBearing);
             case ExifTagValue.GPSDestDistance:
                 return new ExifRational(ExifTag.GPSDestDistance);
+            case ExifTagValue.GPSHPositioningError:
+                return new ExifRational(ExifTag.GPSHPositioningError);
 
             case ExifTagValue.WhitePoint:
                 return new ExifRationalArray(ExifTag.WhitePoint);

--- a/tests/ImageSharp.Tests/Metadata/Profiles/Exif/Values/ExifValuesTests.cs
+++ b/tests/ImageSharp.Tests/Metadata/Profiles/Exif/Values/ExifValuesTests.cs
@@ -128,6 +128,7 @@ public class ExifValuesTests
         { ExifTag.GPSImgDirection },
         { ExifTag.GPSDestBearing },
         { ExifTag.GPSDestDistance },
+        { ExifTag.GPSHPositioningError },
     };
 
     public static TheoryData<ExifTag> RationalArrayTags => new TheoryData<ExifTag>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Fixes #2542 

This PR adds the missing GPSHPositioningError Exif tag. I've also checked that all the other GPS related tags are present, this is the only one that seem to have been missed.

<!-- Thanks for contributing to ImageSharp! -->
