### PR TITLE
WebP - Reduce the allocations in lossless encoding

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
@@ -85,7 +85,7 @@ internal static class BackwardReferenceEncoder
             }
 
             // Keep the best backward references.
-            using Vp8LHistogram histo = new(memoryAllocator, worst, cacheBitsTmp);
+            using Vp8LHistogram histo = Vp8LHistogram.Create(memoryAllocator, worst, cacheBitsTmp);
             double bitCost = histo.EstimateBits(stats, bitsEntropy);
 
             if (lz77TypeBest == 0 || bitCost < bitCostBest)
@@ -102,7 +102,7 @@ internal static class BackwardReferenceEncoder
         {
             Vp8LHashChain hashChainTmp = lz77TypeBest == (int)Vp8LLz77Type.Lz77Standard ? hashChain : hashChainBox!;
             BackwardReferencesTraceBackwards(width, height, memoryAllocator, bgra, cacheBits, hashChainTmp, best, worst);
-            using Vp8LHistogram histo = new(memoryAllocator, worst, cacheBits);
+            using Vp8LHistogram histo = Vp8LHistogram.Create(memoryAllocator, worst, cacheBits);
             double bitCostTrace = histo.EstimateBits(stats, bitsEntropy);
             if (bitCostTrace < bitCostBest)
             {

--- a/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
@@ -85,7 +85,7 @@ internal static class BackwardReferenceEncoder
             }
 
             // Keep the best backward references.
-            using Vp8LHistogram histo = Vp8LHistogram.Create(memoryAllocator, worst, cacheBitsTmp);
+            using OwnedVp8LHistogram histo = OwnedVp8LHistogram.Create(memoryAllocator, worst, cacheBitsTmp);
             double bitCost = histo.EstimateBits(stats, bitsEntropy);
 
             if (lz77TypeBest == 0 || bitCost < bitCostBest)
@@ -102,7 +102,7 @@ internal static class BackwardReferenceEncoder
         {
             Vp8LHashChain hashChainTmp = lz77TypeBest == (int)Vp8LLz77Type.Lz77Standard ? hashChain : hashChainBox!;
             BackwardReferencesTraceBackwards(width, height, memoryAllocator, bgra, cacheBits, hashChainTmp, best, worst);
-            using Vp8LHistogram histo = Vp8LHistogram.Create(memoryAllocator, worst, cacheBits);
+            using OwnedVp8LHistogram histo = OwnedVp8LHistogram.Create(memoryAllocator, worst, cacheBits);
             double bitCostTrace = histo.EstimateBits(stats, bitsEntropy);
             if (bitCostTrace < bitCostBest)
             {

--- a/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
@@ -37,7 +37,7 @@ internal class CostModel
 
     public void Build(int xSize, int cacheBits, Vp8LBackwardRefs backwardRefs)
     {
-        using Vp8LHistogram histogram = new(this.memoryAllocator, cacheBits);
+        using Vp8LHistogram histogram = Vp8LHistogram.Create(this.memoryAllocator, cacheBits);
 
         // The following code is similar to HistogramCreate but converts the distance to plane code.
         for (int i = 0; i < backwardRefs.Refs.Count; i++)

--- a/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
@@ -1,18 +1,23 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using SixLabors.ImageSharp.Memory;
+
 namespace SixLabors.ImageSharp.Formats.Webp.Lossless;
 
 internal class CostModel
 {
+    private readonly MemoryAllocator memoryAllocator;
     private const int ValuesInBytes = 256;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CostModel"/> class.
     /// </summary>
+    /// <param name="memoryAllocator">The memory allocator.</param>
     /// <param name="literalArraySize">The literal array size.</param>
-    public CostModel(int literalArraySize)
+    public CostModel(MemoryAllocator memoryAllocator, int literalArraySize)
     {
+        this.memoryAllocator = memoryAllocator;
         this.Alpha = new double[ValuesInBytes];
         this.Red = new double[ValuesInBytes];
         this.Blue = new double[ValuesInBytes];
@@ -32,13 +37,12 @@ internal class CostModel
 
     public void Build(int xSize, int cacheBits, Vp8LBackwardRefs backwardRefs)
     {
-        var histogram = new Vp8LHistogram(cacheBits);
-        using System.Collections.Generic.List<PixOrCopy>.Enumerator refsEnumerator = backwardRefs.Refs.GetEnumerator();
+        using Vp8LHistogram histogram = new(this.memoryAllocator, cacheBits);
 
         // The following code is similar to HistogramCreate but converts the distance to plane code.
-        while (refsEnumerator.MoveNext())
+        for (int i = 0; i < backwardRefs.Refs.Count; i++)
         {
-            histogram.AddSinglePixOrCopy(refsEnumerator.Current, true, xSize);
+            histogram.AddSinglePixOrCopy(backwardRefs.Refs[i], true, xSize);
         }
 
         ConvertPopulationCountTableToBitEstimates(histogram.NumCodes(), histogram.Literal, this.Literal);
@@ -70,7 +74,7 @@ internal class CostModel
 
     public double GetLiteralCost(uint v) => this.Alpha[v >> 24] + this.Red[(v >> 16) & 0xff] + this.Literal[(v >> 8) & 0xff] + this.Blue[v & 0xff];
 
-    private static void ConvertPopulationCountTableToBitEstimates(int numSymbols, uint[] populationCounts, double[] output)
+    private static void ConvertPopulationCountTableToBitEstimates(int numSymbols, Span<uint> populationCounts, double[] output)
     {
         uint sum = 0;
         int nonzeros = 0;

--- a/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
@@ -37,7 +37,7 @@ internal class CostModel
 
     public void Build(int xSize, int cacheBits, Vp8LBackwardRefs backwardRefs)
     {
-        using Vp8LHistogram histogram = Vp8LHistogram.Create(this.memoryAllocator, cacheBits);
+        using OwnedVp8LHistogram histogram = OwnedVp8LHistogram.Create(this.memoryAllocator, cacheBits);
 
         // The following code is similar to HistogramCreate but converts the distance to plane code.
         for (int i = 0; i < backwardRefs.Refs.Count; i++)

--- a/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
@@ -172,8 +172,8 @@ internal static class HistogramEncoder
             // Skip the histogram if it is completely empty, which can happen for tiles with no information (when they are skipped because of LZ77).
             if (!origHistogram.IsUsed(0) && !origHistogram.IsUsed(1) && !origHistogram.IsUsed(2) && !origHistogram.IsUsed(3) && !origHistogram.IsUsed(4))
             {
-                origHistograms.DisposeAt(i);
-                histograms.DisposeAt(i);
+                origHistograms[i] = null;
+                histograms[i] = null;
                 histogramSymbols[i] = InvalidHistogramSymbol;
             }
             else
@@ -254,7 +254,7 @@ internal static class HistogramEncoder
                         // Move the (better) merged histogram to its final slot.
                         (histograms[first], curCombo) = (curCombo, histograms[first]);
 
-                        histograms.DisposeAt(idx);
+                        histograms[idx] = null;
                         indicesToRemove.Add(idx);
                         clusterMappings[clusters[idx]] = clusters[first];
                     }
@@ -415,7 +415,7 @@ internal static class HistogramEncoder
             // Merge the histograms and remove bestIdx2 from the list.
             HistogramAdd(histograms[bestIdx2], histograms[bestIdx1], histograms[bestIdx1]);
             histograms[bestIdx1].BitCost = histoPriorityList[0].CostCombo;
-            histograms.DisposeAt(bestIdx2);
+            histograms[bestIdx2] = null;
             numUsed--;
 
             for (int j = 0; j < histoPriorityList.Count;)
@@ -512,7 +512,7 @@ internal static class HistogramEncoder
             histograms[idx1].BitCost = histoPriorityList[0].CostCombo;
 
             // Remove merged histogram.
-            histograms.DisposeAt(idx2);
+            histograms[idx2] = null;
 
             // Remove pairs intersecting the just combined best pair.
             for (int i = 0; i < histoPriorityList.Count;)

--- a/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
@@ -383,8 +383,7 @@ internal static class HistogramEncoder
                 idx2 = mappings[idx2];
 
                 // Calculate cost reduction on combination.
-                double currCost = 0;
-                currCost = HistoPriorityListPush(histoPriorityList, maxSize, histograms, idx1, idx2, bestCost, stats, bitsEntropy);
+                double currCost = HistoPriorityListPush(histoPriorityList, maxSize, histograms, idx1, idx2, bestCost, stats, bitsEntropy);
 
                 // Found a better pair?
                 if (currCost < 0)

--- a/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
@@ -3,6 +3,7 @@
 #nullable disable
 
 using System.Runtime.CompilerServices;
+using SixLabors.ImageSharp.Memory;
 
 namespace SixLabors.ImageSharp.Formats.Webp.Lossless;
 
@@ -27,19 +28,28 @@ internal static class HistogramEncoder
 
     private const ushort InvalidHistogramSymbol = ushort.MaxValue;
 
-    public static void GetHistoImageSymbols(int xSize, int ySize, Vp8LBackwardRefs refs, uint quality, int histoBits, int cacheBits, List<Vp8LHistogram> imageHisto, Vp8LHistogram tmpHisto, Span<ushort> histogramSymbols)
+    public static void GetHistoImageSymbols(
+        MemoryAllocator memoryAllocator,
+        int xSize,
+        int ySize,
+        Vp8LBackwardRefs refs,
+        uint quality,
+        int histoBits,
+        int cacheBits,
+        Vp8LHistogramSet imageHisto,
+        Vp8LHistogram tmpHisto,
+        Span<ushort> histogramSymbols)
     {
         int histoXSize = histoBits > 0 ? LosslessUtils.SubSampleSize(xSize, histoBits) : 1;
         int histoYSize = histoBits > 0 ? LosslessUtils.SubSampleSize(ySize, histoBits) : 1;
         int imageHistoRawSize = histoXSize * histoYSize;
-        int entropyCombineNumBins = BinSize;
+        const int entropyCombineNumBins = BinSize;
+
+        // TODO: Allocations!
         ushort[] mapTmp = new ushort[imageHistoRawSize];
         ushort[] clusterMappings = new ushort[imageHistoRawSize];
-        var origHisto = new List<Vp8LHistogram>(imageHistoRawSize);
-        for (int i = 0; i < imageHistoRawSize; i++)
-        {
-            origHisto.Add(new Vp8LHistogram(cacheBits));
-        }
+
+        using Vp8LHistogramSet origHisto = new(memoryAllocator, imageHistoRawSize, cacheBits);
 
         // Construct the histograms from the backward references.
         HistogramBuild(xSize, histoBits, refs, origHisto);
@@ -61,7 +71,7 @@ internal static class HistogramEncoder
             OptimizeHistogramSymbols(clusterMappings, numClusters, mapTmp, histogramSymbols);
         }
 
-        float x = quality / 100.0f;
+        float x = quality / 100F;
 
         // Cubic ramp between 1 and MaxHistoGreedy:
         int thresholdSize = (int)(1 + (x * x * x * (MaxHistoGreedy - 1)));
@@ -77,26 +87,25 @@ internal static class HistogramEncoder
         HistogramRemap(origHisto, imageHisto, histogramSymbols);
     }
 
-    private static void RemoveEmptyHistograms(List<Vp8LHistogram> histograms)
+    private static void RemoveEmptyHistograms(Vp8LHistogramSet histograms)
     {
-        int size = 0;
-        for (int i = 0; i < histograms.Count; i++)
+        for (int i = histograms.Count - 1; i >= 0; i--)
         {
             if (histograms[i] == null)
             {
-                continue;
+                histograms.RemoveAt(i);
             }
-
-            histograms[size++] = histograms[i];
         }
-
-        histograms.RemoveRange(size, histograms.Count - size);
     }
 
     /// <summary>
     /// Construct the histograms from the backward references.
     /// </summary>
-    private static void HistogramBuild(int xSize, int histoBits, Vp8LBackwardRefs backwardRefs, List<Vp8LHistogram> histograms)
+    private static void HistogramBuild(
+        int xSize,
+        int histoBits,
+        Vp8LBackwardRefs backwardRefs,
+        Vp8LHistogramSet histograms)
     {
         int x = 0, y = 0;
         int histoXSize = LosslessUtils.SubSampleSize(xSize, histoBits);
@@ -119,10 +128,10 @@ internal static class HistogramEncoder
     /// Partition histograms to different entropy bins for three dominant (literal,
     /// red and blue) symbol costs and compute the histogram aggregate bitCost.
     /// </summary>
-    private static void HistogramAnalyzeEntropyBin(List<Vp8LHistogram> histograms, ushort[] binMap)
+    private static void HistogramAnalyzeEntropyBin(Vp8LHistogramSet histograms, ushort[] binMap)
     {
         int histoSize = histograms.Count;
-        var costRange = new DominantCostRange();
+        DominantCostRange costRange = new();
 
         // Analyze the dominant (literal, red and blue) entropy costs.
         for (int i = 0; i < histoSize; i++)
@@ -148,25 +157,28 @@ internal static class HistogramEncoder
         }
     }
 
-    private static int HistogramCopyAndAnalyze(List<Vp8LHistogram> origHistograms, List<Vp8LHistogram> histograms, Span<ushort> histogramSymbols)
+    private static int HistogramCopyAndAnalyze(
+        Vp8LHistogramSet origHistograms,
+        Vp8LHistogramSet histograms,
+        Span<ushort> histogramSymbols)
     {
-        var stats = new Vp8LStreaks();
-        var bitsEntropy = new Vp8LBitEntropy();
+        Vp8LStreaks stats = new();
+        Vp8LBitEntropy bitsEntropy = new();
         for (int clusterId = 0, i = 0; i < origHistograms.Count; i++)
         {
             Vp8LHistogram origHistogram = origHistograms[i];
             origHistogram.UpdateHistogramCost(stats, bitsEntropy);
 
             // Skip the histogram if it is completely empty, which can happen for tiles with no information (when they are skipped because of LZ77).
-            if (!origHistogram.IsUsed[0] && !origHistogram.IsUsed[1] && !origHistogram.IsUsed[2] && !origHistogram.IsUsed[3] && !origHistogram.IsUsed[4])
+            if (!origHistogram.IsUsed(0) && !origHistogram.IsUsed(1) && !origHistogram.IsUsed(2) && !origHistogram.IsUsed(3) && !origHistogram.IsUsed(4))
             {
-                origHistograms[i] = null;
-                histograms[i] = null;
+                origHistograms.DisposeAt(i);
+                histograms.DisposeAt(i);
                 histogramSymbols[i] = InvalidHistogramSymbol;
             }
             else
             {
-                histograms[i] = (Vp8LHistogram)origHistogram.DeepClone();
+                origHistogram.CopyTo(histograms[i]);
                 histogramSymbols[i] = (ushort)clusterId++;
             }
         }
@@ -184,7 +196,7 @@ internal static class HistogramEncoder
     }
 
     private static void HistogramCombineEntropyBin(
-        List<Vp8LHistogram> histograms,
+        Vp8LHistogramSet histograms,
         Span<ushort> clusters,
         ushort[] clusterMappings,
         Vp8LHistogram curCombo,
@@ -205,9 +217,9 @@ internal static class HistogramEncoder
             clusterMappings[idx] = (ushort)idx;
         }
 
-        var indicesToRemove = new List<int>();
-        var stats = new Vp8LStreaks();
-        var bitsEntropy = new Vp8LBitEntropy();
+        List<int> indicesToRemove = new();
+        Vp8LStreaks stats = new();
+        Vp8LBitEntropy bitsEntropy = new();
         for (int idx = 0; idx < histograms.Count; idx++)
         {
             if (histograms[idx] == null)
@@ -236,15 +248,13 @@ internal static class HistogramEncoder
                     // histogram pairs. In that case, we fallback to combining
                     // histograms as usual to avoid increasing the header size.
                     bool tryCombine = curCombo.TrivialSymbol != NonTrivialSym || (histograms[idx].TrivialSymbol == NonTrivialSym && histograms[first].TrivialSymbol == NonTrivialSym);
-                    int maxCombineFailures = 32;
+                    const int maxCombineFailures = 32;
                     if (tryCombine || binInfo[binId].NumCombineFailures >= maxCombineFailures)
                     {
                         // Move the (better) merged histogram to its final slot.
-                        Vp8LHistogram tmp = curCombo;
-                        curCombo = histograms[first];
-                        histograms[first] = tmp;
+                        (histograms[first], curCombo) = (curCombo, histograms[first]);
 
-                        histograms[idx] = null;
+                        histograms.DisposeAt(idx);
                         indicesToRemove.Add(idx);
                         clusterMappings[clusters[idx]] = clusters[first];
                     }
@@ -256,9 +266,9 @@ internal static class HistogramEncoder
             }
         }
 
-        foreach (int index in indicesToRemove.OrderByDescending(i => i))
+        for (int i = indicesToRemove.Count - 1; i >= 0; i--)
         {
-            histograms.RemoveAt(index);
+            histograms.RemoveAt(indicesToRemove[i]);
         }
     }
 
@@ -318,15 +328,15 @@ internal static class HistogramEncoder
     /// Perform histogram aggregation using a stochastic approach.
     /// </summary>
     /// <returns>true if a greedy approach needs to be performed afterwards, false otherwise.</returns>
-    private static bool HistogramCombineStochastic(List<Vp8LHistogram> histograms, int minClusterSize)
+    private static bool HistogramCombineStochastic(Vp8LHistogramSet histograms, int minClusterSize)
     {
         uint seed = 1;
         int triesWithNoSuccess = 0;
         int numUsed = histograms.Count(h => h != null);
         int outerIters = numUsed;
         int numTriesNoSuccess = (int)((uint)outerIters / 2);
-        var stats = new Vp8LStreaks();
-        var bitsEntropy = new Vp8LBitEntropy();
+        Vp8LStreaks stats = new();
+        Vp8LBitEntropy bitsEntropy = new();
 
         if (numUsed < minClusterSize)
         {
@@ -335,25 +345,25 @@ internal static class HistogramEncoder
 
         // Priority list of histogram pairs. Its size impacts the quality of the compression and the speed:
         // the smaller the faster but the worse for the compression.
-        var histoPriorityList = new List<HistogramPair>();
-        int maxSize = 9;
+        List<HistogramPair> histoPriorityList = new();
+        const int maxSize = 9;
 
         // Fill the initial mapping.
         Span<int> mappings = histograms.Count <= 64 ? stackalloc int[histograms.Count] : new int[histograms.Count];
-        for (int j = 0, iter = 0; iter < histograms.Count; iter++)
+        for (int j = 0, i = 0; i < histograms.Count; i++)
         {
-            if (histograms[iter] == null)
+            if (histograms[i] == null)
             {
                 continue;
             }
 
-            mappings[j++] = iter;
+            mappings[j++] = i;
         }
 
         // Collapse similar histograms.
-        for (int iter = 0; iter < outerIters && numUsed >= minClusterSize && ++triesWithNoSuccess < numTriesNoSuccess; iter++)
+        for (int i = 0; i < outerIters && numUsed >= minClusterSize && ++triesWithNoSuccess < numTriesNoSuccess; i++)
         {
-            double bestCost = histoPriorityList.Count == 0 ? 0.0d : histoPriorityList[0].CostDiff;
+            double bestCost = histoPriorityList.Count == 0 ? 0D : histoPriorityList[0].CostDiff;
             int numTries = (int)((uint)numUsed / 2);
             uint randRange = (uint)((numUsed - 1) * numUsed);
 
@@ -373,7 +383,8 @@ internal static class HistogramEncoder
                 idx2 = mappings[idx2];
 
                 // Calculate cost reduction on combination.
-                double currCost = HistoPriorityListPush(histoPriorityList, maxSize, histograms, idx1, idx2, bestCost, stats, bitsEntropy);
+                double currCost = 0;
+                currCost = HistoPriorityListPush(histoPriorityList, maxSize, histograms, idx1, idx2, bestCost, stats, bitsEntropy);
 
                 // Found a better pair?
                 if (currCost < 0)
@@ -398,13 +409,13 @@ internal static class HistogramEncoder
 
             int mappingIndex = mappings.IndexOf(bestIdx2);
             Span<int> src = mappings.Slice(mappingIndex + 1, numUsed - mappingIndex - 1);
-            Span<int> dst = mappings.Slice(mappingIndex);
+            Span<int> dst = mappings[mappingIndex..];
             src.CopyTo(dst);
 
             // Merge the histograms and remove bestIdx2 from the list.
             HistogramAdd(histograms[bestIdx2], histograms[bestIdx1], histograms[bestIdx1]);
-            histograms.ElementAt(bestIdx1).BitCost = histoPriorityList[0].CostCombo;
-            histograms[bestIdx2] = null;
+            histograms[bestIdx1].BitCost = histoPriorityList[0].CostCombo;
+            histograms.DisposeAt(bestIdx2);
             numUsed--;
 
             for (int j = 0; j < histoPriorityList.Count;)
@@ -418,7 +429,7 @@ internal static class HistogramEncoder
                 // check for it all the time nevertheless.
                 if (isIdx1Best && isIdx2Best)
                 {
-                    histoPriorityList[j] = histoPriorityList[histoPriorityList.Count - 1];
+                    histoPriorityList[j] = histoPriorityList[^1];
                     histoPriorityList.RemoveAt(histoPriorityList.Count - 1);
                     continue;
                 }
@@ -439,18 +450,17 @@ internal static class HistogramEncoder
                 // Make sure the index order is respected.
                 if (p.Idx1 > p.Idx2)
                 {
-                    int tmp = p.Idx2;
-                    p.Idx2 = p.Idx1;
-                    p.Idx1 = tmp;
+                    (p.Idx1, p.Idx2) = (p.Idx2, p.Idx1);
                 }
 
                 if (doEval)
                 {
                     // Re-evaluate the cost of an updated pair.
-                    HistoListUpdatePair(histograms[p.Idx1], histograms[p.Idx2], stats, bitsEntropy, 0.0d, p);
-                    if (p.CostDiff >= 0.0d)
+                    HistoListUpdatePair(histograms[p.Idx1], histograms[p.Idx2], stats, bitsEntropy, 0D, p);
+
+                    if (p.CostDiff >= 0D)
                     {
-                        histoPriorityList[j] = histoPriorityList[histoPriorityList.Count - 1];
+                        histoPriorityList[j] = histoPriorityList[^1];
                         histoPriorityList.RemoveAt(histoPriorityList.Count - 1);
                         continue;
                     }
@@ -463,20 +473,18 @@ internal static class HistogramEncoder
             triesWithNoSuccess = 0;
         }
 
-        bool doGreedy = numUsed <= minClusterSize;
-
-        return doGreedy;
+        return numUsed <= minClusterSize;
     }
 
-    private static void HistogramCombineGreedy(List<Vp8LHistogram> histograms)
+    private static void HistogramCombineGreedy(Vp8LHistogramSet histograms)
     {
         int histoSize = histograms.Count(h => h != null);
 
         // Priority list of histogram pairs.
-        var histoPriorityList = new List<HistogramPair>();
+        List<HistogramPair> histoPriorityList = new();
         int maxSize = histoSize * histoSize;
-        var stats = new Vp8LStreaks();
-        var bitsEntropy = new Vp8LBitEntropy();
+        Vp8LStreaks stats = new();
+        Vp8LBitEntropy bitsEntropy = new();
 
         for (int i = 0; i < histoSize; i++)
         {
@@ -504,16 +512,17 @@ internal static class HistogramEncoder
             histograms[idx1].BitCost = histoPriorityList[0].CostCombo;
 
             // Remove merged histogram.
-            histograms[idx2] = null;
+            histograms.DisposeAt(idx2);
 
             // Remove pairs intersecting the just combined best pair.
+            // TODO: Reversing this will avoid the need to remove from the end of the list.
             for (int i = 0; i < histoPriorityList.Count;)
             {
-                HistogramPair p = histoPriorityList.ElementAt(i);
+                HistogramPair p = histoPriorityList[i];
                 if (p.Idx1 == idx1 || p.Idx2 == idx1 || p.Idx1 == idx2 || p.Idx2 == idx2)
                 {
                     // Replace item at pos i with the last one and shrinking the list.
-                    histoPriorityList[i] = histoPriorityList[histoPriorityList.Count - 1];
+                    histoPriorityList[i] = histoPriorityList[^1];
                     histoPriorityList.RemoveAt(histoPriorityList.Count - 1);
                 }
                 else
@@ -536,12 +545,15 @@ internal static class HistogramEncoder
         }
     }
 
-    private static void HistogramRemap(List<Vp8LHistogram> input, List<Vp8LHistogram> output, Span<ushort> symbols)
+    private static void HistogramRemap(
+        Vp8LHistogramSet input,
+        Vp8LHistogramSet output,
+        Span<ushort> symbols)
     {
         int inSize = input.Count;
         int outSize = output.Count;
-        var stats = new Vp8LStreaks();
-        var bitsEntropy = new Vp8LBitEntropy();
+        Vp8LStreaks stats = new();
+        Vp8LBitEntropy bitsEntropy = new();
         if (outSize > 1)
         {
             for (int i = 0; i < inSize; i++)
@@ -577,11 +589,11 @@ internal static class HistogramEncoder
         }
 
         // Recompute each output.
-        int paletteCodeBits = output.First().PaletteCodeBits;
-        output.Clear();
+        int paletteCodeBits = output[0].PaletteCodeBits;
         for (int i = 0; i < outSize; i++)
         {
-            output.Add(new Vp8LHistogram(paletteCodeBits));
+            output[i].Clear();
+            output[i].PaletteCodeBits = paletteCodeBits;
         }
 
         for (int i = 0; i < inSize; i++)
@@ -600,20 +612,26 @@ internal static class HistogramEncoder
     /// Create a pair from indices "idx1" and "idx2" provided its cost is inferior to "threshold", a negative entropy.
     /// </summary>
     /// <returns>The cost of the pair, or 0 if it superior to threshold.</returns>
-    private static double HistoPriorityListPush(List<HistogramPair> histoList, int maxSize, List<Vp8LHistogram> histograms, int idx1, int idx2, double threshold, Vp8LStreaks stats, Vp8LBitEntropy bitsEntropy)
+    private static double HistoPriorityListPush(
+        List<HistogramPair> histoList,
+        int maxSize,
+        Vp8LHistogramSet histograms,
+        int idx1,
+        int idx2,
+        double threshold,
+        Vp8LStreaks stats,
+        Vp8LBitEntropy bitsEntropy)
     {
-        var pair = new HistogramPair();
+        HistogramPair pair = new();
 
         if (histoList.Count == maxSize)
         {
-            return 0.0d;
+            return 0D;
         }
 
         if (idx1 > idx2)
         {
-            int tmp = idx2;
-            idx2 = idx1;
-            idx1 = tmp;
+            (idx1, idx2) = (idx2, idx1);
         }
 
         pair.Idx1 = idx1;
@@ -637,9 +655,16 @@ internal static class HistogramEncoder
     }
 
     /// <summary>
-    /// Update the cost diff and combo of a pair of histograms. This needs to be called when the the histograms have been merged with a third one.
+    /// Update the cost diff and combo of a pair of histograms. This needs to be called when the histograms have been
+    /// merged with a third one.
     /// </summary>
-    private static void HistoListUpdatePair(Vp8LHistogram h1, Vp8LHistogram h2, Vp8LStreaks stats, Vp8LBitEntropy bitsEntropy, double threshold, HistogramPair pair)
+    private static void HistoListUpdatePair(
+        Vp8LHistogram h1,
+        Vp8LHistogram h2,
+        Vp8LStreaks stats,
+        Vp8LBitEntropy bitsEntropy,
+        double threshold,
+        HistogramPair pair)
     {
         double sumCost = h1.BitCost + h2.BitCost;
         pair.CostCombo = 0.0d;

--- a/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HuffmanUtils.cs
@@ -25,7 +25,7 @@ internal static class HuffmanUtils
         0x1, 0x9, 0x5, 0xd, 0x3, 0xb, 0x7, 0xf
     };
 
-    public static void CreateHuffmanTree(uint[] histogram, int treeDepthLimit, bool[] bufRle, Span<HuffmanTree> huffTree, HuffmanTreeCode huffCode)
+    public static void CreateHuffmanTree(Span<uint> histogram, int treeDepthLimit, bool[] bufRle, Span<HuffmanTree> huffTree, HuffmanTreeCode huffCode)
     {
         int numSymbols = huffCode.NumSymbols;
         bufRle.AsSpan().Clear();
@@ -40,7 +40,7 @@ internal static class HuffmanUtils
     /// Change the population counts in a way that the consequent
     /// Huffman tree compression, especially its RLE-part, give smaller output.
     /// </summary>
-    public static void OptimizeHuffmanForRle(int length, bool[] goodForRle, uint[] counts)
+    public static void OptimizeHuffmanForRle(int length, bool[] goodForRle, Span<uint> counts)
     {
         // 1) Let's make the Huffman code more compatible with rle encoding.
         for (; length >= 0; --length)
@@ -116,7 +116,7 @@ internal static class HuffmanUtils
                     {
                         // We don't want to change value at counts[i],
                         // that is already belonging to the next stride. Thus - 1.
-                        counts[i - k - 1] = count;
+                        counts[(int)(i - k - 1)] = count;
                     }
                 }
 
@@ -159,7 +159,7 @@ internal static class HuffmanUtils
     /// <param name="histogramSize">The size of the histogram.</param>
     /// <param name="treeDepthLimit">The tree depth limit.</param>
     /// <param name="bitDepths">How many bits are used for the symbol.</param>
-    public static void GenerateOptimalTree(Span<HuffmanTree> tree, uint[] histogram, int histogramSize, int treeDepthLimit, byte[] bitDepths)
+    public static void GenerateOptimalTree(Span<HuffmanTree> tree, Span<uint> histogram, int histogramSize, int treeDepthLimit, byte[] bitDepths)
     {
         uint countMin;
         int treeSizeOrig = 0;
@@ -177,7 +177,7 @@ internal static class HuffmanUtils
             return;
         }
 
-        Span<HuffmanTree> treePool = tree.Slice(treeSizeOrig);
+        Span<HuffmanTree> treePool = tree[treeSizeOrig..];
 
         // For block sizes with less than 64k symbols we never need to do a
         // second iteration of this loop.
@@ -202,7 +202,7 @@ internal static class HuffmanUtils
             }
 
             // Build the Huffman tree.
-            Span<HuffmanTree> treeSlice = tree.Slice(0, treeSize);
+            Span<HuffmanTree> treeSlice = tree[..treeSize];
             treeSlice.Sort(HuffmanTree.Compare);
 
             if (treeSize > 1)
@@ -357,7 +357,7 @@ internal static class HuffmanUtils
         // Special case code with only one value.
         if (offsets[WebpConstants.MaxAllowedCodeLength] == 1)
         {
-            var huffmanCode = new HuffmanCode()
+            HuffmanCode huffmanCode = new()
             {
                 BitsUsed = 0,
                 Value = (uint)sorted[0]
@@ -390,7 +390,7 @@ internal static class HuffmanUtils
 
             for (; countsLen > 0; countsLen--)
             {
-                var huffmanCode = new HuffmanCode()
+                HuffmanCode huffmanCode = new()
                 {
                     BitsUsed = len,
                     Value = (uint)sorted[symbol++]
@@ -432,7 +432,7 @@ internal static class HuffmanUtils
                     };
                 }
 
-                var huffmanCode = new HuffmanCode
+                HuffmanCode huffmanCode = new()
                 {
                     BitsUsed = len - rootBits,
                     Value = (uint)sorted[symbol++]

--- a/src/ImageSharp/Formats/Webp/Lossless/PixOrCopy.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/PixOrCopy.cs
@@ -37,7 +37,7 @@ internal sealed class PixOrCopy
         Len = len
     };
 
-    public uint Literal(int component) => (this.BgraOrDistance >> (component * 8)) & 0xff;
+    public int Literal(int component) => (int)(this.BgraOrDistance >> (component * 8)) & 0xFF;
 
     public uint CacheIdx() => this.BgraOrDistance;
 

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LBitEntropy.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LBitEntropy.cs
@@ -125,7 +125,7 @@ internal class Vp8LBitEntropy
     /// <summary>
     /// Get the entropy for the distribution 'X'.
     /// </summary>
-    public void BitsEntropyUnrefined(uint[] x, int length, Vp8LStreaks stats)
+    public void BitsEntropyUnrefined(Span<uint> x, int length, Vp8LStreaks stats)
     {
         int i;
         int iPrev = 0;
@@ -147,7 +147,7 @@ internal class Vp8LBitEntropy
         this.Entropy += LosslessUtils.FastSLog2(this.Sum);
     }
 
-    public void GetCombinedEntropyUnrefined(uint[] x, uint[] y, int length, Vp8LStreaks stats)
+    public void GetCombinedEntropyUnrefined(Span<uint> x, Span<uint> y, int length, Vp8LStreaks stats)
     {
         int i;
         int iPrev = 0;
@@ -169,7 +169,7 @@ internal class Vp8LBitEntropy
         this.Entropy += LosslessUtils.FastSLog2(this.Sum);
     }
 
-    public void GetEntropyUnrefined(uint[] x, int length, Vp8LStreaks stats)
+    public void GetEntropyUnrefined(Span<uint> x, int length, Vp8LStreaks stats)
     {
         int i;
         int iPrev = 0;

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -885,7 +885,7 @@ internal class Vp8LEncoder : IDisposable
 
     private void StoreFullHuffmanCode(Span<HuffmanTree> huffTree, HuffmanTreeToken[] tokens, HuffmanTreeCode tree)
     {
-        // TODO: Allocations.
+        // TODO: Allocations. This method is called in a loop.
         int i;
         byte[] codeLengthBitDepth = new byte[WebpConstants.CodeLengthCodes];
         short[] codeLengthBitDepthSymbols = new short[WebpConstants.CodeLengthCodes];
@@ -1628,6 +1628,7 @@ internal class Vp8LEncoder : IDisposable
             }
         }
 
+        // TODO: Allocations.
         int end = 5 * histogramImage.Count;
         for (int i = 0; i < end; i++)
         {
@@ -1641,9 +1642,9 @@ internal class Vp8LEncoder : IDisposable
         }
 
         // Create Huffman trees.
-        // TODO: Allocations. Size here has a max and can be sliced.
+        // TODO: Allocations.
         bool[] bufRle = new bool[maxNumSymbols];
-        Span<HuffmanTree> huffTree = stackalloc HuffmanTree[3 * maxNumSymbols];
+        HuffmanTree[] huffTree = new HuffmanTree[3 * maxNumSymbols];
 
         for (int i = 0; i < histogramImage.Count; i++)
         {

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -589,7 +589,7 @@ internal class Vp8LEncoder : IDisposable
             Vp8LBackwardRefs refsTmp = this.Refs[refsBest.Equals(this.Refs[0]) ? 1 : 0];
 
             this.bitWriter.Reset(bwInit);
-            using Vp8LHistogram tmpHisto = Vp8LHistogram.Create(this.memoryAllocator, cacheBits);
+            using OwnedVp8LHistogram tmpHisto = OwnedVp8LHistogram.Create(this.memoryAllocator, cacheBits);
             using Vp8LHistogramSet histogramImage = new(this.memoryAllocator, histogramImageXySize, cacheBits);
 
             // Build histogram image and symbols from backward references.

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -589,7 +589,7 @@ internal class Vp8LEncoder : IDisposable
             Vp8LBackwardRefs refsTmp = this.Refs[refsBest.Equals(this.Refs[0]) ? 1 : 0];
 
             this.bitWriter.Reset(bwInit);
-            using Vp8LHistogram tmpHisto = new(this.memoryAllocator, cacheBits);
+            using Vp8LHistogram tmpHisto = Vp8LHistogram.Create(this.memoryAllocator, cacheBits);
             using Vp8LHistogramSet histogramImage = new(this.memoryAllocator, histogramImageXySize, cacheBits);
 
             // Build histogram image and symbols from backward references.

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogramSet.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogramSet.cs
@@ -13,30 +13,39 @@ namespace SixLabors.ImageSharp.Formats.Webp.Lossless;
 internal sealed class Vp8LHistogramSet : IEnumerable<Vp8LHistogram>, IDisposable
 {
     private readonly IMemoryOwner<uint> buffer;
+    private MemoryHandle bufferHandle;
     private readonly List<Vp8LHistogram> items;
     private bool isDisposed;
 
     public Vp8LHistogramSet(MemoryAllocator memoryAllocator, int capacity, int cacheBits)
     {
         this.buffer = memoryAllocator.Allocate<uint>(Vp8LHistogram.BufferSize * capacity, AllocationOptions.Clean);
+        this.bufferHandle = this.buffer.Memory.Pin();
 
-        this.items = new List<Vp8LHistogram>(capacity);
-        for (int i = 0; i < capacity; i++)
+        unsafe
         {
-            Memory<uint> subBuffer = this.buffer.Memory.Slice(Vp8LHistogram.BufferSize * i, Vp8LHistogram.BufferSize);
-            this.items.Add(new Vp8LHistogram(subBuffer, cacheBits));
+            uint* basePointer = (uint*)this.bufferHandle.Pointer;
+            this.items = new List<Vp8LHistogram>(capacity);
+            for (int i = 0; i < capacity; i++)
+            {
+                this.items.Add(new MemberVp8LHistogram(basePointer + (Vp8LHistogram.BufferSize * i), cacheBits));
+            }
         }
     }
 
     public Vp8LHistogramSet(MemoryAllocator memoryAllocator, Vp8LBackwardRefs refs, int capacity, int cacheBits)
     {
         this.buffer = memoryAllocator.Allocate<uint>(Vp8LHistogram.BufferSize * capacity, AllocationOptions.Clean);
+        this.bufferHandle = this.buffer.Memory.Pin();
 
-        this.items = new List<Vp8LHistogram>(capacity);
-        for (int i = 0; i < capacity; i++)
+        unsafe
         {
-            Memory<uint> subBuffer = this.buffer.Memory.Slice(Vp8LHistogram.BufferSize * i, Vp8LHistogram.BufferSize);
-            this.items.Add(new Vp8LHistogram(subBuffer, refs, cacheBits));
+            uint* basePointer = (uint*)this.bufferHandle.Pointer;
+            this.items = new List<Vp8LHistogram>(capacity);
+            for (int i = 0; i < capacity; i++)
+            {
+                this.items.Add(new MemberVp8LHistogram(basePointer + (Vp8LHistogram.BufferSize * i), refs, cacheBits));
+            }
         }
     }
 
@@ -49,30 +58,13 @@ internal sealed class Vp8LHistogramSet : IEnumerable<Vp8LHistogram>, IDisposable
     public Vp8LHistogram this[int index]
     {
         get => this.items[index];
-
-        // TODO: Should we check and throw for null?
         set => this.items[index] = value;
-    }
-
-    public void DisposeAt(int index)
-    {
-        this.CheckDisposed();
-
-        Vp8LHistogram item = this.items[index];
-        item?.Dispose();
-        this.items[index] = null;
     }
 
     public void RemoveAt(int index)
     {
         this.CheckDisposed();
-
-        Vp8LHistogram item = this.items[index];
-        item?.Dispose();
         this.items.RemoveAt(index);
-#pragma warning disable IDE0059 // Unnecessary assignment of a value
-        item = null;
-#pragma warning restore IDE0059 // Unnecessary assignment of a value
     }
 
     public void Dispose()
@@ -82,13 +74,8 @@ internal sealed class Vp8LHistogramSet : IEnumerable<Vp8LHistogram>, IDisposable
             return;
         }
 
-        foreach (Vp8LHistogram item in this.items)
-        {
-            // First, make sure to unpin individual sub buffers.
-            item?.Dispose();
-        }
-
         this.buffer.Dispose();
+        this.bufferHandle.Dispose();
         this.items.Clear();
         this.isDisposed = true;
     }
@@ -107,4 +94,17 @@ internal sealed class Vp8LHistogramSet : IEnumerable<Vp8LHistogram>, IDisposable
     }
 
     private static void ThrowDisposed() => throw new ObjectDisposedException(nameof(Vp8LHistogramSet));
+
+    private sealed unsafe class MemberVp8LHistogram : Vp8LHistogram
+    {
+        public MemberVp8LHistogram(uint* basePointer, int paletteCodeBits)
+            : base(basePointer, paletteCodeBits)
+        {
+        }
+
+        public MemberVp8LHistogram(uint* basePointer, Vp8LBackwardRefs refs, int paletteCodeBits)
+            : base(basePointer, refs, paletteCodeBits)
+        {
+        }
+    }
 }

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogramSet.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogramSet.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+#nullable disable
+
+using System.Buffers;
+using System.Collections;
+using System.Diagnostics;
+using SixLabors.ImageSharp.Memory;
+
+namespace SixLabors.ImageSharp.Formats.Webp.Lossless;
+
+internal sealed class Vp8LHistogramSet : IEnumerable<Vp8LHistogram>, IDisposable
+{
+    private readonly IMemoryOwner<uint> buffer;
+    private readonly List<Vp8LHistogram> items;
+    private bool isDisposed;
+
+    public Vp8LHistogramSet(MemoryAllocator memoryAllocator, int capacity, int cacheBits)
+    {
+        this.buffer = memoryAllocator.Allocate<uint>(Vp8LHistogram.BufferSize * capacity, AllocationOptions.Clean);
+
+        this.items = new List<Vp8LHistogram>(capacity);
+        for (int i = 0; i < capacity; i++)
+        {
+            SetItemMemoryOwner owner = new(this.buffer.Memory.Slice(Vp8LHistogram.BufferSize * i, Vp8LHistogram.BufferSize));
+            this.items.Add(new Vp8LHistogram(owner, cacheBits));
+        }
+    }
+
+    public Vp8LHistogramSet(MemoryAllocator memoryAllocator, Vp8LBackwardRefs refs, int capacity, int cacheBits)
+    {
+        this.buffer = memoryAllocator.Allocate<uint>(Vp8LHistogram.BufferSize * capacity, AllocationOptions.Clean);
+
+        this.items = new List<Vp8LHistogram>(capacity);
+        for (int i = 0; i < capacity; i++)
+        {
+            SetItemMemoryOwner owner = new(this.buffer.Memory.Slice(Vp8LHistogram.BufferSize * i, Vp8LHistogram.BufferSize));
+            this.items.Add(new Vp8LHistogram(owner, refs, cacheBits));
+        }
+    }
+
+    public Vp8LHistogramSet(int capacity) => this.items = new(capacity);
+
+    public Vp8LHistogramSet() => this.items = new();
+
+    public int Count => this.items.Count;
+
+    public Vp8LHistogram this[int index]
+    {
+        get => this.items[index];
+
+        // TODO: Should we check and throw for null?
+        set => this.items[index] = value;
+    }
+
+    public void DisposeAt(int index)
+    {
+        this.CheckDisposed();
+
+        Vp8LHistogram item = this.items[index];
+        item?.Dispose();
+        this.items[index] = null;
+    }
+
+    public void RemoveAt(int index)
+    {
+        this.CheckDisposed();
+
+        Vp8LHistogram item = this.items[index];
+        item?.Dispose();
+        this.items.RemoveAt(index);
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
+        item = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
+    }
+
+    public void Dispose()
+    {
+        if (this.isDisposed)
+        {
+            return;
+        }
+
+        this.buffer.Dispose();
+
+        foreach (Vp8LHistogram item in this.items)
+        {
+            item?.Dispose();
+        }
+
+        this.items.Clear();
+        this.isDisposed = true;
+    }
+
+    public IEnumerator<Vp8LHistogram> GetEnumerator() => ((IEnumerable<Vp8LHistogram>)this.items).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)this.items).GetEnumerator();
+
+    [Conditional("DEBUG")]
+    private void CheckDisposed()
+    {
+        if (this.isDisposed)
+        {
+            ThrowDisposed();
+        }
+    }
+
+    private static void ThrowDisposed() => throw new ObjectDisposedException(nameof(Vp8LHistogramSet));
+
+    private sealed class SetItemMemoryOwner : IMemoryOwner<uint>
+    {
+        public SetItemMemoryOwner(Memory<uint> memory) => this.Memory = memory;
+
+        public Memory<uint> Memory { get; }
+
+        public void Dispose()
+        {
+            // Do nothing, the underlying memory is owned by the parent set.
+        }
+    }
+}

--- a/tests/ImageSharp.Benchmarks/Codecs/Webp/EncodeWebp.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Webp/EncodeWebp.cs
@@ -43,9 +43,9 @@ public class EncodeWebp
     [Benchmark(Description = "Magick Webp Lossy")]
     public void MagickWebpLossy()
     {
-        using var memoryStream = new MemoryStream();
+        using MemoryStream memoryStream = new();
 
-        var defines = new WebPWriteDefines
+        WebPWriteDefines defines = new()
         {
             Lossless = false,
             Method = 4,
@@ -65,7 +65,7 @@ public class EncodeWebp
     [Benchmark(Description = "ImageSharp Webp Lossy")]
     public void ImageSharpWebpLossy()
     {
-        using var memoryStream = new MemoryStream();
+        using MemoryStream memoryStream = new();
         this.webp.Save(memoryStream, new WebpEncoder()
         {
             FileFormat = WebpFileFormatType.Lossy,
@@ -80,8 +80,8 @@ public class EncodeWebp
     [Benchmark(Baseline = true, Description = "Magick Webp Lossless")]
     public void MagickWebpLossless()
     {
-        using var memoryStream = new MemoryStream();
-        var defines = new WebPWriteDefines
+        using MemoryStream memoryStream = new();
+        WebPWriteDefines defines = new()
         {
             Lossless = true,
             Method = 4,
@@ -97,12 +97,13 @@ public class EncodeWebp
     [Benchmark(Description = "ImageSharp Webp Lossless")]
     public void ImageSharpWebpLossless()
     {
-        using var memoryStream = new MemoryStream();
+        using MemoryStream memoryStream = new();
         this.webp.Save(memoryStream, new WebpEncoder()
         {
             FileFormat = WebpFileFormatType.Lossless,
             Method = WebpEncodingMethod.Level4,
             NearLossless = false,
+            Quality = 75,
 
             // This is equal to exact = false in libwebp, which is the default.
             TransparentColorMode = WebpTransparentColorMode.Clear

--- a/tests/ImageSharp.Tests/Formats/WebP/DominantCostRangeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/DominantCostRangeTests.cs
@@ -25,12 +25,10 @@ public class DominantCostRangeTests
     {
         // arrange
         DominantCostRange dominantCostRange = new();
-        using Vp8LHistogram histogram = new(Configuration.Default.MemoryAllocator, 10)
-        {
-            LiteralCost = 1.0d,
-            RedCost = 2.0d,
-            BlueCost = 3.0d
-        };
+        using Vp8LHistogram histogram = Vp8LHistogram.Create(Configuration.Default.MemoryAllocator, 10);
+        histogram.LiteralCost = 1.0d;
+        histogram.RedCost = 2.0d;
+        histogram.BlueCost = 3.0d;
 
         // act
         dominantCostRange.UpdateDominantCostRange(histogram);
@@ -59,13 +57,12 @@ public class DominantCostRangeTests
             RedMax = 191.0,
             RedMin = 109.0
         };
-        using Vp8LHistogram histogram = new(Configuration.Default.MemoryAllocator, 6)
-        {
-            LiteralCost = 247.0d,
-            RedCost = 112.0d,
-            BlueCost = 202.0d,
-            BitCost = 733.0d
-        };
+        using Vp8LHistogram histogram = Vp8LHistogram.Create(Configuration.Default.MemoryAllocator, 6);
+        histogram.LiteralCost = 247.0d;
+        histogram.RedCost = 112.0d;
+        histogram.BlueCost = 202.0d;
+        histogram.BitCost = 733.0d;
+
         dominantCostRange.UpdateDominantCostRange(histogram);
 
         // act

--- a/tests/ImageSharp.Tests/Formats/WebP/DominantCostRangeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/DominantCostRangeTests.cs
@@ -11,7 +11,7 @@ public class DominantCostRangeTests
     [Fact]
     public void DominantCost_Constructor()
     {
-        var dominantCostRange = new DominantCostRange();
+        DominantCostRange dominantCostRange = new();
         Assert.Equal(0, dominantCostRange.LiteralMax);
         Assert.Equal(double.MaxValue, dominantCostRange.LiteralMin);
         Assert.Equal(0, dominantCostRange.RedMax);
@@ -24,8 +24,8 @@ public class DominantCostRangeTests
     public void UpdateDominantCostRange_Works()
     {
         // arrange
-        var dominantCostRange = new DominantCostRange();
-        var histogram = new Vp8LHistogram(10)
+        DominantCostRange dominantCostRange = new();
+        using Vp8LHistogram histogram = new(Configuration.Default.MemoryAllocator, 10)
         {
             LiteralCost = 1.0d,
             RedCost = 2.0d,
@@ -50,7 +50,7 @@ public class DominantCostRangeTests
     public void GetHistoBinIndex_Works(int partitions, int expectedIndex)
     {
         // arrange
-        var dominantCostRange = new DominantCostRange()
+        DominantCostRange dominantCostRange = new()
         {
             BlueMax = 253.4625,
             BlueMin = 109.0,
@@ -59,7 +59,7 @@ public class DominantCostRangeTests
             RedMax = 191.0,
             RedMin = 109.0
         };
-        var histogram = new Vp8LHistogram(6)
+        using Vp8LHistogram histogram = new(Configuration.Default.MemoryAllocator, 6)
         {
             LiteralCost = 247.0d,
             RedCost = 112.0d,

--- a/tests/ImageSharp.Tests/Formats/WebP/DominantCostRangeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/DominantCostRangeTests.cs
@@ -25,7 +25,7 @@ public class DominantCostRangeTests
     {
         // arrange
         DominantCostRange dominantCostRange = new();
-        using Vp8LHistogram histogram = Vp8LHistogram.Create(Configuration.Default.MemoryAllocator, 10);
+        using OwnedVp8LHistogram histogram = OwnedVp8LHistogram.Create(Configuration.Default.MemoryAllocator, 10);
         histogram.LiteralCost = 1.0d;
         histogram.RedCost = 2.0d;
         histogram.BlueCost = 3.0d;
@@ -57,7 +57,7 @@ public class DominantCostRangeTests
             RedMax = 191.0,
             RedMin = 109.0
         };
-        using Vp8LHistogram histogram = Vp8LHistogram.Create(Configuration.Default.MemoryAllocator, 6);
+        using OwnedVp8LHistogram histogram = OwnedVp8LHistogram.Create(Configuration.Default.MemoryAllocator, 6);
         histogram.LiteralCost = 247.0d;
         histogram.RedCost = 112.0d;
         histogram.BlueCost = 202.0d;

--- a/tests/ImageSharp.Tests/Formats/WebP/Vp8LHistogramTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/Vp8LHistogramTests.cs
@@ -78,15 +78,15 @@ public class Vp8LHistogramTests
         }
 
         MemoryAllocator memoryAllocator = Configuration.Default.MemoryAllocator;
-        using Vp8LHistogram histogram0 = Vp8LHistogram.Create(memoryAllocator, backwardRefs, 3);
-        using Vp8LHistogram histogram1 = Vp8LHistogram.Create(memoryAllocator, backwardRefs, 3);
+        using OwnedVp8LHistogram histogram0 = OwnedVp8LHistogram.Create(memoryAllocator, backwardRefs, 3);
+        using OwnedVp8LHistogram histogram1 = OwnedVp8LHistogram.Create(memoryAllocator, backwardRefs, 3);
         for (int i = 0; i < 5; i++)
         {
             histogram0.IsUsed(i, true);
             histogram1.IsUsed(i, true);
         }
 
-        using Vp8LHistogram output = Vp8LHistogram.Create(memoryAllocator, 3);
+        using OwnedVp8LHistogram output = OwnedVp8LHistogram.Create(memoryAllocator, 3);
 
         // act
         histogram0.Add(histogram1, output);

--- a/tests/ImageSharp.Tests/Formats/WebP/Vp8LHistogramTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/Vp8LHistogramTests.cs
@@ -78,15 +78,15 @@ public class Vp8LHistogramTests
         }
 
         MemoryAllocator memoryAllocator = Configuration.Default.MemoryAllocator;
-        using Vp8LHistogram histogram0 = new(memoryAllocator, backwardRefs, 3);
-        using Vp8LHistogram histogram1 = new(memoryAllocator, backwardRefs, 3);
+        using Vp8LHistogram histogram0 = Vp8LHistogram.Create(memoryAllocator, backwardRefs, 3);
+        using Vp8LHistogram histogram1 = Vp8LHistogram.Create(memoryAllocator, backwardRefs, 3);
         for (int i = 0; i < 5; i++)
         {
             histogram0.IsUsed(i, true);
             histogram1.IsUsed(i, true);
         }
 
-        using Vp8LHistogram output = new(memoryAllocator, 3);
+        using Vp8LHistogram output = Vp8LHistogram.Create(memoryAllocator, 3);
 
         // act
         histogram0.Add(histogram1, output);

--- a/tests/ImageSharp.Tests/Formats/WebP/Vp8LHistogramTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/Vp8LHistogramTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Six Labors Split License.
 
 using SixLabors.ImageSharp.Formats.Webp.Lossless;
+using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Tests.TestUtilities;
 
 namespace SixLabors.ImageSharp.Tests.Formats.Webp;
@@ -65,7 +66,7 @@ public class Vp8LHistogramTests
         // All remaining values are expected to be zero.
         literals.AsSpan().CopyTo(expectedLiterals);
 
-        var backwardRefs = new Vp8LBackwardRefs(pixelData.Length);
+        Vp8LBackwardRefs backwardRefs = new(pixelData.Length);
         for (int i = 0; i < pixelData.Length; i++)
         {
             backwardRefs.Add(new PixOrCopy()
@@ -76,15 +77,16 @@ public class Vp8LHistogramTests
             });
         }
 
-        var histogram0 = new Vp8LHistogram(backwardRefs, 3);
-        var histogram1 = new Vp8LHistogram(backwardRefs, 3);
+        MemoryAllocator memoryAllocator = Configuration.Default.MemoryAllocator;
+        using Vp8LHistogram histogram0 = new(memoryAllocator, backwardRefs, 3);
+        using Vp8LHistogram histogram1 = new(memoryAllocator, backwardRefs, 3);
         for (int i = 0; i < 5; i++)
         {
-            histogram0.IsUsed[i] = true;
-            histogram1.IsUsed[i] = true;
+            histogram0.IsUsed(i, true);
+            histogram1.IsUsed(i, true);
         }
 
-        var output = new Vp8LHistogram(3);
+        using Vp8LHistogram output = new(memoryAllocator, 3);
 
         // act
         histogram0.Add(histogram1, output);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

This PR refactors the `Vp8LHistogram` type to use pooled allocations. It also introduces the concept of a `Vp8LHistogramSet` type to allow allocating a single buffer for a collection.

Benchmark indicates a 20ms speedup for lossless encoding while using less than half the original allocated memory.

<!-- Thanks for contributing to ImageSharp! -->

```
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22621
11th Gen Intel Core i7-11370H 3.30GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=8.0.100-rc.1.23455.8
  [Host]     : .NET 6.0.22 (6.0.2223.42425), X64 RyuJIT
  Job-ZADQXC : .NET 6.0.22 (6.0.2223.42425), X64 RyuJIT

Runtime=.NET 6.0  Arguments=/p:DebugType=portable  IterationCount=3
LaunchCount=1  WarmupCount=3
```
**Main**

|                     Method |    TestImage |      Mean |     Error |   StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|--------------------------- |------------- |----------:|----------:|---------:|------:|--------:|----------:|----------:|----------:|----------:|
|        'Magick Webp Lossy' | Png/Bike.png |  22.30 ms |  5.533 ms | 0.303 ms |  0.14 |    0.00 |         - |         - |         - |     68 KB |
|    'ImageSharp Webp Lossy' | Png/Bike.png |  74.82 ms |  2.291 ms | 0.126 ms |  0.46 |    0.00 | 2428.5714 |  142.8571 |         - | 15,187 KB |
|     'Magick Webp Lossless' | Png/Bike.png | 161.16 ms | 22.093 ms | 1.211 ms |  1.00 |    0.00 |         - |         - |         - |    518 KB |
| 'ImageSharp Webp Lossless' | Png/Bike.png | 249.44 ms | 58.373 ms | 3.200 ms |  1.55 |    0.02 | 8000.0000 | 4000.0000 | 2000.0000 | 46,532 KB |

**PR**

|                     Method |    TestImage |      Mean |     Error |   StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|--------------------------- |------------- |----------:|----------:|---------:|------:|--------:|----------:|----------:|----------:|----------:|
|        'Magick Webp Lossy' | Png/Bike.png |  22.20 ms |  5.392 ms | 0.296 ms |  0.13 |    0.00 |         - |         - |         - |     68 KB |
|    'ImageSharp Webp Lossy' | Png/Bike.png |  76.90 ms | 61.754 ms | 3.385 ms |  0.46 |    0.01 | 2428.5714 |  142.8571 |         - | 15,187 KB |
|     'Magick Webp Lossless' | Png/Bike.png | 165.44 ms | 85.798 ms | 4.703 ms |  1.00 |    0.00 |         - |         - |         - |    518 KB |
| 'ImageSharp Webp Lossless' | Png/Bike.png | 228.72 ms | 40.127 ms | 2.199 ms |  1.38 |    0.05 | 3000.0000 | 2000.0000 | 2000.0000 | 20,623 KB |