### PR TITLE
Switch to Bottom as upper bound for Quantizer Rect

### DIFF
--- a/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/QuantizeProcessor{TPixel}.cs
@@ -43,7 +43,7 @@ internal class QuantizeProcessor<TPixel> : ImageProcessor<TPixel>
         int offsetX = interest.Left;
         Buffer2D<TPixel> sourceBuffer = source.PixelBuffer;
 
-        for (int y = interest.Y; y < interest.Height; y++)
+        for (int y = interest.Y; y < interest.Bottom; y++)
         {
             Span<TPixel> row = sourceBuffer.DangerousGetRowSpan(y);
             ReadOnlySpan<byte> quantizedRow = quantized.DangerousGetRowSpan(y - offsetY);


### PR DESCRIPTION
Hi.

I was trying out Quantizer with custom rects. I couldn't get it to work and checked the code. To me it seems to be a typo where the `interest.Height` was used rather than `interest.Bottom`. The x-dimension `interest.Left` and `interest.Right` is used which makes sense to me.

I did the change and it worked for me but then when I tried running the tests I got multiple image comparison failures.

So perhaps this is the intended behavior and I misunderstood the API. Or it is a good fix and oracles should be regenerated (but I don't know how).

I don't really know what is the right choice here so I thought I create a draft pull request even though the tests fails and you can tell me what do or just close it if it works as intended.

Regards,.