### PR TITLE
PBM decoder robustness improvements and BufferedReadStream observability

### DIFF
--- a/src/ImageSharp/Formats/ImageDecoderUtilities.cs
+++ b/src/ImageSharp/Formats/ImageDecoderUtilities.cs
@@ -50,7 +50,8 @@ internal static class ImageDecoderUtilities
         CancellationToken cancellationToken)
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        using BufferedReadStream bufferedReadStream = new(configuration, stream, cancellationToken);
+        // Test may pass a BufferedReadStream in order to monitor EOF hits, if so, use the existing instance.
+        BufferedReadStream bufferedReadStream = stream as BufferedReadStream ?? new BufferedReadStream(configuration, stream, cancellationToken);
 
         try
         {
@@ -63,6 +64,13 @@ internal static class ImageDecoderUtilities
         catch (Exception)
         {
             throw;
+        }
+        finally
+        {
+            if (bufferedReadStream != stream)
+            {
+                bufferedReadStream.Dispose();
+            }
         }
     }
 

--- a/src/ImageSharp/Formats/Pbm/BinaryDecoder.cs
+++ b/src/ImageSharp/Formats/Pbm/BinaryDecoder.cs
@@ -71,7 +71,11 @@ internal class BinaryDecoder
 
         for (int y = 0; y < height; y++)
         {
-            stream.Read(rowSpan);
+            if (stream.Read(rowSpan) == 0)
+            {
+                return;
+            }
+
             Span<TPixel> pixelSpan = pixels.DangerousGetRowSpan(y);
             PixelOperations<TPixel>.Instance.FromL8Bytes(
                 configuration,
@@ -93,7 +97,11 @@ internal class BinaryDecoder
 
         for (int y = 0; y < height; y++)
         {
-            stream.Read(rowSpan);
+            if (stream.Read(rowSpan) == 0)
+            {
+                return;
+            }
+
             Span<TPixel> pixelSpan = pixels.DangerousGetRowSpan(y);
             PixelOperations<TPixel>.Instance.FromL16Bytes(
                 configuration,
@@ -115,7 +123,11 @@ internal class BinaryDecoder
 
         for (int y = 0; y < height; y++)
         {
-            stream.Read(rowSpan);
+            if (stream.Read(rowSpan) == 0)
+            {
+                return;
+            }
+
             Span<TPixel> pixelSpan = pixels.DangerousGetRowSpan(y);
             PixelOperations<TPixel>.Instance.FromRgb24Bytes(
                 configuration,
@@ -137,7 +149,11 @@ internal class BinaryDecoder
 
         for (int y = 0; y < height; y++)
         {
-            stream.Read(rowSpan);
+            if (stream.Read(rowSpan) == 0)
+            {
+                return;
+            }
+
             Span<TPixel> pixelSpan = pixels.DangerousGetRowSpan(y);
             PixelOperations<TPixel>.Instance.FromRgb48Bytes(
                 configuration,
@@ -161,6 +177,11 @@ internal class BinaryDecoder
             for (int x = 0; x < width;)
             {
                 int raw = stream.ReadByte();
+                if (raw < 0)
+                {
+                    return;
+                }
+
                 int stopBit = Math.Min(8, width - x);
                 for (int bit = 0; bit < stopBit; bit++)
                 {

--- a/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
+++ b/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
@@ -13,8 +13,9 @@ internal static class BufferedReadStreamExtensions
     /// <summary>
     /// Skip over any whitespace or any comments and signal if EOF has been reached.
     /// </summary>
+    /// <param name="stream">The buffered read stream.</param>
     /// <returns><see langword="false"/> if EOF has been reached while reading the stream; see langword="true"/> otherwise.</returns>
-    public static bool SkipWhitespaceAndComments(this BufferedReadStream stream)
+    public static bool TrySkipWhitespaceAndComments(this BufferedReadStream stream)
     {
         bool isWhitespace;
         do
@@ -53,12 +54,14 @@ internal static class BufferedReadStreamExtensions
     /// <summary>
     /// Read a decimal text value and signal if EOF has been reached.
     /// </summary>
+    /// <param name="stream">The buffered read stream.</param>
+    /// <param name="value">The read value.</param>
     /// <returns><see langword="false"/> if EOF has been reached while reading the stream; <see langword="true"/> otherwise.</returns>
     /// <remarks>
     /// A 'false' return value doesn't mean that the parsing has been failed, since it's possible to reach EOF while reading the last decimal in the file.
     /// It's up to the call site to handle such a situation.
     /// </remarks>
-    public static bool ReadDecimal(this BufferedReadStream stream, out int value)
+    public static bool TryReadDecimal(this BufferedReadStream stream, out int value)
     {
         value = 0;
         while (true)

--- a/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
+++ b/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
@@ -13,12 +13,17 @@ internal static class BufferedReadStreamExtensions
     /// <summary>
     /// Skip over any whitespace or any comments.
     /// </summary>
-    public static void SkipWhitespaceAndComments(this BufferedReadStream stream)
+    /// <returns><see langword="false"/> if EOF has been reached while reading the stream; see langword="true"/> otherwise.</returns>
+    public static bool TrySkipWhitespaceAndComments(this BufferedReadStream stream)
     {
         bool isWhitespace;
         do
         {
             int val = stream.ReadByte();
+            if (val < 0)
+            {
+                return false;
+            }
 
             // Comments start with '#' and end at the next new-line.
             if (val == 0x23)
@@ -27,8 +32,12 @@ internal static class BufferedReadStreamExtensions
                 do
                 {
                     innerValue = stream.ReadByte();
+                    if (innerValue < 0)
+                    {
+                        return false;
+                    }
                 }
-                while (innerValue is not 0x0a and not -0x1);
+                while (innerValue is not 0x0a);
 
                 // Continue searching for whitespace.
                 val = innerValue;
@@ -38,18 +47,29 @@ internal static class BufferedReadStreamExtensions
         }
         while (isWhitespace);
         stream.Seek(-1, SeekOrigin.Current);
+        return true;
     }
 
     /// <summary>
     /// Read a decimal text value.
     /// </summary>
-    /// <returns>The integer value of the decimal.</returns>
-    public static int ReadDecimal(this BufferedReadStream stream)
+    /// <returns><see langword="false"/> if EOF has been reached while reading the stream; see langword="true"/> otherwise.</returns>
+    /// <remarks>
+    /// A 'false' return value doesn't mean that the parsing has been failed, since it's possible to reach EOF while reading the last decimal in the file.
+    /// It's up to the call site to handle such a situation.
+    /// </remarks>
+    public static bool TryReadDecimal(this BufferedReadStream stream, out int value)
     {
-        int value = 0;
+        value = 0;
         while (true)
         {
-            int current = stream.ReadByte() - 0x30;
+            int current = stream.ReadByte();
+            if (current < 0)
+            {
+                return false;
+            }
+
+            current -= 0x30;
             if ((uint)current > 9)
             {
                 break;
@@ -58,6 +78,6 @@ internal static class BufferedReadStreamExtensions
             value = (value * 10) + current;
         }
 
-        return value;
+        return true;
     }
 }

--- a/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
+++ b/src/ImageSharp/Formats/Pbm/BufferedReadStreamExtensions.cs
@@ -11,10 +11,10 @@ namespace SixLabors.ImageSharp.Formats.Pbm;
 internal static class BufferedReadStreamExtensions
 {
     /// <summary>
-    /// Skip over any whitespace or any comments.
+    /// Skip over any whitespace or any comments and signal if EOF has been reached.
     /// </summary>
     /// <returns><see langword="false"/> if EOF has been reached while reading the stream; see langword="true"/> otherwise.</returns>
-    public static bool TrySkipWhitespaceAndComments(this BufferedReadStream stream)
+    public static bool SkipWhitespaceAndComments(this BufferedReadStream stream)
     {
         bool isWhitespace;
         do
@@ -51,14 +51,14 @@ internal static class BufferedReadStreamExtensions
     }
 
     /// <summary>
-    /// Read a decimal text value.
+    /// Read a decimal text value and signal if EOF has been reached.
     /// </summary>
-    /// <returns><see langword="false"/> if EOF has been reached while reading the stream; see langword="true"/> otherwise.</returns>
+    /// <returns><see langword="false"/> if EOF has been reached while reading the stream; <see langword="true"/> otherwise.</returns>
     /// <remarks>
     /// A 'false' return value doesn't mean that the parsing has been failed, since it's possible to reach EOF while reading the last decimal in the file.
     /// It's up to the call site to handle such a situation.
     /// </remarks>
-    public static bool TryReadDecimal(this BufferedReadStream stream, out int value)
+    public static bool ReadDecimal(this BufferedReadStream stream, out int value)
     {
         value = 0;
         while (true)

--- a/src/ImageSharp/Formats/Pbm/PbmDecoderCore.cs
+++ b/src/ImageSharp/Formats/Pbm/PbmDecoderCore.cs
@@ -145,18 +145,18 @@ internal sealed class PbmDecoderCore : IImageDecoderInternals
                 throw new InvalidImageContentException("Unknown of not implemented image type encountered.");
         }
 
-        if (!stream.TrySkipWhitespaceAndComments() ||
-            !stream.TryReadDecimal(out int width) ||
-            !stream.TrySkipWhitespaceAndComments() ||
-            !stream.TryReadDecimal(out int height) ||
-            !stream.TrySkipWhitespaceAndComments())
+        if (!stream.SkipWhitespaceAndComments() ||
+            !stream.ReadDecimal(out int width) ||
+            !stream.SkipWhitespaceAndComments() ||
+            !stream.ReadDecimal(out int height) ||
+            !stream.SkipWhitespaceAndComments())
         {
             ThrowPrematureEof();
         }
 
         if (this.colorType != PbmColorType.BlackAndWhite)
         {
-            if (!stream.TryReadDecimal(out this.maxPixelValue))
+            if (!stream.ReadDecimal(out this.maxPixelValue))
             {
                 ThrowPrematureEof();
             }
@@ -170,7 +170,7 @@ internal sealed class PbmDecoderCore : IImageDecoderInternals
                 this.componentType = PbmComponentType.Byte;
             }
 
-            stream.TrySkipWhitespaceAndComments();
+            stream.SkipWhitespaceAndComments();
         }
         else
         {

--- a/src/ImageSharp/Formats/Pbm/PbmDecoderCore.cs
+++ b/src/ImageSharp/Formats/Pbm/PbmDecoderCore.cs
@@ -96,6 +96,7 @@ internal sealed class PbmDecoderCore : IImageDecoderInternals
     /// Processes the ppm header.
     /// </summary>
     /// <param name="stream">The input stream.</param>
+    /// <exception cref="InvalidImageContentException">An EOF marker has been read before the image has been decoded.</exception>
     private void ProcessHeader(BufferedReadStream stream)
     {
         Span<byte> buffer = stackalloc byte[2];
@@ -145,18 +146,18 @@ internal sealed class PbmDecoderCore : IImageDecoderInternals
                 throw new InvalidImageContentException("Unknown of not implemented image type encountered.");
         }
 
-        if (!stream.SkipWhitespaceAndComments() ||
-            !stream.ReadDecimal(out int width) ||
-            !stream.SkipWhitespaceAndComments() ||
-            !stream.ReadDecimal(out int height) ||
-            !stream.SkipWhitespaceAndComments())
+        if (!stream.TrySkipWhitespaceAndComments() ||
+            !stream.TryReadDecimal(out int width) ||
+            !stream.TrySkipWhitespaceAndComments() ||
+            !stream.TryReadDecimal(out int height) ||
+            !stream.TrySkipWhitespaceAndComments())
         {
             ThrowPrematureEof();
         }
 
         if (this.colorType != PbmColorType.BlackAndWhite)
         {
-            if (!stream.ReadDecimal(out this.maxPixelValue))
+            if (!stream.TryReadDecimal(out this.maxPixelValue))
             {
                 ThrowPrematureEof();
             }
@@ -170,7 +171,7 @@ internal sealed class PbmDecoderCore : IImageDecoderInternals
                 this.componentType = PbmComponentType.Byte;
             }
 
-            stream.SkipWhitespaceAndComments();
+            stream.TrySkipWhitespaceAndComments();
         }
         else
         {

--- a/src/ImageSharp/Formats/Pbm/PlainDecoder.cs
+++ b/src/ImageSharp/Formats/Pbm/PlainDecoder.cs
@@ -70,9 +70,9 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                stream.TryReadDecimal(out int value);
+                stream.ReadDecimal(out int value);
                 rowSpan[x] = new L8((byte)value);
-                eofReached = !stream.TrySkipWhitespaceAndComments();
+                eofReached = !stream.SkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;
@@ -106,9 +106,9 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                stream.TryReadDecimal(out int value);
+                stream.ReadDecimal(out int value);
                 rowSpan[x] = new L16((ushort)value);
-                eofReached = !stream.TrySkipWhitespaceAndComments();
+                eofReached = !stream.SkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;
@@ -142,20 +142,20 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                if (!stream.TryReadDecimal(out int red) ||
-                    !stream.TrySkipWhitespaceAndComments() ||
-                    !stream.TryReadDecimal(out int green) ||
-                    !stream.TrySkipWhitespaceAndComments())
+                if (!stream.ReadDecimal(out int red) ||
+                    !stream.SkipWhitespaceAndComments() ||
+                    !stream.ReadDecimal(out int green) ||
+                    !stream.SkipWhitespaceAndComments())
                 {
                     // Reached EOF before reading a full RGB value
                     eofReached = true;
                     break;
                 }
 
-                stream.TryReadDecimal(out int blue);
+                stream.ReadDecimal(out int blue);
 
                 rowSpan[x] = new Rgb24((byte)red, (byte)green, (byte)blue);
-                eofReached = !stream.TrySkipWhitespaceAndComments();
+                eofReached = !stream.SkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;
@@ -189,20 +189,20 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                if (!stream.TryReadDecimal(out int red) ||
-                    !stream.TrySkipWhitespaceAndComments() ||
-                    !stream.TryReadDecimal(out int green) ||
-                    !stream.TrySkipWhitespaceAndComments())
+                if (!stream.ReadDecimal(out int red) ||
+                    !stream.SkipWhitespaceAndComments() ||
+                    !stream.ReadDecimal(out int green) ||
+                    !stream.SkipWhitespaceAndComments())
                 {
                     // Reached EOF before reading a full RGB value
                     eofReached = true;
                     break;
                 }
 
-                stream.TryReadDecimal(out int blue);
+                stream.ReadDecimal(out int blue);
 
                 rowSpan[x] = new Rgb48((ushort)red, (ushort)green, (ushort)blue);
-                eofReached = !stream.TrySkipWhitespaceAndComments();
+                eofReached = !stream.SkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;
@@ -236,10 +236,10 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                stream.TryReadDecimal(out int value);
+                stream.ReadDecimal(out int value);
 
                 rowSpan[x] = value == 0 ? White : Black;
-                eofReached = !stream.TrySkipWhitespaceAndComments();
+                eofReached = !stream.SkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;

--- a/src/ImageSharp/Formats/Pbm/PlainDecoder.cs
+++ b/src/ImageSharp/Formats/Pbm/PlainDecoder.cs
@@ -70,9 +70,9 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                stream.ReadDecimal(out int value);
+                stream.TryReadDecimal(out int value);
                 rowSpan[x] = new L8((byte)value);
-                eofReached = !stream.SkipWhitespaceAndComments();
+                eofReached = !stream.TrySkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;
@@ -106,9 +106,9 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                stream.ReadDecimal(out int value);
+                stream.TryReadDecimal(out int value);
                 rowSpan[x] = new L16((ushort)value);
-                eofReached = !stream.SkipWhitespaceAndComments();
+                eofReached = !stream.TrySkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;
@@ -142,20 +142,20 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                if (!stream.ReadDecimal(out int red) ||
-                    !stream.SkipWhitespaceAndComments() ||
-                    !stream.ReadDecimal(out int green) ||
-                    !stream.SkipWhitespaceAndComments())
+                if (!stream.TryReadDecimal(out int red) ||
+                    !stream.TrySkipWhitespaceAndComments() ||
+                    !stream.TryReadDecimal(out int green) ||
+                    !stream.TrySkipWhitespaceAndComments())
                 {
                     // Reached EOF before reading a full RGB value
                     eofReached = true;
                     break;
                 }
 
-                stream.ReadDecimal(out int blue);
+                stream.TryReadDecimal(out int blue);
 
                 rowSpan[x] = new Rgb24((byte)red, (byte)green, (byte)blue);
-                eofReached = !stream.SkipWhitespaceAndComments();
+                eofReached = !stream.TrySkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;
@@ -189,20 +189,20 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                if (!stream.ReadDecimal(out int red) ||
-                    !stream.SkipWhitespaceAndComments() ||
-                    !stream.ReadDecimal(out int green) ||
-                    !stream.SkipWhitespaceAndComments())
+                if (!stream.TryReadDecimal(out int red) ||
+                    !stream.TrySkipWhitespaceAndComments() ||
+                    !stream.TryReadDecimal(out int green) ||
+                    !stream.TrySkipWhitespaceAndComments())
                 {
                     // Reached EOF before reading a full RGB value
                     eofReached = true;
                     break;
                 }
 
-                stream.ReadDecimal(out int blue);
+                stream.TryReadDecimal(out int blue);
 
                 rowSpan[x] = new Rgb48((ushort)red, (ushort)green, (ushort)blue);
-                eofReached = !stream.SkipWhitespaceAndComments();
+                eofReached = !stream.TrySkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;
@@ -236,10 +236,10 @@ internal class PlainDecoder
         {
             for (int x = 0; x < width; x++)
             {
-                stream.ReadDecimal(out int value);
+                stream.TryReadDecimal(out int value);
 
                 rowSpan[x] = value == 0 ? White : Black;
-                eofReached = !stream.SkipWhitespaceAndComments();
+                eofReached = !stream.TrySkipWhitespaceAndComments();
                 if (eofReached)
                 {
                     break;

--- a/src/ImageSharp/Formats/Pbm/PlainDecoder.cs
+++ b/src/ImageSharp/Formats/Pbm/PlainDecoder.cs
@@ -65,13 +65,18 @@ internal class PlainDecoder
         using IMemoryOwner<L8> row = allocator.Allocate<L8>(width);
         Span<L8> rowSpan = row.GetSpan();
 
+        bool eofReached = false;
         for (int y = 0; y < height; y++)
         {
             for (int x = 0; x < width; x++)
             {
-                byte value = (byte)stream.ReadDecimal();
-                stream.SkipWhitespaceAndComments();
-                rowSpan[x] = new L8(value);
+                stream.TryReadDecimal(out int value);
+                rowSpan[x] = new L8((byte)value);
+                eofReached = !stream.TrySkipWhitespaceAndComments();
+                if (eofReached)
+                {
+                    break;
+                }
             }
 
             Span<TPixel> pixelSpan = pixels.DangerousGetRowSpan(y);
@@ -79,6 +84,11 @@ internal class PlainDecoder
                 configuration,
                 rowSpan,
                 pixelSpan);
+
+            if (eofReached)
+            {
+                return;
+            }
         }
     }
 
@@ -91,13 +101,18 @@ internal class PlainDecoder
         using IMemoryOwner<L16> row = allocator.Allocate<L16>(width);
         Span<L16> rowSpan = row.GetSpan();
 
+        bool eofReached = false;
         for (int y = 0; y < height; y++)
         {
             for (int x = 0; x < width; x++)
             {
-                ushort value = (ushort)stream.ReadDecimal();
-                stream.SkipWhitespaceAndComments();
-                rowSpan[x] = new L16(value);
+                stream.TryReadDecimal(out int value);
+                rowSpan[x] = new L16((ushort)value);
+                eofReached = !stream.TrySkipWhitespaceAndComments();
+                if (eofReached)
+                {
+                    break;
+                }
             }
 
             Span<TPixel> pixelSpan = pixels.DangerousGetRowSpan(y);
@@ -105,6 +120,11 @@ internal class PlainDecoder
                 configuration,
                 rowSpan,
                 pixelSpan);
+
+            if (eofReached)
+            {
+                return;
+            }
         }
     }
 
@@ -117,17 +137,29 @@ internal class PlainDecoder
         using IMemoryOwner<Rgb24> row = allocator.Allocate<Rgb24>(width);
         Span<Rgb24> rowSpan = row.GetSpan();
 
+        bool eofReached = false;
         for (int y = 0; y < height; y++)
         {
             for (int x = 0; x < width; x++)
             {
-                byte red = (byte)stream.ReadDecimal();
-                stream.SkipWhitespaceAndComments();
-                byte green = (byte)stream.ReadDecimal();
-                stream.SkipWhitespaceAndComments();
-                byte blue = (byte)stream.ReadDecimal();
-                stream.SkipWhitespaceAndComments();
-                rowSpan[x] = new Rgb24(red, green, blue);
+                if (!stream.TryReadDecimal(out int red) ||
+                    !stream.TrySkipWhitespaceAndComments() ||
+                    !stream.TryReadDecimal(out int green) ||
+                    !stream.TrySkipWhitespaceAndComments())
+                {
+                    // Reached EOF before reading a full RGB value
+                    eofReached = true;
+                    break;
+                }
+
+                stream.TryReadDecimal(out int blue);
+
+                rowSpan[x] = new Rgb24((byte)red, (byte)green, (byte)blue);
+                eofReached = !stream.TrySkipWhitespaceAndComments();
+                if (eofReached)
+                {
+                    break;
+                }
             }
 
             Span<TPixel> pixelSpan = pixels.DangerousGetRowSpan(y);
@@ -135,6 +167,11 @@ internal class PlainDecoder
                 configuration,
                 rowSpan,
                 pixelSpan);
+
+            if (eofReached)
+            {
+                return;
+            }
         }
     }
 
@@ -147,17 +184,29 @@ internal class PlainDecoder
         using IMemoryOwner<Rgb48> row = allocator.Allocate<Rgb48>(width);
         Span<Rgb48> rowSpan = row.GetSpan();
 
+        bool eofReached = false;
         for (int y = 0; y < height; y++)
         {
             for (int x = 0; x < width; x++)
             {
-                ushort red = (ushort)stream.ReadDecimal();
-                stream.SkipWhitespaceAndComments();
-                ushort green = (ushort)stream.ReadDecimal();
-                stream.SkipWhitespaceAndComments();
-                ushort blue = (ushort)stream.ReadDecimal();
-                stream.SkipWhitespaceAndComments();
-                rowSpan[x] = new Rgb48(red, green, blue);
+                if (!stream.TryReadDecimal(out int red) ||
+                    !stream.TrySkipWhitespaceAndComments() ||
+                    !stream.TryReadDecimal(out int green) ||
+                    !stream.TrySkipWhitespaceAndComments())
+                {
+                    // Reached EOF before reading a full RGB value
+                    eofReached = true;
+                    break;
+                }
+
+                stream.TryReadDecimal(out int blue);
+
+                rowSpan[x] = new Rgb48((ushort)red, (ushort)green, (ushort)blue);
+                eofReached = !stream.TrySkipWhitespaceAndComments();
+                if (eofReached)
+                {
+                    break;
+                }
             }
 
             Span<TPixel> pixelSpan = pixels.DangerousGetRowSpan(y);
@@ -165,6 +214,11 @@ internal class PlainDecoder
                 configuration,
                 rowSpan,
                 pixelSpan);
+
+            if (eofReached)
+            {
+                return;
+            }
         }
     }
 
@@ -177,13 +231,19 @@ internal class PlainDecoder
         using IMemoryOwner<L8> row = allocator.Allocate<L8>(width);
         Span<L8> rowSpan = row.GetSpan();
 
+        bool eofReached = false;
         for (int y = 0; y < height; y++)
         {
             for (int x = 0; x < width; x++)
             {
-                int value = stream.ReadDecimal();
-                stream.SkipWhitespaceAndComments();
+                stream.TryReadDecimal(out int value);
+
                 rowSpan[x] = value == 0 ? White : Black;
+                eofReached = !stream.TrySkipWhitespaceAndComments();
+                if (eofReached)
+                {
+                    break;
+                }
             }
 
             Span<TPixel> pixelSpan = pixels.DangerousGetRowSpan(y);
@@ -191,6 +251,11 @@ internal class PlainDecoder
                 configuration,
                 rowSpan,
                 pixelSpan);
+
+            if (eofReached)
+            {
+                return;
+            }
         }
     }
 }

--- a/src/ImageSharp/IO/BufferedReadStream.cs
+++ b/src/ImageSharp/IO/BufferedReadStream.cs
@@ -69,6 +69,11 @@ internal sealed class BufferedReadStream : Stream
     }
 
     /// <summary>
+    /// Gets the number indicating the EOF hits occured while reading from this instance.
+    /// </summary>
+    public int EofHitCount { get; private set; }
+
+    /// <summary>
     /// Gets the size, in bytes, of the underlying buffer.
     /// </summary>
     public int BufferSize
@@ -142,6 +147,7 @@ internal sealed class BufferedReadStream : Stream
     {
         if (this.readerPosition >= this.Length)
         {
+            this.EofHitCount++;
             return -1;
         }
 
@@ -294,7 +300,7 @@ internal sealed class BufferedReadStream : Stream
 
         this.readerPosition += n;
         this.readBufferIndex += n;
-
+        this.CheckEof(n);
         return n;
     }
 
@@ -352,6 +358,7 @@ internal sealed class BufferedReadStream : Stream
 
         this.Position += n;
 
+        this.CheckEof(n);
         return n;
     }
 
@@ -416,6 +423,15 @@ internal sealed class BufferedReadStream : Stream
         else
         {
             Buffer.BlockCopy(this.readBuffer, this.readBufferIndex, buffer, offset, count);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void CheckEof(int read)
+    {
+        if (read == 0)
+        {
+            this.EofHitCount++;
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Pbm;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Tests.TestUtilities;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 using static SixLabors.ImageSharp.Tests.TestImages.Pbm;
 
@@ -123,9 +124,21 @@ public class PbmDecoderTests
     }
 
     [Fact]
-    public void LargeHeader_PrematureEof()
+    public void PlainText_PrematureEof()
     {
-        byte[] bytes = Encoding.ASCII.GetBytes($"P1\n100000 100000\n");
-        Assert.Throws<InvalidImageContentException>(() => Image.Load(bytes));
+        byte[] bytes = Encoding.ASCII.GetBytes($"P1\n100 100\n1 0 1 0 1 0");
+        using EofHitCounter eofHitCounter = EofHitCounter.RunDecoder(bytes);
+
+        Assert.True(eofHitCounter.EofHitCount <= 2);
+        Assert.Equal(new Size(100, 100), eofHitCounter.Image.Size);
+    }
+
+    [Fact]
+    public void Binary_PrematureEof()
+    {
+        using EofHitCounter eofHitCounter = EofHitCounter.RunDecoder(RgbBinaryPrematureEof);
+
+        Assert.True(eofHitCounter.EofHitCount <= 2);
+        Assert.Equal(new Size(29, 30), eofHitCounter.Image.Size);
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Text;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Pbm;
 using SixLabors.ImageSharp.PixelFormats;
@@ -119,5 +120,12 @@ public class PbmDecoderTests
             provider,
             testOutputDetails: details,
             appendPixelTypeToFileName: false);
+    }
+
+    [Fact]
+    public void LargeHeader_PrematureEof()
+    {
+        byte[] bytes = Encoding.ASCII.GetBytes($"P1\n100000 100000\n");
+        Assert.Throws<InvalidImageContentException>(() => Image.Load(bytes));
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Pbm/PbmMetadataTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/PbmMetadataTests.cs
@@ -83,12 +83,9 @@ public class PbmMetadataTests
     }
 
     [Fact]
-    public void Identify_HandlesCraftedDenialOfServiceString()
+    public void Identify_EofInHeader_ThrowsInvalidImageContentException()
     {
         byte[] bytes = Convert.FromBase64String("UDEjWAAACQAAAAA=");
-        ImageInfo info = Image.Identify(bytes);
-        Assert.Equal(default, info.Size);
-        Configuration.Default.ImageFormatsManager.TryFindFormatByFileExtension("pbm", out IImageFormat format);
-        Assert.Equal(format!, info.Metadata.DecodedImageFormat);
+        Assert.Throws<InvalidImageContentException>(() => Image.Identify(bytes));
     }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -1040,6 +1040,7 @@ public static class TestImages
         public const string GrayscalePlainNormalized = "Pbm/grayscale_plain_normalized.pgm";
         public const string GrayscalePlainMagick = "Pbm/grayscale_plain_magick.pgm";
         public const string RgbBinary = "Pbm/00000_00000.ppm";
+        public const string RgbBinaryPrematureEof = "Pbm/00000_00000_premature_eof.ppm";
         public const string RgbPlain = "Pbm/rgb_plain.ppm";
         public const string RgbPlainNormalized = "Pbm/rgb_plain_normalized.ppm";
         public const string RgbPlainMagick = "Pbm/rgb_plain_magick.ppm";

--- a/tests/ImageSharp.Tests/TestUtilities/EofHitCounter.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/EofHitCounter.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.IO;
+
+namespace SixLabors.ImageSharp.Tests.TestUtilities;
+
+internal class EofHitCounter : IDisposable
+{
+    private readonly BufferedReadStream stream;
+
+    public EofHitCounter(BufferedReadStream stream, Image image)
+    {
+        this.stream = stream;
+        this.Image = image;
+    }
+
+    public int EofHitCount => this.stream.EofHitCount;
+
+    public Image Image { get; private set; }
+
+    public static EofHitCounter RunDecoder(string testImage) => RunDecoder(TestFile.Create(testImage).Bytes);
+
+    public static EofHitCounter RunDecoder(byte[] imageData)
+    {
+        BufferedReadStream stream = new(Configuration.Default, new MemoryStream(imageData));
+        Image image = Image.Load(stream);
+        return new EofHitCounter(stream, image);
+    }
+
+    public void Dispose()
+    {
+        this.stream.Dispose();
+        this.Image.Dispose();
+    }
+}

--- a/tests/Images/Input/Pbm/00000_00000_premature_eof.ppm
+++ b/tests/Images/Input/Pbm/00000_00000_premature_eof.ppm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39cf6ca5b2f9d428c0c33e0fc7ab5e92c31e0c8a7d9e0276b9285f51a8ff547c
+size 69


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Add additonal checks to handle corrupt files better in the PBM decoder.

Also extend `BufferedReadStream` to monitor the number of times it has been made to hit EOF by read calls. This improves the testability of decoder behavior. The perf impact of the `BufferedReadStream` change is [within the margin of error](https://gist.github.com/antonfirsov/456c748e5bf1dc52c41f1e416560e4f1).