### PR TITLE
[release/2.1] Disallow allocation attempts of unrepresentable sizes

### DIFF
--- a/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
@@ -121,6 +121,11 @@ namespace SixLabors.ImageSharp.Memory
             AllocationOptions options = AllocationOptions.None)
         {
             long totalLengthInBytes = totalLength * Unsafe.SizeOf<T>();
+            if (totalLengthInBytes < 0)
+            {
+                throw new InvalidMemoryOperationException("Attempted to allocate a MemoryGroup of a size that is not representable.");
+            }
+
             if (totalLengthInBytes <= this.sharedArrayPoolThresholdInBytes)
             {
                 var buffer = new SharedArrayPoolBuffer<T>((int)totalLength);

--- a/tests/ImageSharp.Tests/Image/ImageTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.cs
@@ -41,6 +41,10 @@ namespace SixLabors.ImageSharp.Tests
             }
 
             [Fact]
+            public void Width_Height_SizeNotRepresentable_ThrowsInvalidImageOperationException()
+                => Assert.Throws<InvalidMemoryOperationException>(() => new Image<Rgba32>(int.MaxValue, int.MaxValue));
+
+            [Fact]
             public void Configuration_Width_Height()
             {
                 Configuration configuration = Configuration.Default.Clone();

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -112,6 +112,13 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
         }
 
         [Fact]
+        public void AllocateGroup_SizeInBytesOverLongMaxValue_ThrowsInvalidMemoryOperationException()
+        {
+            var allocator = new UniformUnmanagedMemoryPoolMemoryAllocator(null);
+            Assert.Throws<InvalidMemoryOperationException>(() => allocator.AllocateGroup<S4>(int.MaxValue * (long)int.MaxValue, int.MaxValue));
+        }
+
+        [Fact]
         public unsafe void Allocate_MemoryIsPinnableMultipleTimes()
         {
             var allocator = new UniformUnmanagedMemoryPoolMemoryAllocator(null);


### PR DESCRIPTION
Backport of #2545 to `release/2.1`.