### PR TITLE
[release/3.0] Disallow allocation attempts of unrepresentable sizes

### DIFF
--- a/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
@@ -117,6 +117,11 @@ internal sealed class UniformUnmanagedMemoryPoolMemoryAllocator : MemoryAllocato
         AllocationOptions options = AllocationOptions.None)
     {
         long totalLengthInBytes = totalLength * Unsafe.SizeOf<T>();
+        if (totalLengthInBytes < 0)
+        {
+            throw new InvalidMemoryOperationException("Attempted to allocate a MemoryGroup of a size that is not representable.");
+        }
+
         if (totalLengthInBytes <= this.sharedArrayPoolThresholdInBytes)
         {
             var buffer = new SharedArrayPoolBuffer<T>((int)totalLength);

--- a/tests/ImageSharp.Tests/Image/ImageTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.cs
@@ -6,6 +6,7 @@ using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Tests.Memory;
@@ -34,6 +35,10 @@ public partial class ImageTests
                 Assert.Equal(Configuration.Default, image.GetConfiguration());
             }
         }
+
+        [Fact]
+        public void Width_Height_SizeNotRepresentable_ThrowsInvalidImageOperationException()
+            => Assert.Throws<InvalidMemoryOperationException>(() => new Image<Rgba32>(int.MaxValue, int.MaxValue));
 
         [Fact]
         public void Configuration_Width_Height()

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -108,6 +108,13 @@ public class UniformUnmanagedPoolMemoryAllocatorTests
     }
 
     [Fact]
+    public void AllocateGroup_SizeInBytesOverLongMaxValue_ThrowsInvalidMemoryOperationException()
+    {
+        var allocator = new UniformUnmanagedMemoryPoolMemoryAllocator(null);
+        Assert.Throws<InvalidMemoryOperationException>(() => allocator.AllocateGroup<S4>(int.MaxValue * (long)int.MaxValue, int.MaxValue));
+    }
+
+    [Fact]
     public unsafe void Allocate_MemoryIsPinnableMultipleTimes()
     {
         var allocator = new UniformUnmanagedMemoryPoolMemoryAllocator(null);


### PR DESCRIPTION
Backport of #2545 to `release/v3.0.x`. I created that branch by renaming `release/v3.0.2`.