### PR TITLE
Confirm we can correctly decode jpegs with malformed D0-D7 chunks.

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -353,4 +353,15 @@ public partial class JpegDecoderTests
         Assert.Equal(65503, image.Width);
         Assert.Equal(65503, image.Height);
     }
+
+    // https://github.com/SixLabors/ImageSharp/issues/2517
+    [Theory]
+    [WithFile(TestImages.Jpeg.Issues.Issue2517, PixelTypes.Rgba32)]
+    public void Issue2517_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
+        image.DebugSave(provider);
+        image.CompareToOriginal(provider);
+    }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -307,6 +307,7 @@ public static class TestImages
             public const string Issue2478_JFXX = "Jpg/issues/issue-2478-jfxx.jpg";
             public const string Issue2564 = "Jpg/issues/issue-2564.jpg";
             public const string HangBadScan = "Jpg/issues/Hang_C438A851.jpg";
+            public const string Issue2517 = "Jpg/issues/issue2517-bad-d7.jpg";
 
             public static class Fuzz
             {

--- a/tests/Images/Input/Jpg/issues/issue2517-bad-d7.jpg
+++ b/tests/Images/Input/Jpg/issues/issue2517-bad-d7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:650a933db9c4f76fa3e6a8ed35d061a5740c613acd1026d99461eb014d8947b2
+size 179015


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Looks like this already works. Just added the test file for confirmation. 

<!-- Thanks for contributing to ImageSharp! -->
