### PR TITLE
Handle dedup of local palette of 256 length

### DIFF
--- a/src/ImageSharp/Formats/Webp/BitReader/Vp8LBitReader.cs
+++ b/src/ImageSharp/Formats/Webp/BitReader/Vp8LBitReader.cs
@@ -71,7 +71,7 @@ internal class Vp8LBitReader : BitReaderBase
         this.Eos = false;
 
         ulong currentValue = 0;
-        System.Span<byte> dataSpan = this.Data.Memory.Span;
+        Span<byte> dataSpan = this.Data.Memory.Span;
         for (int i = 0; i < 8; i++)
         {
             currentValue |= (ulong)dataSpan[i] << (8 * i);
@@ -103,7 +103,7 @@ internal class Vp8LBitReader : BitReaderBase
         }
 
         ulong currentValue = 0;
-        System.Span<byte> dataSpan = this.Data.Memory.Span;
+        Span<byte> dataSpan = this.Data.Memory.Span;
         for (int i = 0; i < length; i++)
         {
             currentValue |= (ulong)dataSpan[i] << (8 * i);

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -487,6 +487,7 @@ public static class TestImages
         public const string GlobalQuantizationTest = "Gif/GlobalQuantizationTest.gif";
         public const string MixedDisposal = "Gif/mixed-disposal.gif";
         public const string M4nb = "Gif/m4nb.gif";
+        public const string Bit18RGBCube = "Gif/18-bit_RGB_Cube.gif";
 
         // Test images from https://github.com/robert-ancell/pygif/tree/master/test-suite
         public const string ZeroSize = "Gif/image-zero-size.gif";
@@ -533,7 +534,8 @@ public static class TestImages
             Issues.Issue2450_A,
             Issues.Issue2450_B,
             Issues.BadDescriptorWidth,
-            Issues.Issue1530
+            Issues.Issue1530,
+            Bit18RGBCube
         };
     }
 

--- a/tests/Images/Input/Gif/18-bit_RGB_Cube.gif
+++ b/tests/Images/Input/Gif/18-bit_RGB_Cube.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5148c8c192385966ec6ad5b3d35195a878355d71146a958e5ef02b7642a4e883
+size 4311986


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
@saucecontrol found me an image that broke the new encoder. We'd missed an edge case here when local palettes are 256 length. 

I'll update main once this is merged. 

<!-- Thanks for contributing to ImageSharp! -->
