### PR TITLE
Correctly calculate foreground Rectangle when negative background location is set (3.1 fix)

### DIFF
--- a/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
+++ b/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
@@ -87,12 +87,14 @@ internal class DrawImageProcessor<TPixelBg, TPixelFg> : ImageProcessor<TPixelBg>
         if (this.BackgroundLocation.X < 0)
         {
             foregroundRectangle.Width += this.BackgroundLocation.X;
+            foregroundRectangle.X -= this.BackgroundLocation.X;
             left = 0;
         }
 
         if (this.BackgroundLocation.Y < 0)
         {
             foregroundRectangle.Height += this.BackgroundLocation.Y;
+            foregroundRectangle.Y -= this.BackgroundLocation.Y;
             top = 0;
         }
 

--- a/tests/ImageSharp.Tests/Drawing/DrawImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/DrawImageTests.cs
@@ -251,4 +251,25 @@ public class DrawImageTests
             appendPixelTypeToFileName: false,
             appendSourceFileOrDescription: false);
     }
+
+    [Theory]
+    [WithFile(TestImages.Png.Issue2447, PixelTypes.Rgba32)]
+    public void Issue2608_NegOffset<TPixel>(TestImageProvider<TPixel> provider)
+    where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> foreground = provider.GetImage();
+        using Image<Rgba32> background = new(100, 100, new Rgba32(0, 255, 255));
+
+        background.Mutate(c => c.DrawImage(foreground, new Point(-10, -10), new Rectangle(32, 32, 32, 32), 1F));
+
+        background.DebugSave(
+            provider,
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
+
+        background.CompareToReferenceOutput(
+            provider,
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
+    }
 }

--- a/tests/Images/External/ReferenceOutput/Drawing/DrawImageTests/Issue2608_NegOffset.png
+++ b/tests/Images/External/ReferenceOutput/Drawing/DrawImageTests/Issue2608_NegOffset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edfd0e17aa304f5b16ad42a761c044c3d617aaee9b9e1e74674567bbcd74d532
+size 590


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This fixes #2608 which incorrectly handles the a negative drawing target/background location when drawing an image, ensuing the correct portion of the foreground image is retained and never cropped incorrectly.

The foreground rectangle is supposed to be in the foreground images coordinate space where are the background location is in the background images coordinate space, so we need to offset the x, y by the amount we shrink it by when unifying them to determine the portion of the foreground we are interested in.


This still does not change the rules for the foregrounds rectangle as that should not  support a negative x,y but only effects the background/target location we will draw the final cropped foreground image to.