### PR TITLE
Handle case when Foreground image overhangs bottom of background image during DrawImage Call (3.1 target)

### DIFF
--- a/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
+++ b/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
@@ -96,14 +96,14 @@ internal class DrawImageProcessor<TPixelBg, TPixelFg> : ImageProcessor<TPixelBg>
             top = 0;
         }
 
-        if (left + foregroundRectangle.Width > source.Width)
+        if (left > source.Width - foregroundRectangle.Width)
         {
             // will overhange, lets trim it down
             int diff = (left + foregroundRectangle.Width) - source.Width;
             foregroundRectangle.Width -= diff;
         }
 
-        if (top + foregroundRectangle.Height > source.Height)
+        if (top > source.Height - foregroundRectangle.Height)
         {
             // will overhange, lets trim it down
             int diff = (top + foregroundRectangle.Height) - source.Height;

--- a/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
+++ b/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
@@ -96,6 +96,20 @@ internal class DrawImageProcessor<TPixelBg, TPixelFg> : ImageProcessor<TPixelBg>
             top = 0;
         }
 
+        if (left + foregroundRectangle.Width > source.Width)
+        {
+            // will overhange, lets trim it down
+            int diff = (left + foregroundRectangle.Width) - source.Width;
+            foregroundRectangle.Width -= diff;
+        }
+
+        if (top + foregroundRectangle.Height > source.Height)
+        {
+            // will overhange, lets trim it down
+            int diff = (top + foregroundRectangle.Height) - source.Height;
+            foregroundRectangle.Height -= diff;
+        }
+
         int width = foregroundRectangle.Width;
         int height = foregroundRectangle.Height;
         if (width <= 0 || height <= 0)

--- a/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
+++ b/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
@@ -96,19 +96,9 @@ internal class DrawImageProcessor<TPixelBg, TPixelFg> : ImageProcessor<TPixelBg>
             top = 0;
         }
 
-        if (left > source.Width - foregroundRectangle.Width)
-        {
-            // will overhange, lets trim it down
-            int diff = (left + foregroundRectangle.Width) - source.Width;
-            foregroundRectangle.Width -= diff;
-        }
-
-        if (top > source.Height - foregroundRectangle.Height)
-        {
-            // will overhange, lets trim it down
-            int diff = (top + foregroundRectangle.Height) - source.Height;
-            foregroundRectangle.Height -= diff;
-        }
+        // clamp the height/width to the availible space left to prevent overflowing
+        foregroundRectangle.Width = Math.Min(source.Width - left, foregroundRectangle.Width);
+        foregroundRectangle.Height = Math.Min(source.Height - top, foregroundRectangle.Height);
 
         int width = foregroundRectangle.Width;
         int height = foregroundRectangle.Height;

--- a/tests/ImageSharp.Tests/Drawing/DrawImageTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/DrawImageTests.cs
@@ -251,4 +251,25 @@ public class DrawImageTests
             appendPixelTypeToFileName: false,
             appendSourceFileOrDescription: false);
     }
+
+    [Theory]
+    [WithFile(TestImages.Png.Issue2447, PixelTypes.Rgba32)]
+    public void Issue2603<TPixel>(TestImageProvider<TPixel> provider)
+    where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> foreground = provider.GetImage();
+        using Image<Rgba32> background = new(100, 100, new Rgba32(0, 255, 255));
+
+        background.Mutate(c => c.DrawImage(foreground, new Point(80, 80), new Rectangle(32, 32, 32, 32), 1F));
+
+        background.DebugSave(
+            provider,
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
+
+        background.CompareToReferenceOutput(
+            provider,
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
+    }
 }

--- a/tests/Images/External/ReferenceOutput/Drawing/DrawImageTests/Issue2603.png
+++ b/tests/Images/External/ReferenceOutput/Drawing/DrawImageTests/Issue2603.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:307ef8cea7999e615420740bb0a403a64b24f1fff5356c2ac45c1952f84c5e4c
+size 508


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Prevents the `ArgumentOutOfRangeException` when the area of interest of the foreground image will be drawn past the edge of the bounds of the background image.

fixes #2603 
related to #2609

Targeting 3.1 release branch
