### PR TITLE
Fix handling gif encoding for global palettes. 

### DIFF
--- a/src/ImageSharp/Formats/Gif/MetadataExtensions.cs
+++ b/src/ImageSharp/Formats/Gif/MetadataExtensions.cs
@@ -82,6 +82,9 @@ public static partial class MetadataExtensions
         // has a local palette with 256 colors and is not transparent we should use 'Source'.
         bool blendSource = source.DisposalMethod == GifDisposalMethod.RestoreToBackground || (source.LocalColorTable?.Length == 256 && !source.HasTransparency);
 
+        // If the color table is global and frame has no transparency. Consider it 'Source' also.
+        blendSource |= source.ColorTableMode == GifColorTableMode.Global && !source.HasTransparency;
+
         return new()
         {
             ColorTable = source.LocalColorTable,

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -488,6 +488,7 @@ public static class TestImages
         public const string MixedDisposal = "Gif/mixed-disposal.gif";
         public const string M4nb = "Gif/m4nb.gif";
         public const string Bit18RGBCube = "Gif/18-bit_RGB_Cube.gif";
+        public const string Global256NoTrans = "Gif/global-256-no-trans.gif";
 
         // Test images from https://github.com/robert-ancell/pygif/tree/master/test-suite
         public const string ZeroSize = "Gif/image-zero-size.gif";
@@ -535,7 +536,8 @@ public static class TestImages
             Issues.Issue2450_B,
             Issues.BadDescriptorWidth,
             Issues.Issue1530,
-            Bit18RGBCube
+            Bit18RGBCube,
+            Global256NoTrans
         };
     }
 

--- a/tests/Images/Input/Gif/global-256-no-trans.gif
+++ b/tests/Images/Input/Gif/global-256-no-trans.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce8ed23b4e21328886f5aa7579079123ff6401efdf65e162e565b056ffddab56
+size 669286


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
See https://github.com/SixLabors/ImageSharp.Web/issues/344#issuecomment-1849642440

When an input gif has a full, non-transparent global palette we should use own to allow deduplication. Same image is reduced by 26% on encode. 

<!-- Thanks for contributing to ImageSharp! -->
