### PR TITLE
Fix Paeth Filter decode on platforms that do not support Ssse3

### DIFF
--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -35,9 +35,9 @@ internal static class PaethFilter
         // row:  a d
         // The Paeth function predicts d to be whichever of a, b, or c is nearest to
         // p = a + b - c.
-        if (Sse2.IsSupported && bytesPerPixel is 4)
+        if (Ssse3.IsSupported && bytesPerPixel is 4)
         {
-            DecodeSse3(scanline, previousScanline);
+            DecodeSsse3(scanline, previousScanline);
         }
         else if (AdvSimd.Arm64.IsSupported && bytesPerPixel is 4)
         {
@@ -50,7 +50,7 @@ internal static class PaethFilter
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void DecodeSse3(Span<byte> scanline, Span<byte> previousScanline)
+    private static void DecodeSsse3(Span<byte> scanline, Span<byte> previousScanline)
     {
         ref byte scanBaseRef = ref MemoryMarshal.GetReference(scanline);
         ref byte prevBaseRef = ref MemoryMarshal.GetReference(previousScanline);

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderFilterTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderFilterTests.cs
@@ -171,5 +171,8 @@ public class PngDecoderFilterTests
     public void PaethFilter_WithHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPaethFilterTest, HwIntrinsics.AllowAll);
 
     [Fact]
+    public void PaethFilter_WithoutSsse3_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPaethFilterTest, HwIntrinsics.DisableSSSE3);
+
+    [Fact]
     public void PaethFilter_WithoutHardwareIntrinsics_Works() => FeatureTestRunner.RunWithHwIntrinsicsFeature(RunPaethFilterTest, HwIntrinsics.DisableHWIntrinsic);
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #2617 

<!-- Thanks for contributing to ImageSharp! -->
