### PR TITLE
Adjusted the casing of the Webp format name

### DIFF
--- a/src/ImageSharp/Formats/Webp/WebpFormat.cs
+++ b/src/ImageSharp/Formats/Webp/WebpFormat.cs
@@ -18,7 +18,7 @@ public sealed class WebpFormat : IImageFormat<WebpMetadata, WebpFrameMetadata>
     public static WebpFormat Instance { get; } = new WebpFormat();
 
     /// <inheritdoc/>
-    public string Name => "Webp";
+    public string Name => "WEBP";
 
     /// <inheritdoc/>
     public string DefaultMimeType => "image/webp";


### PR DESCRIPTION
I adjusted the casing the Webp format name. It is the only format that has a mixed case name. All other formats are in upper case. This helps eliminate the need for case insensitive matching of format names (which is not always possible).
