### PR TITLE
Make DrawImage processor more robust to bad input.

### DIFF
--- a/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
+++ b/src/ImageSharp/Processing/Processors/Drawing/DrawImageProcessor{TPixelBg,TPixelFg}.cs
@@ -98,9 +98,10 @@ internal class DrawImageProcessor<TPixelBg, TPixelFg> : ImageProcessor<TPixelBg>
             top = 0;
         }
 
-        // clamp the height/width to the availible space left to prevent overflowing
+        // Clamp the height/width to the available space left to prevent overflowing
         foregroundRectangle.Width = Math.Min(source.Width - left, foregroundRectangle.Width);
         foregroundRectangle.Height = Math.Min(source.Height - top, foregroundRectangle.Height);
+        foregroundRectangle = Rectangle.Intersect(foregroundRectangle, this.ForegroundImage.Bounds);
 
         int width = foregroundRectangle.Width;
         int height = foregroundRectangle.Height;
@@ -111,7 +112,6 @@ internal class DrawImageProcessor<TPixelBg, TPixelFg> : ImageProcessor<TPixelBg>
         }
 
         // Sanitize the dimensions so that we don't try and sample outside the image.
-        foregroundRectangle = Rectangle.Intersect(foregroundRectangle, this.ForegroundImage.Bounds);
         Rectangle backgroundRectangle = Rectangle.Intersect(new(left, top, width, height), this.SourceRectangle);
         Configuration configuration = this.Configuration;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Moving the foreground image intersect to before the sanitation check ensures invalid arguments are not processed.

Fixes #2663 will duplicate for main following this fix.

<!-- Thanks for contributing to ImageSharp! -->
