### PR TITLE
Add option to WebP encoder to ignore animation

### DIFF
--- a/src/ImageSharp/Formats/Webp/WebpEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/WebpEncoder.cs
@@ -77,6 +77,11 @@ public sealed class WebpEncoder : ImageEncoder
     /// </summary>
     public int NearLosslessQuality { get; init; } = 100;
 
+    /// <summary>
+    /// Gets a value indicating whether to ignore the animation and save as a static image when encoding.
+    /// </summary>
+    public bool IgnoreAnimation { get; init; }
+
     /// <inheritdoc/>
     protected override void Encode<TPixel>(Image<TPixel> image, Stream stream, CancellationToken cancellationToken)
     {

--- a/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
@@ -71,6 +71,11 @@ internal sealed class WebpEncoderCore : IImageEncoderInternals
     private readonly int nearLosslessQuality;
 
     /// <summary>
+    /// Whether to ignore the animation and save as a static image when encoding.
+    /// </summary>
+    private readonly bool ignoreAnimation;
+
+    /// <summary>
     /// Indicating what file format compression should be used.
     /// Defaults to lossy.
     /// </summary>
@@ -101,6 +106,7 @@ internal sealed class WebpEncoderCore : IImageEncoderInternals
         this.skipMetadata = encoder.SkipMetadata;
         this.nearLossless = encoder.NearLossless;
         this.nearLosslessQuality = encoder.NearLosslessQuality;
+        this.ignoreAnimation = encoder.IgnoreAnimation;
     }
 
     /// <summary>
@@ -129,7 +135,7 @@ internal sealed class WebpEncoderCore : IImageEncoderInternals
 
         if (lossless)
         {
-            bool hasAnimation = image.Frames.Count > 1;
+            bool hasAnimation = !this.ignoreAnimation && (image.Frames.Count > 1);
 
             using Vp8LEncoder encoder = new(
                 this.memoryAllocator,

--- a/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
@@ -220,7 +220,7 @@ internal sealed class WebpEncoderCore : IImageEncoderInternals
                 this.spatialNoiseShaping,
                 this.alphaCompression);
 
-            if (image.Frames.Count > 1)
+            if (!this.ignoreAnimation && image.Frames.Count > 1)
             {
                 // TODO: What about alpha here?
                 encoder.EncodeHeader(image, stream, false, true);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [?] I have provided test coverage for my change (where applicable)
   - Would be glad to, not really sure how to write such a test

### Description
Details at: https://github.com/SixLabors/ImageSharp/discussions/2697

TLDR; While the new ability to encode animated WebPs is amazing, there are cases in which one would want to encode both an animated and static version of the image without decoding multiple times. A simple flag is sufficient to make this possible.
