### PR TITLE
Ensure VP8X alpha flag is updated correctly.

### DIFF
--- a/src/ImageSharp/Common/Helpers/RiffHelper.cs
+++ b/src/ImageSharp/Common/Helpers/RiffHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers.Binary;
 using System.Text;
+using SixLabors.ImageSharp.Formats.Webp.Chunks;
 
 namespace SixLabors.ImageSharp.Common.Helpers;
 
@@ -107,6 +108,7 @@ internal static class RiffHelper
             position++;
         }
 
+        // Add the size of the encoded file to the Riff header.
         BinaryPrimitives.WriteUInt32LittleEndian(buffer, dataSize);
         stream.Position = sizePosition;
         stream.Write(buffer);
@@ -120,5 +122,18 @@ internal static class RiffHelper
         return sizePosition;
     }
 
-    public static void EndWriteRiffFile(Stream stream, long sizePosition) => EndWriteChunk(stream, sizePosition);
+    public static void EndWriteRiffFile(Stream stream, in WebpVp8X vp8x, bool updateVp8x, long sizePosition)
+    {
+        EndWriteChunk(stream, sizePosition + 4);
+
+        // Write the VP8X chunk if necessary.
+        if (updateVp8x)
+        {
+            long position = stream.Position;
+
+            stream.Position = sizePosition + 12;
+            vp8x.WriteTo(stream);
+            stream.Position = position;
+        }
+    }
 }

--- a/src/ImageSharp/Formats/Webp/Chunks/WebpVp8X.cs
+++ b/src/ImageSharp/Formats/Webp/Chunks/WebpVp8X.cs
@@ -5,7 +5,7 @@ using SixLabors.ImageSharp.Common.Helpers;
 
 namespace SixLabors.ImageSharp.Formats.Webp.Chunks;
 
-internal readonly struct WebpVp8X
+internal readonly struct WebpVp8X : IEquatable<WebpVp8X>
 {
     public WebpVp8X(bool hasAnimation, bool hasXmp, bool hasExif, bool hasAlpha, bool hasIcc, uint width, uint height)
     {
@@ -53,6 +53,24 @@ internal readonly struct WebpVp8X
     /// </summary>
     public uint Height { get; }
 
+    public static bool operator ==(WebpVp8X left, WebpVp8X right) => left.Equals(right);
+
+    public static bool operator !=(WebpVp8X left, WebpVp8X right) => !(left == right);
+
+    public override bool Equals(object? obj) => obj is WebpVp8X x && this.Equals(x);
+
+    public bool Equals(WebpVp8X other)
+        => this.HasAnimation == other.HasAnimation
+        && this.HasXmp == other.HasXmp
+        && this.HasExif == other.HasExif
+        && this.HasAlpha == other.HasAlpha
+        && this.HasIcc == other.HasIcc
+        && this.Width == other.Width
+        && this.Height == other.Height;
+
+    public override int GetHashCode() 
+        => HashCode.Combine(this.HasAnimation, this.HasXmp, this.HasExif, this.HasAlpha, this.HasIcc, this.Width, this.Height);
+
     public void Validate(uint maxDimension, ulong maxCanvasPixels)
     {
         if (this.Width > maxDimension || this.Height > maxDimension)
@@ -66,6 +84,9 @@ internal readonly struct WebpVp8X
             WebpThrowHelper.ThrowInvalidImageDimensions("The product of image width and height MUST be at most 2^32 - 1");
         }
     }
+
+    public WebpVp8X WithAlpha(bool hasAlpha)
+        => new(this.HasAnimation, this.HasXmp, this.HasExif, hasAlpha, this.HasIcc, this.Width, this.Height);
 
     public void WriteTo(Stream stream)
     {

--- a/src/ImageSharp/Formats/Webp/Chunks/WebpVp8X.cs
+++ b/src/ImageSharp/Formats/Webp/Chunks/WebpVp8X.cs
@@ -68,7 +68,7 @@ internal readonly struct WebpVp8X : IEquatable<WebpVp8X>
         && this.Width == other.Width
         && this.Height == other.Height;
 
-    public override int GetHashCode() 
+    public override int GetHashCode()
         => HashCode.Combine(this.HasAnimation, this.HasXmp, this.HasExif, this.HasAlpha, this.HasIcc, this.Width, this.Height);
 
     public void Validate(uint maxDimension, ulong maxCanvasPixels)

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -237,7 +237,7 @@ internal class Vp8LEncoder : IDisposable
     /// </summary>
     public Vp8LHashChain HashChain { get; }
 
-    public void EncodeHeader<TPixel>(Image<TPixel> image, Stream stream, bool hasAnimation)
+    public WebpVp8X EncodeHeader<TPixel>(Image<TPixel> image, Stream stream, bool hasAnimation)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         // Write bytes from the bit-writer buffer to the stream.
@@ -247,7 +247,8 @@ internal class Vp8LEncoder : IDisposable
         ExifProfile exifProfile = this.skipMetadata ? null : metadata.ExifProfile;
         XmpProfile xmpProfile = this.skipMetadata ? null : metadata.XmpProfile;
 
-        BitWriterBase.WriteTrunksBeforeData(
+        // The alpha flag is updated following encoding.
+        WebpVp8X vp8x = BitWriterBase.WriteTrunksBeforeData(
             stream,
             (uint)image.Width,
             (uint)image.Height,
@@ -262,9 +263,11 @@ internal class Vp8LEncoder : IDisposable
             WebpMetadata webpMetadata = WebpCommonUtils.GetWebpMetadata(image);
             BitWriterBase.WriteAnimationParameter(stream, webpMetadata.BackgroundColor, webpMetadata.RepeatCount);
         }
+
+        return vp8x;
     }
 
-    public void EncodeFooter<TPixel>(Image<TPixel> image, Stream stream)
+    public void EncodeFooter<TPixel>(Image<TPixel> image, in WebpVp8X vp8x, bool hasAlpha, Stream stream, long initialPosition)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         // Write bytes from the bit-writer buffer to the stream.
@@ -273,7 +276,9 @@ internal class Vp8LEncoder : IDisposable
         ExifProfile exifProfile = this.skipMetadata ? null : metadata.ExifProfile;
         XmpProfile xmpProfile = this.skipMetadata ? null : metadata.XmpProfile;
 
-        BitWriterBase.WriteTrunksAfterData(stream, exifProfile, xmpProfile);
+        bool updateVp8x = hasAlpha && vp8x != default;
+        WebpVp8X updated = updateVp8x ? vp8x.WithAlpha(true) : vp8x;
+        BitWriterBase.WriteTrunksAfterData(stream, in updated, updateVp8x, initialPosition, exifProfile, xmpProfile);
     }
 
     /// <summary>
@@ -285,7 +290,8 @@ internal class Vp8LEncoder : IDisposable
     /// <param name="frameMetadata">The frame metadata.</param>
     /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
     /// <param name="hasAnimation">Flag indicating, if an animation parameter is present.</param>
-    public void Encode<TPixel>(ImageFrame<TPixel> frame, Rectangle bounds, WebpFrameMetadata frameMetadata, Stream stream, bool hasAnimation)
+    /// <returns>A <see cref="bool"/> indicating whether the frame contains an alpha channel.</returns>
+    public bool Encode<TPixel>(ImageFrame<TPixel> frame, Rectangle bounds, WebpFrameMetadata frameMetadata, Stream stream, bool hasAnimation)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         // Convert image pixels to bgra array.
@@ -324,6 +330,8 @@ internal class Vp8LEncoder : IDisposable
         {
             RiffHelper.EndWriteChunk(stream, prevPosition);
         }
+
+        return hasAlpha;
     }
 
     /// <summary>
@@ -502,7 +510,7 @@ internal class Vp8LEncoder : IDisposable
     /// <typeparam name="TPixel">The type of the pixels.</typeparam>
     /// <param name="pixels">The frame pixel buffer to convert.</param>
     /// <returns>true, if the image is non opaque.</returns>
-    private bool ConvertPixelsToBgra<TPixel>(Buffer2DRegion<TPixel> pixels)
+    public bool ConvertPixelsToBgra<TPixel>(Buffer2DRegion<TPixel> pixels)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         bool nonOpaque = false;

--- a/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossy/Vp8Encoder.cs
@@ -311,7 +311,7 @@ internal class Vp8Encoder : IDisposable
     /// </summary>
     private int MbHeaderLimit { get; }
 
-    public void EncodeHeader<TPixel>(Image<TPixel> image, Stream stream, bool hasAlpha, bool hasAnimation)
+    public WebpVp8X EncodeHeader<TPixel>(Image<TPixel> image, Stream stream, bool hasAlpha, bool hasAnimation)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         // Write bytes from the bitwriter buffer to the stream.
@@ -321,7 +321,7 @@ internal class Vp8Encoder : IDisposable
         ExifProfile exifProfile = this.skipMetadata ? null : metadata.ExifProfile;
         XmpProfile xmpProfile = this.skipMetadata ? null : metadata.XmpProfile;
 
-        BitWriterBase.WriteTrunksBeforeData(
+        WebpVp8X vp8x = BitWriterBase.WriteTrunksBeforeData(
             stream,
             (uint)image.Width,
             (uint)image.Height,
@@ -336,9 +336,11 @@ internal class Vp8Encoder : IDisposable
             WebpMetadata webpMetadata = WebpCommonUtils.GetWebpMetadata(image);
             BitWriterBase.WriteAnimationParameter(stream, webpMetadata.BackgroundColor, webpMetadata.RepeatCount);
         }
+
+        return vp8x;
     }
 
-    public void EncodeFooter<TPixel>(Image<TPixel> image, Stream stream)
+    public void EncodeFooter<TPixel>(Image<TPixel> image, in WebpVp8X vp8x, bool hasAlpha, Stream stream, long initialPosition)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         // Write bytes from the bitwriter buffer to the stream.
@@ -347,7 +349,9 @@ internal class Vp8Encoder : IDisposable
         ExifProfile exifProfile = this.skipMetadata ? null : metadata.ExifProfile;
         XmpProfile xmpProfile = this.skipMetadata ? null : metadata.XmpProfile;
 
-        BitWriterBase.WriteTrunksAfterData(stream, exifProfile, xmpProfile);
+        bool updateVp8x = hasAlpha && vp8x != default;
+        WebpVp8X updated = updateVp8x ? vp8x.WithAlpha(true) : vp8x;
+        BitWriterBase.WriteTrunksAfterData(stream, in updated, updateVp8x, initialPosition, exifProfile, xmpProfile);
     }
 
     /// <summary>
@@ -358,9 +362,10 @@ internal class Vp8Encoder : IDisposable
     /// <param name="stream">The stream to encode the image data to.</param>
     /// <param name="bounds">The region of interest within the frame to encode.</param>
     /// <param name="frameMetadata">The frame metadata.</param>
-    public void EncodeAnimation<TPixel>(ImageFrame<TPixel> frame, Stream stream, Rectangle bounds, WebpFrameMetadata frameMetadata)
-        where TPixel : unmanaged, IPixel<TPixel> =>
-        this.Encode(stream, frame, bounds, frameMetadata, true, null);
+    /// <returns>A <see cref="bool"/> indicating whether the frame contains an alpha channel.</returns>
+    public bool EncodeAnimation<TPixel>(ImageFrame<TPixel> frame, Stream stream, Rectangle bounds, WebpFrameMetadata frameMetadata)
+        where TPixel : unmanaged, IPixel<TPixel>
+        => this.Encode(stream, frame, bounds, frameMetadata, true, null);
 
     /// <summary>
     /// Encodes the static image frame to the specified stream.
@@ -385,7 +390,8 @@ internal class Vp8Encoder : IDisposable
     /// <param name="frameMetadata">The frame metadata.</param>
     /// <param name="hasAnimation">Flag indicating, if an animation parameter is present.</param>
     /// <param name="image">The image to encode from.</param>
-    private void Encode<TPixel>(Stream stream, ImageFrame<TPixel> frame, Rectangle bounds, WebpFrameMetadata frameMetadata, bool hasAnimation, Image<TPixel> image)
+    /// <returns>A <see cref="bool"/> indicating whether the frame contains an alpha channel.</returns>
+    private bool Encode<TPixel>(Stream stream, ImageFrame<TPixel> frame, Rectangle bounds, WebpFrameMetadata frameMetadata, bool hasAnimation, Image<TPixel> image)
         where TPixel : unmanaged, IPixel<TPixel>
     {
         int width = bounds.Width;
@@ -515,6 +521,8 @@ internal class Vp8Encoder : IDisposable
         {
             encodedAlphaData?.Dispose();
         }
+
+        return hasAlpha;
     }
 
     /// <inheritdoc/>

--- a/src/ImageSharp/Formats/Webp/WebpChunkParsingUtils.cs
+++ b/src/ImageSharp/Formats/Webp/WebpChunkParsingUtils.cs
@@ -2,7 +2,6 @@
 // Licensed under the Six Labors Split License.
 
 using System.Buffers.Binary;
-using System.Drawing;
 using SixLabors.ImageSharp.Formats.Webp.BitReader;
 using SixLabors.ImageSharp.Formats.Webp.Lossy;
 using SixLabors.ImageSharp.IO;

--- a/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
@@ -54,7 +54,7 @@ internal sealed class WebpDecoderCore : IImageDecoderInternals, IDisposable
     /// <summary>
     /// The flag to decide how to handle the background color in the Animation Chunk.
     /// </summary>
-    private BackgroundColorHandling backgroundColorHandling;
+    private readonly BackgroundColorHandling backgroundColorHandling;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WebpDecoderCore"/> class.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
When encoding webp image using the [extended format](https://developers.google.com/speed/webp/docs/riff_container#extended_file_format) we must ensure that the VP8X chunk contains the correct alpha flags in order to correctly display alpha color.

Fixes #2692 and https://github.com/SixLabors/ImageSharp/issues/2528#issuecomment-1993901348

<!-- Thanks for contributing to ImageSharp! -->
