### PR TITLE
Backport - Only exit JPEG scan decoding after multiple EOF hits

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
@@ -84,9 +84,6 @@ internal struct JpegBitReader
     [MethodImpl(InliningOptions.ShortMethod)]
     public bool HasBadMarker() => this.Marker != JpegConstants.Markers.XFF && !this.HasRestartMarker();
 
-    [MethodImpl(InliningOptions.ShortMethod)]
-    public bool HasEndMarker() => this.Marker == JpegConstants.Markers.EOI;
-
     [MethodImpl(InliningOptions.AlwaysInline)]
     public void FillBuffer()
     {

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/JpegBitReader.cs
@@ -223,7 +223,7 @@ internal struct JpegBitReader
         // we know we have hit the EOI and completed decoding the scan buffer.
         if (value == -1 || (this.badData && this.data == 0 && this.stream.Position >= this.stream.Length))
         {
-            // We've passed the end of the file stream which means there's no EOI marker
+            // We've hit the end of the file stream more times than allowed which means there's no EOI marker
             // in the image or the SOS marker has the wrong dimensions set.
             if (this.eofHitCount > JpegConstants.Huffman.FetchLoop)
             {

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -364,4 +364,15 @@ public partial class JpegDecoderTests
         image.DebugSave(provider);
         image.CompareToOriginal(provider);
     }
+
+    // https://github.com/SixLabors/ImageSharp/issues/2638
+    [Theory]
+    [WithFile(TestImages.Jpeg.Issues.Issue2638, PixelTypes.Rgba32)]
+    public void Issue2638_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
+        image.DebugSave(provider);
+        image.CompareToOriginal(provider);
+    }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -315,6 +315,7 @@ public static class TestImages
             public const string Issue2564 = "Jpg/issues/issue-2564.jpg";
             public const string HangBadScan = "Jpg/issues/Hang_C438A851.jpg";
             public const string Issue2517 = "Jpg/issues/issue2517-bad-d7.jpg";
+            public const string Issue2638 = "Jpg/issues/Issue2638.jpg";
 
             public static class Fuzz
             {

--- a/tests/Images/Input/Jpg/issues/Issue2638.jpg
+++ b/tests/Images/Input/Jpg/issues/Issue2638.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:208d5b0b727bbef120a7e090e020a48f99c9e264c2d3939ba749f8620853c1fe
+size 70876


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backport of #2701 Fixes #2638 

<!-- Thanks for contributing to ImageSharp! -->
