### PR TITLE
Limit all memory allocations to configurable values.

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -1422,6 +1422,16 @@ internal sealed class BmpDecoderCore : IImageDecoderInternals
         this.ReadFileHeader(stream);
         this.ReadInfoHeader(stream);
 
+        // BMPs with negative-or-zero width are invalid. Also, reject extremely wide images
+        // to keep the math sane. And reject int.MinValue as a height because you can't
+        // get its absolute value (because -int.MinValue is one more than int.MaxValue).
+        const int k64KWidth = 65535;
+        bool sizeOk = this.infoHeader.Width > 0 && this.infoHeader.Width <= k64KWidth && this.infoHeader.Height != int.MinValue;
+        if (!sizeOk)
+        {
+            BmpThrowHelper.ThrowInvalidImageContentException($"Invalid file header dimensions found. {this.infoHeader.Width}x{this.infoHeader.Height}px.");
+        }
+
         // see http://www.drdobbs.com/architecture-and-design/the-bmp-file-format-part-1/184409517
         // If the height is negative, then this is a Windows bitmap whose origin
         // is the upper-left corner and not the lower-left. The inverted flag

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -1422,16 +1422,6 @@ internal sealed class BmpDecoderCore : IImageDecoderInternals
         this.ReadFileHeader(stream);
         this.ReadInfoHeader(stream);
 
-        // BMPs with negative-or-zero width are invalid. Also, reject extremely wide images
-        // to keep the math sane. And reject int.MinValue as a height because you can't
-        // get its absolute value (because -int.MinValue is one more than int.MaxValue).
-        const int k64KWidth = 65535;
-        bool sizeOk = this.infoHeader.Width > 0 && this.infoHeader.Width <= k64KWidth && this.infoHeader.Height != int.MinValue;
-        if (!sizeOk)
-        {
-            BmpThrowHelper.ThrowInvalidImageContentException($"Invalid file header dimensions found. {this.infoHeader.Width}x{this.infoHeader.Height}px.");
-        }
-
         // see http://www.drdobbs.com/architecture-and-design/the-bmp-file-format-part-1/184409517
         // If the height is negative, then this is a Windows bitmap whose origin
         // is the upper-left corner and not the lower-left. The inverted flag

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/ComponentProcessors/ComponentProcessor.cs
@@ -16,7 +16,7 @@ internal abstract class ComponentProcessor : IDisposable
         this.Component = component;
 
         this.BlockAreaSize = component.SubSamplingDivisors * blockSize;
-        this.ColorBuffer = memoryAllocator.Allocate2DOveraligned<float>(
+        this.ColorBuffer = memoryAllocator.Allocate2DOverAligned<float>(
             postProcessorBufferSize.Width,
             postProcessorBufferSize.Height,
             this.BlockAreaSize.Height);

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/ComponentProcessor.cs
@@ -28,7 +28,7 @@ internal class ComponentProcessor : IDisposable
         this.blockAreaSize = component.SubSamplingDivisors * 8;
 
         // alignment of 8 so each block stride can be sampled from a single 'ref pointer'
-        this.ColorBuffer = memoryAllocator.Allocate2DOveraligned<float>(
+        this.ColorBuffer = memoryAllocator.Allocate2DOverAligned<float>(
             postProcessorBufferSize.Width,
             postProcessorBufferSize.Height,
             8,

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1968,6 +1968,9 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
         }
 
         // We rent the buffer here to return it afterwards in Decode()
+        // We don't want to throw a degenerated memory exception here as we want to allow partial decoding
+        // so limit the length.
+        length = (int)Math.Min(length, this.currentStream.Length - this.currentStream.Position);
         IMemoryOwner<byte> buffer = this.configuration.MemoryAllocator.Allocate<byte>(length, AllocationOptions.Clean);
 
         this.currentStream.Read(buffer.GetSpan(), 0, length);

--- a/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
@@ -29,8 +29,8 @@ public abstract class MemoryAllocator
     /// <summary>
     /// Gets or sets the maximum allowable allocatable size of a 1 dimensional buffer.
     /// </summary>
-    /// Defaults to <value>65535 * 4.</value>
-    public int MaxAllocatableSize1D { get; set; } = ushort.MaxValue * 4;
+    /// Defaults to <value>65535 * 64.</value>
+    public int MaxAllocatableSize1D { get; set; } = ushort.MaxValue * 64;
 
     /// <summary>
     /// Gets the length of the largest contiguous buffer that can be handled by this allocator instance in bytes.

--- a/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
@@ -21,6 +21,18 @@ public abstract class MemoryAllocator
     public static MemoryAllocator Default { get; } = Create();
 
     /// <summary>
+    /// Gets or sets the maximum allowable allocatable size of a 2 dimensional buffer.
+    /// Defaults to <value>65535 * 65535.</value>
+    /// </summary>
+    public Size MaxAllocatableSize2D { get; set; } = new Size(ushort.MaxValue, ushort.MaxValue);
+
+    /// <summary>
+    /// Gets or sets the maximum allowable allocatable size of a 1 dimensional buffer.
+    /// </summary>
+    /// Defaults to <value>65535 * 4.</value>
+    public int MaxAllocatableSize1D { get; set; } = ushort.MaxValue * 4;
+
+    /// <summary>
     /// Gets the length of the largest contiguous buffer that can be handled by this allocator instance in bytes.
     /// </summary>
     /// <returns>The length of the largest contiguous buffer that can be handled by this allocator instance.</returns>
@@ -42,7 +54,7 @@ public abstract class MemoryAllocator
         new UniformUnmanagedMemoryPoolMemoryAllocator(options.MaximumPoolSizeMegabytes);
 
     /// <summary>
-    /// Allocates an <see cref="IMemoryOwner{T}" />, holding a <see cref="Memory{T}"/> of length <paramref name="length"/>.
+    /// Allocates an <see cref="IMemoryOwner{T}"/>, holding a <see cref="Memory{T}"/> of length <paramref name="length"/>.
     /// </summary>
     /// <typeparam name="T">Type of the data stored in the buffer.</typeparam>
     /// <param name="length">Size of the buffer to allocate.</param>
@@ -64,6 +76,7 @@ public abstract class MemoryAllocator
     /// <summary>
     /// Allocates a <see cref="MemoryGroup{T}"/>.
     /// </summary>
+    /// <typeparam name="T">Type of the data stored in the buffer.</typeparam>
     /// <param name="totalLength">The total length of the buffer.</param>
     /// <param name="bufferAlignment">The expected alignment (eg. to make sure image rows fit into single buffers).</param>
     /// <param name="options">The <see cref="AllocationOptions"/>.</param>

--- a/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
@@ -135,7 +135,7 @@ public abstract class MemoryAllocator
         // It's possible to require buffers that are not related to image dimensions.
         // For example, when we need to allocate buffers for IDAT chunks in PNG files or when allocating
         // cache buffers for image quantization.
-        // Limit the maximum buffer size to 64MB for 64bit processes and 32MB for 32 bit processes.
+        // Limit the maximum buffer size to 64MB for 64-bit processes and 32MB for 32-bit processes.
         int limitInMB = Environment.Is64BitProcess ? 64 : 32;
         return limitInMB * 1024 * 1024;
     }

--- a/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
@@ -29,8 +29,8 @@ public abstract class MemoryAllocator
     /// <summary>
     /// Gets or sets the maximum allowable allocatable size of a 1 dimensional buffer.
     /// </summary>
-    /// Defaults to <value>65535 * 64.</value>
-    public int MaxAllocatableSize1D { get; set; } = ushort.MaxValue * 64;
+    /// Defaults to <value>1073741823.</value>
+    public int MaxAllocatableSize1D { get; set; } = int.MaxValue / 2;
 
     /// <summary>
     /// Gets the length of the largest contiguous buffer that can be handled by this allocator instance in bytes.
@@ -88,4 +88,14 @@ public abstract class MemoryAllocator
         AllocationOptions options = AllocationOptions.None)
         where T : struct
         => MemoryGroup<T>.Allocate(this, totalLength, bufferAlignment, options);
+
+    internal static void MemoryGuardMustBeBetweenOrEqualTo(int value, int min, int max, string paramName)
+    {
+        if (value >= min && value <= max)
+        {
+            return;
+        }
+
+        throw new InvalidMemoryOperationException($"Parameter \"{paramName}\" must be between or equal to {min} and {max}, was {value}");
+    }
 }

--- a/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
@@ -17,7 +17,7 @@ public sealed class SimpleGcMemoryAllocator : MemoryAllocator
     /// <inheritdoc />
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        Guard.MustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
+        MemoryGuardMustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
 
         return new BasicArrayBuffer<T>(new T[length]);
     }

--- a/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 using System.Buffers;
@@ -7,7 +7,7 @@ using SixLabors.ImageSharp.Memory.Internals;
 namespace SixLabors.ImageSharp.Memory;
 
 /// <summary>
-/// Implements <see cref="MemoryAllocator"/> by newing up managed arrays on every allocation request.
+/// Implements <see cref="MemoryAllocator"/> by creating new managed arrays on every allocation request.
 /// </summary>
 public sealed class SimpleGcMemoryAllocator : MemoryAllocator
 {
@@ -17,7 +17,7 @@ public sealed class SimpleGcMemoryAllocator : MemoryAllocator
     /// <inheritdoc />
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        Guard.MustBeGreaterThanOrEqualTo(length, 0, nameof(length));
+        Guard.MustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
 
         return new BasicArrayBuffer<T>(new T[length]);
     }

--- a/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
@@ -12,7 +12,7 @@ namespace SixLabors.ImageSharp.Memory;
 public sealed class SimpleGcMemoryAllocator : MemoryAllocator
 {
     /// <inheritdoc />
-    protected internal override int GetBufferCapacityInBytes() => int.MaxValue;
+    protected internal override int GetBufferCapacityInBytes() => this.MaxAllocatableSize1DInBytes;
 
     /// <inheritdoc />
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)

--- a/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
@@ -17,7 +17,7 @@ public sealed class SimpleGcMemoryAllocator : MemoryAllocator
     /// <inheritdoc />
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        MemoryGuardMustBeBetweenOrEqualTo<T>(length, 0, this.MaxAllocatableSize1DInBytes, nameof(length));
+        this.MemoryGuardAllocation1D<T>(length, nameof(length));
 
         return new BasicArrayBuffer<T>(new T[length]);
     }

--- a/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/SimpleGcMemoryAllocator.cs
@@ -17,7 +17,7 @@ public sealed class SimpleGcMemoryAllocator : MemoryAllocator
     /// <inheritdoc />
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        MemoryGuardMustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
+        MemoryGuardMustBeBetweenOrEqualTo<T>(length, 0, this.MaxAllocatableSize1DInBytes, nameof(length));
 
         return new BasicArrayBuffer<T>(new T[length]);
     }

--- a/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
@@ -81,7 +81,7 @@ internal sealed class UniformUnmanagedMemoryPoolMemoryAllocator : MemoryAllocato
     /// <inheritdoc />
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        MemoryGuardMustBeBetweenOrEqualTo<T>(length, 0, this.MaxAllocatableSize1DInBytes, nameof(length));
+        this.MemoryGuardAllocation1D<T>(length, nameof(length));
         int lengthInBytes = length * Unsafe.SizeOf<T>();
 
         if (lengthInBytes <= this.sharedArrayPoolThresholdInBytes)

--- a/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
@@ -81,7 +81,7 @@ internal sealed class UniformUnmanagedMemoryPoolMemoryAllocator : MemoryAllocato
     /// <inheritdoc />
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        Guard.MustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
+        MemoryGuardMustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
         int lengthInBytes = length * Unsafe.SizeOf<T>();
 
         if (lengthInBytes <= this.sharedArrayPoolThresholdInBytes)

--- a/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
@@ -81,7 +81,7 @@ internal sealed class UniformUnmanagedMemoryPoolMemoryAllocator : MemoryAllocato
     /// <inheritdoc />
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        MemoryGuardMustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
+        MemoryGuardMustBeBetweenOrEqualTo<T>(length, 0, this.MaxAllocatableSize1DInBytes, nameof(length));
         int lengthInBytes = length * Unsafe.SizeOf<T>();
 
         if (lengthInBytes <= this.sharedArrayPoolThresholdInBytes)

--- a/src/ImageSharp/Memory/Allocators/UnmanagedMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UnmanagedMemoryAllocator.cs
@@ -20,7 +20,7 @@ internal class UnmanagedMemoryAllocator : MemoryAllocator
 
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        MemoryGuardMustBeBetweenOrEqualTo<T>(length, 0, this.MaxAllocatableSize1DInBytes, nameof(length));
+        this.MemoryGuardAllocation1D<T>(length, nameof(length));
 
         UnmanagedBuffer<T> buffer = UnmanagedBuffer<T>.Allocate(length);
         if (options.Has(AllocationOptions.Clean))

--- a/src/ImageSharp/Memory/Allocators/UnmanagedMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UnmanagedMemoryAllocator.cs
@@ -20,7 +20,7 @@ internal class UnmanagedMemoryAllocator : MemoryAllocator
 
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        Guard.MustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
+        MemoryGuardMustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
 
         UnmanagedBuffer<T> buffer = UnmanagedBuffer<T>.Allocate(length);
         if (options.Has(AllocationOptions.Clean))

--- a/src/ImageSharp/Memory/Allocators/UnmanagedMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UnmanagedMemoryAllocator.cs
@@ -20,7 +20,9 @@ internal class UnmanagedMemoryAllocator : MemoryAllocator
 
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        var buffer = UnmanagedBuffer<T>.Allocate(length);
+        Guard.MustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
+
+        UnmanagedBuffer<T> buffer = UnmanagedBuffer<T>.Allocate(length);
         if (options.Has(AllocationOptions.Clean))
         {
             buffer.GetSpan().Clear();

--- a/src/ImageSharp/Memory/Allocators/UnmanagedMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UnmanagedMemoryAllocator.cs
@@ -20,7 +20,7 @@ internal class UnmanagedMemoryAllocator : MemoryAllocator
 
     public override IMemoryOwner<T> Allocate<T>(int length, AllocationOptions options = AllocationOptions.None)
     {
-        MemoryGuardMustBeBetweenOrEqualTo(length, 0, this.MaxAllocatableSize1D, nameof(length));
+        MemoryGuardMustBeBetweenOrEqualTo<T>(length, 0, this.MaxAllocatableSize1DInBytes, nameof(length));
 
         UnmanagedBuffer<T> buffer = UnmanagedBuffer<T>.Allocate(length);
         if (options.Has(AllocationOptions.Clean))

--- a/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
+++ b/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
@@ -18,20 +18,23 @@ public static class MemoryAllocatorExtensions
     /// <param name="memoryAllocator">The memory allocator.</param>
     /// <param name="width">The buffer width.</param>
     /// <param name="height">The buffer height.</param>
-    /// <param name="preferContiguosImageBuffers">A value indicating whether the allocated buffer should be contiguous, unless bigger than <see cref="int.MaxValue"/>.</param>
+    /// <param name="preferContiguousImageBuffers">A value indicating whether the allocated buffer should be contiguous, unless bigger than <see cref="int.MaxValue"/>.</param>
     /// <param name="options">The allocation options.</param>
     /// <returns>The <see cref="Buffer2D{T}"/>.</returns>
     public static Buffer2D<T> Allocate2D<T>(
         this MemoryAllocator memoryAllocator,
         int width,
         int height,
-        bool preferContiguosImageBuffers,
+        bool preferContiguousImageBuffers,
         AllocationOptions options = AllocationOptions.None)
         where T : struct
     {
+        Guard.MustBeBetweenOrEqualTo(width, 0, memoryAllocator.MaxAllocatableSize2D.Width, nameof(width));
+        Guard.MustBeBetweenOrEqualTo(height, 0, memoryAllocator.MaxAllocatableSize2D.Height, nameof(height));
+
         long groupLength = (long)width * height;
         MemoryGroup<T> memoryGroup;
-        if (preferContiguosImageBuffers && groupLength < int.MaxValue)
+        if (preferContiguousImageBuffers && groupLength < int.MaxValue)
         {
             IMemoryOwner<T> buffer = memoryAllocator.Allocate<T>((int)groupLength, options);
             memoryGroup = MemoryGroup<T>.CreateContiguous(buffer, false);
@@ -69,16 +72,16 @@ public static class MemoryAllocatorExtensions
     /// <typeparam name="T">The type of buffer items to allocate.</typeparam>
     /// <param name="memoryAllocator">The memory allocator.</param>
     /// <param name="size">The buffer size.</param>
-    /// <param name="preferContiguosImageBuffers">A value indicating whether the allocated buffer should be contiguous, unless bigger than <see cref="int.MaxValue"/>.</param>
+    /// <param name="preferContiguousImageBuffers">A value indicating whether the allocated buffer should be contiguous, unless bigger than <see cref="int.MaxValue"/>.</param>
     /// <param name="options">The allocation options.</param>
     /// <returns>The <see cref="Buffer2D{T}"/>.</returns>
     public static Buffer2D<T> Allocate2D<T>(
         this MemoryAllocator memoryAllocator,
         Size size,
-        bool preferContiguosImageBuffers,
+        bool preferContiguousImageBuffers,
         AllocationOptions options = AllocationOptions.None)
         where T : struct =>
-        Allocate2D<T>(memoryAllocator, size.Width, size.Height, preferContiguosImageBuffers, options);
+        Allocate2D<T>(memoryAllocator, size.Width, size.Height, preferContiguousImageBuffers, options);
 
     /// <summary>
     /// Allocates a buffer of value type objects interpreted as a 2D region
@@ -96,7 +99,7 @@ public static class MemoryAllocatorExtensions
         where T : struct =>
         Allocate2D<T>(memoryAllocator, size.Width, size.Height, false, options);
 
-    internal static Buffer2D<T> Allocate2DOveraligned<T>(
+    internal static Buffer2D<T> Allocate2DOverAligned<T>(
         this MemoryAllocator memoryAllocator,
         int width,
         int height,
@@ -104,6 +107,9 @@ public static class MemoryAllocatorExtensions
         AllocationOptions options = AllocationOptions.None)
         where T : struct
     {
+        Guard.MustBeBetweenOrEqualTo(width, 0, memoryAllocator.MaxAllocatableSize2D.Width, nameof(width));
+        Guard.MustBeBetweenOrEqualTo(height, 0, memoryAllocator.MaxAllocatableSize2D.Height, nameof(height));
+
         long groupLength = (long)width * height;
         MemoryGroup<T> memoryGroup = memoryAllocator.AllocateGroup<T>(
             groupLength,
@@ -127,6 +133,8 @@ public static class MemoryAllocatorExtensions
         int paddingInBytes)
     {
         int length = (width * pixelSizeInBytes) + paddingInBytes;
+        Guard.MustBeBetweenOrEqualTo(length, 0, memoryAllocator.MaxAllocatableSize1D, nameof(length));
+
         return memoryAllocator.Allocate<byte>(length);
     }
 }

--- a/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
+++ b/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
@@ -29,8 +29,8 @@ public static class MemoryAllocatorExtensions
         AllocationOptions options = AllocationOptions.None)
         where T : struct
     {
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(width, 0, memoryAllocator.MaxAllocatableSize2D.Width, nameof(width));
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(height, 0, memoryAllocator.MaxAllocatableSize2D.Height, nameof(height));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<T>(width, 0, memoryAllocator.MaxAllocatableSize2DInBytes.Width, nameof(width));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<T>(height, 0, memoryAllocator.MaxAllocatableSize2DInBytes.Height, nameof(height));
 
         long groupLength = (long)width * height;
         MemoryGroup<T> memoryGroup;
@@ -107,8 +107,8 @@ public static class MemoryAllocatorExtensions
         AllocationOptions options = AllocationOptions.None)
         where T : struct
     {
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(width, 0, memoryAllocator.MaxAllocatableSize2D.Width, nameof(width));
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(height, 0, memoryAllocator.MaxAllocatableSize2D.Height, nameof(height));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<T>(width, 0, memoryAllocator.MaxAllocatableSize2DInBytes.Width, nameof(width));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<T>(height, 0, memoryAllocator.MaxAllocatableSize2DInBytes.Height, nameof(height));
 
         long groupLength = (long)width * height;
         MemoryGroup<T> memoryGroup = memoryAllocator.AllocateGroup<T>(
@@ -133,7 +133,7 @@ public static class MemoryAllocatorExtensions
         int paddingInBytes)
     {
         int length = (width * pixelSizeInBytes) + paddingInBytes;
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(length, 0, memoryAllocator.MaxAllocatableSize1D, nameof(length));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<byte>(length, 0, memoryAllocator.MaxAllocatableSize1DInBytes, nameof(length));
 
         return memoryAllocator.Allocate<byte>(length);
     }

--- a/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
+++ b/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
@@ -29,8 +29,8 @@ public static class MemoryAllocatorExtensions
         AllocationOptions options = AllocationOptions.None)
         where T : struct
     {
-        Guard.MustBeBetweenOrEqualTo(width, 0, memoryAllocator.MaxAllocatableSize2D.Width, nameof(width));
-        Guard.MustBeBetweenOrEqualTo(height, 0, memoryAllocator.MaxAllocatableSize2D.Height, nameof(height));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(width, 0, memoryAllocator.MaxAllocatableSize2D.Width, nameof(width));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(height, 0, memoryAllocator.MaxAllocatableSize2D.Height, nameof(height));
 
         long groupLength = (long)width * height;
         MemoryGroup<T> memoryGroup;
@@ -107,8 +107,8 @@ public static class MemoryAllocatorExtensions
         AllocationOptions options = AllocationOptions.None)
         where T : struct
     {
-        Guard.MustBeBetweenOrEqualTo(width, 0, memoryAllocator.MaxAllocatableSize2D.Width, nameof(width));
-        Guard.MustBeBetweenOrEqualTo(height, 0, memoryAllocator.MaxAllocatableSize2D.Height, nameof(height));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(width, 0, memoryAllocator.MaxAllocatableSize2D.Width, nameof(width));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(height, 0, memoryAllocator.MaxAllocatableSize2D.Height, nameof(height));
 
         long groupLength = (long)width * height;
         MemoryGroup<T> memoryGroup = memoryAllocator.AllocateGroup<T>(
@@ -133,7 +133,7 @@ public static class MemoryAllocatorExtensions
         int paddingInBytes)
     {
         int length = (width * pixelSizeInBytes) + paddingInBytes;
-        Guard.MustBeBetweenOrEqualTo(length, 0, memoryAllocator.MaxAllocatableSize1D, nameof(length));
+        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo(length, 0, memoryAllocator.MaxAllocatableSize1D, nameof(length));
 
         return memoryAllocator.Allocate<byte>(length);
     }

--- a/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
+++ b/src/ImageSharp/Memory/MemoryAllocatorExtensions.cs
@@ -29,8 +29,7 @@ public static class MemoryAllocatorExtensions
         AllocationOptions options = AllocationOptions.None)
         where T : struct
     {
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<T>(width, 0, memoryAllocator.MaxAllocatableSize2DInBytes.Width, nameof(width));
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<T>(height, 0, memoryAllocator.MaxAllocatableSize2DInBytes.Height, nameof(height));
+        memoryAllocator.MemoryGuardAllocation2D<T>(new Size(width, height), "size");
 
         long groupLength = (long)width * height;
         MemoryGroup<T> memoryGroup;
@@ -107,8 +106,7 @@ public static class MemoryAllocatorExtensions
         AllocationOptions options = AllocationOptions.None)
         where T : struct
     {
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<T>(width, 0, memoryAllocator.MaxAllocatableSize2DInBytes.Width, nameof(width));
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<T>(height, 0, memoryAllocator.MaxAllocatableSize2DInBytes.Height, nameof(height));
+        memoryAllocator.MemoryGuardAllocation2D<T>(new Size(width, height), "size");
 
         long groupLength = (long)width * height;
         MemoryGroup<T> memoryGroup = memoryAllocator.AllocateGroup<T>(
@@ -133,8 +131,7 @@ public static class MemoryAllocatorExtensions
         int paddingInBytes)
     {
         int length = (width * pixelSizeInBytes) + paddingInBytes;
-        MemoryAllocator.MemoryGuardMustBeBetweenOrEqualTo<byte>(length, 0, memoryAllocator.MaxAllocatableSize1DInBytes, nameof(length));
-
+        memoryAllocator.MemoryGuardAllocation1D<byte>(length, nameof(length));
         return memoryAllocator.Allocate<byte>(length);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeKernelMap.cs
@@ -50,7 +50,7 @@ internal partial class ResizeKernelMap : IDisposable
         this.sourceLength = sourceLength;
         this.DestinationLength = destinationLength;
         this.MaxDiameter = (radius * 2) + 1;
-        this.data = memoryAllocator.Allocate2D<float>(this.MaxDiameter, bufferHeight, preferContiguosImageBuffers: true, AllocationOptions.Clean);
+        this.data = memoryAllocator.Allocate2D<float>(this.MaxDiameter, bufferHeight, preferContiguousImageBuffers: true, AllocationOptions.Clean);
         this.pinHandle = this.data.DangerousGetSingleMemory().Pin();
         this.kernels = new ResizeKernel[destinationLength];
         this.tempValues = new double[this.MaxDiameter];

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
@@ -83,7 +83,7 @@ internal sealed class ResizeWorker<TPixel> : IDisposable
         this.transposedFirstPassBuffer = configuration.MemoryAllocator.Allocate2D<Vector4>(
             this.workerHeight,
             targetWorkingRect.Width,
-            preferContiguosImageBuffers: true,
+            preferContiguousImageBuffers: true,
             options: AllocationOptions.Clean);
 
         this.tempRowBuffer = configuration.MemoryAllocator.Allocate<Vector4>(this.sourceRectangle.Width);

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -563,7 +563,7 @@ public class BmpDecoderTests
     [WithFile(Issue2696, PixelTypes.Rgba32)]
     public void BmpDecoder_ThrowsException_Issue2696<TPixel>(TestImageProvider<TPixel> provider)
     where TPixel : unmanaged, IPixel<TPixel>
-        => Assert.Throws<InvalidImageContentException>(() =>
+        => Assert.Throws<ArgumentOutOfRangeException>(() =>
         {
             using Image<TPixel> image = provider.GetImage(BmpDecoder.Instance);
         });

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -558,4 +558,13 @@ public class BmpDecoderTests
         // Compare to reference output instead.
         image.CompareToReferenceOutput(provider, extension: "png");
     }
+
+    [Theory]
+    [WithFile(Issue2696, PixelTypes.Rgba32)]
+    public void BmpDecoder_ThrowsException_Issue2696<TPixel>(TestImageProvider<TPixel> provider)
+    where TPixel : unmanaged, IPixel<TPixel>
+        => Assert.Throws<InvalidImageContentException>(() =>
+        {
+            using Image<TPixel> image = provider.GetImage(BmpDecoder.Instance);
+        });
 }

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -563,7 +563,7 @@ public class BmpDecoderTests
     [WithFile(Issue2696, PixelTypes.Rgba32)]
     public void BmpDecoder_ThrowsException_Issue2696<TPixel>(TestImageProvider<TPixel> provider)
     where TPixel : unmanaged, IPixel<TPixel>
-        => Assert.Throws<ArgumentOutOfRangeException>(() =>
+        => Assert.Throws<InvalidImageContentException>(() =>
         {
             using Image<TPixel> image = provider.GetImage(BmpDecoder.Instance);
         });

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -351,8 +351,8 @@ public class BmpEncoderTests
 
     public static TheoryData<Size> Encode_WorksWithSizeGreaterThen65k_Data { get; set; } = new()
     {
-        { new Size(1, MemoryAllocator.DefaultMaxAllocatableSize2DInBytes.Height + 1) },
-        { new Size(MemoryAllocator.DefaultMaxAllocatableSize2DInBytes.Width + 1, 1) }
+        { new Size(65535, 1) },
+        { new Size(1, 65535) },
     };
 
     [Theory]
@@ -362,7 +362,7 @@ public class BmpEncoderTests
         Exception exception = Record.Exception(() =>
         {
             Configuration configuration = Configuration.CreateDefaultInstance();
-            configuration.MemoryAllocator = new UniformUnmanagedMemoryPoolMemoryAllocator(null) { MaxAllocatableSize2DInBytes = size + new Size(1, 1) };
+            configuration.MemoryAllocator = new UniformUnmanagedMemoryPoolMemoryAllocator(null) { MaxAllocatableSize2DInBytes = ulong.MaxValue };
             using Image image = new Image<L8>(configuration, size.Width, size.Height);
             using MemoryStream memStream = new();
             image.Save(memStream, BmpEncoder);

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -349,16 +349,21 @@ public class BmpEncoderTests
         Assert.Equal(expectedProfileBytes, actualProfileBytes);
     }
 
+    public static TheoryData<Size> Encode_WorksWithSizeGreaterThen65k_Data { get; set; } = new()
+    {
+        { new Size(1, MemoryAllocator.DefaultMaxAllocatableSize2DInBytes.Height + 1) },
+        { new Size(MemoryAllocator.DefaultMaxAllocatableSize2DInBytes.Width + 1, 1) }
+    };
+
     [Theory]
-    [InlineData(1, 65536)]
-    [InlineData(65536, 1)]
-    public void Encode_WorksWithSizeGreaterThen65k(int width, int height)
+    [MemberData(nameof(Encode_WorksWithSizeGreaterThen65k_Data))]
+    public void Encode_WorksWithSizeGreaterThen65k(Size size)
     {
         Exception exception = Record.Exception(() =>
         {
-            Configuration c = Configuration.CreateDefaultInstance();
-            c.MemoryAllocator = new UniformUnmanagedMemoryPoolMemoryAllocator(null) { MaxAllocatableSize2D = new(65537, 65537) };
-            using Image image = new Image<Rgba32>(c, width, height);
+            Configuration configuration = Configuration.CreateDefaultInstance();
+            configuration.MemoryAllocator = new UniformUnmanagedMemoryPoolMemoryAllocator(null) { MaxAllocatableSize2DInBytes = size + new Size(1, 1) };
+            using Image image = new Image<L8>(configuration, size.Width, size.Height);
             using MemoryStream memStream = new();
             image.Save(memStream, BmpEncoder);
         });

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpEncoderTests.cs
@@ -3,6 +3,7 @@
 
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
@@ -349,13 +350,15 @@ public class BmpEncoderTests
     }
 
     [Theory]
-    [InlineData(1, 66535)]
-    [InlineData(66535, 1)]
+    [InlineData(1, 65536)]
+    [InlineData(65536, 1)]
     public void Encode_WorksWithSizeGreaterThen65k(int width, int height)
     {
         Exception exception = Record.Exception(() =>
         {
-            using Image image = new Image<Rgba32>(width, height);
+            Configuration c = Configuration.CreateDefaultInstance();
+            c.MemoryAllocator = new UniformUnmanagedMemoryPoolMemoryAllocator(null) { MaxAllocatableSize2D = new(65537, 65537) };
+            using Image image = new Image<Rgba32>(c, width, height);
             using MemoryStream memStream = new();
             image.Save(memStream, BmpEncoder);
         });

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -338,7 +338,7 @@ public partial class JpegDecoderTests
     }
 
     [Theory]
-    [WithFile(TestImages.Jpeg.Issues.HangBadScan, PixelTypes.L8)]
+    [WithFile(TestImages.Jpeg.Issues.HangBadScan, PixelTypes.Rgba32)]
     public void DecodeHang_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
         => Assert.Throws<InvalidImageContentException>(() => { using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance); });

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -339,20 +339,9 @@ public partial class JpegDecoderTests
 
     [Theory]
     [WithFile(TestImages.Jpeg.Issues.HangBadScan, PixelTypes.L8)]
-    public void DecodeHang<TPixel>(TestImageProvider<TPixel> provider)
+    public void DecodeHang_ThrowsException<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
-    {
-        if (TestEnvironment.IsWindows &&
-            TestEnvironment.RunsOnCI)
-        {
-            // Windows CI runs consistently fail with OOM.
-            return;
-        }
-
-        using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
-        Assert.Equal(65503, image.Width);
-        Assert.Equal(65503, image.Height);
-    }
+        => Assert.Throws<InvalidImageContentException>(() => { using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance); });
 
     // https://github.com/SixLabors/ImageSharp/issues/2517
     [Theory]

--- a/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
@@ -21,7 +21,7 @@ public class SimpleGcMemoryAllocatorTests
 
     [Theory]
     [InlineData(-1)]
-    [InlineData((ushort.MaxValue * 4) + 1)]
+    [InlineData((ushort.MaxValue * 64) + 1)]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
     {
         ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate<BigStruct>(length));

--- a/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
@@ -21,6 +21,7 @@ public class SimpleGcMemoryAllocatorTests
 
     [Theory]
     [InlineData(-1)]
+    [InlineData((ushort.MaxValue * 4) + 1)]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
     {
         ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate<BigStruct>(length));

--- a/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
@@ -17,18 +17,23 @@ public class SimpleGcMemoryAllocatorTests
         }
     }
 
-    protected SimpleGcMemoryAllocator MemoryAllocator { get; } = new SimpleGcMemoryAllocator();
+    protected SimpleGcMemoryAllocator TestMemoryAllocator { get; } = new SimpleGcMemoryAllocator();
+
+    public static TheoryData<int> InvalidLengths { get; set; } = new()
+    {
+        { -1 },
+        { MemoryAllocator.DefaultMaxAllocatableSize1DInBytes + 1 }
+    };
 
     [Theory]
-    [InlineData(-1)]
-    [InlineData(1073741823 + 1)]
+    [MemberData(nameof(InvalidLengths))]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
-        => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate<BigStruct>(length));
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate<BigStruct>(length));
 
     [Fact]
     public unsafe void Allocate_MemoryIsPinnableMultipleTimes()
     {
-        SimpleGcMemoryAllocator allocator = this.MemoryAllocator;
+        SimpleGcMemoryAllocator allocator = this.TestMemoryAllocator;
         using IMemoryOwner<byte> memoryOwner = allocator.Allocate<byte>(100);
 
         using (MemoryHandle pin = memoryOwner.Memory.Pin())

--- a/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
@@ -21,12 +21,9 @@ public class SimpleGcMemoryAllocatorTests
 
     [Theory]
     [InlineData(-1)]
-    [InlineData((ushort.MaxValue * 64) + 1)]
+    [InlineData(1073741823 + 1)]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
-    {
-        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate<BigStruct>(length));
-        Assert.Equal("length", ex.ParamName);
-    }
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate<BigStruct>(length));
 
     [Fact]
     public unsafe void Allocate_MemoryIsPinnableMultipleTimes()

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -114,9 +114,14 @@ public class UniformUnmanagedPoolMemoryAllocatorTests
         Assert.Throws<InvalidMemoryOperationException>(() => allocator.AllocateGroup<S4>(int.MaxValue * (long)int.MaxValue, int.MaxValue));
     }
 
+    public static TheoryData<int> InvalidLengths { get; set; } = new()
+    {
+        { -1 },
+        { MemoryAllocator.DefaultMaxAllocatableSize1DInBytes + 1 }
+    };
+
     [Theory]
-    [InlineData(-1)]
-    [InlineData(1073741823 + 1)]
+    [MemberData(nameof(InvalidLengths))]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
         => Assert.Throws<InvalidMemoryOperationException>(() => new UniformUnmanagedMemoryPoolMemoryAllocator(null).Allocate<byte>(length));
 

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -116,12 +116,9 @@ public class UniformUnmanagedPoolMemoryAllocatorTests
 
     [Theory]
     [InlineData(-1)]
-    [InlineData((ushort.MaxValue * 64) + 1)]
+    [InlineData(1073741823 + 1)]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
-    {
-        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => new UniformUnmanagedMemoryPoolMemoryAllocator(null).Allocate<byte>(length));
-        Assert.Equal("length", ex.ParamName);
-    }
+        => Assert.Throws<InvalidMemoryOperationException>(() => new UniformUnmanagedMemoryPoolMemoryAllocator(null).Allocate<byte>(length));
 
     [Fact]
     public unsafe void Allocate_MemoryIsPinnableMultipleTimes()

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -114,6 +114,15 @@ public class UniformUnmanagedPoolMemoryAllocatorTests
         Assert.Throws<InvalidMemoryOperationException>(() => allocator.AllocateGroup<S4>(int.MaxValue * (long)int.MaxValue, int.MaxValue));
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData((ushort.MaxValue * 4) + 1)]
+    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
+    {
+        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => new UniformUnmanagedMemoryPoolMemoryAllocator(null).Allocate<byte>(length));
+        Assert.Equal("length", ex.ParamName);
+    }
+
     [Fact]
     public unsafe void Allocate_MemoryIsPinnableMultipleTimes()
     {

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -116,7 +116,7 @@ public class UniformUnmanagedPoolMemoryAllocatorTests
 
     [Theory]
     [InlineData(-1)]
-    [InlineData((ushort.MaxValue * 4) + 1)]
+    [InlineData((ushort.MaxValue * 64) + 1)]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
     {
         ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => new UniformUnmanagedMemoryPoolMemoryAllocator(null).Allocate<byte>(length));

--- a/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
@@ -72,11 +72,11 @@ public partial class Buffer2DTests
         using Buffer2D<byte> buffer = useSizeOverload ?
             this.MemoryAllocator.Allocate2D<byte>(
                 new Size(200, 200),
-                preferContiguosImageBuffers: true) :
+                preferContiguousImageBuffers: true) :
             this.MemoryAllocator.Allocate2D<byte>(
             200,
             200,
-            preferContiguosImageBuffers: true);
+            preferContiguousImageBuffers: true);
         Assert.Equal(1, buffer.FastMemoryGroup.Count);
         Assert.Equal(200 * 200, buffer.FastMemoryGroup.TotalLength);
     }
@@ -87,7 +87,7 @@ public partial class Buffer2DTests
     {
         this.MemoryAllocator.BufferCapacityInBytes = sizeof(int) * bufferCapacity;
 
-        using Buffer2D<int> buffer = this.MemoryAllocator.Allocate2DOveraligned<int>(width, height, alignmentMultiplier);
+        using Buffer2D<int> buffer = this.MemoryAllocator.Allocate2DOverAligned<int>(width, height, alignmentMultiplier);
         MemoryGroup<int> memoryGroup = buffer.FastMemoryGroup;
         int expectedAlignment = width * alignmentMultiplier;
 
@@ -337,4 +337,22 @@ public partial class Buffer2DTests
         Assert.False(mgBefore.IsValid);
         Assert.NotSame(mgBefore, buffer1.MemoryGroup);
     }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(ushort.MaxValue + 1)]
+    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate2D<byte>(length, length));
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(ushort.MaxValue + 1)]
+    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_Size(int length)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate2D<byte>(new Size(length, length)));
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(ushort.MaxValue + 1)]
+    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_OverAligned(int length)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate2DOverAligned<byte>(length, length, 1));
 }

--- a/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
@@ -4,6 +4,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
 
 // ReSharper disable InconsistentNaming
 namespace SixLabors.ImageSharp.Tests.Memory;
@@ -341,21 +342,22 @@ public partial class Buffer2DTests
     public static TheoryData<Size> InvalidLengths { get; set; } = new()
     {
         { new(-1, -1) },
-        { MemoryAllocator.DefaultMaxAllocatableSize2DInBytes + new Size(1, 1) }
+        { new(32768, 32767) },
+        { new(32767, 32768) }
     };
 
     [Theory]
     [MemberData(nameof(InvalidLengths))]
-    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(Size size)
-        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate2D<byte>(size.Width, size.Height));
+    public void Allocate_IncorrectAmount_ThrowsCorrect_InvalidMemoryOperationException(Size size)
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate2D<Rgba32>(size.Width, size.Height));
 
     [Theory]
     [MemberData(nameof(InvalidLengths))]
-    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_Size(Size size)
-        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate2D<byte>(new Size(size)));
+    public void Allocate_IncorrectAmount_ThrowsCorrect_InvalidMemoryOperationException_Size(Size size)
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate2D<Rgba32>(new Size(size)));
 
     [Theory]
     [MemberData(nameof(InvalidLengths))]
-    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_OverAligned(Size size)
-        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate2DOverAligned<byte>(size.Width, size.Height, 1));
+    public void Allocate_IncorrectAmount_ThrowsCorrect_InvalidMemoryOperationException_OverAligned(Size size)
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate2DOverAligned<Rgba32>(size.Width, size.Height, 1));
 }

--- a/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
@@ -23,7 +23,7 @@ public partial class Buffer2DTests
         }
     }
 
-    private TestMemoryAllocator MemoryAllocator { get; } = new TestMemoryAllocator();
+    private TestMemoryAllocator TestMemoryAllocator { get; } = new TestMemoryAllocator();
 
     private const int Big = 99999;
 
@@ -33,9 +33,9 @@ public partial class Buffer2DTests
     [InlineData(300, 42, 777)]
     public unsafe void Construct(int bufferCapacity, int width, int height)
     {
-        this.MemoryAllocator.BufferCapacityInBytes = sizeof(TestStructs.Foo) * bufferCapacity;
+        this.TestMemoryAllocator.BufferCapacityInBytes = sizeof(TestStructs.Foo) * bufferCapacity;
 
-        using (Buffer2D<TestStructs.Foo> buffer = this.MemoryAllocator.Allocate2D<TestStructs.Foo>(width, height))
+        using (Buffer2D<TestStructs.Foo> buffer = this.TestMemoryAllocator.Allocate2D<TestStructs.Foo>(width, height))
         {
             Assert.Equal(width, buffer.Width);
             Assert.Equal(height, buffer.Height);
@@ -51,9 +51,9 @@ public partial class Buffer2DTests
     [InlineData(3, 0, 0)]
     public unsafe void Construct_Empty(int bufferCapacity, int width, int height)
     {
-        this.MemoryAllocator.BufferCapacityInBytes = sizeof(TestStructs.Foo) * bufferCapacity;
+        this.TestMemoryAllocator.BufferCapacityInBytes = sizeof(TestStructs.Foo) * bufferCapacity;
 
-        using (Buffer2D<TestStructs.Foo> buffer = this.MemoryAllocator.Allocate2D<TestStructs.Foo>(width, height))
+        using (Buffer2D<TestStructs.Foo> buffer = this.TestMemoryAllocator.Allocate2D<TestStructs.Foo>(width, height))
         {
             Assert.Equal(width, buffer.Width);
             Assert.Equal(height, buffer.Height);
@@ -67,13 +67,13 @@ public partial class Buffer2DTests
     [InlineData(true)]
     public void Construct_PreferContiguousImageBuffers_AllocatesContiguousRegardlessOfCapacity(bool useSizeOverload)
     {
-        this.MemoryAllocator.BufferCapacityInBytes = 10_000;
+        this.TestMemoryAllocator.BufferCapacityInBytes = 10_000;
 
         using Buffer2D<byte> buffer = useSizeOverload ?
-            this.MemoryAllocator.Allocate2D<byte>(
+            this.TestMemoryAllocator.Allocate2D<byte>(
                 new Size(200, 200),
                 preferContiguousImageBuffers: true) :
-            this.MemoryAllocator.Allocate2D<byte>(
+            this.TestMemoryAllocator.Allocate2D<byte>(
             200,
             200,
             preferContiguousImageBuffers: true);
@@ -85,9 +85,9 @@ public partial class Buffer2DTests
     [InlineData(50, 10, 20, 4)]
     public void Allocate2DOveraligned(int bufferCapacity, int width, int height, int alignmentMultiplier)
     {
-        this.MemoryAllocator.BufferCapacityInBytes = sizeof(int) * bufferCapacity;
+        this.TestMemoryAllocator.BufferCapacityInBytes = sizeof(int) * bufferCapacity;
 
-        using Buffer2D<int> buffer = this.MemoryAllocator.Allocate2DOverAligned<int>(width, height, alignmentMultiplier);
+        using Buffer2D<int> buffer = this.TestMemoryAllocator.Allocate2DOverAligned<int>(width, height, alignmentMultiplier);
         MemoryGroup<int> memoryGroup = buffer.FastMemoryGroup;
         int expectedAlignment = width * alignmentMultiplier;
 
@@ -97,7 +97,7 @@ public partial class Buffer2DTests
     [Fact]
     public void CreateClean()
     {
-        using (Buffer2D<int> buffer = this.MemoryAllocator.Allocate2D<int>(42, 42, AllocationOptions.Clean))
+        using (Buffer2D<int> buffer = this.TestMemoryAllocator.Allocate2D<int>(42, 42, AllocationOptions.Clean))
         {
             Span<int> span = buffer.DangerousGetSingleSpan();
             for (int j = 0; j < span.Length; j++)
@@ -117,9 +117,9 @@ public partial class Buffer2DTests
     [InlineData(200, 100, 30, 4, 2)]
     public unsafe void DangerousGetRowSpan_TestAllocator(int bufferCapacity, int width, int height, int y, int expectedBufferIndex)
     {
-        this.MemoryAllocator.BufferCapacityInBytes = sizeof(TestStructs.Foo) * bufferCapacity;
+        this.TestMemoryAllocator.BufferCapacityInBytes = sizeof(TestStructs.Foo) * bufferCapacity;
 
-        using (Buffer2D<TestStructs.Foo> buffer = this.MemoryAllocator.Allocate2D<TestStructs.Foo>(width, height))
+        using (Buffer2D<TestStructs.Foo> buffer = this.TestMemoryAllocator.Allocate2D<TestStructs.Foo>(width, height))
         {
             Span<TestStructs.Foo> span = buffer.DangerousGetRowSpan(y);
 
@@ -194,8 +194,8 @@ public partial class Buffer2DTests
     [InlineData(30, 4, 1, -1)]
     public void TryGetPaddedRowSpanY(int bufferCapacity, int y, int padding, int expectedBufferIndex)
     {
-        this.MemoryAllocator.BufferCapacityInBytes = bufferCapacity;
-        using Buffer2D<byte> buffer = this.MemoryAllocator.Allocate2D<byte>(3, 5);
+        this.TestMemoryAllocator.BufferCapacityInBytes = bufferCapacity;
+        using Buffer2D<byte> buffer = this.TestMemoryAllocator.Allocate2D<byte>(3, 5);
 
         bool expectSuccess = expectedBufferIndex >= 0;
         bool success = buffer.DangerousTryGetPaddedRowSpan(y, padding, out Span<byte> paddedSpan);
@@ -219,8 +219,8 @@ public partial class Buffer2DTests
     [MemberData(nameof(GetRowSpanY_OutOfRange_Data))]
     public void GetRowSpan_OutOfRange(int bufferCapacity, int width, int height, int y)
     {
-        this.MemoryAllocator.BufferCapacityInBytes = bufferCapacity;
-        using Buffer2D<byte> buffer = this.MemoryAllocator.Allocate2D<byte>(width, height);
+        this.TestMemoryAllocator.BufferCapacityInBytes = bufferCapacity;
+        using Buffer2D<byte> buffer = this.TestMemoryAllocator.Allocate2D<byte>(width, height);
 
         Exception ex = Assert.ThrowsAny<Exception>(() => buffer.DangerousGetRowSpan(y));
         Assert.True(ex is ArgumentOutOfRangeException || ex is IndexOutOfRangeException);
@@ -242,8 +242,8 @@ public partial class Buffer2DTests
     [MemberData(nameof(Indexer_OutOfRange_Data))]
     public void Indexer_OutOfRange(int bufferCapacity, int width, int height, int x, int y)
     {
-        this.MemoryAllocator.BufferCapacityInBytes = bufferCapacity;
-        using Buffer2D<byte> buffer = this.MemoryAllocator.Allocate2D<byte>(width, height);
+        this.TestMemoryAllocator.BufferCapacityInBytes = bufferCapacity;
+        using Buffer2D<byte> buffer = this.TestMemoryAllocator.Allocate2D<byte>(width, height);
 
         Exception ex = Assert.ThrowsAny<Exception>(() => buffer[x, y]++);
         Assert.True(ex is ArgumentOutOfRangeException || ex is IndexOutOfRangeException);
@@ -257,9 +257,9 @@ public partial class Buffer2DTests
     [InlineData(500, 200, 30, 199, 29)]
     public unsafe void Indexer(int bufferCapacity, int width, int height, int x, int y)
     {
-        this.MemoryAllocator.BufferCapacityInBytes = sizeof(TestStructs.Foo) * bufferCapacity;
+        this.TestMemoryAllocator.BufferCapacityInBytes = sizeof(TestStructs.Foo) * bufferCapacity;
 
-        using (Buffer2D<TestStructs.Foo> buffer = this.MemoryAllocator.Allocate2D<TestStructs.Foo>(width, height))
+        using (Buffer2D<TestStructs.Foo> buffer = this.TestMemoryAllocator.Allocate2D<TestStructs.Foo>(width, height))
         {
             int bufferIndex = (width * y) / buffer.FastMemoryGroup.BufferLength;
             int subBufferStart = (width * y) - (bufferIndex * buffer.FastMemoryGroup.BufferLength);
@@ -284,7 +284,7 @@ public partial class Buffer2DTests
     public void CopyColumns(int width, int height, int startIndex, int destIndex, int columnCount)
     {
         var rnd = new Random(123);
-        using (Buffer2D<float> b = this.MemoryAllocator.Allocate2D<float>(width, height))
+        using (Buffer2D<float> b = this.TestMemoryAllocator.Allocate2D<float>(width, height))
         {
             rnd.RandomFill(b.DangerousGetSingleSpan(), 0, 1);
 
@@ -306,7 +306,7 @@ public partial class Buffer2DTests
     public void CopyColumns_InvokeMultipleTimes()
     {
         var rnd = new Random(123);
-        using (Buffer2D<float> b = this.MemoryAllocator.Allocate2D<float>(100, 100))
+        using (Buffer2D<float> b = this.TestMemoryAllocator.Allocate2D<float>(100, 100))
         {
             rnd.RandomFill(b.DangerousGetSingleSpan(), 0, 1);
 
@@ -328,8 +328,8 @@ public partial class Buffer2DTests
     [Fact]
     public void PublicMemoryGroup_IsMemoryGroupView()
     {
-        using Buffer2D<int> buffer1 = this.MemoryAllocator.Allocate2D<int>(10, 10);
-        using Buffer2D<int> buffer2 = this.MemoryAllocator.Allocate2D<int>(10, 10);
+        using Buffer2D<int> buffer1 = this.TestMemoryAllocator.Allocate2D<int>(10, 10);
+        using Buffer2D<int> buffer2 = this.TestMemoryAllocator.Allocate2D<int>(10, 10);
         IMemoryGroup<int> mgBefore = buffer1.MemoryGroup;
 
         Buffer2D<int>.SwapOrCopyContent(buffer1, buffer2);
@@ -338,21 +338,24 @@ public partial class Buffer2DTests
         Assert.NotSame(mgBefore, buffer1.MemoryGroup);
     }
 
-    [Theory]
-    [InlineData(-1)]
-    [InlineData(ushort.MaxValue + 1)]
-    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
-        => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate2D<byte>(length, length));
+    public static TheoryData<Size> InvalidLengths { get; set; } = new()
+    {
+        { new(-1, -1) },
+        { MemoryAllocator.DefaultMaxAllocatableSize2DInBytes + new Size(1, 1) }
+    };
 
     [Theory]
-    [InlineData(-1)]
-    [InlineData(ushort.MaxValue + 1)]
-    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_Size(int length)
-        => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate2D<byte>(new Size(length, length)));
+    [MemberData(nameof(InvalidLengths))]
+    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(Size size)
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate2D<byte>(size.Width, size.Height));
 
     [Theory]
-    [InlineData(-1)]
-    [InlineData(ushort.MaxValue + 1)]
-    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_OverAligned(int length)
-        => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate2DOverAligned<byte>(length, length, 1));
+    [MemberData(nameof(InvalidLengths))]
+    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_Size(Size size)
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate2D<byte>(new Size(size)));
+
+    [Theory]
+    [MemberData(nameof(InvalidLengths))]
+    public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_OverAligned(Size size)
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.TestMemoryAllocator.Allocate2DOverAligned<byte>(size.Width, size.Height, 1));
 }

--- a/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
@@ -342,17 +342,17 @@ public partial class Buffer2DTests
     [InlineData(-1)]
     [InlineData(ushort.MaxValue + 1)]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
-        => Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate2D<byte>(length, length));
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate2D<byte>(length, length));
 
     [Theory]
     [InlineData(-1)]
     [InlineData(ushort.MaxValue + 1)]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_Size(int length)
-        => Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate2D<byte>(new Size(length, length)));
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate2D<byte>(new Size(length, length)));
 
     [Theory]
     [InlineData(-1)]
     [InlineData(ushort.MaxValue + 1)]
     public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException_OverAligned(int length)
-        => Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate2DOverAligned<byte>(length, length, 1));
+        => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate2DOverAligned<byte>(length, length, 1));
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -441,6 +441,8 @@ public static class TestImages
 
         public const string BlackWhitePalletDataMatrix = "Bmp/bit1datamatrix.bmp";
 
+        public const string Issue2696 = "Bmp/issue-2696.bmp";
+
         public static readonly string[] BitFields =
         {
               Rgb32bfdef,

--- a/tests/Images/Input/Bmp/issue-2696.bmp
+++ b/tests/Images/Input/Bmp/issue-2696.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc42cda9bac8fc73351ad03bf55214069bb8d31ea5bdd806321a8cc8b56c282e
+size 126


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

While the [specification](https://www.loc.gov/preservation/digital/formats/fdd/fdd000189.shtml) does not apply a limitation on BMP dimensions, on some machines attempting to decode a malformed or extremely large BMP can lead to OOM exceptions. 

This change limits the dimensions to match the default set by browsers. For example [Firefox](https://searchfox.org/mozilla-central/source/image/decoders/nsBMPDecoder.cpp#603) 

Fixes #2696 

<!-- Thanks for contributing to ImageSharp! -->
