### PR TITLE
V2 - Limit all memory allocations in the MemoryAllocator layer 

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -1504,6 +1504,9 @@ namespace SixLabors.ImageSharp.Formats.Png
         private IMemoryOwner<byte> ReadChunkData(int length)
         {
             // We rent the buffer here to return it afterwards in Decode()
+            // We don't want to throw a degenerated memory exception here as we want to allow partial decoding
+            // so limit the length.
+            length = (int)Math.Min(length, this.currentStream.Length - this.currentStream.Position);
             IMemoryOwner<byte> buffer = this.Configuration.MemoryAllocator.Allocate<byte>(length, AllocationOptions.Clean);
 
             this.currentStream.Read(buffer.GetSpan(), 0, length);

--- a/src/ImageSharp/Memory/Allocators/Internals/UnmanagedMemoryHandle.cs
+++ b/src/ImageSharp/Memory/Allocators/Internals/UnmanagedMemoryHandle.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Memory.Internals
     internal struct UnmanagedMemoryHandle : IEquatable<UnmanagedMemoryHandle>
     {
         // Number of allocation re-attempts when detecting OutOfMemoryException.
-        private const int MaxAllocationAttempts = 1000;
+        private const int MaxAllocationAttempts = 10;
 
         // Track allocations for testing purposes:
         private static int totalOutstandingHandles;

--- a/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.Memory
 {
@@ -11,6 +13,8 @@ namespace SixLabors.ImageSharp.Memory
     /// </summary>
     public abstract class MemoryAllocator
     {
+        private const int OneGigabyte = 1 << 30;
+
         /// <summary>
         /// Gets the default platform-specific global <see cref="MemoryAllocator"/> instance that
         /// serves as the default value for <see cref="Configuration.MemoryAllocator"/>.
@@ -20,6 +24,10 @@ namespace SixLabors.ImageSharp.Memory
         /// to change the default allocator used by <see cref="Image"/> and it's operations.
         /// </summary>
         public static MemoryAllocator Default { get; } = Create();
+
+        internal long MemoryGroupAllocationLimitBytes { get; private set; } = Environment.Is64BitProcess ? 4L * OneGigabyte : OneGigabyte;
+
+        internal int SingleBufferAllocationLimitBytes { get; private set; } = OneGigabyte;
 
         /// <summary>
         /// Gets the length of the largest contiguous buffer that can be handled by this allocator instance in bytes.
@@ -31,16 +39,24 @@ namespace SixLabors.ImageSharp.Memory
         /// Creates a default instance of a <see cref="MemoryAllocator"/> optimized for the executing platform.
         /// </summary>
         /// <returns>The <see cref="MemoryAllocator"/>.</returns>
-        public static MemoryAllocator Create() =>
-            new UniformUnmanagedMemoryPoolMemoryAllocator(null);
+        public static MemoryAllocator Create() => Create(default);
 
         /// <summary>
         /// Creates the default <see cref="MemoryAllocator"/> using the provided options.
         /// </summary>
         /// <param name="options">The <see cref="MemoryAllocatorOptions"/>.</param>
         /// <returns>The <see cref="MemoryAllocator"/>.</returns>
-        public static MemoryAllocator Create(MemoryAllocatorOptions options) =>
-            new UniformUnmanagedMemoryPoolMemoryAllocator(options.MaximumPoolSizeMegabytes);
+        public static MemoryAllocator Create(MemoryAllocatorOptions options)
+        {
+            UniformUnmanagedMemoryPoolMemoryAllocator allocator = new(options.MaximumPoolSizeMegabytes);
+            if (options.AllocationLimitMegabytes.HasValue)
+            {
+                allocator.MemoryGroupAllocationLimitBytes = options.AllocationLimitMegabytes.Value * 1024 * 1024;
+                allocator.SingleBufferAllocationLimitBytes = (int)Math.Min(allocator.SingleBufferAllocationLimitBytes, allocator.MemoryGroupAllocationLimitBytes);
+            }
+
+            return allocator;
+        }
 
         /// <summary>
         /// Allocates an <see cref="IMemoryOwner{T}" />, holding a <see cref="Memory{T}"/> of length <paramref name="length"/>.
@@ -65,16 +81,35 @@ namespace SixLabors.ImageSharp.Memory
         /// <summary>
         /// Allocates a <see cref="MemoryGroup{T}"/>.
         /// </summary>
+        /// <typeparam name="T">The type of element to allocate.</typeparam>
         /// <param name="totalLength">The total length of the buffer.</param>
         /// <param name="bufferAlignment">The expected alignment (eg. to make sure image rows fit into single buffers).</param>
         /// <param name="options">The <see cref="AllocationOptions"/>.</param>
         /// <returns>A new <see cref="MemoryGroup{T}"/>.</returns>
         /// <exception cref="InvalidMemoryOperationException">Thrown when 'blockAlignment' converted to bytes is greater than the buffer capacity of the allocator.</exception>
-        internal virtual MemoryGroup<T> AllocateGroup<T>(
+        internal MemoryGroup<T> AllocateGroup<T>(
             long totalLength,
             int bufferAlignment,
             AllocationOptions options = AllocationOptions.None)
             where T : struct
-            => MemoryGroup<T>.Allocate(this, totalLength, bufferAlignment, options);
+        {
+            if (totalLength < 0)
+            {
+                throw new InvalidMemoryOperationException($"Attempted to allocate a buffer of negative length={totalLength}.");
+            }
+
+            ulong totalLengthInBytes = (ulong)totalLength * (ulong)Unsafe.SizeOf<T>();
+            if (totalLengthInBytes > (ulong)this.MemoryGroupAllocationLimitBytes)
+            {
+                throw new InvalidMemoryOperationException($"Attempted to allocate a buffer of length={totalLengthInBytes} that exceeded the limit {this.MemoryGroupAllocationLimitBytes}.");
+            }
+
+            // Cast to long is safe because we already checked that the total length is within the limit.
+            return this.AllocateGroupCore<T>(totalLength, (long)totalLengthInBytes, bufferAlignment, options);
+        }
+
+        internal virtual MemoryGroup<T> AllocateGroupCore<T>(long totalLengthInElements, long totalLengthInBytes, int bufferAlignment, AllocationOptions options)
+            where T : struct
+            => MemoryGroup<T>.Allocate(this, totalLengthInElements, bufferAlignment, options);
     }
 }

--- a/src/ImageSharp/Memory/Allocators/MemoryAllocatorOptions.cs
+++ b/src/ImageSharp/Memory/Allocators/MemoryAllocatorOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.ImageSharp.Memory
@@ -9,6 +9,7 @@ namespace SixLabors.ImageSharp.Memory
     public struct MemoryAllocatorOptions
     {
         private int? maximumPoolSizeMegabytes;
+        private int? allocationLimitMegabytes;
 
         /// <summary>
         /// Gets or sets a value defining the maximum size of the <see cref="MemoryAllocator"/>'s internal memory pool
@@ -25,6 +26,24 @@ namespace SixLabors.ImageSharp.Memory
                 }
 
                 this.maximumPoolSizeMegabytes = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value defining the maximum (discontiguous) buffer size that can be allocated by the allocator in Megabytes.
+        /// <see langword="null"/> means platform default: 1GB on 32-bit processes, 4GB on 64-bit processes.
+        /// </summary>
+        public int? AllocationLimitMegabytes
+        {
+            readonly get => this.allocationLimitMegabytes;
+            set
+            {
+                if (value.HasValue)
+                {
+                    Guard.MustBeGreaterThan(value.Value, 0, nameof(this.AllocationLimitMegabytes));
+                }
+
+                this.allocationLimitMegabytes = value;
             }
         }
     }

--- a/src/ImageSharp/Memory/InvalidMemoryOperationException.cs
+++ b/src/ImageSharp/Memory/InvalidMemoryOperationException.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SixLabors.ImageSharp.Memory
 {

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -624,9 +624,13 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
         [WithFile(Issue2696, PixelTypes.Rgba32)]
         public void BmpDecoder_ThrowsException_Issue2696<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
-            => Assert.Throws<InvalidImageContentException>(() =>
-            {
-                using Image<TPixel> image = provider.GetImage(BmpDecoder);
-            });
+        {
+            // On V2 this is throwing InvalidOperationException,
+            // because of the validation logic in BmpInfoHeader.VerifyDimensions().
+            Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using Image<TPixel> image = provider.GetImage(BmpDecoder);
+                });
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BmpDecoderTests.cs
@@ -619,5 +619,14 @@ namespace SixLabors.ImageSharp.Tests.Formats.Bmp
                 // image.CompareToOriginal(provider);
             }
         }
+
+        [Theory]
+        [WithFile(Issue2696, PixelTypes.Rgba32)]
+        public void BmpDecoder_ThrowsException_Issue2696<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+            => Assert.Throws<InvalidImageContentException>(() =>
+            {
+                using Image<TPixel> image = provider.GetImage(BmpDecoder);
+            });
     }
 }

--- a/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/SimpleGcMemoryAllocatorTests.cs
@@ -21,13 +21,17 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
 
         protected SimpleGcMemoryAllocator MemoryAllocator { get; } = new SimpleGcMemoryAllocator();
 
-        [Theory]
-        [InlineData(-1)]
-        public void Allocate_IncorrectAmount_ThrowsCorrect_ArgumentOutOfRangeException(int length)
+        public static TheoryData<int> InvalidLengths { get; set; } = new()
         {
-            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => this.MemoryAllocator.Allocate<BigStruct>(length));
-            Assert.Equal("length", ex.ParamName);
-        }
+            { -1 },
+            { (1 << 30) + 1 }
+        };
+
+        [Theory]
+        [MemberData(nameof(InvalidLengths))]
+        public void Allocate_IncorrectAmount_ThrowsCorrect_InvalidMemoryOperationException(int length)
+            => Assert.Throws<InvalidMemoryOperationException>(
+                () => this.MemoryAllocator.Allocate<BigStruct>(length));
 
         [Fact]
         public unsafe void Allocate_MemoryIsPinnableMultipleTimes()

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -398,6 +398,30 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
             }
         }
 
+        [Fact]
+        public void Allocate_OverLimit_ThrowsInvalidMemoryOperationException()
+        {
+            MemoryAllocator allocator = MemoryAllocator.Create(new MemoryAllocatorOptions()
+            {
+                AllocationLimitMegabytes = 4
+            });
+            const int oneMb = 1 << 20;
+            allocator.Allocate<byte>(4 * oneMb).Dispose(); // Should work
+            Assert.Throws<InvalidMemoryOperationException>(() => allocator.Allocate<byte>(5 * oneMb));
+        }
+
+        [Fact]
+        public void AllocateGroup_OverLimit_ThrowsInvalidMemoryOperationException()
+        {
+            MemoryAllocator allocator = MemoryAllocator.Create(new MemoryAllocatorOptions()
+            {
+                AllocationLimitMegabytes = 4
+            });
+            const int oneMb = 1 << 20;
+            allocator.AllocateGroup<byte>(4 * oneMb, 1024).Dispose(); // Should work
+            Assert.Throws<InvalidMemoryOperationException>(() => allocator.AllocateGroup<byte>(5 * oneMb, 1024));
+        }
+
 #if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void Issue2001_NegativeMemoryReportedByGc()

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -118,6 +118,17 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
             Assert.Throws<InvalidMemoryOperationException>(() => allocator.AllocateGroup<S4>(int.MaxValue * (long)int.MaxValue, int.MaxValue));
         }
 
+        public static TheoryData<int> InvalidLengths { get; set; } = new()
+        {
+            { -1 },
+            { (1 << 30) + 1 }
+        };
+
+        [Theory]
+        [MemberData(nameof(InvalidLengths))]
+        public void Allocate_IncorrectAmount_ThrowsCorrect_InvalidMemoryOperationException(int length)
+            => Assert.Throws<InvalidMemoryOperationException>(() => new UniformUnmanagedMemoryPoolMemoryAllocator(null).Allocate<S512>(length));
+
         [Fact]
         public unsafe void Allocate_MemoryIsPinnableMultipleTimes()
         {

--- a/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Buffer2DTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
 
 using Xunit;
 
@@ -342,5 +343,27 @@ namespace SixLabors.ImageSharp.Tests.Memory
             Assert.False(mgBefore.IsValid);
             Assert.NotSame(mgBefore, buffer1.MemoryGroup);
         }
+            
+        public static TheoryData<Size> InvalidLengths { get; set; } = new()
+        {
+            { new(-1, -1) },
+            { new(32768, 32769) },
+            { new(32769, 32768) }
+        };
+
+        [Theory]
+        [MemberData(nameof(InvalidLengths))]
+        public void Allocate_IncorrectAmount_ThrowsCorrect_InvalidMemoryOperationException(Size size)
+            => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate2D<Rgba32>(size.Width, size.Height));
+
+        [Theory]
+        [MemberData(nameof(InvalidLengths))]
+        public void Allocate_IncorrectAmount_ThrowsCorrect_InvalidMemoryOperationException_Size(Size size)
+            => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate2D<Rgba32>(new Size(size)));
+
+        [Theory]
+        [MemberData(nameof(InvalidLengths))]
+        public void Allocate_IncorrectAmount_ThrowsCorrect_InvalidMemoryOperationException_OverAligned(Size size)
+            => Assert.Throws<InvalidMemoryOperationException>(() => this.MemoryAllocator.Allocate2DOveraligned<Rgba32>(size.Width, size.Height, 1));
     }
 }

--- a/tests/ImageSharp.Tests/Memory/DiscontiguousBuffers/MemoryGroupTests.Allocate.cs
+++ b/tests/ImageSharp.Tests/Memory/DiscontiguousBuffers/MemoryGroupTests.Allocate.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -10,7 +9,6 @@ using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Memory.Internals;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SixLabors.ImageSharp.Tests.Memory.DiscontiguousBuffers
 {
@@ -225,12 +223,18 @@ namespace SixLabors.ImageSharp.Tests.Memory.DiscontiguousBuffers
     [StructLayout(LayoutKind.Sequential, Size = 5)]
     internal struct S5
     {
-        public override string ToString() => "S5";
+        public override readonly string ToString() => nameof(S5);
     }
 
     [StructLayout(LayoutKind.Sequential, Size = 4)]
     internal struct S4
     {
-        public override string ToString() => "S4";
+        public override readonly string ToString() => nameof(S4);
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 512)]
+    internal struct S512
+    {
+        public override readonly string ToString() => nameof(S512);
     }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -387,6 +387,8 @@ namespace SixLabors.ImageSharp.Tests
             public const string Rgba321010102 = "Bmp/rgba32-1010102.bmp";
             public const string RgbaAlphaBitfields = "Bmp/rgba32abf.bmp";
 
+            public const string Issue2696 = "Bmp/issue-2696.bmp";
+
             public static readonly string[] BitFields =
             {
                   Rgb32bfdef,

--- a/tests/Images/Input/Bmp/issue-2696.bmp
+++ b/tests/Images/Input/Bmp/issue-2696.bmp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de7e7ec0454a55f6a76c859f356b240a3d4cb56ca50dfa209a1813dd09e12076
-size 143
+oid sha256:bc42cda9bac8fc73351ad03bf55214069bb8d31ea5bdd806321a8cc8b56c282e
+size 126

--- a/tests/Images/Input/Bmp/issue-2696.bmp
+++ b/tests/Images/Input/Bmp/issue-2696.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de7e7ec0454a55f6a76c859f356b240a3d4cb56ca50dfa209a1813dd09e12076
+size 143


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backport of #2706 for v2

<!-- Thanks for contributing to ImageSharp! -->
