### PR TITLE
Clear Pixel Buffers on Decode.

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/SpectralConverter{TPixel}.cs
@@ -201,7 +201,8 @@ internal class SpectralConverter<TPixel> : SpectralConverter, IDisposable
         this.pixelBuffer = allocator.Allocate2D<TPixel>(
             pixelSize.Width,
             pixelSize.Height,
-            this.Configuration.PreferContiguousImageBuffers);
+            this.Configuration.PreferContiguousImageBuffers,
+            AllocationOptions.Clean);
         this.paddedProxyPixelRow = allocator.Allocate<TPixel>(pixelSize.Width + 3);
 
         // Component processors from spectral to RGB

--- a/src/ImageSharp/Formats/Tga/TgaDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tga/TgaDecoderCore.cs
@@ -84,7 +84,7 @@ internal sealed class TgaDecoderCore : IImageDecoderInternals
                 throw new UnknownImageFormatException("Width or height cannot be 0");
             }
 
-            Image<TPixel> image = Image.CreateUninitialized<TPixel>(this.configuration, this.fileHeader.Width, this.fileHeader.Height, this.metadata);
+            Image<TPixel> image = new(this.configuration, this.fileHeader.Width, this.fileHeader.Height, this.metadata);
             Buffer2D<TPixel> pixels = image.GetRootFramePixelBuffer();
 
             if (this.fileHeader.ColorMapType == 1)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Ensure that all decoders clear the pixel buffer on allocation.

<!-- Thanks for contributing to ImageSharp! -->
