### PR TITLE
V2 - Limit Read Palette Indices

### DIFF
--- a/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
+++ b/src/ImageSharp/Formats/Png/PngScanlineProcessor.cs
@@ -250,6 +250,7 @@ namespace SixLabors.ImageSharp.Formats.Png
             ref TPixel rowSpanRef = ref MemoryMarshal.GetReference(rowSpan);
             ReadOnlySpan<Rgb24> palettePixels = MemoryMarshal.Cast<byte, Rgb24>(palette);
             ref Rgb24 palettePixelsRef = ref MemoryMarshal.GetReference(palettePixels);
+            int maxIndex = palettePixels.Length - 1;
 
             if (paletteAlpha?.Length > 0)
             {
@@ -260,7 +261,7 @@ namespace SixLabors.ImageSharp.Formats.Png
 
                 for (int x = 0; x < header.Width; x++)
                 {
-                    int index = Unsafe.Add(ref scanlineSpanRef, x);
+                    int index = Numerics.Clamp(Unsafe.Add(ref scanlineSpanRef, x), 0, maxIndex);
                     rgba.Rgb = Unsafe.Add(ref palettePixelsRef, index);
                     rgba.A = paletteAlpha.Length > index ? Unsafe.Add(ref paletteAlphaRef, index) : byte.MaxValue;
 
@@ -272,8 +273,8 @@ namespace SixLabors.ImageSharp.Formats.Png
             {
                 for (int x = 0; x < header.Width; x++)
                 {
-                    int index = Unsafe.Add(ref scanlineSpanRef, x);
-                    Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, index);
+                    uint index = Unsafe.Add(ref scanlineSpanRef, x);
+                    Rgb24 rgb = Unsafe.Add(ref palettePixelsRef, (int)Math.Min(index, maxIndex));
 
                     pixel.FromRgb24(rgb);
                     Unsafe.Add(ref rowSpanRef, x) = pixel;

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -526,5 +526,13 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
                     "Disco")
                 .Dispose();
         }
+
+        [Theory]
+        [InlineData(TestImages.Png.Bad.Issue2714BadPalette)]
+        public void Decode_BadPalette(string file)
+        {
+            string path = Path.GetFullPath(Path.Combine(TestEnvironment.InputImagesDirectoryFullPath, file));
+            using Image image = Image.Load(path);
+        }
     }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -156,6 +156,8 @@ namespace SixLabors.ImageSharp.Tests
                 // Invalid color type.
                 public const string ColorTypeOne = "Png/xc1n0g08.png";
                 public const string ColorTypeNine = "Png/xc9n2c08.png";
+
+                public const string Issue2714BadPalette = "Png/issues/Issue_2714.png";
             }
         }
 

--- a/tests/Images/Input/Png/issues/Issue_2714.png
+++ b/tests/Images/Input/Png/issues/Issue_2714.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a4b6efc3090dbd70ae9efe97ea817464845263536beea4e80fd7c884dee6c5a
+size 128


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backport of #2718 for v2.

<!-- Thanks for contributing to ImageSharp! -->
