### PR TITLE
Fix MacOS jobs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
             sdk: 8.0.x
             runtime: -x64
             codecov: false
-          - os: macos-latest
+          - os: macos-13 # macos-latest runs on arm64 runners where libgdiplus is unavailable
             framework: net8.0
             sdk: 8.0.x
             runtime: -x64

--- a/tests/ImageSharp.Tests/TestFormat.cs
+++ b/tests/ImageSharp.Tests/TestFormat.cs
@@ -229,8 +229,7 @@ public class TestFormat : IImageFormatConfigurationModule, IImageFormat
             return this.testFormat.Sample<TPixel>();
         }
 
-        protected override Image Decode(TestDecoderOptions options, Stream stream, CancellationToken cancellationToken)
-            => this.Decode<TestPixelForAgnosticDecode>(options, stream, cancellationToken);
+        protected override Image Decode(TestDecoderOptions options, Stream stream, CancellationToken cancellationToken) => this.Decode<TestPixelForAgnosticDecode>(options, stream, cancellationToken);
     }
 
     public class TestDecoderOptions : ISpecializedDecoderOptions

--- a/tests/ImageSharp.Tests/TestFormat.cs
+++ b/tests/ImageSharp.Tests/TestFormat.cs
@@ -229,7 +229,8 @@ public class TestFormat : IImageFormatConfigurationModule, IImageFormat
             return this.testFormat.Sample<TPixel>();
         }
 
-        protected override Image Decode(TestDecoderOptions options, Stream stream, CancellationToken cancellationToken) => this.Decode<TestPixelForAgnosticDecode>(options, stream, cancellationToken);
+        protected override Image Decode(TestDecoderOptions options, Stream stream, CancellationToken cancellationToken)
+            => this.Decode<TestPixelForAgnosticDecode>(options, stream, cancellationToken);
     }
 
     public class TestDecoderOptions : ISpecializedDecoderOptions


### PR DESCRIPTION
~Dummy PR to run against `macos-latest` on CI.~

As noted in https://github.com/SixLabors/ImageSharp/pull/2728#issuecomment-2078083691, we need to use `macos-13` to get the tests running.

In long term we need to migrate away from using `System.Drawing.Common` reference implementations, at least on Mac.