### PR TITLE
Fix overflow in MemoryAllocator.Create(options)

### DIFF
--- a/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
@@ -49,7 +49,7 @@ public abstract class MemoryAllocator
         UniformUnmanagedMemoryPoolMemoryAllocator allocator = new(options.MaximumPoolSizeMegabytes);
         if (options.AllocationLimitMegabytes.HasValue)
         {
-            allocator.MemoryGroupAllocationLimitBytes = options.AllocationLimitMegabytes.Value * 1024 * 1024;
+            allocator.MemoryGroupAllocationLimitBytes = options.AllocationLimitMegabytes.Value * 1024L * 1024L;
             allocator.SingleBufferAllocationLimitBytes = (int)Math.Min(allocator.SingleBufferAllocationLimitBytes, allocator.MemoryGroupAllocationLimitBytes);
         }
 

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -442,4 +442,16 @@ public class UniformUnmanagedPoolMemoryAllocatorTests
         allocator.AllocateGroup<byte>(4 * oneMb, 1024).Dispose(); // Should work
         Assert.Throws<InvalidMemoryOperationException>(() => allocator.AllocateGroup<byte>(5 * oneMb, 1024));
     }
+
+    [Fact]
+    public void MemoryAllocator_Create_SetHighLimit()
+    {
+        const long size32GB = 32L * (1 << 30);
+        MemoryAllocator allocator = MemoryAllocator.Create(new MemoryAllocatorOptions()
+        {
+            AllocationLimitMegabytes = (int)(size32GB / 1024)
+        });
+        using MemoryGroup<byte> memoryGroup = allocator.AllocateGroup<byte>(size32GB, 1024);
+        Assert.Equal(size32GB, memoryGroup.TotalLength);
+    }
 }

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -449,13 +449,13 @@ public class UniformUnmanagedPoolMemoryAllocatorTests
         RemoteExecutor.Invoke(RunTest).Dispose();
         static void RunTest()
         {
-            const long size32GB = 32L * (1 << 30);
+            const long threeGB = 3L * (1 << 30);
             MemoryAllocator allocator = MemoryAllocator.Create(new MemoryAllocatorOptions()
             {
-                AllocationLimitMegabytes = (int)(size32GB / 1024)
+                AllocationLimitMegabytes = (int)(threeGB / 1024)
             });
-            using MemoryGroup<byte> memoryGroup = allocator.AllocateGroup<byte>(size32GB, 1024);
-            Assert.Equal(size32GB, memoryGroup.TotalLength);
+            using MemoryGroup<byte> memoryGroup = allocator.AllocateGroup<byte>(threeGB, 1024);
+            Assert.Equal(threeGB, memoryGroup.TotalLength);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -443,15 +443,19 @@ public class UniformUnmanagedPoolMemoryAllocatorTests
         Assert.Throws<InvalidMemoryOperationException>(() => allocator.AllocateGroup<byte>(5 * oneMb, 1024));
     }
 
-    [Fact]
+    [ConditionalFact(typeof(Environment), nameof(Environment.Is64BitProcess))]
     public void MemoryAllocator_Create_SetHighLimit()
     {
-        const long size32GB = 32L * (1 << 30);
-        MemoryAllocator allocator = MemoryAllocator.Create(new MemoryAllocatorOptions()
+        RemoteExecutor.Invoke(RunTest).Dispose();
+        static void RunTest()
         {
-            AllocationLimitMegabytes = (int)(size32GB / 1024)
-        });
-        using MemoryGroup<byte> memoryGroup = allocator.AllocateGroup<byte>(size32GB, 1024);
-        Assert.Equal(size32GB, memoryGroup.TotalLength);
+            const long size32GB = 32L * (1 << 30);
+            MemoryAllocator allocator = MemoryAllocator.Create(new MemoryAllocatorOptions()
+            {
+                AllocationLimitMegabytes = (int)(size32GB / 1024)
+            });
+            using MemoryGroup<byte> memoryGroup = allocator.AllocateGroup<byte>(size32GB, 1024);
+            Assert.Equal(size32GB, memoryGroup.TotalLength);
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix an overlook from #2706. See https://github.com/SixLabors/ImageSharp/commit/92b82779ac8e7a032989533bb9a01ef092186b2e#r141770676.
