### PR TITLE
[2.1] Fix overflow in MemoryAllocator.Create(options)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
             sdk-preview: true
             runtime: -x64
             codecov: false
-          - os: macos-latest
+          - os: macos-13 # macos-latest runs on arm64 runners
             framework: net6.0
             sdk: 6.0.x
             sdk-preview: true
@@ -38,7 +38,7 @@ jobs:
             framework: net5.0
             runtime: -x64
             codecov: false
-          - os: macos-latest
+          - os: macos-13 # macos-latest runs on arm64 runners
             framework: net5.0
             runtime: -x64
             codecov: false
@@ -50,7 +50,7 @@ jobs:
             framework: netcoreapp3.1
             runtime: -x64
             codecov: false
-          - os: macos-latest
+          - os: macos-13 # macos-latest runs on arm64 runners
             framework: netcoreapp3.1
             runtime: -x64
             codecov: false

--- a/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/MemoryAllocator.cs
@@ -51,7 +51,7 @@ namespace SixLabors.ImageSharp.Memory
             UniformUnmanagedMemoryPoolMemoryAllocator allocator = new(options.MaximumPoolSizeMegabytes);
             if (options.AllocationLimitMegabytes.HasValue)
             {
-                allocator.MemoryGroupAllocationLimitBytes = options.AllocationLimitMegabytes.Value * 1024 * 1024;
+                allocator.MemoryGroupAllocationLimitBytes = options.AllocationLimitMegabytes.Value * 1024L * 1024L;
                 allocator.SingleBufferAllocationLimitBytes = (int)Math.Min(allocator.SingleBufferAllocationLimitBytes, allocator.MemoryGroupAllocationLimitBytes);
             }
 

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -436,5 +436,21 @@ namespace SixLabors.ImageSharp.Tests.Memory.Allocators
             }
         }
 #endif
+
+        [ConditionalFact(typeof(Environment), nameof(Environment.Is64BitProcess))]
+        public void MemoryAllocator_Create_SetHighLimit()
+        {
+            RemoteExecutor.Invoke(RunTest).Dispose();
+            static void RunTest()
+            {
+                const long threeGB = 3L * (1 << 30);
+                MemoryAllocator allocator = MemoryAllocator.Create(new MemoryAllocatorOptions()
+                {
+                    AllocationLimitMegabytes = (int)(threeGB / 1024)
+                });
+                using MemoryGroup<byte> memoryGroup = allocator.AllocateGroup<byte>(threeGB, 1024);
+                Assert.Equal(threeGB, memoryGroup.TotalLength);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Backport of #2730 to `release/2.1.x`