### PR TITLE
GifDecoder: Limit lzw bits to a maximum of 12 bits

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -463,6 +463,7 @@ internal sealed class GifDecoderCore : IImageDecoderInternals
         finally
         {
             indices?.Dispose();
+            this.currentLocalColorTable?.Dispose();
         }
     }
 

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -463,7 +463,6 @@ internal sealed class GifDecoderCore : IImageDecoderInternals
         finally
         {
             indices?.Dispose();
-            this.currentLocalColorTable?.Dispose();
         }
     }
 

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -20,6 +20,11 @@ internal sealed class LzwDecoder : IDisposable
     private const int MaxStackSize = 4096;
 
     /// <summary>
+    /// The maximum bits for a lzw code.
+    /// </summary>
+    private const int MaximumLzwBits = 12;
+
+    /// <summary>
     /// The null code.
     /// </summary>
     private const int NullCode = -1;
@@ -73,7 +78,7 @@ internal sealed class LzwDecoder : IDisposable
         // It is possible to specify a larger LZW minimum code size than the palette length in bits
         // which may leave a gap in the codes where no colors are assigned.
         // http://www.matthewflickinger.com/lab/whatsinagif/lzw_image_data.asp#lzw_compression
-        if (minCodeSize < 2 || clearCode > MaxStackSize)
+        if (minCodeSize < 2 || minCodeSize > MaximumLzwBits || clearCode > MaxStackSize)
         {
             // Don't attempt to decode the frame indices.
             // Theoretically we could determine a min code size from the length of the provided
@@ -245,7 +250,7 @@ internal sealed class LzwDecoder : IDisposable
         // It is possible to specify a larger LZW minimum code size than the palette length in bits
         // which may leave a gap in the codes where no colors are assigned.
         // http://www.matthewflickinger.com/lab/whatsinagif/lzw_image_data.asp#lzw_compression
-        if (minCodeSize < 2 || clearCode > MaxStackSize)
+        if (minCodeSize < 2 || minCodeSize > MaximumLzwBits || clearCode > MaxStackSize)
         {
             // Don't attempt to decode the frame indices.
             // Theoretically we could determine a min code size from the length of the provided

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -83,7 +83,7 @@ internal sealed class LzwDecoder : IDisposable
             // Don't attempt to decode the frame indices.
             // Theoretically we could determine a min code size from the length of the provided
             // color palette but we won't bother since the image is most likely corrupted.
-            GifThrowHelper.ThrowInvalidImageContentException("Gif Image does not contain a valid LZW minimum code.");
+            return;
         }
 
         // The resulting index table length.

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -296,15 +296,9 @@ public class GifDecoderTests
     public void Issue2012BadMinCode<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        Exception ex = Record.Exception(
-            () =>
-            {
-                using Image<TPixel> image = provider.GetImage();
-                image.DebugSave(provider);
-            });
-
-        Assert.NotNull(ex);
-        Assert.Contains("Gif Image does not contain a valid LZW minimum code.", ex.Message);
+        using Image<TPixel> image = provider.GetImage();
+        image.DebugSave(provider);
+        image.CompareToReferenceOutput(provider);
     }
 
     // https://bugzilla.mozilla.org/show_bug.cgi?id=55918
@@ -325,14 +319,8 @@ public class GifDecoderTests
     public void IssueTooLargeLzwBits<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        Exception ex = Record.Exception(
-            () =>
-            {
-                using Image<TPixel> image = provider.GetImage();
-                image.DebugSave(provider);
-            });
-
-        Assert.NotNull(ex);
-        Assert.Contains("Gif Image does not contain a valid LZW minimum code.", ex.Message);
+        using Image<TPixel> image = provider.GetImage();
+        image.DebugSaveMultiFrame(provider);
+        image.CompareToReferenceOutputMultiFrame(provider, ImageComparer.Exact);
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -318,4 +318,21 @@ public class GifDecoderTests
         image.DebugSave(provider);
         image.CompareFirstFrameToReferenceOutput(ImageComparer.Exact, provider);
     }
+
+    // https://github.com/SixLabors/ImageSharp/issues/2743
+    [Theory]
+    [WithFile(TestImages.Gif.Issues.BadMaxLzwBits, PixelTypes.Rgba32)]
+    public void IssueTooLargeLzwBits<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        Exception ex = Record.Exception(
+            () =>
+            {
+                using Image<TPixel> image = provider.GetImage();
+                image.DebugSave(provider);
+            });
+
+        Assert.NotNull(ex);
+        Assert.Contains("Gif Image does not contain a valid LZW minimum code.", ex.Message);
+    }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -516,6 +516,7 @@ public static class TestImages
             public const string BadAppExtLength = "Gif/issues/issue405_badappextlength252.gif";
             public const string BadAppExtLength_2 = "Gif/issues/issue405_badappextlength252-2.gif";
             public const string BadDescriptorWidth = "Gif/issues/issue403_baddescriptorwidth.gif";
+            public const string BadMaxLzwBits = "Gif/issues/issue_2743.gif";
             public const string DeferredClearCode = "Gif/issues/bugzilla-55918.gif";
             public const string Issue1505 = "Gif/issues/issue1505_argumentoutofrange.png";
             public const string Issue1530 = "Gif/issues/issue1530.gif";

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012BadMinCode_Rgba32_issue2012_drona1.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012BadMinCode_Rgba32_issue2012_drona1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3a24c066895fd3a76649da376485cbc1912d6a3ae15369575f523e66364b3b6
+size 141563

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/00.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:800d1ec2d7c7c99d449db1f49ef202cf18214016eae65ebc4216d6f4b1f4d328
+size 537

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/01.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94dcd97831b16165f3331e429d72d7ef546e04038cab754c7918f9cf535ff30a
+size 542

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/02.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec1a589a8fae1b17a82b70a9583ea2ee012a476b1fa8fdba27fee2b7ce0403b2
+size 540

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/03.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c8751f4fafd5c56066dbb8d64a3890fc420a3bd66881a55e309ba274b6d14e4
+size 542

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/04.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b78516c9874cb15de4c4b98ed307e8105d962fc6bfa7aa3490b2c7e13b455a2d
+size 544

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/05.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c8751f4fafd5c56066dbb8d64a3890fc420a3bd66881a55e309ba274b6d14e4
+size 542

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/06.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/06.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec1a589a8fae1b17a82b70a9583ea2ee012a476b1fa8fdba27fee2b7ce0403b2
+size 540

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/07.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/07.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:489642f0c81fd12e97007fe6feb11b0e93e351199a922ce038069a3782ad0722
+size 135

--- a/tests/Images/Input/Gif/issues/issue_2743.gif
+++ b/tests/Images/Input/Gif/issues/issue_2743.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4be51cb9c258a6518d791ad2810fa0d71449805a5d5a8f95dcc7da2dc558ed73
+size 166413


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

The image provided in #2743 has some invalid lzwCode length. This PR changes the gif lzw decoder to raise an exception when the lzwCode is larger then 12 Bits. 