### PR TITLE
GifDecoder : Allow skipping bad metadata using identify

### DIFF
--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -255,7 +255,7 @@ internal sealed class LzwDecoder : IDisposable
             // Don't attempt to decode the frame indices.
             // Theoretically we could determine a min code size from the length of the provided
             // color palette but we won't bother since the image is most likely corrupted.
-            GifThrowHelper.ThrowInvalidImageContentException("Gif Image does not contain a valid LZW minimum code.");
+            return;
         }
 
         int codeSize = minCodeSize + 1;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Follow up to #2744 that changes the behavior to skip bad min/max codes. Fixes #2743 

<!-- Thanks for contributing to ImageSharp! -->
