### PR TITLE
v3.1.x - Backport Webp: Fix Issue 2763/2692

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -699,6 +699,8 @@ internal class Vp8LEncoder : IDisposable
                     }
                 }
 
+                histogramImageSize = maxIndex;
+
                 this.bitWriter.PutBits((uint)(this.HistoBits - 2), 3);
                 this.EncodeImageNoHuffman(
                     histogramBgra,
@@ -714,7 +716,7 @@ internal class Vp8LEncoder : IDisposable
             // Store Huffman codes.
             // Find maximum number of symbols for the huffman tree-set.
             int maxTokens = 0;
-            for (int i = 0; i < 5 * histogramImage.Count; i++)
+            for (int i = 0; i < 5 * histogramImageSize; i++)
             {
                 HuffmanTreeCode codes = huffmanCodes[i];
                 if (maxTokens < codes.NumSymbols)
@@ -729,7 +731,7 @@ internal class Vp8LEncoder : IDisposable
                 tokens[i] = new HuffmanTreeToken();
             }
 
-            for (int i = 0; i < 5 * histogramImage.Count; i++)
+            for (int i = 0; i < 5 * histogramImageSize; i++)
             {
                 HuffmanTreeCode codes = huffmanCodes[i];
                 this.StoreHuffmanCode(huffTree, tokens, codes);

--- a/src/ImageSharp/Formats/Webp/WebpChunkParsingUtils.cs
+++ b/src/ImageSharp/Formats/Webp/WebpChunkParsingUtils.cs
@@ -218,10 +218,6 @@ internal static class WebpChunkParsingUtils
 
         // 3 reserved bytes should follow which are supposed to be zero.
         stream.Read(buffer, 0, 3);
-        if (buffer[0] != 0 || buffer[1] != 0 || buffer[2] != 0)
-        {
-            WebpThrowHelper.ThrowImageFormatException("reserved bytes should be zero");
-        }
 
         // 3 bytes for the width.
         uint width = ReadUInt24LittleEndian(stream, buffer) + 1;

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
@@ -497,6 +497,25 @@ public class WebpEncoderTests
         image.VerifyEncoder(provider, "webp", string.Empty, encoder, ImageComparer.Tolerant(0.04f));
     }
 
+    // https://github.com/SixLabors/ImageSharp/issues/2763
+    [Theory]
+    [WithFile(Lossy.Issue2763, PixelTypes.Rgba32)]
+    public void WebpDecoder_CanDecode_Issue2763<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        WebpEncoder encoder = new()
+        {
+            Quality = 84,
+            FileFormat = WebpFileFormatType.Lossless
+        };
+
+        using Image<TPixel> image = provider.GetImage(PngDecoder.Instance);
+        image.SaveAsWebp(@"C:\Users\james\Downloads\2763-fixed.webp", encoder);
+
+        image.DebugSave(provider);
+        image.VerifyEncoder(provider, "webp", string.Empty, encoder);
+    }
+
     public static void RunEncodeLossy_WithPeakImage()
     {
         TestImageProvider<Rgba32> provider = TestImageProvider<Rgba32>.File(TestImageLossyFullPath);

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
@@ -510,8 +510,6 @@ public class WebpEncoderTests
         };
 
         using Image<TPixel> image = provider.GetImage(PngDecoder.Instance);
-        image.SaveAsWebp(@"C:\Users\james\Downloads\2763-fixed.webp", encoder);
-
         image.DebugSave(provider);
         image.VerifyEncoder(provider, "webp", string.Empty, encoder);
     }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -820,6 +820,7 @@ public static class TestImages
             public const string Issue2243 = "Webp/issues/Issue2243.webp";
             public const string Issue2257 = "Webp/issues/Issue2257.webp";
             public const string Issue2670 = "Webp/issues/Issue2670.webp";
+            public const string Issue2763 = "Webp/issues/Issue2763.png";
         }
     }
 

--- a/tests/Images/Input/Webp/issues/Issue2763.png
+++ b/tests/Images/Input/Webp/issues/Issue2763.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb221c5045e9bcbfdb7f4704aa571d910ca0d382fe4748319fe56f4c8c2aab78
+size 429101


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backport of #2767 
Also contains a fix for #2692 

<!-- Thanks for contributing to ImageSharp! -->
