### PR TITLE
Correctly break during Png decoding

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -208,7 +208,7 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                             currentFrameControl = this.ReadFrameControlChunk(chunk.Data.GetSpan());
                             break;
                         case PngChunkType.FrameData:
-                            if (frameCount == this.maxFrames)
+                            if (frameCount >= this.maxFrames)
                             {
                                 goto EOF;
                             }
@@ -266,7 +266,7 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                                 previousFrameControl = currentFrameControl;
                             }
 
-                            if (frameCount == this.maxFrames)
+                            if (frameCount >= this.maxFrames)
                             {
                                 goto EOF;
                             }
@@ -389,7 +389,7 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                             break;
                         case PngChunkType.FrameControl:
                             ++frameCount;
-                            if (frameCount == this.maxFrames)
+                            if (frameCount >= this.maxFrames)
                             {
                                 break;
                             }
@@ -397,7 +397,7 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                             lastFrameControl = this.ReadFrameControlChunk(chunk.Data.GetSpan());
                             break;
                         case PngChunkType.FrameData:
-                            if (frameCount == this.maxFrames)
+                            if (frameCount >= this.maxFrames)
                             {
                                 break;
                             }

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -204,18 +204,13 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                             break;
                         case PngChunkType.FrameControl:
                             frameCount++;
-                            if (frameCount == this.maxFrames)
-                            {
-                                break;
-                            }
-
                             currentFrame = null;
                             currentFrameControl = this.ReadFrameControlChunk(chunk.Data.GetSpan());
                             break;
                         case PngChunkType.FrameData:
                             if (frameCount == this.maxFrames)
                             {
-                                break;
+                                goto EOF;
                             }
 
                             if (image is null)
@@ -269,6 +264,11 @@ internal sealed class PngDecoderCore : IImageDecoderInternals
                             {
                                 previousFrame = currentFrame;
                                 previousFrameControl = currentFrameControl;
+                            }
+
+                            if (frameCount == this.maxFrames)
+                            {
+                                goto EOF;
                             }
 
                             break;

--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -701,4 +701,14 @@ public partial class PngDecoderTests
         string path = Path.GetFullPath(Path.Combine(TestEnvironment.InputImagesDirectoryFullPath, file));
         using Image image = Image.Load(path);
     }
+
+    [Theory]
+    [WithFile(TestImages.Png.Issue2752, PixelTypes.Rgba32)]
+    public void CanDecodeJustOneFrame<TPixel>(TestImageProvider<TPixel> provider)
+    where TPixel : unmanaged, IPixel<TPixel>
+    {
+        DecoderOptions options = new() { MaxFrames = 1 };
+        using Image<TPixel> image = provider.GetImage(PngDecoder.Instance, options);
+        Assert.Equal(1, image.Frames.Count);
+    }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -156,6 +156,9 @@ public static class TestImages
         // Issue 2668: https://github.com/SixLabors/ImageSharp/issues/2668
         public const string Issue2668 = "Png/issues/Issue_2668.png";
 
+        // Issue 2752: https://github.com/SixLabors/ImageSharp/issues/2752
+        public const string Issue2752 = "Png/issues/Issue_2752.png";
+
         public static class Bad
         {
             public const string MissingDataChunk = "Png/xdtn0g01.png";

--- a/tests/Images/Input/Png/issues/Issue_2752.png
+++ b/tests/Images/Input/Png/issues/Issue_2752.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d4cb44eea721009c616de30a1f18c1de59635de4b313b13d685456a529ced97
+size 5590983


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #2752 

We weren't breaking from the loop only the nested switch. We were also missing a chunk break. The first `fcTL` chunk in a PNG is followed by one or more `IDAT` chunk, only subsequent `fcTL` chunks are followed by `fdAT` chunks.

The test image contains the following chunks. 

```
IHDR, pHYs, acTL, fcTL, IDAT ×3, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT,
fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, 
fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT,
fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT,
fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL,
fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT,
fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, fcTL, fdAT, fdAT, IEND
```

<!-- Thanks for contributing to ImageSharp! -->
