### PR TITLE
Backport 2759 to 2.1.x

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -23,6 +23,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         public FrameDecodingMode DecodingMode { get; set; } = FrameDecodingMode.All;
 
+        /// <summary>
+        /// Gets or sets the maximum number of gif frames.
+        /// </summary>
+        public uint MaxFrames { get; set; } = uint.MaxValue;
+
         /// <inheritdoc/>
         public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
             where TPixel : unmanaged, IPixel<TPixel>

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -100,19 +100,13 @@ namespace SixLabors.ImageSharp.Formats.Gif
         public GifDecoderCore(Configuration configuration, IGifDecoderOptions options)
         {
             this.skipMetadata = options.IgnoreMetadata;
-            this.DecodingMode = options.DecodingMode;
             this.configuration = configuration ?? Configuration.Default;
-            this.maxFrames = options.MaxFrames;
+            this.maxFrames = options.DecodingMode == FrameDecodingMode.All ? options.MaxFrames : 1;
             this.memoryAllocator = this.configuration.MemoryAllocator;
         }
 
         /// <inheritdoc />
         public Configuration Configuration => this.configuration;
-
-        /// <summary>
-        /// Gets the decoding mode for multi-frame images.
-        /// </summary>
-        public FrameDecodingMode DecodingMode { get; }
 
         /// <summary>
         /// Gets the dimensions of the image.

--- a/src/ImageSharp/Formats/Gif/GifThrowHelper.cs
+++ b/src/ImageSharp/Formats/Gif/GifThrowHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.Formats.Gif
@@ -24,5 +25,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// if no inner exception is specified.</param>
         [MethodImpl(InliningOptions.ColdPath)]
         public static void ThrowInvalidImageContentException(string errorMessage, Exception innerException) => throw new InvalidImageContentException(errorMessage, innerException);
+
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowNoHeader() => throw new InvalidImageContentException("Gif image does not contain a Logical Screen Descriptor.");
+
+        [MethodImpl(InliningOptions.ColdPath)]
+        public static void ThrowNoData() => throw new InvalidImageContentException("Unable to read Gif image data");
     }
 }

--- a/src/ImageSharp/Formats/Gif/IGifDecoderOptions.cs
+++ b/src/ImageSharp/Formats/Gif/IGifDecoderOptions.cs
@@ -19,5 +19,10 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// Gets the decoding mode for multi-frame images.
         /// </summary>
         FrameDecodingMode DecodingMode { get; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of gif frames.
+        /// </summary>
+        uint MaxFrames { get; set; }
     }
 }

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -21,6 +21,11 @@ namespace SixLabors.ImageSharp.Formats.Gif
         private const int MaxStackSize = 4096;
 
         /// <summary>
+        /// The maximum bits for a lzw code.
+        /// </summary>
+        private const int MaximumLzwBits = 12;
+
+        /// <summary>
         /// The null code.
         /// </summary>
         private const int NullCode = -1;
@@ -41,28 +46,28 @@ namespace SixLabors.ImageSharp.Formats.Gif
         private readonly IMemoryOwner<int> suffix;
 
         /// <summary>
-    /// The scratch buffer for reading data blocks.
-    /// </summary>
-    private readonly IMemoryOwner<byte> scratchBuffer;
+        /// The scratch buffer for reading data blocks.
+        /// </summary>
+        private readonly IMemoryOwner<byte> scratchBuffer;
 
-    /// <summary>
+        /// <summary>
         /// The pixel stack buffer.
         /// </summary>
         private readonly IMemoryOwner<int> pixelStack;
-    private readonly int minCodeSize;
-    private readonly int clearCode;
-    private readonly int endCode;
-    private int code;
-    private int codeSize;
-    private int codeMask;
-    private int availableCode;
-    private int oldCode = NullCode;
-    private int bits;
-    private int top;
-    private int count;
-    private int bufferIndex;
-    private int data;
-    private int first;
+        private readonly int minCodeSize;
+        private readonly int clearCode;
+        private readonly int endCode;
+        private int code;
+        private int codeSize;
+        private int codeMask;
+        private int availableCode;
+        private int oldCode = NullCode;
+        private int bits;
+        private int top;
+        private int count;
+        private int bufferIndex;
+        private int data;
+        private int first;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LzwDecoder"/> class
@@ -70,216 +75,280 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         /// <param name="memoryAllocator">The <see cref="MemoryAllocator"/> to use for buffer allocations.</param>
         /// <param name="stream">The stream to read from.</param>
-    /// <param name="minCodeSize">The minimum code size.</param>
+        /// <param name="minCodeSize">The minimum code size.</param>
         /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
-    public LzwDecoder(MemoryAllocator memoryAllocator, BufferedReadStream stream, int minCodeSize)
+        public LzwDecoder(MemoryAllocator memoryAllocator, BufferedReadStream stream, int minCodeSize)
         {
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
 
             this.prefix = memoryAllocator.Allocate<int>(MaxStackSize, AllocationOptions.Clean);
             this.suffix = memoryAllocator.Allocate<int>(MaxStackSize, AllocationOptions.Clean);
             this.pixelStack = memoryAllocator.Allocate<int>(MaxStackSize + 1, AllocationOptions.Clean);
-        this.scratchBuffer = memoryAllocator.Allocate<byte>(byte.MaxValue, AllocationOptions.None);
-        this.minCodeSize = minCodeSize;
+            this.scratchBuffer = memoryAllocator.Allocate<byte>(byte.MaxValue, AllocationOptions.None);
+            this.minCodeSize = minCodeSize;
 
-        // Calculate the clear code. The value of the clear code is 2 ^ minCodeSize
-        this.clearCode = 1 << minCodeSize;
-        this.codeSize = minCodeSize + 1;
-        this.codeMask = (1 << this.codeSize) - 1;
-        this.endCode = this.clearCode + 1;
-        this.availableCode = this.clearCode + 2;
+            // Calculate the clear code. The value of the clear code is 2 ^ minCodeSize
+            this.clearCode = 1 << minCodeSize;
+            this.codeSize = minCodeSize + 1;
+            this.codeMask = (1 << this.codeSize) - 1;
+            this.endCode = this.clearCode + 1;
+            this.availableCode = this.clearCode + 2;
 
-        ref int suffixRef = ref MemoryMarshal.GetReference(this.suffix.GetSpan());
-        for (this.code = 0; this.code < this.clearCode; this.code++)
-        {
-            Unsafe.Add(ref suffixRef, (uint)this.code) = (byte)this.code;
-        }
+            ref int suffixRef = ref MemoryMarshal.GetReference(this.suffix.GetSpan());
+            for (this.code = 0; this.code < this.clearCode; this.code++)
+            {
+                Unsafe.Add(ref suffixRef, this.code) = (byte)this.code;
+            }
         }
 
         /// <summary>
-    /// Gets a value indicating whether the minimum code size is valid.
+        /// Gets a value indicating whether the minimum code size is valid.
         /// </summary>
-    /// <param name="minCodeSize">The minimum code size.</param>
-    /// <returns>
-    /// <see langword="true"/> if the minimum code size is valid; otherwise, <see langword="false"/>.
-    /// </returns>
-    public static bool IsValidMinCodeSize(int minCodeSize)
+        /// <param name="minCodeSize">The minimum code size.</param>
+        /// <returns>
+        /// <see langword="true"/> if the minimum code size is valid; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsValidMinCodeSize(int minCodeSize)
         {
             // It is possible to specify a larger LZW minimum code size than the palette length in bits
             // which may leave a gap in the codes where no colors are assigned.
             // http://www.matthewflickinger.com/lab/whatsinagif/lzw_image_data.asp#lzw_compression
-        int clearCode = 1 << minCodeSize;
-        if (minCodeSize < 2 || minCodeSize > MaximumLzwBits || clearCode > MaxStackSize)
-        {
-            // Don't attempt to decode the frame indices.
-            // Theoretically we could determine a min code size from the length of the provided
-            // color palette but we won't bother since the image is most likely corrupted.
-            return false;
+            int clearCode = 1 << minCodeSize;
+            if (minCodeSize < 2 || minCodeSize > MaximumLzwBits || clearCode > MaxStackSize)
+            {
+                // Don't attempt to decode the frame indices.
+                // Theoretically we could determine a min code size from the length of the provided
+                // color palette but we won't bother since the image is most likely corrupted.
+                return false;
             }
 
-        return true;
-    }
+            return true;
+        }
 
-    /// <summary>
-    /// Decodes and decompresses all pixel indices for a single row from the stream, assigning the pixel values to the buffer.
-    /// </summary>
-    /// <param name="indices">The pixel indices array to decode to.</param>
-    public void DecodePixelRow(Span<byte> indices)
-    {
-        indices.Clear();
+        /// <summary>
+        /// Decodes and decompresses all pixel indices for a single row from the stream, assigning the pixel values to the buffer.
+        /// </summary>
+        /// <param name="indices">The pixel indices array to decode to.</param>
+        public void DecodePixelRow(Span<byte> indices)
+        {
+            indices.Clear();
 
-        ref byte pixelsRowRef = ref MemoryMarshal.GetReference(indices);
+            ref byte pixelsRowRef = ref MemoryMarshal.GetReference(indices);
             ref int prefixRef = ref MemoryMarshal.GetReference(this.prefix.GetSpan());
             ref int suffixRef = ref MemoryMarshal.GetReference(this.suffix.GetSpan());
             ref int pixelStackRef = ref MemoryMarshal.GetReference(this.pixelStack.GetSpan());
-        Span<byte> buffer = this.scratchBuffer.GetSpan();
+            Span<byte> buffer = this.scratchBuffer.GetSpan();
 
             int x = 0;
-        int xyz = 0;
-        while (xyz < indices.Length)
-        {
-            if (this.top == 0)
+            int xyz = 0;
+            while (xyz < indices.Length)
+            {
+                if (this.top == 0)
                 {
-                if (this.bits < this.codeSize)
+                    if (this.bits < this.codeSize)
                     {
                         // Load bytes until there are enough bits for a code.
-                    if (this.count == 0)
+                        if (this.count == 0)
                         {
                             // Read a new data block.
-                        this.count = this.ReadBlock(buffer);
-                        if (this.count == 0)
+                            this.count = this.ReadBlock(buffer);
+                            if (this.count == 0)
                             {
                                 break;
                             }
 
-                        this.bufferIndex = 0;
+                            this.bufferIndex = 0;
                         }
 
-                    this.data += buffer[this.bufferIndex] << this.bits;
+                        this.data += buffer[this.bufferIndex] << this.bits;
 
-                    this.bits += 8;
-                    this.bufferIndex++;
-                    this.count--;
+                        this.bits += 8;
+                        this.bufferIndex++;
+                        this.count--;
                         continue;
                     }
 
                     // Get the next code
-                this.code = this.data & this.codeMask;
-                this.data >>= this.codeSize;
-                this.bits -= this.codeSize;
+                    this.code = this.data & this.codeMask;
+                    this.data >>= this.codeSize;
+                    this.bits -= this.codeSize;
 
                     // Interpret the code
-                if (this.code > this.availableCode || this.code == this.endCode)
+                    if (this.code > this.availableCode || this.code == this.endCode)
                     {
                         break;
                     }
 
-                if (this.code == this.clearCode)
+                    if (this.code == this.clearCode)
                     {
                         // Reset the decoder
-                    this.codeSize = this.minCodeSize + 1;
-                    this.codeMask = (1 << this.codeSize) - 1;
-                    this.availableCode = this.clearCode + 2;
-                    this.oldCode = NullCode;
-                        continue;
-                    }
-
-                if (this.oldCode == NullCode)
-                    {
-                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
-                    this.oldCode = this.code;
-                    this.first = this.code;
-                int inCode = this.code;
-                if (this.code == this.availableCode)
-                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = (byte)this.first;
-                    this.code = this.oldCode;
-                while (this.code > this.clearCode)
-                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
-                    this.code = Unsafe.Add(ref prefixRef, (uint)this.code);
-                int suffixCode = Unsafe.Add(ref suffixRef, (uint)this.code);
-                this.first = suffixCode;
-                Unsafe.Add(ref pixelStackRef, (uint)this.top++) = suffixCode;
-                if (this.availableCode < MaxStackSize)
-                    Unsafe.Add(ref prefixRef, (uint)this.availableCode) = this.oldCode;
-                    Unsafe.Add(ref suffixRef, (uint)this.availableCode) = this.first;
-                    this.availableCode++;
-                    if (this.availableCode == this.codeMask + 1 && this.availableCode < MaxStackSize)
-                        this.codeSize++;
+                        this.codeSize = this.minCodeSize + 1;
                         this.codeMask = (1 << this.codeSize) - 1;
-                this.oldCode = inCode;
-            this.top--;
-            Unsafe.Add(ref pixelsRowRef, (uint)x++) = (byte)Unsafe.Add(ref pixelStackRef, (uint)this.top);
-    public void SkipIndices(int length)
-    {
-        Span<byte> buffer = this.scratchBuffer.GetSpan();
-        int xyz = 0;
-            if (this.top == 0)
-                if (this.bits < this.codeSize)
-                    if (this.count == 0)
-                        this.count = this.ReadBlock(buffer);
-                        if (this.count == 0)
-                        this.bufferIndex = 0;
-                    this.data += buffer[this.bufferIndex] << this.bits;
-                    this.bits += 8;
-                    this.bufferIndex++;
-                    this.count--;
-                this.code = this.data & this.codeMask;
-                this.data >>= this.codeSize;
-                this.bits -= this.codeSize;
-                if (this.code > this.availableCode || this.code == this.endCode)
-                if (this.code == this.clearCode)
-                    this.codeSize = this.minCodeSize + 1;
-                    this.codeMask = (1 << this.codeSize) - 1;
-                    this.availableCode = this.clearCode + 2;
-                    this.oldCode = NullCode;
-                if (this.oldCode == NullCode)
-                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
-                    this.oldCode = this.code;
-                    this.first = this.code;
+                        this.availableCode = this.clearCode + 2;
+                        this.oldCode = NullCode;
                         continue;
                     }
 
-                int inCode = this.code;
-                if (this.code == this.availableCode)
+                    if (this.oldCode == NullCode)
                     {
-                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = (byte)this.first;
-
-                    this.code = this.oldCode;
+                        Unsafe.Add(ref pixelStackRef, this.top++) = Unsafe.Add(ref suffixRef, this.code);
+                        this.oldCode = this.code;
+                        this.first = this.code;
+                        continue;
                     }
 
-                while (this.code > this.clearCode)
+                    int inCode = this.code;
+                    if (this.code == this.availableCode)
                     {
-                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
-                    this.code = Unsafe.Add(ref prefixRef, (uint)this.code);
+                        Unsafe.Add(ref pixelStackRef, this.top++) = (byte)this.first;
+
+                        this.code = this.oldCode;
                     }
 
-                int suffixCode = Unsafe.Add(ref suffixRef, (uint)this.code);
-                this.first = suffixCode;
-                Unsafe.Add(ref pixelStackRef, (uint)this.top++) = suffixCode;
+                    while (this.code > this.clearCode)
+                    {
+                        Unsafe.Add(ref pixelStackRef, this.top++) = Unsafe.Add(ref suffixRef, this.code);
+                        this.code = Unsafe.Add(ref prefixRef, this.code);
+                    }
+
+                    int suffixCode = Unsafe.Add(ref suffixRef, this.code);
+                    this.first = suffixCode;
+                    Unsafe.Add(ref pixelStackRef, this.top++) = suffixCode;
 
                     // Fix for Gifs that have "deferred clear code" as per here :
                     // https://bugzilla.mozilla.org/show_bug.cgi?id=55918
-                if (this.availableCode < MaxStackSize)
+                    if (this.availableCode < MaxStackSize)
                     {
-                    Unsafe.Add(ref prefixRef, (uint)this.availableCode) = this.oldCode;
-                    Unsafe.Add(ref suffixRef, (uint)this.availableCode) = this.first;
-                    this.availableCode++;
-                    if (this.availableCode == this.codeMask + 1 && this.availableCode < MaxStackSize)
+                        Unsafe.Add(ref prefixRef, this.availableCode) = this.oldCode;
+                        Unsafe.Add(ref suffixRef, this.availableCode) = this.first;
+                        this.availableCode++;
+                        if (this.availableCode == this.codeMask + 1 && this.availableCode < MaxStackSize)
                         {
-                        this.codeSize++;
-                        this.codeMask = (1 << this.codeSize) - 1;
+                            this.codeSize++;
+                            this.codeMask = (1 << this.codeSize) - 1;
                         }
                     }
 
-                this.oldCode = inCode;
+                    this.oldCode = inCode;
                 }
 
                 // Pop a pixel off the pixel stack.
-            this.top--;
+                this.top--;
 
                 // Clear missing pixels
                 xyz++;
-                Unsafe.Add(ref pixelsRowRef, x++) = (byte)Unsafe.Add(ref pixelStackRef, top);
+                Unsafe.Add(ref pixelsRowRef, x++) = (byte)Unsafe.Add(ref pixelStackRef, this.top);
+            }
+        }
+
+        /// <summary>
+        /// Decodes and decompresses all pixel indices from the stream allowing skipping of the data.
+        /// </summary>
+        /// <param name="length">The resulting index table length.</param>
+        public void SkipIndices(int length)
+        {
+            ref int prefixRef = ref MemoryMarshal.GetReference(this.prefix.GetSpan());
+            ref int suffixRef = ref MemoryMarshal.GetReference(this.suffix.GetSpan());
+            ref int pixelStackRef = ref MemoryMarshal.GetReference(this.pixelStack.GetSpan());
+            Span<byte> buffer = this.scratchBuffer.GetSpan();
+
+            int xyz = 0;
+            while (xyz < length)
+            {
+                if (this.top == 0)
+                {
+                    if (this.bits < this.codeSize)
+                    {
+                        // Load bytes until there are enough bits for a code.
+                        if (this.count == 0)
+                        {
+                            // Read a new data block.
+                            this.count = this.ReadBlock(buffer);
+                            if (this.count == 0)
+                            {
+                                break;
+                            }
+
+                            this.bufferIndex = 0;
+                        }
+
+                        this.data += buffer[this.bufferIndex] << this.bits;
+
+                        this.bits += 8;
+                        this.bufferIndex++;
+                        this.count--;
+                        continue;
+                    }
+
+                    // Get the next code
+                    this.code = this.data & this.codeMask;
+                    this.data >>= this.codeSize;
+                    this.bits -= this.codeSize;
+
+                    // Interpret the code
+                    if (this.code > this.availableCode || this.code == this.endCode)
+                    {
+                        break;
+                    }
+
+                    if (this.code == this.clearCode)
+                    {
+                        // Reset the decoder
+                        this.codeSize = this.minCodeSize + 1;
+                        this.codeMask = (1 << this.codeSize) - 1;
+                        this.availableCode = this.clearCode + 2;
+                        this.oldCode = NullCode;
+                        continue;
+                    }
+
+                    if (this.oldCode == NullCode)
+                    {
+                        Unsafe.Add(ref pixelStackRef, this.top++) = Unsafe.Add(ref suffixRef, this.code);
+                        this.oldCode = this.code;
+                        this.first = this.code;
+                        continue;
+                    }
+
+                    int inCode = this.code;
+                    if (this.code == this.availableCode)
+                    {
+                        Unsafe.Add(ref pixelStackRef, this.top++) = (byte)this.first;
+
+                        this.code = this.oldCode;
+                    }
+
+                    while (this.code > this.clearCode)
+                    {
+                        Unsafe.Add(ref pixelStackRef, this.top++) = Unsafe.Add(ref suffixRef, this.code);
+                        this.code = Unsafe.Add(ref prefixRef, this.code);
+                    }
+
+                    int suffixCode = Unsafe.Add(ref suffixRef, this.code);
+                    this.first = suffixCode;
+                    Unsafe.Add(ref pixelStackRef, this.top++) = suffixCode;
+
+                    // Fix for Gifs that have "deferred clear code" as per here :
+                    // https://bugzilla.mozilla.org/show_bug.cgi?id=55918
+                    if (this.availableCode < MaxStackSize)
+                    {
+                        Unsafe.Add(ref prefixRef, this.availableCode) = this.oldCode;
+                        Unsafe.Add(ref suffixRef, this.availableCode) = this.first;
+                        this.availableCode++;
+                        if (this.availableCode == this.codeMask + 1 && this.availableCode < MaxStackSize)
+                        {
+                            this.codeSize++;
+                            this.codeMask = (1 << this.codeSize) - 1;
+                        }
+                    }
+
+                    this.oldCode = inCode;
+                }
+
+                // Pop a pixel off the pixel stack.
+                this.top--;
+
+                // Clear missing pixels
+                xyz++;
             }
         }
 
@@ -312,6 +381,7 @@ namespace SixLabors.ImageSharp.Formats.Gif
             this.prefix.Dispose();
             this.suffix.Dispose();
             this.pixelStack.Dispose();
-        this.scratchBuffer.Dispose();
+            this.scratchBuffer.Dispose();
+        }
     }
 }

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -41,9 +41,28 @@ namespace SixLabors.ImageSharp.Formats.Gif
         private readonly IMemoryOwner<int> suffix;
 
         /// <summary>
+    /// The scratch buffer for reading data blocks.
+    /// </summary>
+    private readonly IMemoryOwner<byte> scratchBuffer;
+
+    /// <summary>
         /// The pixel stack buffer.
         /// </summary>
         private readonly IMemoryOwner<int> pixelStack;
+    private readonly int minCodeSize;
+    private readonly int clearCode;
+    private readonly int endCode;
+    private int code;
+    private int codeSize;
+    private int codeMask;
+    private int availableCode;
+    private int oldCode = NullCode;
+    private int bits;
+    private int top;
+    private int count;
+    private int bufferIndex;
+    private int data;
+    private int first;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LzwDecoder"/> class
@@ -51,181 +70,212 @@ namespace SixLabors.ImageSharp.Formats.Gif
         /// </summary>
         /// <param name="memoryAllocator">The <see cref="MemoryAllocator"/> to use for buffer allocations.</param>
         /// <param name="stream">The stream to read from.</param>
+    /// <param name="minCodeSize">The minimum code size.</param>
         /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
-        public LzwDecoder(MemoryAllocator memoryAllocator, BufferedReadStream stream)
+    public LzwDecoder(MemoryAllocator memoryAllocator, BufferedReadStream stream, int minCodeSize)
         {
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
 
             this.prefix = memoryAllocator.Allocate<int>(MaxStackSize, AllocationOptions.Clean);
             this.suffix = memoryAllocator.Allocate<int>(MaxStackSize, AllocationOptions.Clean);
             this.pixelStack = memoryAllocator.Allocate<int>(MaxStackSize + 1, AllocationOptions.Clean);
+        this.scratchBuffer = memoryAllocator.Allocate<byte>(byte.MaxValue, AllocationOptions.None);
+        this.minCodeSize = minCodeSize;
+
+        // Calculate the clear code. The value of the clear code is 2 ^ minCodeSize
+        this.clearCode = 1 << minCodeSize;
+        this.codeSize = minCodeSize + 1;
+        this.codeMask = (1 << this.codeSize) - 1;
+        this.endCode = this.clearCode + 1;
+        this.availableCode = this.clearCode + 2;
+
+        ref int suffixRef = ref MemoryMarshal.GetReference(this.suffix.GetSpan());
+        for (this.code = 0; this.code < this.clearCode; this.code++)
+        {
+            Unsafe.Add(ref suffixRef, (uint)this.code) = (byte)this.code;
+        }
         }
 
         /// <summary>
-        /// Decodes and decompresses all pixel indices from the stream.
+    /// Gets a value indicating whether the minimum code size is valid.
         /// </summary>
-        /// <param name="minCodeSize">Minimum code size of the data.</param>
-        /// <param name="pixels">The pixel array to decode to.</param>
-        public void DecodePixels(int minCodeSize, Buffer2D<byte> pixels)
+    /// <param name="minCodeSize">The minimum code size.</param>
+    /// <returns>
+    /// <see langword="true"/> if the minimum code size is valid; otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool IsValidMinCodeSize(int minCodeSize)
         {
-            // Calculate the clear code. The value of the clear code is 2 ^ minCodeSize
-            int clearCode = 1 << minCodeSize;
-
             // It is possible to specify a larger LZW minimum code size than the palette length in bits
             // which may leave a gap in the codes where no colors are assigned.
             // http://www.matthewflickinger.com/lab/whatsinagif/lzw_image_data.asp#lzw_compression
-            if (minCodeSize < 2 || clearCode > MaxStackSize)
-            {
-                // Don't attempt to decode the frame indices.
-                // Theoretically we could determine a min code size from the length of the provided
-                // color palette but we won't bother since the image is most likely corrupted.
-                GifThrowHelper.ThrowInvalidImageContentException("Gif Image does not contain a valid LZW minimum code.");
+        int clearCode = 1 << minCodeSize;
+        if (minCodeSize < 2 || minCodeSize > MaximumLzwBits || clearCode > MaxStackSize)
+        {
+            // Don't attempt to decode the frame indices.
+            // Theoretically we could determine a min code size from the length of the provided
+            // color palette but we won't bother since the image is most likely corrupted.
+            return false;
             }
 
-            // The resulting index table length.
-            int width = pixels.Width;
-            int height = pixels.Height;
-            int length = width * height;
+        return true;
+    }
 
-            int codeSize = minCodeSize + 1;
+    /// <summary>
+    /// Decodes and decompresses all pixel indices for a single row from the stream, assigning the pixel values to the buffer.
+    /// </summary>
+    /// <param name="indices">The pixel indices array to decode to.</param>
+    public void DecodePixelRow(Span<byte> indices)
+    {
+        indices.Clear();
 
-            // Calculate the end code
-            int endCode = clearCode + 1;
-
-            // Calculate the available code.
-            int availableCode = clearCode + 2;
-
-            // Jillzhangs Code see: http://giflib.codeplex.com/
-            // Adapted from John Cristy's ImageMagick.
-            int code;
-            int oldCode = NullCode;
-            int codeMask = (1 << codeSize) - 1;
-            int bits = 0;
-
-            int top = 0;
-            int count = 0;
-            int bi = 0;
-            int xyz = 0;
-
-            int data = 0;
-            int first = 0;
-
+        ref byte pixelsRowRef = ref MemoryMarshal.GetReference(indices);
             ref int prefixRef = ref MemoryMarshal.GetReference(this.prefix.GetSpan());
             ref int suffixRef = ref MemoryMarshal.GetReference(this.suffix.GetSpan());
             ref int pixelStackRef = ref MemoryMarshal.GetReference(this.pixelStack.GetSpan());
+        Span<byte> buffer = this.scratchBuffer.GetSpan();
 
-            for (code = 0; code < clearCode; code++)
-            {
-                Unsafe.Add(ref suffixRef, code) = (byte)code;
-            }
-
-            Span<byte> buffer = stackalloc byte[byte.MaxValue];
-
-            int y = 0;
             int x = 0;
-            int rowMax = width;
-            ref byte pixelsRowRef = ref MemoryMarshal.GetReference(pixels.DangerousGetRowSpan(y));
-            while (xyz < length)
-            {
-                // Reset row reference.
-                if (xyz == rowMax)
+        int xyz = 0;
+        while (xyz < indices.Length)
+        {
+            if (this.top == 0)
                 {
-                    x = 0;
-                    pixelsRowRef = ref MemoryMarshal.GetReference(pixels.DangerousGetRowSpan(++y));
-                    rowMax = (y * width) + width;
-                }
-
-                if (top == 0)
-                {
-                    if (bits < codeSize)
+                if (this.bits < this.codeSize)
                     {
                         // Load bytes until there are enough bits for a code.
-                        if (count == 0)
+                    if (this.count == 0)
                         {
                             // Read a new data block.
-                            count = this.ReadBlock(buffer);
-                            if (count == 0)
+                        this.count = this.ReadBlock(buffer);
+                        if (this.count == 0)
                             {
                                 break;
                             }
 
-                            bi = 0;
+                        this.bufferIndex = 0;
                         }
 
-                        data += buffer[bi] << bits;
+                    this.data += buffer[this.bufferIndex] << this.bits;
 
-                        bits += 8;
-                        bi++;
-                        count--;
+                    this.bits += 8;
+                    this.bufferIndex++;
+                    this.count--;
                         continue;
                     }
 
                     // Get the next code
-                    code = data & codeMask;
-                    data >>= codeSize;
-                    bits -= codeSize;
+                this.code = this.data & this.codeMask;
+                this.data >>= this.codeSize;
+                this.bits -= this.codeSize;
 
                     // Interpret the code
-                    if (code > availableCode || code == endCode)
+                if (this.code > this.availableCode || this.code == this.endCode)
                     {
                         break;
                     }
 
-                    if (code == clearCode)
+                if (this.code == this.clearCode)
                     {
                         // Reset the decoder
-                        codeSize = minCodeSize + 1;
-                        codeMask = (1 << codeSize) - 1;
-                        availableCode = clearCode + 2;
-                        oldCode = NullCode;
+                    this.codeSize = this.minCodeSize + 1;
+                    this.codeMask = (1 << this.codeSize) - 1;
+                    this.availableCode = this.clearCode + 2;
+                    this.oldCode = NullCode;
                         continue;
                     }
 
-                    if (oldCode == NullCode)
+                if (this.oldCode == NullCode)
                     {
-                        Unsafe.Add(ref pixelStackRef, top++) = Unsafe.Add(ref suffixRef, code);
-                        oldCode = code;
-                        first = code;
+                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
+                    this.oldCode = this.code;
+                    this.first = this.code;
+                int inCode = this.code;
+                if (this.code == this.availableCode)
+                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = (byte)this.first;
+                    this.code = this.oldCode;
+                while (this.code > this.clearCode)
+                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
+                    this.code = Unsafe.Add(ref prefixRef, (uint)this.code);
+                int suffixCode = Unsafe.Add(ref suffixRef, (uint)this.code);
+                this.first = suffixCode;
+                Unsafe.Add(ref pixelStackRef, (uint)this.top++) = suffixCode;
+                if (this.availableCode < MaxStackSize)
+                    Unsafe.Add(ref prefixRef, (uint)this.availableCode) = this.oldCode;
+                    Unsafe.Add(ref suffixRef, (uint)this.availableCode) = this.first;
+                    this.availableCode++;
+                    if (this.availableCode == this.codeMask + 1 && this.availableCode < MaxStackSize)
+                        this.codeSize++;
+                        this.codeMask = (1 << this.codeSize) - 1;
+                this.oldCode = inCode;
+            this.top--;
+            Unsafe.Add(ref pixelsRowRef, (uint)x++) = (byte)Unsafe.Add(ref pixelStackRef, (uint)this.top);
+    public void SkipIndices(int length)
+    {
+        Span<byte> buffer = this.scratchBuffer.GetSpan();
+        int xyz = 0;
+            if (this.top == 0)
+                if (this.bits < this.codeSize)
+                    if (this.count == 0)
+                        this.count = this.ReadBlock(buffer);
+                        if (this.count == 0)
+                        this.bufferIndex = 0;
+                    this.data += buffer[this.bufferIndex] << this.bits;
+                    this.bits += 8;
+                    this.bufferIndex++;
+                    this.count--;
+                this.code = this.data & this.codeMask;
+                this.data >>= this.codeSize;
+                this.bits -= this.codeSize;
+                if (this.code > this.availableCode || this.code == this.endCode)
+                if (this.code == this.clearCode)
+                    this.codeSize = this.minCodeSize + 1;
+                    this.codeMask = (1 << this.codeSize) - 1;
+                    this.availableCode = this.clearCode + 2;
+                    this.oldCode = NullCode;
+                if (this.oldCode == NullCode)
+                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
+                    this.oldCode = this.code;
+                    this.first = this.code;
                         continue;
                     }
 
-                    int inCode = code;
-                    if (code == availableCode)
+                int inCode = this.code;
+                if (this.code == this.availableCode)
                     {
-                        Unsafe.Add(ref pixelStackRef, top++) = (byte)first;
+                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = (byte)this.first;
 
-                        code = oldCode;
+                    this.code = this.oldCode;
                     }
 
-                    while (code > clearCode)
+                while (this.code > this.clearCode)
                     {
-                        Unsafe.Add(ref pixelStackRef, top++) = Unsafe.Add(ref suffixRef, code);
-                        code = Unsafe.Add(ref prefixRef, code);
+                    Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
+                    this.code = Unsafe.Add(ref prefixRef, (uint)this.code);
                     }
 
-                    int suffixCode = Unsafe.Add(ref suffixRef, code);
-                    first = suffixCode;
-                    Unsafe.Add(ref pixelStackRef, top++) = suffixCode;
+                int suffixCode = Unsafe.Add(ref suffixRef, (uint)this.code);
+                this.first = suffixCode;
+                Unsafe.Add(ref pixelStackRef, (uint)this.top++) = suffixCode;
 
                     // Fix for Gifs that have "deferred clear code" as per here :
                     // https://bugzilla.mozilla.org/show_bug.cgi?id=55918
-                    if (availableCode < MaxStackSize)
+                if (this.availableCode < MaxStackSize)
                     {
-                        Unsafe.Add(ref prefixRef, availableCode) = oldCode;
-                        Unsafe.Add(ref suffixRef, availableCode) = first;
-                        availableCode++;
-                        if (availableCode == codeMask + 1 && availableCode < MaxStackSize)
+                    Unsafe.Add(ref prefixRef, (uint)this.availableCode) = this.oldCode;
+                    Unsafe.Add(ref suffixRef, (uint)this.availableCode) = this.first;
+                    this.availableCode++;
+                    if (this.availableCode == this.codeMask + 1 && this.availableCode < MaxStackSize)
                         {
-                            codeSize++;
-                            codeMask = (1 << codeSize) - 1;
+                        this.codeSize++;
+                        this.codeMask = (1 << this.codeSize) - 1;
                         }
                     }
 
-                    oldCode = inCode;
+                this.oldCode = inCode;
                 }
 
                 // Pop a pixel off the pixel stack.
-                top--;
+            this.top--;
 
                 // Clear missing pixels
                 xyz++;
@@ -262,6 +312,6 @@ namespace SixLabors.ImageSharp.Formats.Gif
             this.prefix.Dispose();
             this.suffix.Dispose();
             this.pixelStack.Dispose();
-        }
+        this.scratchBuffer.Dispose();
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/Components/Quantization.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Quantization.cs
@@ -147,7 +147,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
                 quality = (int)Math.Round(5000.0 / sumPercent);
             }
 
-            return quality;
+        return Numerics.Clamp(quality, MinQualityFactor, MaxQualityFactor);
         }
 
         /// <summary>

--- a/src/ImageSharp/Formats/Jpeg/Components/Quantization.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Quantization.cs
@@ -147,7 +147,7 @@ namespace SixLabors.ImageSharp.Formats.Jpeg.Components
                 quality = (int)Math.Round(5000.0 / sumPercent);
             }
 
-        return Numerics.Clamp(quality, MinQualityFactor, MaxQualityFactor);
+            return Numerics.Clamp(quality, MinQualityFactor, MaxQualityFactor);
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -290,15 +290,9 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
         public void Issue2012BadMinCode<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>
         {
-            Exception ex = Record.Exception(
-                () =>
-                {
-                    using Image<TPixel> image = provider.GetImage();
-                    image.DebugSave(provider);
-                });
-
-            Assert.NotNull(ex);
-            Assert.Contains("Gif Image does not contain a valid LZW minimum code.", ex.Message);
+            using Image<TPixel> image = provider.GetImage();
+            image.DebugSave(provider);
+            image.CompareToReferenceOutput(provider);
         }
 
         // https://bugzilla.mozilla.org/show_bug.cgi?id=55918

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -183,6 +183,17 @@ namespace SixLabors.ImageSharp.Tests.Formats.Gif
             image.CompareToReferenceOutputMultiFrame(provider, ImageComparer.Exact);
         }
 
+    // https://github.com/SixLabors/ImageSharp/issues/2758
+    [Theory]
+    [WithFile(TestImages.Gif.Issues.Issue2758, PixelTypes.Rgba32)]
+    public void Issue2758_BadDescriptorDimensions<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage();
+        image.DebugSaveMultiFrame(provider);
+        image.CompareToReferenceOutputMultiFrame(provider, ImageComparer.Exact);
+    }
+
         // https://github.com/SixLabors/ImageSharp/issues/405
         [Theory]
         [WithFile(TestImages.Gif.Issues.BadAppExtLength, PixelTypes.Rgba32)]

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
@@ -10,6 +10,7 @@ using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.Metadata.Profiles.Icc;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 
 using Xunit;
 
@@ -361,6 +362,32 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             {
                 ExifProfile exif = image.Metadata.ExifProfile;
                 VerifyEncodedStrings(exif);
+    }
+
+    // https://github.com/SixLabors/ImageSharp/issues/2758
+    [Theory]
+    [WithFile(TestImages.Jpeg.Issues.Issue2758, PixelTypes.L8)]
+    public void Issue2758_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
+
+        Assert.Equal(59787, image.Width);
+        Assert.Equal(511, image.Height);
+
+        JpegMetadata meta = image.Metadata.GetJpegMetadata();
+
+        // Quality determination should be between 1-100.
+        Assert.Equal(15, meta.LuminanceQuality);
+        Assert.Equal(1, meta.ChrominanceQuality);
+
+        // We want to test the encoder to ensure the determined values can be encoded but not by encoding
+        // the full size image as it would be too slow.
+        // We will crop the image to a smaller size and then encode it.
+        image.Mutate(x => x.Crop(new(0, 0, 100, 100)));
+
+        using MemoryStream ms = new();
+        image.Save(ms, new JpegEncoder());
             }
         }
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.Metadata.cs
@@ -362,33 +362,32 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             {
                 ExifProfile exif = image.Metadata.ExifProfile;
                 VerifyEncodedStrings(exif);
-    }
-
-    // https://github.com/SixLabors/ImageSharp/issues/2758
-    [Theory]
-    [WithFile(TestImages.Jpeg.Issues.Issue2758, PixelTypes.L8)]
-    public void Issue2758_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
-        where TPixel : unmanaged, IPixel<TPixel>
-    {
-        using Image<TPixel> image = provider.GetImage(JpegDecoder.Instance);
-
-        Assert.Equal(59787, image.Width);
-        Assert.Equal(511, image.Height);
-
-        JpegMetadata meta = image.Metadata.GetJpegMetadata();
-
-        // Quality determination should be between 1-100.
-        Assert.Equal(15, meta.LuminanceQuality);
-        Assert.Equal(1, meta.ChrominanceQuality);
-
-        // We want to test the encoder to ensure the determined values can be encoded but not by encoding
-        // the full size image as it would be too slow.
-        // We will crop the image to a smaller size and then encode it.
-        image.Mutate(x => x.Crop(new(0, 0, 100, 100)));
-
-        using MemoryStream ms = new();
-        image.Save(ms, new JpegEncoder());
             }
+        }
+
+        [Theory(Skip = "2.1 JPEG decoder detects this image as invalid.")]
+        [WithFile(TestImages.Jpeg.Issues.Issue2758, PixelTypes.L8)]
+        public void Issue2758_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage();
+
+            Assert.Equal(59787, image.Width);
+            Assert.Equal(511, image.Height);
+
+            JpegMetadata meta = image.Metadata.GetJpegMetadata();
+
+            // Quality determination should be between 1-100.
+            Assert.Equal(15, meta.LuminanceQuality);
+            Assert.Equal(1, meta.ChrominanceQuality);
+
+            // We want to test the encoder to ensure the determined values can be encoded but not by encoding
+            // the full size image as it would be too slow.
+            // We will crop the image to a smaller size and then encode it.
+            image.Mutate(x => x.Crop(new(0, 0, 100, 100)));
+
+            using MemoryStream ms = new();
+            image.Save(ms, new JpegEncoder());
         }
 
         private static void VerifyEncodedStrings(ExifProfile exif)

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -269,6 +269,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string ValidExifArgumentNullExceptionOnEncode = "Jpg/issues/Issue2087-exif-null-reference-on-encode.jpg";
                 public const string Issue2133DeduceColorSpace = "Jpg/issues/Issue2133.jpg";
                 public const string HangBadScan = "Jpg/issues/Hang_C438A851.jpg";
+            public const string Issue2758 = "Jpg/issues/issue-2758.jpg";
 
                 public static class Fuzz
                 {

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -462,6 +462,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string Issue1962NoColorTable = "Gif/issues/issue1962_tiniest_gif_1st.gif";
                 public const string Issue2012EmptyXmp = "Gif/issues/issue2012_Stronghold-Crusader-Extreme-Cover.gif";
                 public const string Issue2012BadMinCode = "Gif/issues/issue2012_drona1.gif";
+            public const string Issue2758 = "Gif/issues/issue_2758.gif";
             }
 
             public static readonly string[] All = { Rings, Giphy, Cheers, Trans, Kumin, Leo, Ratio4x1, Ratio1x4 };

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012BadMinCode_Rgba32_issue2012_drona1.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2012BadMinCode_Rgba32_issue2012_drona1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:588d055a93c7b4fdb62e8b77f3ae08753a9e8990151cb0523f5e761996189b70
+size 142244

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2758_BadDescriptorDimensions_Rgba32_issue_2758.gif/00.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2758_BadDescriptorDimensions_Rgba32_issue_2758.gif/00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f39b23217f1d095eeb8eed5ccea36be813c307a60ef4b1942e9f74028451c38
+size 81944

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2758_BadDescriptorDimensions_Rgba32_issue_2758.gif/01.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2758_BadDescriptorDimensions_Rgba32_issue_2758.gif/01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f39b23217f1d095eeb8eed5ccea36be813c307a60ef4b1942e9f74028451c38
+size 81944

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/07.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueTooLargeLzwBits_Rgba32_issue_2743.gif/07.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5016a323018f09e292165ad5392d82dcbad5e79c2b6b93aff3322dffff80b309
+size 126

--- a/tests/Images/Input/Gif/issues/issue_2758.gif
+++ b/tests/Images/Input/Gif/issues/issue_2758.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13e9374181c7536d1d2ecb514753a5290c0ec06234ca079c6c8c8a832586b668
+size 199

--- a/tests/Images/Input/Jpg/issues/issue-2758.jpg
+++ b/tests/Images/Input/Jpg/issues/issue-2758.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f32a238b57b7073f7442f8ae7efd6ba3ae4cda30d57e6666fb8a1eaa27108558
+size 1412


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Implemented it by a full port of 3.1.x Gif Decoder, so it contains improvements and behavioral changes made since then. It also decodes some stuff 2.1 API doesn't expose.

I didn't fully understand what was the JPEG change about, but the 2.1 decoder detects it as an invalid image. Added the test as a skipped test.