### PR TITLE
Fix filtering on PNG encode.

### DIFF
--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -169,7 +169,7 @@ internal static class AverageFilter
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
             Vector256<byte> allBitsSet = Avx2.CompareEqual(sumAccumulator, sumAccumulator).AsByte();
 
-            for (nuint xLeft = x - bytesPerPixel; x <= (uint)(scanline.Length - Vector256<byte>.Count); xLeft += (uint)Vector256<byte>.Count)
+            for (nuint xLeft = x - bytesPerPixel; (int)x <= scanline.Length - Vector256<byte>.Count; xLeft += (uint)Vector256<byte>.Count)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> left = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -192,7 +192,7 @@ internal static class AverageFilter
             Vector128<int> sumAccumulator = Vector128<int>.Zero;
             Vector128<byte> allBitsSet = Sse2.CompareEqual(sumAccumulator, sumAccumulator).AsByte();
 
-            for (nuint xLeft = x - bytesPerPixel; x <= (uint)(scanline.Length - Vector128<byte>.Count); xLeft += (uint)Vector128<byte>.Count)
+            for (nuint xLeft = x - bytesPerPixel; (int)x <= scanline.Length - Vector128<byte>.Count; xLeft += (uint)Vector128<byte>.Count)
             {
                 Vector128<byte> scan = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector128<byte> left = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -136,7 +136,7 @@ internal static class SubFilter
             Vector256<byte> zero = Vector256<byte>.Zero;
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
 
-            for (nuint xLeft = x - (uint)bytesPerPixel; x <= (uint)(scanline.Length - Vector256<byte>.Count); xLeft += (uint)Vector256<byte>.Count)
+            for (nuint xLeft = x - (uint)bytesPerPixel; (int)x <= (scanline.Length - Vector256<byte>.Count); xLeft += (uint)Vector256<byte>.Count)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> prev = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));
@@ -150,11 +150,12 @@ internal static class SubFilter
 
             sum += Numerics.EvenReduceSum(sumAccumulator);
         }
-        else if (Vector.IsHardwareAccelerated)
+        else
+        if (Vector.IsHardwareAccelerated)
         {
             Vector<uint> sumAccumulator = Vector<uint>.Zero;
 
-            for (nuint xLeft = x - (uint)bytesPerPixel; x <= (uint)(scanline.Length - Vector<byte>.Count); xLeft += (uint)Vector<byte>.Count)
+            for (nuint xLeft = x - (uint)bytesPerPixel; (int)x <= (scanline.Length - Vector<byte>.Count); xLeft += (uint)Vector<byte>.Count)
             {
                 Vector<byte> scan = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector<byte> prev = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, xLeft));

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -179,7 +179,7 @@ internal static class UpFilter
             Vector256<byte> zero = Vector256<byte>.Zero;
             Vector256<int> sumAccumulator = Vector256<int>.Zero;
 
-            for (; x <= (uint)(scanline.Length - Vector256<byte>.Count);)
+            for (; (int)x <= scanline.Length - Vector256<byte>.Count;)
             {
                 Vector256<byte> scan = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector256<byte> above = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref prevBaseRef, x));
@@ -197,7 +197,7 @@ internal static class UpFilter
         {
             Vector<uint> sumAccumulator = Vector<uint>.Zero;
 
-            for (; x <= (uint)(scanline.Length - Vector<byte>.Count);)
+            for (; (int)x <= scanline.Length - Vector<byte>.Count;)
             {
                 Vector<byte> scan = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref scanBaseRef, x));
                 Vector<byte> above = Unsafe.As<byte, Vector<byte>>(ref Unsafe.Add(ref prevBaseRef, x));

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -1477,7 +1477,11 @@ internal sealed class PngEncoderCore : IImageEncoderInternals, IDisposable
         // Use options, then check metadata, if nothing set there then we suggest
         // a sensible default based upon the pixel format.
         this.colorType = encoder.ColorType ?? pngMetadata.ColorType ?? SuggestColorType<TPixel>();
-        if (!encoder.FilterMethod.HasValue)
+        if (encoder.FilterMethod.HasValue)
+        {
+            this.filterMethod = encoder.FilterMethod.Value;
+        }
+        else
         {
             // Specification recommends default filter method None for paletted images and Paeth for others.
             this.filterMethod = this.colorType is PngColorType.Palette ? PngFilterMethod.None : PngFilterMethod.Paeth;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #2771 where the filter method was ignored when encoding PNGs. Also fixes a SIMD accelerated unsigned integer overflow defect in several of the filters which was masked by this issue. 

<!-- Thanks for contributing to ImageSharp! -->
