### PR TITLE
Fix ImageMetadata docs typo

### DIFF
--- a/src/ImageSharp/Metadata/ImageMetadata.cs
+++ b/src/ImageSharp/Metadata/ImageMetadata.cs
@@ -165,7 +165,7 @@ public sealed class ImageMetadata : IDeepCloneable<ImageMetadata>
     public CicpProfile? CicpProfile { get; set; }
 
     /// <summary>
-    /// Gets the original format, if any, the image was decode from.
+    /// Gets the original format, if any, from which the image was decoded.
     /// </summary>
     public IImageFormat? DecodedImageFormat { get; internal set; }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes a typo in `ImageMetadata` docs which bugged me, no big deal.

<!-- Thanks for contributing to ImageSharp! -->
