### PR TITLE
Fix using dither in BmpEncoder when bit per pixel is <= 4

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -575,7 +575,9 @@ internal sealed class BmpEncoderCore
     {
         using IQuantizer<TPixel> frameQuantizer = this.quantizer.CreatePixelSpecificQuantizer<TPixel>(configuration, new QuantizerOptions()
         {
-            MaxColors = 16
+            MaxColors = 16,
+            Dither = this.quantizer.Options.Dither,
+            DitherScale = this.quantizer.Options.DitherScale
         });
 
         frameQuantizer.BuildPalette(this.pixelSamplingStrategy, image);
@@ -623,7 +625,9 @@ internal sealed class BmpEncoderCore
     {
         using IQuantizer<TPixel> frameQuantizer = this.quantizer.CreatePixelSpecificQuantizer<TPixel>(configuration, new QuantizerOptions()
         {
-            MaxColors = 4
+            MaxColors = 4,
+            Dither = this.quantizer.Options.Dither,
+            DitherScale = this.quantizer.Options.DitherScale
         });
 
         frameQuantizer.BuildPalette(this.pixelSamplingStrategy, image);
@@ -680,7 +684,9 @@ internal sealed class BmpEncoderCore
     {
         using IQuantizer<TPixel> frameQuantizer = this.quantizer.CreatePixelSpecificQuantizer<TPixel>(configuration, new QuantizerOptions()
         {
-            MaxColors = 2
+            MaxColors = 2,
+            Dither = this.quantizer.Options.Dither,
+            DitherScale = this.quantizer.Options.DitherScale
         });
 
         frameQuantizer.BuildPalette(this.pixelSamplingStrategy, image);


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This is a fix for #2817 
<!-- Thanks for contributing to ImageSharp! -->
