### PR TITLE
WEBP : Use Correct Width With AlphaDecoder 

### DIFF
--- a/src/ImageSharp/Formats/Webp/AlphaDecoder.cs
+++ b/src/ImageSharp/Formats/Webp/AlphaDecoder.cs
@@ -183,7 +183,7 @@ internal class AlphaDecoder : IDisposable
         else
         {
             this.LosslessDecoder.DecodeImageData(this.Vp8LDec, this.Vp8LDec.Pixels.Memory.Span);
-            this.ExtractAlphaRows(this.Vp8LDec);
+            this.ExtractAlphaRows(this.Vp8LDec, this.Width);
         }
     }
 
@@ -257,14 +257,15 @@ internal class AlphaDecoder : IDisposable
     /// Once the image-stream is decoded into ARGB color values, the transparency information will be extracted from the green channel of the ARGB quadruplet.
     /// </summary>
     /// <param name="dec">The VP8L decoder.</param>
-    private void ExtractAlphaRows(Vp8LDecoder dec)
+    /// <param name="width">The image width.</param>
+    private void ExtractAlphaRows(Vp8LDecoder dec, int width)
     {
         int numRowsToProcess = dec.Height;
-        int width = dec.Width;
         Span<uint> input = dec.Pixels.Memory.Span;
         Span<byte> output = this.Alpha.Memory.Span;
 
         // Extract alpha (which is stored in the green plane).
+        // the final width (!= dec->width_)
         int pixelCount = width * numRowsToProcess;
         WebpLosslessDecoder.ApplyInverseTransforms(dec, input, this.memoryAllocator);
         ExtractGreen(input, output, pixelCount);

--- a/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/LosslessUtils.cs
@@ -269,7 +269,11 @@ internal static unsafe class LosslessUtils
     /// </summary>
     /// <param name="transform">The transform data contains color table size and the entries in the color table.</param>
     /// <param name="pixelData">The pixel data to apply the reverse transform on.</param>
-    public static void ColorIndexInverseTransform(Vp8LTransform transform, Span<uint> pixelData)
+    /// <param name="outputSpan">The resulting pixel data with the reversed transformation data.</param>
+    public static void ColorIndexInverseTransform(
+        Vp8LTransform transform,
+        Span<uint> pixelData,
+        Span<uint> outputSpan)
     {
         int bitsPerPixel = 8 >> transform.Bits;
         int width = transform.XSize;
@@ -282,7 +286,6 @@ internal static unsafe class LosslessUtils
             int countMask = pixelsPerByte - 1;
             int bitMask = (1 << bitsPerPixel) - 1;
 
-            uint[] decodedPixelData = new uint[width * height];
             int pixelDataPos = 0;
             for (int y = 0; y < height; y++)
             {
@@ -298,12 +301,12 @@ internal static unsafe class LosslessUtils
                         packedPixels = GetArgbIndex(pixelData[pixelDataPos++]);
                     }
 
-                    decodedPixelData[decodedPixels++] = colorMap[(int)(packedPixels & bitMask)];
+                    outputSpan[decodedPixels++] = colorMap[(int)(packedPixels & bitMask)];
                     packedPixels >>= bitsPerPixel;
                 }
             }
 
-            decodedPixelData.AsSpan().CopyTo(pixelData);
+            outputSpan.CopyTo(pixelData);
         }
         else
         {

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
@@ -524,11 +524,11 @@ public class WebpEncoderTests
     {
         WebpEncoder encoder = new()
         {
+            Quality = 100
         };
 
         using Image<TPixel> image = provider.GetImage();
-        image.DebugSave(provider);
-        image.VerifyEncoder(provider, "webp", string.Empty, encoder);
+        image.VerifyEncoder(provider, "webp", string.Empty, encoder, ImageComparer.TolerantPercentage(0.0994F));
     }
 
     public static void RunEncodeLossy_WithPeakImage()

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpEncoderTests.cs
@@ -516,6 +516,21 @@ public class WebpEncoderTests
         image.VerifyEncoder(provider, "webp", string.Empty, encoder);
     }
 
+    // https://github.com/SixLabors/ImageSharp/issues/2801
+    [Theory]
+    [WithFile(Lossy.Issue2801, PixelTypes.Rgba32)]
+    public void WebpDecoder_CanDecode_Issue2801<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        WebpEncoder encoder = new()
+        {
+        };
+
+        using Image<TPixel> image = provider.GetImage();
+        image.DebugSave(provider);
+        image.VerifyEncoder(provider, "webp", string.Empty, encoder);
+    }
+
     public static void RunEncodeLossy_WithPeakImage()
     {
         TestImageProvider<Rgba32> provider = TestImageProvider<Rgba32>.File(TestImageLossyFullPath);

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -827,6 +827,7 @@ public static class TestImages
             public const string Issue2257 = "Webp/issues/Issue2257.webp";
             public const string Issue2670 = "Webp/issues/Issue2670.webp";
             public const string Issue2763 = "Webp/issues/Issue2763.png";
+            public const string Issue2801 = "Webp/issues/Issue2801.webp";
         }
     }
 

--- a/tests/Images/Input/Webp/issues/Issue2801.webp
+++ b/tests/Images/Input/Webp/issues/Issue2801.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e90a0d853ddf70d823d8da44eb6c57081e955b1fb7f436a1fd88ca5e5c75a003
+size 261212


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #2801 

The Alpha decoder was using the incorrect width. Updated and copied the comment from the original code. I also moved an allocation to our memory allocator. 



<!-- Thanks for contributing to ImageSharp! -->
