### PR TITLE
Remove Unsafe usage from `GifDecoderCore` and optimize loops

### DIFF
--- a/tests/ImageSharp.Benchmarks/Codecs/Gif/DecodeGif.cs
+++ b/tests/ImageSharp.Benchmarks/Codecs/Gif/DecodeGif.cs
@@ -26,7 +26,7 @@ public class DecodeGif
         }
     }
 
-    [Params(TestImages.Gif.Rings)]
+    [Params(TestImages.Gif.Cheers)]
     public string TestImage { get; set; }
 
     [Benchmark(Baseline = true, Description = "System.Drawing Gif")]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

Originally wanted to straightly PR the idea in #2850, but felt like we need to do something about the high amount of unsafe code in `GifDecoderCore` before touching anything there. By simply removing Unsafe, I noticed a minor perf drop. I managed compensate it by changing the inner loops so the JIT can remove bounds checks at least for one of the spans.

### Benchmarks

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
.NET SDK 9.0.100
  [Host]     : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2
  Job-JOLLXK : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2

Runtime=.NET 8.0  Arguments=/p:DebugType=portable  IterationCount=3
LaunchCount=1  WarmupCount=3

//// main ////

| Method               | TestImage      | Mean       | Error      | StdDev    | Ratio | RatioSD | Gen0     | Gen1     | Gen2     | Allocated  | Alloc Ratio |
|--------------------- |--------------- |-----------:|-----------:|----------:|------:|--------:|---------:|---------:|---------:|-----------:|------------:|
| 'System.Drawing Gif' | Gif/cheers.gif |   4.503 ms |  0.8688 ms | 0.0476 ms |  1.00 |    0.01 | 328.1250 | 328.1250 | 328.1250 | 3011.75 KB |        1.00 |
| 'ImageSharp Gif'     | Gif/cheers.gif | 116.477 ms | 21.8437 ms | 1.1973 ms | 25.87 |    0.33 |        - |        - |        - |  135.04 KB |        0.04 |

//// Just dropping Unsafe ////
| Method               | TestImage      | Mean       | Error     | StdDev    | Ratio | RatioSD | Gen0     | Gen1     | Gen2     | Allocated  | Alloc Ratio |
|--------------------- |--------------- |-----------:|----------:|----------:|------:|--------:|---------:|---------:|---------:|-----------:|------------:|
| 'System.Drawing Gif' | Gif/cheers.gif |   4.536 ms |  2.058 ms | 0.1128 ms |  1.00 |    0.03 | 328.1250 | 328.1250 | 328.1250 | 3011.69 KB |        1.00 |
| 'ImageSharp Gif'     | Gif/cheers.gif | 120.442 ms | 25.420 ms | 1.3934 ms | 26.56 |    0.63 |        - |        - |        - |  135.04 KB |        0.04 |

//// PR ////
| Method               | TestImage      | Mean       | Error     | StdDev    | Ratio | RatioSD | Gen0     | Gen1     | Gen2     | Allocated  | Alloc Ratio |
|--------------------- |--------------- |-----------:|----------:|----------:|------:|--------:|---------:|---------:|---------:|-----------:|------------:|
| 'System.Drawing Gif' | Gif/cheers.gif |   4.456 ms |  1.580 ms | 0.0866 ms |  1.00 |    0.02 | 328.1250 | 328.1250 | 328.1250 | 3011.75 KB |        1.00 |
| 'ImageSharp Gif'     | Gif/cheers.gif | 116.112 ms | 28.261 ms | 1.5491 ms | 26.07 |    0.53 |        - |        - |        - |  135.04 KB |        0.04 |
```