### PR TITLE
V3: Gracefully handle LZW overflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -146,7 +146,7 @@ jobs:
           XUNIT_PATH: .\tests\ImageSharp.Tests # Required for xunit
 
       - name: Export Failed Output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: actual_output_${{ runner.os }}_${{ matrix.options.framework }}${{ matrix.options.runtime }}.zip

--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -137,6 +137,7 @@ internal sealed class LzwDecoder : IDisposable
         ref int suffixRef = ref MemoryMarshal.GetReference(this.suffix.GetSpan());
         ref int pixelStackRef = ref MemoryMarshal.GetReference(this.pixelStack.GetSpan());
         Span<byte> buffer = this.scratchBuffer.GetSpan();
+        int maxTop = this.pixelStack.Length() - 1;
 
         int x = 0;
         int xyz = 0;
@@ -204,7 +205,7 @@ internal sealed class LzwDecoder : IDisposable
                     this.code = this.oldCode;
                 }
 
-                while (this.code > this.clearCode)
+                while (this.code > this.clearCode && this.top < maxTop)
                 {
                     Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
                     this.code = Unsafe.Add(ref prefixRef, (uint)this.code);
@@ -250,6 +251,7 @@ internal sealed class LzwDecoder : IDisposable
         ref int suffixRef = ref MemoryMarshal.GetReference(this.suffix.GetSpan());
         ref int pixelStackRef = ref MemoryMarshal.GetReference(this.pixelStack.GetSpan());
         Span<byte> buffer = this.scratchBuffer.GetSpan();
+        int maxTop = this.pixelStack.Length() - 1;
 
         int xyz = 0;
         while (xyz < length)
@@ -316,7 +318,7 @@ internal sealed class LzwDecoder : IDisposable
                     this.code = this.oldCode;
                 }
 
-                while (this.code > this.clearCode)
+                while (this.code > this.clearCode && this.top < maxTop)
                 {
                     Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
                     this.code = Unsafe.Add(ref prefixRef, (uint)this.code);

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -334,4 +334,16 @@ public class GifDecoderTests
         image.DebugSaveMultiFrame(provider);
         image.CompareToReferenceOutputMultiFrame(provider, ImageComparer.Exact);
     }
+
+    // https://github.com/SixLabors/ImageSharp/issues/2859
+    [Theory]
+    [WithFile(TestImages.Gif.Issues.Issue2859_A, PixelTypes.Rgba32)]
+    [WithFile(TestImages.Gif.Issues.Issue2859_B, PixelTypes.Rgba32)]
+    public void Issue2859_LZWPixelStackOverflow<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage();
+        image.DebugSaveMultiFrame(provider);
+        image.CompareToReferenceOutputMultiFrame(provider, ImageComparer.Exact);
+    }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -535,6 +535,8 @@ public static class TestImages
             public const string Issue2450_B = "Gif/issues/issue_2450_2.gif";
             public const string Issue2198 = "Gif/issues/issue_2198.gif";
             public const string Issue2758 = "Gif/issues/issue_2758.gif";
+            public const string Issue2859_A = "Gif/issues/issue_2859_A.gif";
+            public const string Issue2859_B = "Gif/issues/issue_2859_B.gif";
         }
 
         public static readonly string[] Animated =

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2859_LZWPixelStackOverflow_Rgba32_issue_2859_A.gif/00.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2859_LZWPixelStackOverflow_Rgba32_issue_2859_A.gif/00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daa78347749c6ff49891e2e379a373599cd35c98b453af9bf8eac52f615f935c
+size 12237

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2859_LZWPixelStackOverflow_Rgba32_issue_2859_B.gif/00.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2859_LZWPixelStackOverflow_Rgba32_issue_2859_B.gif/00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:731299281f942f277ce6803e0adda3b5dd0395eb79cae26cabc9d56905fae0fd
+size 1833

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2859_LZWPixelStackOverflow_Rgba32_issue_2859_B.gif/01.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/Issue2859_LZWPixelStackOverflow_Rgba32_issue_2859_B.gif/01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50ccac7739142578d99a76b6d39ba377099d4a7ac30cbb0a5aee44ef1e7c9c8c
+size 1271

--- a/tests/Images/Input/Gif/issues/issue_2859_A.gif
+++ b/tests/Images/Input/Gif/issues/issue_2859_A.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50a1a4afc62a3a36ff83596f1eb55d91cdd184c64e0d1339bbea17205c23eee1
+size 3406142

--- a/tests/Images/Input/Gif/issues/issue_2859_B.gif
+++ b/tests/Images/Input/Gif/issues/issue_2859_B.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db9b2992be772a4f0ac495e994a17c7c50fb6de9794cfb9afc4a3dc26ffdfae0
+size 4543


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

The issue is caused by using the full capacity of the pixel stack for intermediate pushes without reserving a slot for the final push, which leads to an overflow. By capping out the max index we can skip corrupt blocks. 

<!-- Thanks for contributing to ImageSharp! -->

Fixes #2859 
