### PR TITLE
Handle GIF images with missing clear code

### DIFF
--- a/src/ImageSharp/Formats/Gif/LzwDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/LzwDecoder.cs
@@ -204,7 +204,7 @@ internal sealed class LzwDecoder : IDisposable
                     this.code = this.oldCode;
                 }
 
-                while (this.code > this.clearCode)
+                while (this.code > this.clearCode && this.top < MaxStackSize)
                 {
                     Unsafe.Add(ref pixelStackRef, (uint)this.top++) = Unsafe.Add(ref suffixRef, (uint)this.code);
                     this.code = Unsafe.Add(ref prefixRef, (uint)this.code);

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -334,4 +334,15 @@ public class GifDecoderTests
         image.DebugSaveMultiFrame(provider);
         image.CompareToReferenceOutputMultiFrame(provider, ImageComparer.Exact);
     }
+
+    // https://github.com/SixLabors/ImageSharp/issues/2883
+    [Theory]
+    [WithFile(TestImages.Gif.Issues.MissingClearCode, PixelTypes.Rgba32)]
+    public void IssueMissingClearCode<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage();
+        image.DebugSaveMultiFrame(provider);
+        image.CompareToReferenceOutputMultiFrame(provider, ImageComparer.Exact);
+    }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -522,6 +522,7 @@ public static class TestImages
             public const string BadDescriptorWidth = "Gif/issues/issue403_baddescriptorwidth.gif";
             public const string BadMaxLzwBits = "Gif/issues/issue_2743.gif";
             public const string DeferredClearCode = "Gif/issues/bugzilla-55918.gif";
+            public const string MissingClearCode = "Gif/issues/issue2883_missing_clearcode.gif";
             public const string Issue1505 = "Gif/issues/issue1505_argumentoutofrange.png";
             public const string Issue1530 = "Gif/issues/issue1530.gif";
             public const string InvalidColorIndex = "Gif/issues/issue1668_invalidcolorindex.gif";

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueMissingClearCode_Rgba32_issue2883_missing_clearcode.gif/00.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueMissingClearCode_Rgba32_issue2883_missing_clearcode.gif/00.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d96277680234e40770f58ed7f418379dafa7c7337b97342cb19a838ad414c58
+size 3234

--- a/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueMissingClearCode_Rgba32_issue2883_missing_clearcode.gif/01.png
+++ b/tests/Images/External/ReferenceOutput/GifDecoderTests/IssueMissingClearCode_Rgba32_issue2883_missing_clearcode.gif/01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:672a9063340080295e51850f2b7c91efa66dc49384b8d13e5be7e4424dda14c4
+size 3148

--- a/tests/Images/Input/Gif/issues/issue2883_missing_clearcode.gif
+++ b/tests/Images/Input/Gif/issues/issue2883_missing_clearcode.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db9b2992be772a4f0ac495e994a17c7c50fb6de9794cfb9afc4a3dc26ffdfae0
+size 4543


### PR DESCRIPTION
### Prerequisites

- [x ] I have written a descriptive pull-request title
- [x ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x ] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x ] I have provided test coverage for my change (where applicable)

### Description
Closes #2883 

It looks like the LZW decoder is missing a bounds check so if no clear code is read it will result in a buffer overread.

I think this fix makes sense, but I don't know if the resulting output is what is expected. It's probably difficult to know what the output should be if the file is truncated or corrupt.
