### PR TITLE
Backport #2701 to 2.1.x [copy]

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -229,6 +229,19 @@ namespace SixLabors.ImageSharp.Tests.Formats.Jpg
             }
         }
 
+        // https://github.com/SixLabors/ImageSharp/issues/2638
+        [Theory]
+        [WithFile(TestImages.Jpeg.Issues.Issue2638, PixelTypes.Rgba32)]
+        public void Issue2638_DecodeWorks<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using (Image<TPixel> image = provider.GetImage(JpegDecoder))
+            {
+                image.DebugSave(provider);
+                image.CompareToOriginal(provider);
+            }
+        }
+
         // DEBUG ONLY!
         // The PDF.js output should be saved by "tests\ImageSharp.Tests\Formats\Jpg\pdfjs\jpeg-converter.htm"
         // into "\tests\Images\ActualOutput\JpegDecoderTests\"

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -269,7 +269,8 @@ namespace SixLabors.ImageSharp.Tests
                 public const string ValidExifArgumentNullExceptionOnEncode = "Jpg/issues/Issue2087-exif-null-reference-on-encode.jpg";
                 public const string Issue2133DeduceColorSpace = "Jpg/issues/Issue2133.jpg";
                 public const string HangBadScan = "Jpg/issues/Hang_C438A851.jpg";
-            public const string Issue2758 = "Jpg/issues/issue-2758.jpg";
+                public const string Issue2758 = "Jpg/issues/issue-2758.jpg";
+                public const string Issue2638 = "Jpg/issues/Issue2638.jpg";
 
                 public static class Fuzz
                 {

--- a/tests/Images/Input/Jpg/issues/Issue2638.jpg
+++ b/tests/Images/Input/Jpg/issues/Issue2638.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:208d5b0b727bbef120a7e090e020a48f99c9e264c2d3939ba749f8620853c1fe
+size 70876


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Copy of #2868, but without the yaml changes.
