### PR TITLE
Refactor buffer allocation in Vp8BitWriter.cs to use Span<byte> instead of byte[] in WriteFrameHeader

### DIFF
--- a/src/ImageSharp/Formats/Webp/BitWriter/Vp8BitWriter.cs
+++ b/src/ImageSharp/Formats/Webp/BitWriter/Vp8BitWriter.cs
@@ -604,7 +604,7 @@ internal class Vp8BitWriter : BitWriterBase
         uint profile = 0;
         int width = this.enc.Width;
         int height = this.enc.Height;
-        byte[] vp8FrameHeader = new byte[WebpConstants.Vp8FrameHeaderSize];
+        Span<byte> vp8FrameHeader = stackalloc byte[WebpConstants.Vp8FrameHeaderSize];
 
         // Paragraph 9.1.
         uint bits = 0 // keyframe (1b)


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [X] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

This change enhances memory efficiency by reducing heap allocations and leveraging stack allocation for better performance.

