### PR TITLE
Fix #2907. BMP indexed palette parsed wrong

### DIFF
--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -1597,8 +1597,8 @@ internal sealed class BmpDecoderCore : ImageDecoderCore
 
         if (palette.Length > 0)
         {
-            Color[] colorTable = new Color[palette.Length / Unsafe.SizeOf<Bgr24>()];
-            ReadOnlySpan<Bgr24> rgbTable = MemoryMarshal.Cast<byte, Bgr24>(palette);
+            Color[] colorTable = new Color[palette.Length / Unsafe.SizeOf<Bgra32>()];
+            ReadOnlySpan<Bgra32> rgbTable = MemoryMarshal.Cast<byte, Bgra32>(palette);
             Color.FromPixel(rgbTable, colorTable);
             this.bmpMetadata.ColorTable = colorTable;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
