### PR TITLE
V3 Nested sub ifds parsing fix 

### DIFF
--- a/src/ImageSharp/Metadata/Profiles/Exif/ExifReader.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/ExifReader.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using SixLabors.ImageSharp.Memory;
 
@@ -187,11 +188,21 @@ internal abstract class BaseExifReader
 
     protected void ReadSubIfd(List<IExifValue> values)
     {
-        if (this.subIfds is not null)
+        if (this.subIfds != null)
         {
-            foreach (ulong subIfdOffset in this.subIfds)
+            const int maxSubIfds = 8;
+            const int maxNestingLevel = 8;
+            Span<ulong> buf = stackalloc ulong[maxSubIfds];
+            for (int i = 0; i < maxNestingLevel && this.subIfds.Count > 0; i++)
             {
-                this.ReadValues(values, (uint)subIfdOffset);
+                int sz = Math.Min(this.subIfds.Count, maxSubIfds);
+                CollectionsMarshal.AsSpan(this.subIfds)[..sz].CopyTo(buf);
+
+                this.subIfds.Clear();
+                foreach (ulong subIfdOffset in buf[..sz])
+                {
+                    this.ReadValues(values, (uint)subIfdOffset);
+                }
             }
         }
     }
@@ -481,8 +492,9 @@ internal abstract class BaseExifReader
 
         foreach (IExifValue val in values)
         {
-            // Sometimes duplicates appear, can compare val.Tag == exif.Tag
-            if (val == exif)
+            // to skip duplicates must be used Equals method,
+            // == operator not defined for ExifValue and IExifValue
+            if (exif.Equals(val))
             {
                 Debug.WriteLine($"Duplicate Exif tag: tag={exif.Tag}, dataType={exif.DataType}");
                 return;

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -325,6 +325,7 @@ public static class TestImages
             public const string Issue2517 = "Jpg/issues/issue2517-bad-d7.jpg";
             public const string Issue2638 = "Jpg/issues/Issue2638.jpg";
             public const string Issue2758 = "Jpg/issues/issue-2758.jpg";
+            public const string Issue2857 = "Jpg/issues/issue-2857-subsub-ifds.jpg";
 
             public static class Fuzz
             {

--- a/tests/Images/Input/Jpg/issues/issue-2857-subsub-ifds.jpg
+++ b/tests/Images/Input/Jpg/issues/issue-2857-subsub-ifds.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab45137ded01a42658aa94421165a358b184a536b6ab64427d8255e8d78c25b9
+size 2829977


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Reimplement of #2869 for v3.
<!-- Thanks for contributing to ImageSharp! -->
