### PR TITLE
V3 - Use BPP from Color Writer for Compressor

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffEncoderCore.cs
@@ -210,15 +210,6 @@ internal sealed class TiffEncoderCore
         long ifdOffset)
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        using TiffBaseCompressor compressor = TiffCompressorFactory.Create(
-            this.CompressionType ?? TiffCompression.None,
-            writer.BaseStream,
-            this.memoryAllocator,
-            frame.Width,
-            (int)this.BitsPerPixel,
-            this.compressionLevel,
-            this.HorizontalPredictor == TiffPredictor.Horizontal ? this.HorizontalPredictor.Value : TiffPredictor.None);
-
         TiffEncoderEntriesCollector entriesCollector = new();
         using TiffBaseColorWriter<TPixel> colorWriter = TiffColorWriterFactory.Create(
             this.PhotometricInterpretation,
@@ -229,6 +220,15 @@ internal sealed class TiffEncoderCore
             this.configuration,
             entriesCollector,
             (int)this.BitsPerPixel);
+
+        using TiffBaseCompressor compressor = TiffCompressorFactory.Create(
+            this.CompressionType ?? TiffCompression.None,
+            writer.BaseStream,
+            this.memoryAllocator,
+            frame.Width,
+            colorWriter.BitsPerPixel,
+            this.compressionLevel,
+            this.HorizontalPredictor == TiffPredictor.Horizontal ? this.HorizontalPredictor.Value : TiffPredictor.None);
 
         int rowsPerStrip = CalcRowsPerStrip(frame.Height, colorWriter.BytesPerRow, this.CompressionType);
 

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -520,12 +520,12 @@ public class TiffEncoderTests : TiffEncoderBaseTester
 
     [Theory]
     [WithFile(Issue2909, PixelTypes.Rgba32)]
-    public void TiffEncoder_EncodeBiColor_WithLzwCompression_Works<TPixel>(TestImageProvider<TPixel> provider)
+    public void TiffEncoder_WithLzwCompression_Works<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit24, null, TiffCompression.Lzw, imageDecoder: TiffDecoder.Instance);
 
     [Theory]
     [WithFile(Issue2909, PixelTypes.Rgba32)]
-    public void TiffEncoder_EncodeBiColor_WithDeflateCompression_Works<TPixel>(TestImageProvider<TPixel> provider)
+    public void TiffEncoder_WithDeflateCompression_Works<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit24, null, TiffCompression.Deflate, imageDecoder: TiffDecoder.Instance);
 
     [Theory]

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffEncoderTests.cs
@@ -519,6 +519,16 @@ public class TiffEncoderTests : TiffEncoderBaseTester
         where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit1, TiffPhotometricInterpretation.BlackIsZero, TiffCompression.Ccitt1D);
 
     [Theory]
+    [WithFile(Issue2909, PixelTypes.Rgba32)]
+    public void TiffEncoder_EncodeBiColor_WithLzwCompression_Works<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit24, null, TiffCompression.Lzw, imageDecoder: TiffDecoder.Instance);
+
+    [Theory]
+    [WithFile(Issue2909, PixelTypes.Rgba32)]
+    public void TiffEncoder_EncodeBiColor_WithDeflateCompression_Works<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffEncoderCore(provider, TiffBitsPerPixel.Bit24, null, TiffCompression.Deflate, imageDecoder: TiffDecoder.Instance);
+
+    [Theory]
     [WithFile(GrayscaleUncompressed, PixelTypes.L8, TiffPhotometricInterpretation.BlackIsZero, TiffCompression.PackBits)]
     [WithFile(GrayscaleUncompressed16Bit, PixelTypes.L16, TiffPhotometricInterpretation.BlackIsZero, TiffCompression.PackBits)]
     [WithFile(RgbUncompressed, PixelTypes.Rgba32, TiffPhotometricInterpretation.Rgb, TiffCompression.Deflate)]

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -1131,6 +1131,8 @@ public static class TestImages
         public const string InvalidIptcData = "Tiff/7324fcaff3aad96f27899da51c1bb5d9.tiff";
         public const string IptcData = "Tiff/iptc.tiff";
 
+        public const string Issue2909 = "Tiff/Issues/Issue2909.tiff";
+
         public static readonly string[] Multiframes = { MultiframeDeflateWithPreview, MultiframeLzwPredictor /*, MultiFrameDifferentSize, MultiframeDifferentSizeTiled, MultiFrameDifferentVariants,*/ };
 
         public static readonly string[] Metadata = { SampleMetadata };

--- a/tests/Images/Input/Tiff/Issues/Issue2909.tiff
+++ b/tests/Images/Input/Tiff/Issues/Issue2909.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c69a7e7c7920766e98fccd273424a34e9094550e2176a7b4757ab2c0756d084
+size 1272


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Uses the computed `BitsPerPixel` from the color writer instance for the compressor to ensure parity.

Fixes #2909 
<!-- Thanks for contributing to ImageSharp! -->