### PR TITLE
Do not attempt to decode iDAT chunks when image is fully decoded.

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -719,10 +719,20 @@ public partial class PngDecoderTests
     [Theory]
     [WithFile(TestImages.Png.Issue2752, PixelTypes.Rgba32)]
     public void CanDecodeJustOneFrame<TPixel>(TestImageProvider<TPixel> provider)
-    where TPixel : unmanaged, IPixel<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
     {
         DecoderOptions options = new() { MaxFrames = 1 };
         using Image<TPixel> image = provider.GetImage(PngDecoder.Instance, options);
         Assert.Equal(1, image.Frames.Count);
+    }
+
+    [Theory]
+    [WithFile(TestImages.Png.Issue2924, PixelTypes.Rgba32)]
+    public void CanDecode_Issue2924<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage(PngDecoder.Instance);
+        image.DebugSave(provider);
+        image.CompareToReferenceOutput(provider);
     }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -160,6 +160,9 @@ public static class TestImages
         // Issue 2752: https://github.com/SixLabors/ImageSharp/issues/2752
         public const string Issue2752 = "Png/issues/Issue_2752.png";
 
+        // Issue 2924: https://github.com/SixLabors/ImageSharp/issues/2924
+        public const string Issue2924 = "Png/issues/Issue_2924.png";
+
         public static class Bad
         {
             public const string MissingDataChunk = "Png/xdtn0g01.png";

--- a/tests/Images/External/ReferenceOutput/PngDecoderTests/CanDecode_Issue2924_Rgba32_Issue_2924.png
+++ b/tests/Images/External/ReferenceOutput/PngDecoderTests/CanDecode_Issue2924_Rgba32_Issue_2924.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4347cd89196c09496288724afdd876b227063149bba33615c338ebb474a0cb19
+size 47260

--- a/tests/Images/Input/Png/issues/Issue_2924.png
+++ b/tests/Images/Input/Png/issues/Issue_2924.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd366a2de522041c706729b01a6030df6c82a4e87ea3509cc78a47486f097044
+size 49376


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #2924 

With the update to the chunk identification code in v3.1.8, now detects an invalid iDAT chunk containing 6 bytes of data immediately following the correct and complete data. validation code throws an exception in cases, as this information is considered critical.

The revised behavior now ensures an early return when an issue with zLib data arises after the complete decoding of pixel data.  

<!-- Thanks for contributing to ImageSharp! -->
