### PR TITLE
Fix Code Coverage Tests

### DIFF
--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -59,11 +59,6 @@ public static class TestImageExtensions
         bool appendSourceFileOrDescription = true,
         IImageEncoder encoder = null)
     {
-        if (TestEnvironment.RunsWithCodeCoverage)
-        {
-            return image;
-        }
-
         provider.Utility.SaveTestOutputFile(
             image,
             extension,
@@ -112,11 +107,6 @@ public static class TestImageExtensions
         Func<int, int, bool> predicate = null)
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        if (TestEnvironment.RunsWithCodeCoverage)
-        {
-            return image;
-        }
-
         provider.Utility.SaveTestOutputFileMultiFrame(
             image,
             extension,
@@ -298,24 +288,23 @@ public static class TestImageExtensions
             appendPixelTypeToFileName,
             predicate: predicate);
 
-        using (Image<TPixel> debugImage = GetDebugOutputImageMultiFrame<TPixel>(
+        using Image<TPixel> debugImage = GetDebugOutputImageMultiFrame<TPixel>(
             provider,
             image.Frames.Count,
             testOutputDetails,
             extension,
             appendPixelTypeToFileName,
-            predicate: predicate))
+            predicate: predicate);
 
-        using (Image<TPixel> referenceImage = GetReferenceOutputImageMultiFrame<TPixel>(
+        using Image<TPixel> referenceImage = GetReferenceOutputImageMultiFrame<TPixel>(
             provider,
             image.Frames.Count,
             testOutputDetails,
             extension,
             appendPixelTypeToFileName,
-            predicate: predicate))
-        {
-            comparer.VerifySimilarity(referenceImage, debugImage);
-        }
+            predicate: predicate);
+
+        comparer.VerifySimilarity(referenceImage, debugImage);
 
         return image;
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Our code coverage CI build was failing due to an introduced reliance on `DebugSaveXX` working correctly in all build environments. 

Since we no longer run the coverage tests against PRs directly it's best just to remove the condition. 
<!-- Thanks for contributing to ImageSharp! -->
