### PR TITLE
Do not encode WEBP images exceeding max dimensions

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
@@ -58,7 +58,7 @@ internal sealed unsafe partial class JpegEncoderCore
         Guard.NotNull(image, nameof(image));
         Guard.NotNull(stream, nameof(stream));
 
-        if (image.Width >= JpegConstants.MaxLength || image.Height >= JpegConstants.MaxLength)
+        if (image.Width > JpegConstants.MaxLength || image.Height > JpegConstants.MaxLength)
         {
             JpegThrowHelper.ThrowDimensionsTooLarge(image.Width, image.Height);
         }

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LEncoder.cs
@@ -371,9 +371,6 @@ internal class Vp8LEncoder : IDisposable
     /// <param name="inputImgHeight">The input image height.</param>
     private void WriteImageSize(int inputImgWidth, int inputImgHeight)
     {
-        Guard.MustBeLessThan(inputImgWidth, WebpConstants.MaxDimension, nameof(inputImgWidth));
-        Guard.MustBeLessThan(inputImgHeight, WebpConstants.MaxDimension, nameof(inputImgHeight));
-
         uint width = (uint)inputImgWidth - 1;
         uint height = (uint)inputImgHeight - 1;
 

--- a/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpEncoderCore.cs
@@ -132,6 +132,11 @@ internal sealed class WebpEncoderCore
         Guard.NotNull(image, nameof(image));
         Guard.NotNull(stream, nameof(stream));
 
+        if (image.Width > WebpConstants.MaxDimension || image.Height > WebpConstants.MaxDimension)
+        {
+            WebpThrowHelper.ThrowDimensionsTooLarge(image.Width, image.Height);
+        }
+
         bool lossless;
         if (this.fileFormat is not null)
         {

--- a/src/ImageSharp/Formats/Webp/WebpThrowHelper.cs
+++ b/src/ImageSharp/Formats/Webp/WebpThrowHelper.cs
@@ -18,4 +18,7 @@ internal static class WebpThrowHelper
 
     [DoesNotReturn]
     public static void ThrowInvalidImageDimensions(string errorMessage) => throw new InvalidImageContentException(errorMessage);
+
+    [DoesNotReturn]
+    public static void ThrowDimensionsTooLarge(int width, int height) => throw new ImageFormatException($"Image is too large to encode at {width}x{height} for WEBP format.");
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
