### PR TITLE
Fix Typo and Offset in BufferedReadStream

### DIFF
--- a/src/ImageSharp/IO/BufferedReadStream.cs
+++ b/src/ImageSharp/IO/BufferedReadStream.cs
@@ -215,9 +215,9 @@ internal sealed class BufferedReadStream : Stream
     {
         this.Position = origin switch
         {
-            SeekOrigin.Begin => (int)offset,
-            SeekOrigin.Current => (int)(this.Position + offset),
-            SeekOrigin.End => (int)(this.Length + offset),
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => this.Position + offset,
+            SeekOrigin.End => this.Length + offset,
             _ => throw new ArgumentOutOfRangeException(nameof(offset)),
         };
 

--- a/src/ImageSharp/IO/BufferedReadStream.cs
+++ b/src/ImageSharp/IO/BufferedReadStream.cs
@@ -69,7 +69,7 @@ internal sealed class BufferedReadStream : Stream
     }
 
     /// <summary>
-    /// Gets the number indicating the EOF hits occured while reading from this instance.
+    /// Gets the number indicating the EOF hits occurred while reading from this instance.
     /// </summary>
     public int EofHitCount { get; private set; }
 
@@ -213,20 +213,13 @@ internal sealed class BufferedReadStream : Stream
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override long Seek(long offset, SeekOrigin origin)
     {
-        switch (origin)
+        this.Position = origin switch
         {
-            case SeekOrigin.Begin:
-                this.Position = offset;
-                break;
-
-            case SeekOrigin.Current:
-                this.Position += offset;
-                break;
-
-            case SeekOrigin.End:
-                this.Position = this.Length - offset;
-                break;
-        }
+            SeekOrigin.Begin => (int)offset,
+            SeekOrigin.Current => (int)(this.Position + offset),
+            SeekOrigin.End => (int)(this.Length + offset),
+            _ => throw new ArgumentOutOfRangeException(nameof(offset)),
+        };
 
         return this.readerPosition;
     }

--- a/src/ImageSharp/IO/ChunkedMemoryStream.cs
+++ b/src/ImageSharp/IO/ChunkedMemoryStream.cs
@@ -76,9 +76,9 @@ internal sealed class ChunkedMemoryStream : Stream
 
         this.Position = origin switch
         {
-            SeekOrigin.Begin => (int)offset,
-            SeekOrigin.Current => (int)(this.Position + offset),
-            SeekOrigin.End => (int)(this.Length + offset),
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => this.Position + offset,
+            SeekOrigin.End => this.Length + offset,
             _ => throw new ArgumentOutOfRangeException(nameof(offset)),
         };
 


### PR DESCRIPTION
* While checking ChunkedMemoryStream i saw differences in the Seek method of BufferedReadStream

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [ ] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

