### PR TITLE
Remove unneeded loop in IccClut

### DIFF
--- a/src/ImageSharp/Metadata/Profiles/ICC/Various/IccClut.cs
+++ b/src/ImageSharp/Metadata/Profiles/ICC/Various/IccClut.cs
@@ -91,15 +91,7 @@ internal sealed class IccClut : IEquatable<IccClut>
             return false;
         }
 
-        for (int i = 0; i < this.Values.Length; i++)
-        {
-            if (!this.Values.SequenceEqual(other.Values))
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return this.Values.SequenceEqual(other.Values);
     }
 
     private void CheckValues()


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Removed an unneeded loop. Now SequenceEquals is only executed once
