### PR TITLE
V3:  Remove ExifTagValue.InteroperabilityIndex 

### DIFF
--- a/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTagValue.cs
+++ b/src/ImageSharp/Metadata/Profiles/Exif/Tags/ExifTagValue.cs
@@ -24,14 +24,6 @@ internal enum ExifTagValue
     GPSIFDOffset = 0x8825,
 
     /// <summary>
-    /// Indicates the identification of the Interoperability rule.
-    /// See https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/interoperability/interoperabilityindex.html
-    /// </summary>
-    [ExifTagDescription("R98", "Indicates a file conforming to R98 file specification of Recommended Exif Interoperability Rules (ExifR98) or to DCF basic file stipulated by Design Rule for Camera File System.")]
-    [ExifTagDescription("THM", "Indicates a file conforming to DCF thumbnail file stipulated by Design rule for Camera File System.")]
-    InteroperabilityIndex = 0x0001,
-
-    /// <summary>
     /// A general indication of the kind of data contained in this subfile.
     /// See Section 8: Baseline Fields.
     /// </summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backport of #2938 for V3

<!-- Thanks for contributing to ImageSharp! -->
