### PR TITLE
V4 TIFF : Allow additional and undefined extra samples

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffExtraSampleType.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffExtraSampleType.cs
@@ -22,5 +22,11 @@ internal enum TiffExtraSampleType
     /// The extra data is unassociated alpha data is transparency information that logically exists independent of an image;
     /// it is commonly called a soft matte.
     /// </summary>
-    UnassociatedAlphaData = 2
+    UnassociatedAlphaData = 2,
+
+    /// <summary>
+    /// A CorelDRAW-specific value observed in damaged files, indicating unassociated alpha.
+    /// Not part of the official TIFF specification; patched in ImageSharp for compatibility.
+    /// </summary>
+    CorelDrawUnassociatedAlphaData = 999,
 }

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -828,4 +828,9 @@ public class TiffDecoderTests : TiffDecoderBaseTester
             testOutputDetails: details,
             appendPixelTypeToFileName: false);
     }
+
+    [Theory]
+    [WithFile(ExtraSamplesUnspecified, PixelTypes.Rgba32)]
+    public void TiffDecoder_CanDecode_ExtraSamplesUnspecified<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -1136,6 +1136,7 @@ public static class TestImages
         public const string Issues2679 = "Tiff/Issues/Issue2679.tiff";
         public const string JpegCompressedGray0000539558 = "Tiff/Issues/JpegCompressedGray-0000539558.tiff";
         public const string Tiled0000023664 = "Tiff/Issues/tiled-0000023664.tiff";
+        public const string ExtraSamplesUnspecified = "Tiff/Issues/ExtraSamplesUnspecified.tif";
 
         public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
         public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/Images/Input/Tiff/Issues/ExtraSamplesUnspecified.tif
+++ b/tests/Images/Input/Tiff/Issues/ExtraSamplesUnspecified.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71d28f17d2d56481faa4d241fae882eae4f8303c70f85bc3759f6a0c2074979e
+size 1426558


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
See #2408 

This PR removes explicit validation checks that disallow TIFF files with unspecified or multiple `TiffExtraSampleType` values. These checks are unnecessary and overly restrictive.

### Rationale

1. **Decoder logic already defends against unsupported configurations**
   The decoding path only processes known and supported sample layouts (e.g., RGB + unassociated alpha). Unsupported layouts naturally fail at the point of use without requiring upfront rejection.

2. **Unspecified extra samples cannot be meaningfully decoded**
   According to the TIFF specification, `TiffExtraSampleType.UnspecifiedData` provides no semantic meaning. There is no way to determine how such channels should be interpreted. Since these channels carry no defined role, the decoder either discards them or ignores them during processing. Explicit rejection is redundant.

3. **Improved compatibility with real-world files**
   TIFFs produced by some tools (e.g., legacy or proprietary software) may include extra channels with incomplete or non-standard metadata. Allowing the decoder to handle these cases gracefully increases format compatibility without compromising decoder integrity.

### Notes

* This aligns with how libtiff handles ambiguous or malformed `ExtraSamples`, such as the CorelDRAW-specific `999` value.
   See [libtiff 3.9.0beta release](https://libtiff.gitlab.io/libtiff/releases/v3.9.0beta.html)
* Files with unsupported layouts will still fail safely at the decoding stage.


<!-- Thanks for contributing to ImageSharp! -->
