### PR TITLE
V3 TIFF : Allow additional and undefined extra samples

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffExtraSampleType.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffExtraSampleType.cs
@@ -22,5 +22,11 @@ internal enum TiffExtraSampleType
     /// The extra data is unassociated alpha data is transparency information that logically exists independent of an image;
     /// it is commonly called a soft matte.
     /// </summary>
-    UnassociatedAlphaData = 2
+    UnassociatedAlphaData = 2,
+
+    /// <summary>
+    /// A CorelDRAW-specific value observed in damaged files, indicating unassociated alpha.
+    /// Not part of the official TIFF specification; patched in ImageSharp for compatibility.
+    /// </summary>
+    CorelDrawUnassociatedAlphaData = 999
 }

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -772,4 +772,9 @@ public class TiffDecoderTests : TiffDecoderBaseTester
             testOutputDetails: details,
             appendPixelTypeToFileName: false);
     }
+
+    [Theory]
+    [WithFile(ExtraSamplesUnspecified, PixelTypes.Rgba32)]
+    public void TiffDecoder_CanDecode_ExtraSamplesUnspecified<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -1112,6 +1112,7 @@ public static class TestImages
         public const string Issues2587 = "Tiff/Issues/Issue2587.tiff";
         public const string JpegCompressedGray0000539558 = "Tiff/Issues/JpegCompressedGray-0000539558.tiff";
         public const string Tiled0000023664 = "Tiff/Issues/tiled-0000023664.tiff";
+        public const string ExtraSamplesUnspecified = "Tiff/Issues/ExtraSamplesUnspecified.tif";
 
         public const string SmallRgbDeflate = "Tiff/rgb_small_deflate.tiff";
         public const string SmallRgbLzw = "Tiff/rgb_small_lzw.tiff";

--- a/tests/Images/Input/Tiff/Issues/ExtraSamplesUnspecified.tif
+++ b/tests/Images/Input/Tiff/Issues/ExtraSamplesUnspecified.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71d28f17d2d56481faa4d241fae882eae4f8303c70f85bc3759f6a0c2074979e
+size 1426558


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backport of #2941 for V3

<!-- Thanks for contributing to ImageSharp! -->
