### PR TITLE
V3 Backport : Reduce the number of memory allocations in lossless WebP encoder

### DIFF
--- a/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/BackwardReferenceEncoder.cs
@@ -149,9 +149,8 @@ internal static class BackwardReferenceEncoder
         }
 
         // Find the cacheBits giving the lowest entropy.
-        for (int idx = 0; idx < refs.Refs.Count; idx++)
+        foreach (PixOrCopy v in refs)
         {
-            PixOrCopy v = refs.Refs[idx];
             if (v.IsLiteral())
             {
                 uint pix = bgra[pos++];
@@ -387,7 +386,7 @@ internal static class BackwardReferenceEncoder
             colorCache = new ColorCache(cacheBits);
         }
 
-        backwardRefs.Refs.Clear();
+        backwardRefs.Clear();
         for (int ix = 0; ix < chosenPathSize; ix++)
         {
             int len = chosenPath[ix];
@@ -479,7 +478,7 @@ internal static class BackwardReferenceEncoder
             colorCache = new ColorCache(cacheBits);
         }
 
-        refs.Refs.Clear();
+        refs.Clear();
         for (int i = 0; i < pixCount;)
         {
             // Alternative #1: Code the pixels starting at 'i' using backward reference.
@@ -734,7 +733,7 @@ internal static class BackwardReferenceEncoder
             colorCache = new ColorCache(cacheBits);
         }
 
-        refs.Refs.Clear();
+        refs.Clear();
 
         // Add first pixel as literal.
         AddSingleLiteral(bgra[0], useColorCache, colorCache, refs);
@@ -780,9 +779,8 @@ internal static class BackwardReferenceEncoder
     {
         int pixelIndex = 0;
         ColorCache colorCache = new ColorCache(cacheBits);
-        for (int idx = 0; idx < refs.Refs.Count; idx++)
+        foreach (ref PixOrCopy v in refs)
         {
-            PixOrCopy v = refs.Refs[idx];
             if (v.IsLiteral())
             {
                 uint bgraLiteral = v.BgraOrDistance;
@@ -790,9 +788,7 @@ internal static class BackwardReferenceEncoder
                 if (ix >= 0)
                 {
                     // Color cache contains bgraLiteral
-                    v.Mode = PixOrCopyMode.CacheIdx;
-                    v.BgraOrDistance = (uint)ix;
-                    v.Len = 1;
+                    v = PixOrCopy.CreateCacheIdx(ix);
                 }
                 else
                 {
@@ -814,14 +810,13 @@ internal static class BackwardReferenceEncoder
 
     private static void BackwardReferences2DLocality(int xSize, Vp8LBackwardRefs refs)
     {
-        using List<PixOrCopy>.Enumerator c = refs.Refs.GetEnumerator();
-        while (c.MoveNext())
+        foreach (ref PixOrCopy v in refs)
         {
-            if (c.Current.IsCopy())
+            if (v.IsCopy())
             {
-                int dist = (int)c.Current.BgraOrDistance;
+                int dist = (int)v.BgraOrDistance;
                 int transformedDist = DistanceToPlaneCode(xSize, dist);
-                c.Current.BgraOrDistance = (uint)transformedDist;
+                v = PixOrCopy.CreateCopy((uint)transformedDist, v.Len);
             }
         }
     }

--- a/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/CostModel.cs
@@ -40,9 +40,9 @@ internal class CostModel
         using OwnedVp8LHistogram histogram = OwnedVp8LHistogram.Create(this.memoryAllocator, cacheBits);
 
         // The following code is similar to HistogramCreate but converts the distance to plane code.
-        for (int i = 0; i < backwardRefs.Refs.Count; i++)
+        foreach (PixOrCopy v in backwardRefs)
         {
-            histogram.AddSinglePixOrCopy(backwardRefs.Refs[i], true, xSize);
+            histogram.AddSinglePixOrCopy(in v, true, xSize);
         }
 
         ConvertPopulationCountTableToBitEstimates(histogram.NumCodes(), histogram.Literal, this.Literal);

--- a/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/HistogramEncoder.cs
@@ -109,12 +109,11 @@ internal static class HistogramEncoder
     {
         int x = 0, y = 0;
         int histoXSize = LosslessUtils.SubSampleSize(xSize, histoBits);
-        using List<PixOrCopy>.Enumerator backwardRefsEnumerator = backwardRefs.Refs.GetEnumerator();
-        while (backwardRefsEnumerator.MoveNext())
+
+        foreach (PixOrCopy v in backwardRefs)
         {
-            PixOrCopy v = backwardRefsEnumerator.Current;
             int ix = ((y >> histoBits) * histoXSize) + (x >> histoBits);
-            histograms[ix].AddSinglePixOrCopy(v, false);
+            histograms[ix].AddSinglePixOrCopy(in v, false);
             x += v.Len;
             while (x >= xSize)
             {
@@ -465,7 +464,7 @@ internal static class HistogramEncoder
                     }
                 }
 
-                HistoListUpdateHead(histoPriorityList, p);
+                HistoListUpdateHead(histoPriorityList, p, j);
                 j++;
             }
 
@@ -525,7 +524,7 @@ internal static class HistogramEncoder
                 }
                 else
                 {
-                    HistoListUpdateHead(histoPriorityList, p);
+                    HistoListUpdateHead(histoPriorityList, p, i);
                     i++;
                 }
             }
@@ -647,7 +646,7 @@ internal static class HistogramEncoder
 
         histoList.Add(pair);
 
-        HistoListUpdateHead(histoList, pair);
+        HistoListUpdateHead(histoList, pair, histoList.Count - 1);
 
         return pair.CostDiff;
     }
@@ -674,13 +673,11 @@ internal static class HistogramEncoder
     /// <summary>
     /// Check whether a pair in the list should be updated as head or not.
     /// </summary>
-    private static void HistoListUpdateHead(List<HistogramPair> histoList, HistogramPair pair)
+    private static void HistoListUpdateHead(List<HistogramPair> histoList, HistogramPair pair, int idx)
     {
         if (pair.CostDiff < histoList[0].CostDiff)
         {
-            // Replace the best pair.
-            int oldIdx = histoList.IndexOf(pair);
-            histoList[oldIdx] = histoList[0];
+            histoList[idx] = histoList[0];
             histoList[0] = pair;
         }
     }

--- a/src/ImageSharp/Formats/Webp/Lossless/PixOrCopy.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/PixOrCopy.cs
@@ -6,37 +6,24 @@ using System.Diagnostics;
 namespace SixLabors.ImageSharp.Formats.Webp.Lossless;
 
 [DebuggerDisplay("Mode: {Mode}, Len: {Len}, BgraOrDistance: {BgraOrDistance}")]
-internal sealed class PixOrCopy
+internal readonly struct PixOrCopy
 {
-    public PixOrCopyMode Mode { get; set; }
+    public readonly PixOrCopyMode Mode;
+    public readonly ushort Len;
+    public readonly uint BgraOrDistance;
 
-    public ushort Len { get; set; }
-
-    public uint BgraOrDistance { get; set; }
-
-    public static PixOrCopy CreateCacheIdx(int idx) =>
-        new PixOrCopy
-        {
-            Mode = PixOrCopyMode.CacheIdx,
-            BgraOrDistance = (uint)idx,
-            Len = 1
-        };
-
-    public static PixOrCopy CreateLiteral(uint bgra) =>
-        new PixOrCopy
-        {
-            Mode = PixOrCopyMode.Literal,
-            BgraOrDistance = bgra,
-            Len = 1
-        };
-
-    public static PixOrCopy CreateCopy(uint distance, ushort len) =>
-        new PixOrCopy
+    private PixOrCopy(PixOrCopyMode mode, ushort len, uint bgraOrDistance)
     {
-        Mode = PixOrCopyMode.Copy,
-        BgraOrDistance = distance,
-        Len = len
-    };
+        this.Mode = mode;
+        this.Len = len;
+        this.BgraOrDistance = bgraOrDistance;
+    }
+
+    public static PixOrCopy CreateCacheIdx(int idx) => new(PixOrCopyMode.CacheIdx, 1, (uint)idx);
+
+    public static PixOrCopy CreateLiteral(uint bgra) => new(PixOrCopyMode.Literal, 1, bgra);
+
+    public static PixOrCopy CreateCopy(uint distance, ushort len) => new(PixOrCopyMode.Copy, len, distance);
 
     public int Literal(int component) => (int)(this.BgraOrDistance >> (component * 8)) & 0xFF;
 

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LBackwardRefs.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LBackwardRefs.cs
@@ -1,21 +1,28 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Buffers;
+using SixLabors.ImageSharp.Memory;
+
 namespace SixLabors.ImageSharp.Formats.Webp.Lossless;
 
-internal class Vp8LBackwardRefs
+internal class Vp8LBackwardRefs : IDisposable
 {
-    public Vp8LBackwardRefs(int pixels) => this.Refs = new List<PixOrCopy>(pixels);
+    private readonly IMemoryOwner<PixOrCopy> refs;
+    private int count;
 
-    /// <summary>
-    /// Gets or sets the common block-size.
-    /// </summary>
-    public int BlockSize { get; set; }
+    public Vp8LBackwardRefs(MemoryAllocator memoryAllocator, int pixels)
+    {
+        this.refs = memoryAllocator.Allocate<PixOrCopy>(pixels);
+        this.count = 0;
+    }
 
-    /// <summary>
-    /// Gets the backward references.
-    /// </summary>
-    public List<PixOrCopy> Refs { get; }
+    public void Add(PixOrCopy pixOrCopy) => this.refs.Memory.Span[this.count++] = pixOrCopy;
 
-    public void Add(PixOrCopy pixOrCopy) => this.Refs.Add(pixOrCopy);
+    public void Clear() => this.count = 0;
+
+    public Span<PixOrCopy>.Enumerator GetEnumerator() => this.refs.Slice(0, this.count).GetEnumerator();
+
+    /// <inheritdoc/>
+    public void Dispose() => this.refs.Dispose();
 }

--- a/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
+++ b/src/ImageSharp/Formats/Webp/Lossless/Vp8LHistogram.cs
@@ -138,9 +138,9 @@ internal abstract unsafe class Vp8LHistogram
     /// <param name="refs">The backward references.</param>
     public void StoreRefs(Vp8LBackwardRefs refs)
     {
-        for (int i = 0; i < refs.Refs.Count; i++)
+        foreach (PixOrCopy v in refs)
         {
-            this.AddSinglePixOrCopy(refs.Refs[i], false);
+            this.AddSinglePixOrCopy(in v, false);
         }
     }
 
@@ -150,7 +150,7 @@ internal abstract unsafe class Vp8LHistogram
     /// <param name="v">The token to add.</param>
     /// <param name="useDistanceModifier">Indicates whether to use the distance modifier.</param>
     /// <param name="xSize">xSize is only used when useDistanceModifier is true.</param>
-    public void AddSinglePixOrCopy(PixOrCopy v, bool useDistanceModifier, int xSize = 0)
+    public void AddSinglePixOrCopy(in PixOrCopy v, bool useDistanceModifier, int xSize = 0)
     {
         if (v.IsLiteral())
         {

--- a/tests/ImageSharp.Tests/Formats/WebP/Vp8LHistogramTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/Vp8LHistogramTests.cs
@@ -66,18 +66,14 @@ public class Vp8LHistogramTests
         // All remaining values are expected to be zero.
         literals.AsSpan().CopyTo(expectedLiterals);
 
-        Vp8LBackwardRefs backwardRefs = new(pixelData.Length);
+        MemoryAllocator memoryAllocator = Configuration.Default.MemoryAllocator;
+
+        using Vp8LBackwardRefs backwardRefs = new(memoryAllocator, pixelData.Length);
         for (int i = 0; i < pixelData.Length; i++)
         {
-            backwardRefs.Add(new PixOrCopy()
-            {
-                BgraOrDistance = pixelData[i],
-                Len = 1,
-                Mode = PixOrCopyMode.Literal
-            });
+            backwardRefs.Add(PixOrCopy.CreateLiteral(pixelData[i]));
         }
 
-        MemoryAllocator memoryAllocator = Configuration.Default.MemoryAllocator;
         using OwnedVp8LHistogram histogram0 = OwnedVp8LHistogram.Create(memoryAllocator, backwardRefs, 3);
         using OwnedVp8LHistogram histogram1 = OwnedVp8LHistogram.Create(memoryAllocator, backwardRefs, 3);
         for (int i = 0; i < 5; i++)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backport of #2940 for V3.

<!-- Thanks for contributing to ImageSharp! -->
