### PR TITLE
GIF: Check for end of stream when reading comments. 

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -414,6 +414,11 @@ internal sealed class GifDecoderCore : ImageDecoderCore
                 GifThrowHelper.ThrowInvalidImageContentException($"Gif comment length '{length}' exceeds max '{GifConstants.MaxCommentSubBlockLength}' of a comment data block");
             }
 
+            if (length == -1)
+            {
+                GifThrowHelper.ThrowInvalidImageContentException("Unexpected end of stream while reading gif comment");
+            }
+
             if (this.skipMetadata)
             {
                 stream.Seek(length, SeekOrigin.Current);

--- a/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifDecoderTests.cs
@@ -381,4 +381,21 @@ public class GifDecoderTests
         image.DebugSaveMultiFrame(provider);
         image.CompareToReferenceOutputMultiFrame(provider, ImageComparer.Exact);
     }
+
+    // https://github.com/SixLabors/ImageSharp/issues/2953
+    [Theory]
+    [WithFile(TestImages.Gif.Issues.Issue2953, PixelTypes.Rgba32)]
+    public void Issue2953<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        // We should throw a InvalidImageContentException when trying to identify or load an invalid GIF file.
+        TestFile testFile = TestFile.Create(provider.SourceFileOrDescription);
+
+        Assert.Throws<InvalidImageContentException>(() => Image.Identify(testFile.FullPath));
+        Assert.Throws<InvalidImageContentException>(() => Image.Load(testFile.FullPath));
+
+        DecoderOptions options = new() { SkipMetadata = true };
+        Assert.Throws<InvalidImageContentException>(() => Image.Identify(options, testFile.FullPath));
+        Assert.Throws<InvalidImageContentException>(() => Image.Load(options, testFile.FullPath));
+    }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -581,6 +581,7 @@ public static class TestImages
             public const string Issue2866 = "Gif/issues/issue_2866.gif";
             public const string Issue2859_A = "Gif/issues/issue_2859_A.gif";
             public const string Issue2859_B = "Gif/issues/issue_2859_B.gif";
+            public const string Issue2953 = "Gif/issues/issue_2953.gif";
         }
 
         public static readonly string[] Animated =

--- a/tests/Images/Input/Gif/issues/issue_2953.gif
+++ b/tests/Images/Input/Gif/issues/issue_2953.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fa4a002b264a41677cc10f115f3572111852993a53ee8cea5f4ec0bf8dec195
+size 40


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #2953 

<!-- Thanks for contributing to ImageSharp! -->
