### PR TITLE
Backport #2926 to release/2.1.x

### DIFF
--- a/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngDecoderTests.cs
@@ -534,5 +534,15 @@ namespace SixLabors.ImageSharp.Tests.Formats.Png
             string path = Path.GetFullPath(Path.Combine(TestEnvironment.InputImagesDirectoryFullPath, file));
             using Image image = Image.Load(path);
         }
+
+        [Theory]
+        [WithFile(TestImages.Png.Issue2924, PixelTypes.Rgba32)]
+        public void CanDecode_Issue2924<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage(PngDecoder);
+            image.DebugSave(provider);
+            image.CompareToReferenceOutput(provider);
+        }
     }
 }

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -125,6 +125,9 @@ namespace SixLabors.ImageSharp.Tests
             // Discussion 1875: https://github.com/SixLabors/ImageSharp/discussions/1875
             public const string Issue1875 = "Png/raw-profile-type-exif.png";
 
+             // Issue 2924: https://github.com/SixLabors/ImageSharp/issues/2924
+            public const string Issue2924 = "Png/issues/Issue_2924.png";
+
             public static class Bad
             {
                 public const string MissingDataChunk = "Png/xdtn0g01.png";

--- a/tests/Images/External/ReferenceOutput/PngDecoderTests/CanDecode_Issue2924_Rgba32_Issue_2924.png
+++ b/tests/Images/External/ReferenceOutput/PngDecoderTests/CanDecode_Issue2924_Rgba32_Issue_2924.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4347cd89196c09496288724afdd876b227063149bba33615c338ebb474a0cb19
+size 47260

--- a/tests/Images/Input/Png/issues/Issue_2924.png
+++ b/tests/Images/Input/Png/issues/Issue_2924.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd366a2de522041c706729b01a6030df6c82a4e87ea3509cc78a47486f097044
+size 49376


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This backports #2926 to the 2.1 branch, see also #2977 .
