### PR TITLE
Backport v3 : Tiff decoder: Fix issue 2679 

### DIFF
--- a/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderOptionsParser.cs
@@ -637,6 +637,14 @@ internal static class TiffDecoderOptionsParser
             {
                 options.CompressionType = TiffDecoderCompressionType.Jpeg;
 
+                // Some tiff encoder set this to values different from [1, 1]. The jpeg decoder already handles this,
+                // so we set this always to [1, 1], see: https://github.com/SixLabors/ImageSharp/issues/2679
+                if (options.PhotometricInterpretation is TiffPhotometricInterpretation.YCbCr && options.YcbcrSubSampling != null)
+                {
+                    options.YcbcrSubSampling[0] = 1;
+                    options.YcbcrSubSampling[1] = 1;
+                }
+
                 if (options.PhotometricInterpretation is TiffPhotometricInterpretation.YCbCr && options.JpegTables is null)
                 {
                     // Note: Setting PhotometricInterpretation and color type to RGB here, since the jpeg decoder will handle the conversion of the pixel data.

--- a/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/TiffDecoderTests.cs
@@ -705,6 +705,23 @@ public class TiffDecoderTests : TiffDecoderBaseTester
     public void TiffDecoder_CanDecode_BiColorWithMissingBitsPerSample<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel> => TestTiffDecoder(provider);
 
+    // https://github.com/SixLabors/ImageSharp/issues/2679
+    [Theory]
+    [WithFile(Issues2679, PixelTypes.Rgba32)]
+    public void TiffDecoder_CanDecode_JpegCompressedWithIssue2679<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage(TiffDecoder.Instance);
+
+        // The image is handcrafted to simulate issue 2679. ImageMagick will throw an expection here and wont decode,
+        // so we compare to reference output instead.
+        image.DebugSave(provider);
+        image.CompareToReferenceOutput(
+            ImageComparer.Exact,
+            provider,
+            appendPixelTypeToFileName: false);
+    }
+
     [Theory]
     [WithFile(JpegCompressedGray0000539558, PixelTypes.Rgba32)]
     public void TiffDecoder_ThrowsException_WithCircular_IFD_Offsets<TPixel>(TestImageProvider<TPixel> provider)

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -1112,6 +1112,7 @@ public static class TestImages
         public const string Issues2255 = "Tiff/Issues/Issue2255.png";
         public const string Issues2435 = "Tiff/Issues/Issue2435.tiff";
         public const string Issues2587 = "Tiff/Issues/Issue2587.tiff";
+        public const string Issues2679 = "Tiff/Issues/Issue2679.tiff";
         public const string JpegCompressedGray0000539558 = "Tiff/Issues/JpegCompressedGray-0000539558.tiff";
         public const string Tiled0000023664 = "Tiff/Issues/tiled-0000023664.tiff";
         public const string ExtraSamplesUnspecified = "Tiff/Issues/ExtraSamplesUnspecified.tif";

--- a/tests/Images/External/ReferenceOutput/TiffDecoderTests/TiffDecoder_CanDecode_JpegCompressedWithIssue2679_Issue2679.png
+++ b/tests/Images/External/ReferenceOutput/TiffDecoderTests/TiffDecoder_CanDecode_JpegCompressedWithIssue2679_Issue2679.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e1ebab8bf31eb8125c6e46152fdc8935fba1630f53131d2f46cfa7e55eaac8e
+size 80288

--- a/tests/Images/Input/Tiff/Issues/Issue2679.tiff
+++ b/tests/Images/Input/Tiff/Issues/Issue2679.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feb938396b9d5b4c258244197ba382937a52c93f72cc91081c7e6810e4a3b94c
+size 6136


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Backport #2789 for v3. See #2994

<!-- Thanks for contributing to ImageSharp! -->
