### PR TITLE
Throw UnknownImageFormatException for empty input

### DIFF
--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -34,7 +34,12 @@ public abstract partial class Image
     /// <exception cref="UnknownImageFormatException">The encoded image format is unknown.</exception>
     public static unsafe IImageFormat DetectFormat(DecoderOptions options, ReadOnlySpan<byte> buffer)
     {
-        Guard.NotNull(options, nameof(options.Configuration));
+        Guard.NotNull(options, nameof(options));
+
+        if (buffer.IsEmpty)
+        {
+            throw new UnknownImageFormatException("Cannot detect image format from empty data.");
+        }
 
         fixed (byte* ptr = buffer)
         {
@@ -66,6 +71,13 @@ public abstract partial class Image
     /// <exception cref="UnknownImageFormatException">The encoded image format is unknown.</exception>
     public static unsafe ImageInfo Identify(DecoderOptions options, ReadOnlySpan<byte> buffer)
     {
+        Guard.NotNull(options, nameof(options));
+
+        if (buffer.IsEmpty)
+        {
+            throw new UnknownImageFormatException("Cannot identify image format from empty data.");
+        }
+
         fixed (byte* ptr = buffer)
         {
             using UnmanagedMemoryStream stream = new(ptr, buffer.Length);
@@ -99,6 +111,13 @@ public abstract partial class Image
     /// <exception cref="UnknownImageFormatException">The encoded image format is unknown.</exception>
     public static unsafe Image Load(DecoderOptions options, ReadOnlySpan<byte> buffer)
     {
+        Guard.NotNull(options, nameof(options));
+
+        if (buffer.IsEmpty)
+        {
+            throw new UnknownImageFormatException("Cannot load image from empty data.");
+        }
+
         fixed (byte* ptr = buffer)
         {
             using UnmanagedMemoryStream stream = new(ptr, buffer.Length);
@@ -133,6 +152,13 @@ public abstract partial class Image
     public static unsafe Image<TPixel> Load<TPixel>(DecoderOptions options, ReadOnlySpan<byte> data)
         where TPixel : unmanaged, IPixel<TPixel>
     {
+        Guard.NotNull(options, nameof(options));
+
+        if (data.IsEmpty)
+        {
+            throw new UnknownImageFormatException("Cannot load image from empty data.");
+        }
+
         fixed (byte* ptr = data)
         {
             using UnmanagedMemoryStream stream = new(ptr, data.Length);

--- a/src/ImageSharp/Image.LoadPixelData.cs
+++ b/src/ImageSharp/Image.LoadPixelData.cs
@@ -69,6 +69,11 @@ public abstract partial class Image
     {
         Guard.NotNull(configuration, nameof(configuration));
 
+        if (data.IsEmpty)
+        {
+            throw new ArgumentException("Pixel data cannot be empty.", nameof(data));
+        }
+
         int count = width * height;
         Guard.MustBeGreaterThanOrEqualTo(data.Length, count, nameof(data));
 

--- a/tests/ImageSharp.Tests/Image/ImageTests.DetectFormat.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.DetectFormat.cs
@@ -51,6 +51,10 @@ public partial class ImageTests
         }
 
         [Fact]
+        public void FromBytes_EmptySpan_Throws()
+            => Assert.Throws<UnknownImageFormatException>(() => Image.DetectFormat([]));
+
+        [Fact]
         public void FromFileSystemPath_GlobalConfiguration()
         {
             IImageFormat format = Image.DetectFormat(ActualImagePath);

--- a/tests/ImageSharp.Tests/Image/ImageTests.Identify.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Identify.cs
@@ -39,6 +39,10 @@ public partial class ImageTests
         }
 
         [Fact]
+        public void FromBytes_EmptySpan_Throws()
+            => Assert.Throws<UnknownImageFormatException>(() => Image.Identify([]));
+
+        [Fact]
         public void FromBytes_CustomConfiguration()
         {
             DecoderOptions options = new() { Configuration = this.LocalConfiguration };

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FromBytes_PassLocalConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FromBytes_PassLocalConfiguration.cs
@@ -79,5 +79,16 @@ public partial class ImageTests
 
             this.TestFormat.VerifyAgnosticDecodeCall(this.Marker, this.TopLevelConfiguration);
         }
+
+        [Fact]
+        public void FromBytes_EmptySpan_Throws()
+        {
+            DecoderOptions options = new()
+            {
+                Configuration = this.TopLevelConfiguration
+            };
+
+            Assert.Throws<UnknownImageFormatException>(() => Image.Load(options, []));
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FromBytes_UseGlobalConfiguration.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FromBytes_UseGlobalConfiguration.cs
@@ -45,5 +45,9 @@ public partial class ImageTests
             VerifyDecodedImage(img);
             Assert.IsType<BmpFormat>(img.Metadata.DecodedImageFormat);
         }
+
+        [Fact]
+        public void FromBytes_EmptySpan_Throws()
+            => Assert.ThrowsAny<UnknownImageFormatException>(() => Image.Load<Rgba32>([]));
     }
 }

--- a/tests/ImageSharp.Tests/Image/ImageTests.Load_FromStream_ThrowsRightException.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.Load_FromStream_ThrowsRightException.cs
@@ -32,6 +32,17 @@ public partial class ImageTests
                 }
             });
 
-        public void Dispose() => this.Stream?.Dispose();
+        [Fact]
+        public void FromStream_Empty_Throws()
+        {
+            using MemoryStream ms = new();
+            Assert.Throws<UnknownImageFormatException>(() => Image.Load(DecoderOptions.Default, ms));
+        }
+
+        public void Dispose()
+        {
+            this.Stream?.Dispose();
+            GC.SuppressFinalize(this);
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #3009 


<!-- Thanks for contributing to ImageSharp! -->
