### PR TITLE
Undo #2025

### DIFF
--- a/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
+++ b/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs
@@ -71,10 +71,6 @@ internal sealed class UniformUnmanagedMemoryPoolMemoryAllocator : MemoryAllocato
         this.nonPoolAllocator = new UnmanagedMemoryAllocator(unmanagedBufferSizeInBytes);
     }
 
-    // This delegate allows overriding the method returning the available system memory,
-    // so we can test our workaround for https://github.com/dotnet/runtime/issues/65466
-    internal static Func<long> GetTotalAvailableMemoryBytes { get; set; } = () => GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
-
     /// <inheritdoc />
     protected internal override int GetBufferCapacityInBytes() => this.poolBufferSizeInBytes;
 
@@ -155,20 +151,14 @@ internal sealed class UniformUnmanagedMemoryPoolMemoryAllocator : MemoryAllocato
 
     private static long GetDefaultMaxPoolSizeBytes()
     {
-        // On 64 bit set the pool size to a portion of the total available memory.
-        // https://github.com/dotnet/runtime/issues/55126#issuecomment-876779327
         if (Environment.Is64BitProcess)
         {
-            long total = GetTotalAvailableMemoryBytes();
-
-            // Workaround for https://github.com/dotnet/runtime/issues/65466
-            if (total > 0)
-            {
-                return (long)((ulong)total / 8);
-            }
+            // On 64 bit set the pool size to a portion of the total available memory.
+            GCMemoryInfo info = GC.GetGCMemoryInfo();
+            return info.TotalAvailableMemoryBytes / 8;
         }
 
-        // Stick to a conservative value of 128 Megabytes on other platforms and 32 bit .NET 5.0:
+        // Stick to a conservative value of 128 Megabytes on 32 bit.
         return 128 * OneMegabyte;
     }
 }

--- a/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
+++ b/tests/ImageSharp.Tests/Memory/Allocators/UniformUnmanagedPoolMemoryAllocatorTests.cs
@@ -410,19 +410,6 @@ public class UniformUnmanagedPoolMemoryAllocatorTests
     }
 
     [Fact]
-    public void Issue2001_NegativeMemoryReportedByGc()
-    {
-        RemoteExecutor.Invoke(RunTest).Dispose();
-
-        static void RunTest()
-        {
-            // Emulate GC.GetGCMemoryInfo() issue https://github.com/dotnet/runtime/issues/65466
-            UniformUnmanagedMemoryPoolMemoryAllocator.GetTotalAvailableMemoryBytes = () => -402354176;
-            _ = MemoryAllocator.Create();
-        }
-    }
-
-    [Fact]
     public void Allocate_OverLimit_ThrowsInvalidMemoryOperationException()
     {
         MemoryAllocator allocator = MemoryAllocator.Create(new MemoryAllocatorOptions


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
The workaround implemented in #2025 is no longer needed since the underlying .NET issue has been fixed for .NET 7.