### PR TITLE
JPEG - Throw explicit ImageContentException on missing marker.

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -519,6 +519,11 @@ internal sealed class JpegDecoderCore : ImageDecoderCore, IRawJpegData
             fileMarker = FindNextFileMarker(stream);
         }
 
+        if (!metadataOnly && this.Frame is null)
+        {
+            JpegThrowHelper.ThrowInvalidImageContentException("No readable SOFn (Start Of Frame) marker found.");
+        }
+
         this.Metadata.GetJpegMetadata().Interleaved = this.Frame.Interleaved;
     }
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -448,4 +448,13 @@ public partial class JpegDecoderTests
     [InlineData(TestImages.Jpeg.Issues.Issue2948)]
     public void Issue2948_No_SOS_Identify_Throws_InvalidImageContentException(string imagePath)
         => Assert.Throws<InvalidImageContentException>(() => _ = Image.Identify(TestFile.Create(imagePath).Bytes));
+
+    [Fact]
+    public void Issue_3071_Decode_TruncatedJpeg_Throws_InvalidImageContentException()
+        => Assert.Throws<InvalidImageContentException>(() =>
+        {
+            // SOI marker (FF D8) + garbage bytes — only 11 bytes
+            byte[] data = [0xFF, 0xD8, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30];
+            using Image<Rgba32> image = Image.Load<Rgba32>(data);
+        });
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #3071 

<!-- Thanks for contributing to ImageSharp! -->
