### PR TITLE
Allow -1 (unbounded) parallelism; validate settings

### DIFF
--- a/src/ImageSharp/Advanced/ParallelExecutionSettings.cs
+++ b/src/ImageSharp/Advanced/ParallelExecutionSettings.cs
@@ -18,7 +18,10 @@ public readonly struct ParallelExecutionSettings
     /// <summary>
     /// Initializes a new instance of the <see cref="ParallelExecutionSettings"/> struct.
     /// </summary>
-    /// <param name="maxDegreeOfParallelism">The value used for initializing <see cref="ParallelOptions.MaxDegreeOfParallelism"/> when using TPL.</param>
+    /// <param name="maxDegreeOfParallelism">
+    /// The value used for initializing <see cref="ParallelOptions.MaxDegreeOfParallelism"/> when using TPL.
+    /// Set to <c>-1</c> to leave the degree of parallelism unbounded.
+    /// </param>
     /// <param name="minimumPixelsProcessedPerTask">The value for <see cref="MinimumPixelsProcessedPerTask"/>.</param>
     /// <param name="memoryAllocator">The <see cref="MemoryAllocator"/>.</param>
     public ParallelExecutionSettings(
@@ -44,7 +47,10 @@ public readonly struct ParallelExecutionSettings
     /// <summary>
     /// Initializes a new instance of the <see cref="ParallelExecutionSettings"/> struct.
     /// </summary>
-    /// <param name="maxDegreeOfParallelism">The value used for initializing <see cref="ParallelOptions.MaxDegreeOfParallelism"/> when using TPL.</param>
+    /// <param name="maxDegreeOfParallelism">
+    /// The value used for initializing <see cref="ParallelOptions.MaxDegreeOfParallelism"/> when using TPL.
+    /// Set to <c>-1</c> to leave the degree of parallelism unbounded.
+    /// </param>
     /// <param name="memoryAllocator">The <see cref="MemoryAllocator"/>.</param>
     public ParallelExecutionSettings(int maxDegreeOfParallelism, MemoryAllocator memoryAllocator)
         : this(maxDegreeOfParallelism, DefaultMinimumPixelsProcessedPerTask, memoryAllocator)
@@ -58,6 +64,7 @@ public readonly struct ParallelExecutionSettings
 
     /// <summary>
     /// Gets the value used for initializing <see cref="ParallelOptions.MaxDegreeOfParallelism"/> when using TPL.
+    /// A value of <c>-1</c> leaves the degree of parallelism unbounded.
     /// </summary>
     public int MaxDegreeOfParallelism { get; }
 

--- a/src/ImageSharp/Advanced/ParallelRowIterator.cs
+++ b/src/ImageSharp/Advanced/ParallelRowIterator.cs
@@ -44,14 +44,14 @@ public static partial class ParallelRowIterator
         where T : struct, IRowOperation
     {
         ValidateRectangle(rectangle);
+        ValidateSettings(parallelSettings);
 
         int top = rectangle.Top;
         int bottom = rectangle.Bottom;
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
-        int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
+        int numOfSteps = GetNumberOfSteps(width, height, parallelSettings);
 
         // Avoid TPL overhead in this trivial case:
         if (numOfSteps == 1)
@@ -65,7 +65,7 @@ public static partial class ParallelRowIterator
         }
 
         int verticalStep = DivideCeil(rectangle.Height, numOfSteps);
-        ParallelOptions parallelOptions = new() { MaxDegreeOfParallelism = numOfSteps };
+        ParallelOptions parallelOptions = CreateParallelOptions(parallelSettings, numOfSteps);
         RowOperationWrapper<T> wrappingOperation = new(top, bottom, verticalStep, in operation);
 
         _ = Parallel.For(
@@ -109,14 +109,14 @@ public static partial class ParallelRowIterator
         where TBuffer : unmanaged
     {
         ValidateRectangle(rectangle);
+        ValidateSettings(parallelSettings);
 
         int top = rectangle.Top;
         int bottom = rectangle.Bottom;
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
-        int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
+        int numOfSteps = GetNumberOfSteps(width, height, parallelSettings);
         MemoryAllocator allocator = parallelSettings.MemoryAllocator;
         int bufferLength = Unsafe.AsRef(in operation).GetRequiredBufferLength(rectangle);
 
@@ -135,7 +135,7 @@ public static partial class ParallelRowIterator
         }
 
         int verticalStep = DivideCeil(height, numOfSteps);
-        ParallelOptions parallelOptions = new() { MaxDegreeOfParallelism = numOfSteps };
+        ParallelOptions parallelOptions = CreateParallelOptions(parallelSettings, numOfSteps);
         RowOperationWrapper<T, TBuffer> wrappingOperation = new(top, bottom, verticalStep, bufferLength, allocator, in operation);
 
         _ = Parallel.For(
@@ -174,14 +174,14 @@ public static partial class ParallelRowIterator
         where T : struct, IRowIntervalOperation
     {
         ValidateRectangle(rectangle);
+        ValidateSettings(parallelSettings);
 
         int top = rectangle.Top;
         int bottom = rectangle.Bottom;
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
-        int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
+        int numOfSteps = GetNumberOfSteps(width, height, parallelSettings);
 
         // Avoid TPL overhead in this trivial case:
         if (numOfSteps == 1)
@@ -192,7 +192,7 @@ public static partial class ParallelRowIterator
         }
 
         int verticalStep = DivideCeil(rectangle.Height, numOfSteps);
-        ParallelOptions parallelOptions = new() { MaxDegreeOfParallelism = numOfSteps };
+        ParallelOptions parallelOptions = CreateParallelOptions(parallelSettings, numOfSteps);
         RowIntervalOperationWrapper<T> wrappingOperation = new(top, bottom, verticalStep, in operation);
 
         _ = Parallel.For(
@@ -236,14 +236,14 @@ public static partial class ParallelRowIterator
         where TBuffer : unmanaged
     {
         ValidateRectangle(rectangle);
+        ValidateSettings(parallelSettings);
 
         int top = rectangle.Top;
         int bottom = rectangle.Bottom;
         int width = rectangle.Width;
         int height = rectangle.Height;
 
-        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
-        int numOfSteps = Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
+        int numOfSteps = GetNumberOfSteps(width, height, parallelSettings);
         MemoryAllocator allocator = parallelSettings.MemoryAllocator;
         int bufferLength = Unsafe.AsRef(in operation).GetRequiredBufferLength(rectangle);
 
@@ -259,7 +259,7 @@ public static partial class ParallelRowIterator
         }
 
         int verticalStep = DivideCeil(height, numOfSteps);
-        ParallelOptions parallelOptions = new() { MaxDegreeOfParallelism = numOfSteps };
+        ParallelOptions parallelOptions = CreateParallelOptions(parallelSettings, numOfSteps);
         RowIntervalOperationWrapper<T, TBuffer> wrappingOperation = new(top, bottom, verticalStep, bufferLength, allocator, in operation);
 
         _ = Parallel.For(
@@ -272,6 +272,37 @@ public static partial class ParallelRowIterator
     [MethodImpl(InliningOptions.ShortMethod)]
     private static int DivideCeil(long dividend, int divisor) => (int)Math.Min(1 + ((dividend - 1) / divisor), int.MaxValue);
 
+    /// <summary>
+    /// Creates the <see cref="ParallelOptions"/> for the current iteration.
+    /// </summary>
+    /// <param name="parallelSettings">The execution settings.</param>
+    /// <param name="numOfSteps">The number of row partitions to execute.</param>
+    /// <returns>The <see cref="ParallelOptions"/> instance.</returns>
+    [MethodImpl(InliningOptions.ShortMethod)]
+    private static ParallelOptions CreateParallelOptions(in ParallelExecutionSettings parallelSettings, int numOfSteps)
+        => new() { MaxDegreeOfParallelism = parallelSettings.MaxDegreeOfParallelism == -1 ? -1 : numOfSteps };
+
+    /// <summary>
+    /// Calculates the number of row partitions to execute for the given region.
+    /// </summary>
+    /// <param name="width">The width of the region.</param>
+    /// <param name="height">The height of the region.</param>
+    /// <param name="parallelSettings">The execution settings.</param>
+    /// <returns>The number of row partitions to execute.</returns>
+    [MethodImpl(InliningOptions.ShortMethod)]
+    private static int GetNumberOfSteps(int width, int height, in ParallelExecutionSettings parallelSettings)
+    {
+        int maxSteps = DivideCeil(width * (long)height, parallelSettings.MinimumPixelsProcessedPerTask);
+
+        if (parallelSettings.MaxDegreeOfParallelism == -1)
+        {
+            // Row batching cannot produce more useful partitions than the number of rows available.
+            return Math.Min(height, maxSteps);
+        }
+
+        return Math.Min(parallelSettings.MaxDegreeOfParallelism, maxSteps);
+    }
+
     private static void ValidateRectangle(Rectangle rectangle)
     {
         Guard.MustBeGreaterThan(
@@ -283,5 +314,36 @@ public static partial class ParallelRowIterator
             rectangle.Height,
             0,
             $"{nameof(rectangle)}.{nameof(rectangle.Height)}");
+    }
+
+    /// <summary>
+    /// Validates the supplied <see cref="ParallelExecutionSettings"/>.
+    /// </summary>
+    /// <param name="parallelSettings">The execution settings.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <see cref="ParallelExecutionSettings.MaxDegreeOfParallelism"/> or
+    /// <see cref="ParallelExecutionSettings.MinimumPixelsProcessedPerTask"/> is invalid.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <see cref="ParallelExecutionSettings.MemoryAllocator"/> is null.
+    /// This also guards the public <see cref="ParallelExecutionSettings"/> default value, which bypasses constructor validation.
+    /// </exception>
+    private static void ValidateSettings(in ParallelExecutionSettings parallelSettings)
+    {
+        // ParallelExecutionSettings is a public struct, so callers can pass default and bypass constructor validation.
+        if (parallelSettings.MaxDegreeOfParallelism is 0 or < -1)
+        {
+            throw new ArgumentOutOfRangeException(
+                $"{nameof(parallelSettings)}.{nameof(ParallelExecutionSettings.MaxDegreeOfParallelism)}");
+        }
+
+        Guard.MustBeGreaterThan(
+            parallelSettings.MinimumPixelsProcessedPerTask,
+            0,
+            $"{nameof(parallelSettings)}.{nameof(ParallelExecutionSettings.MinimumPixelsProcessedPerTask)}");
+
+        Guard.NotNull(
+            parallelSettings.MemoryAllocator,
+            $"{nameof(parallelSettings)}.{nameof(ParallelExecutionSettings.MemoryAllocator)}");
     }
 }

--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -64,6 +64,7 @@ public sealed class Configuration
     /// <summary>
     /// Gets or sets the maximum number of concurrent tasks enabled in ImageSharp algorithms
     /// configured with this <see cref="Configuration"/> instance.
+    /// Set to <c>-1</c> to leave the degree of parallelism unbounded.
     /// Initialized with <see cref="Environment.ProcessorCount"/> by default.
     /// </summary>
     public int MaxDegreeOfParallelism

--- a/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
+++ b/tests/ImageSharp.Tests/Helpers/ParallelRowIteratorTests.cs
@@ -13,6 +13,7 @@ namespace SixLabors.ImageSharp.Tests.Helpers;
 
 public class ParallelRowIteratorTests
 {
+    public delegate void BufferedRowAction<T>(int y, Span<T> span);
     public delegate void RowIntervalAction<T>(RowInterval rows, Span<T> span);
 
     private readonly ITestOutputHelper output;
@@ -200,6 +201,47 @@ public class ParallelRowIteratorTests
         Assert.Equal(expectedData, actualData);
     }
 
+    [Fact]
+    public void IterateRows_MaxDegreeOfParallelismMinusOne_ShouldVisitAllRows()
+    {
+        ParallelExecutionSettings parallelSettings = new(
+            -1,
+            10,
+            Configuration.Default.MemoryAllocator);
+
+        Rectangle rectangle = new(0, 0, 10, 10);
+        int[] actualData = new int[rectangle.Height];
+
+        void RowAction(int y) => actualData[y]++;
+
+        TestRowActionOperation operation = new(RowAction);
+
+        ParallelRowIterator.IterateRows(
+            rectangle,
+            in parallelSettings,
+            in operation);
+
+        Assert.Equal(Enumerable.Repeat(1, rectangle.Height), actualData);
+    }
+
+    [Fact]
+    public void IterateRowsWithTempBuffer_DefaultSettingsRequireInitialization()
+    {
+        ParallelExecutionSettings parallelSettings = default;
+        Rectangle rect = new(0, 0, 10, 10);
+
+        void RowAction(int y, Span<Rgba32> memory)
+        {
+        }
+
+        TestRowOperation<Rgba32> operation = new(RowAction);
+
+        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ParallelRowIterator.IterateRows<TestRowOperation<Rgba32>, Rgba32>(rect, in parallelSettings, in operation));
+
+        Assert.Contains(nameof(ParallelExecutionSettings.MaxDegreeOfParallelism), ex.Message);
+    }
+
     public static TheoryData<int, int, int, int, int, int, int> IterateRows_WithEffectiveMinimumPixelsLimit_Data =
         new()
         {
@@ -294,6 +336,53 @@ public class ParallelRowIteratorTests
             in operation);
 
         Assert.Equal(expectedNumberOfSteps, actualNumberOfSteps);
+    }
+
+    [Fact]
+    public void IterateRowIntervalsWithTempBuffer_MaxDegreeOfParallelismMinusOne_ShouldVisitAllRows()
+    {
+        ParallelExecutionSettings parallelSettings = new(
+            -1,
+            10,
+            Configuration.Default.MemoryAllocator);
+
+        Rectangle rectangle = new(0, 0, 10, 10);
+        int[] actualData = new int[rectangle.Height];
+
+        void RowAction(RowInterval rows, Span<Vector4> buffer)
+        {
+            for (int y = rows.Min; y < rows.Max; y++)
+            {
+                actualData[y]++;
+            }
+        }
+
+        TestRowIntervalOperation<Vector4> operation = new(RowAction);
+
+        ParallelRowIterator.IterateRowIntervals<TestRowIntervalOperation<Vector4>, Vector4>(
+            rectangle,
+            in parallelSettings,
+            in operation);
+
+        Assert.Equal(Enumerable.Repeat(1, rectangle.Height), actualData);
+    }
+
+    [Fact]
+    public void IterateRows_DefaultSettingsRequireInitialization()
+    {
+        ParallelExecutionSettings parallelSettings = default;
+        Rectangle rect = new(0, 0, 10, 10);
+
+        void RowAction(int y)
+        {
+        }
+
+        TestRowActionOperation operation = new(RowAction);
+
+        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ParallelRowIterator.IterateRows(rect, in parallelSettings, in operation));
+
+        Assert.Contains(nameof(ParallelExecutionSettings.MaxDegreeOfParallelism), ex.Message);
     }
 
     public static readonly TheoryData<int, int, int, int, int, int, int> IterateRectangularBuffer_Data =
@@ -443,6 +532,32 @@ public class ParallelRowIteratorTests
                 this.MaxY.Value = Math.Max(y, this.MaxY.Value);
             }
         }
+    }
+
+    private readonly struct TestRowActionOperation : IRowOperation
+    {
+        private readonly Action<int> action;
+
+        public TestRowActionOperation(Action<int> action)
+            => this.action = action;
+
+        public void Invoke(int y)
+            => this.action(y);
+    }
+
+    private readonly struct TestRowOperation<TBuffer> : IRowOperation<TBuffer>
+        where TBuffer : unmanaged
+    {
+        private readonly BufferedRowAction<TBuffer> action;
+
+        public TestRowOperation(BufferedRowAction<TBuffer> action)
+            => this.action = action;
+
+        public int GetRequiredBufferLength(Rectangle bounds)
+            => bounds.Width;
+
+        public void Invoke(int y, Span<TBuffer> span)
+            => this.action(y, span);
     }
 
     private readonly struct TestRowIntervalOperation : IRowIntervalOperation


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request enhances the flexibility and robustness of parallel execution in ImageSharp by allowing an unbounded degree of parallelism (using `-1`), improving validation for parallel execution settings, and updating the parallel row iteration logic accordingly. It also adds comprehensive tests to ensure the new behaviors are correct and validated.

**Parallel execution improvements:**

* Updated `ParallelExecutionSettings` to document and support `-1` as an unbounded value for `MaxDegreeOfParallelism`, and clarified this in both the code and XML documentation. [[1]](diffhunk://#diff-cfec7ee4d6522f2af997fbf5be095a845c64f084313bf83b35bbb07ad82aae42L21-R24) [[2]](diffhunk://#diff-cfec7ee4d6522f2af997fbf5be095a845c64f084313bf83b35bbb07ad82aae42L47-R53) [[3]](diffhunk://#diff-cfec7ee4d6522f2af997fbf5be095a845c64f084313bf83b35bbb07ad82aae42R67) [[4]](diffhunk://#diff-2b99365bb8b0cb207e3142560a7b257ac71f083b45fe81c21f6a66ecf1cbe9c6R67)
* Refactored the logic in `ParallelRowIterator` to support unbounded parallelism: introduced `GetNumberOfSteps` and `CreateParallelOptions` helpers, and adjusted how the number of steps and parallel options are calculated when `MaxDegreeOfParallelism` is `-1`. [[1]](diffhunk://#diff-a5cf4ae298ce30e75fca62b4d2cb40071e20a39766c414fc3a54b94ddf3c7444R47-R54) [[2]](diffhunk://#diff-a5cf4ae298ce30e75fca62b4d2cb40071e20a39766c414fc3a54b94ddf3c7444L68-R68) [[3]](diffhunk://#diff-a5cf4ae298ce30e75fca62b4d2cb40071e20a39766c414fc3a54b94ddf3c7444R112-R119) [[4]](diffhunk://#diff-a5cf4ae298ce30e75fca62b4d2cb40071e20a39766c414fc3a54b94ddf3c7444L138-R138) [[5]](diffhunk://#diff-a5cf4ae298ce30e75fca62b4d2cb40071e20a39766c414fc3a54b94ddf3c7444R177-R184) [[6]](diffhunk://#diff-a5cf4ae298ce30e75fca62b4d2cb40071e20a39766c414fc3a54b94ddf3c7444L195-R195) [[7]](diffhunk://#diff-a5cf4ae298ce30e75fca62b4d2cb40071e20a39766c414fc3a54b94ddf3c7444R239-R246) [[8]](diffhunk://#diff-a5cf4ae298ce30e75fca62b4d2cb40071e20a39766c414fc3a54b94ddf3c7444L262-R262) [[9]](diffhunk://#diff-a5cf4ae298ce30e75fca62b4d2cb40071e20a39766c414fc3a54b94ddf3c7444R275-R305)

**Validation and safety enhancements:**

* Added `ValidateSettings` to ensure `ParallelExecutionSettings` are valid (e.g., `MaxDegreeOfParallelism` not zero or less than `-1`, `MinimumPixelsProcessedPerTask` > 0, and `MemoryAllocator` not null), guarding against invalid struct defaults and improving error messages.

**Testing improvements:**

* Added tests to verify that using `MaxDegreeOfParallelism = -1` results in all rows being processed, and that default (uninitialized) `ParallelExecutionSettings` throw appropriate exceptions. Introduced helper types for test operations. [[1]](diffhunk://#diff-fe78e11687c9a980f74030e77db1b84450b88b9cb446c04a5beec4e0bac56d34R16) [[2]](diffhunk://#diff-fe78e11687c9a980f74030e77db1b84450b88b9cb446c04a5beec4e0bac56d34R204-R244) [[3]](diffhunk://#diff-fe78e11687c9a980f74030e77db1b84450b88b9cb446c04a5beec4e0bac56d34R341-R387) [[4]](diffhunk://#diff-fe78e11687c9a980f74030e77db1b84450b88b9cb446c04a5beec4e0bac56d34R537-R562)

<!-- Thanks for contributing to ImageSharp! -->
