### PR TITLE
Add more throughput benchmarks and pass Configuration where missed

### DIFF
--- a/tests/ImageSharp.Tests.ProfilingSandbox/ProcessorThroughputBenchmark.cs
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/ProcessorThroughputBenchmark.cs
@@ -6,6 +6,7 @@ using CommandLine;
 using CommandLine.Text;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Processors.Convolution;
 
 namespace SixLabors.ImageSharp.Tests.ProfilingSandbox;
 
@@ -49,6 +50,7 @@ public sealed class ProcessorThroughputBenchmark
         {
             Method.Crop => this.Crop,
             Method.Edges => this.DetectEdges,
+            Method.EdgesCompass => this.EdgesCompass,
             Method.DrawImage => this.DrawImage,
             Method.BinaryThreshold => this.BinaryThreshold,
             Method.Histogram => this.Histogram,
@@ -139,6 +141,13 @@ public sealed class ProcessorThroughputBenchmark
         return image.Width * image.Height;
     }
 
+    private int EdgesCompass()
+    {
+        using Image<Rgba32> image = new(this.options.Width, this.options.Height);
+        image.Mutate(this.configuration, x => x.DetectEdges(EdgeDetectorCompassKernel.Kirsch));
+        return image.Width * image.Height;
+    }
+
     private int Crop()
     {
         using Image<Rgba32> image = new(this.options.Width, this.options.Height);
@@ -180,6 +189,7 @@ public sealed class ProcessorThroughputBenchmark
     private enum Method
     {
         Edges,
+        EdgesCompass,
         Crop,
         DrawImage,
         BinaryThreshold,

--- a/tests/ImageSharp.Tests.ProfilingSandbox/ProcessorThroughputBenchmark.cs
+++ b/tests/ImageSharp.Tests.ProfilingSandbox/ProcessorThroughputBenchmark.cs
@@ -53,6 +53,7 @@ public sealed class ProcessorThroughputBenchmark
             Method.BinaryThreshold => this.BinaryThreshold,
             Method.Histogram => this.Histogram,
             Method.OilPaint => this.OilPaint,
+            Method.GaussianBlur => this.GaussianBlur,
             _ => throw new NotImplementedException(),
         };
 
@@ -151,21 +152,28 @@ public sealed class ProcessorThroughputBenchmark
     {
         using Image<Rgba32> image = new(this.options.Width, this.options.Height);
         using Image<Rgba32> foreground = new(this.options.Width, this.options.Height);
-        image.Mutate(c => c.DrawImage(foreground, 0.5f));
+        image.Mutate(this.configuration, c => c.DrawImage(foreground, 0.5f));
         return image.Width * image.Height;
     }
 
     private int BinaryThreshold()
     {
         using Image<Rgba32> image = new(this.options.Width, this.options.Height);
-        image.Mutate(c => c.BinaryThreshold(0.5f));
+        image.Mutate(this.configuration, c => c.BinaryThreshold(0.5f));
         return image.Width * image.Height;
     }
 
     private int Histogram()
     {
         using Image<Rgba32> image = new(this.options.Width, this.options.Height);
-        image.Mutate(c => c.HistogramEqualization());
+        image.Mutate(this.configuration, c => c.HistogramEqualization());
+        return image.Width * image.Height;
+    }
+
+    private int GaussianBlur()
+    {
+        using Image<Rgba32> image = new(this.options.Width, this.options.Height);
+        image.Mutate(this.configuration, c => c.GaussianBlur());
         return image.Width * image.Height;
     }
 
@@ -176,7 +184,8 @@ public sealed class ProcessorThroughputBenchmark
         DrawImage,
         BinaryThreshold,
         Histogram,
-        OilPaint
+        OilPaint,
+        GaussianBlur,
     }
 
     private sealed class CommandLineOptions


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This is an extension to #3111. `Convolution2PassProcessor` and `EdgeDetectorCompassProcessor` has no drop in throughput when parallelized which implies that `ConvolutionProcessor<TPixel>` doesn't have it either.
