### PR TITLE
Add ImageFrame visitor; use Buffer2D Size/Bounds + Expose Subregion 

### DIFF
--- a/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
+++ b/src/ImageSharp/Advanced/AdvancedImageExtensions.cs
@@ -77,6 +77,15 @@ public static class AdvancedImageExtensions
         => source.AcceptAsync(visitor, cancellationToken);
 
     /// <summary>
+    /// Accepts a <see cref="IImageVisitor"/> to implement a double-dispatch pattern in order to
+    /// apply pixel-specific operations on non-generic <see cref="Image"/> instances
+    /// </summary>
+    /// <param name="source">The source image frame.</param>
+    /// <param name="visitor">The image visitor.</param>
+    public static void AcceptVisitor(this ImageFrame source, IImageFrameVisitor visitor)
+        => source.Accept(visitor);
+
+    /// <summary>
     /// Gets the representation of the pixels as a <see cref="IMemoryGroup{T}"/> containing the backing pixel data of the image
     /// stored in row major order, as a list of contiguous <see cref="Memory{T}"/> blocks in the source image's pixel format.
     /// </summary>

--- a/src/ImageSharp/Advanced/IImageFrameVisitor.cs
+++ b/src/ImageSharp/Advanced/IImageFrameVisitor.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Advanced;
+
+/// <summary>
+/// A visitor to implement a double-dispatch pattern in order to apply pixel-specific operations
+/// on non-generic <see cref="ImageFrame"/> instances.
+/// </summary>
+public interface IImageFrameVisitor
+{
+    /// <summary>
+    /// Provides a pixel-specific implementation for a given operation.
+    /// </summary>
+    /// <param name="frame">The image frame.</param>
+    /// <typeparam name="TPixel">The pixel type.</typeparam>
+    public void Visit<TPixel>(ImageFrame<TPixel> frame)
+        where TPixel : unmanaged, IPixel<TPixel>;
+}

--- a/src/ImageSharp/Advanced/IImageVisitor.cs
+++ b/src/ImageSharp/Advanced/IImageVisitor.cs
@@ -16,7 +16,7 @@ public interface IImageVisitor
     /// </summary>
     /// <param name="image">The image.</param>
     /// <typeparam name="TPixel">The pixel type.</typeparam>
-    void Visit<TPixel>(Image<TPixel> image)
+    public void Visit<TPixel>(Image<TPixel> image)
         where TPixel : unmanaged, IPixel<TPixel>;
 }
 
@@ -33,6 +33,6 @@ public interface IImageVisitorAsync
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <typeparam name="TPixel">The pixel type.</typeparam>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task VisitAsync<TPixel>(Image<TPixel> image, CancellationToken cancellationToken)
+    public Task VisitAsync<TPixel>(Image<TPixel> image, CancellationToken cancellationToken)
         where TPixel : unmanaged, IPixel<TPixel>;
 }

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -303,7 +303,7 @@ internal sealed class GifEncoderCore
         this.WriteGraphicalControlExtension(metadata, stream);
 
         Buffer2D<byte> indices = ((IPixelSource)quantized).PixelBuffer;
-        Rectangle interest = indices.FullRectangle();
+        Rectangle interest = indices.Bounds;
         bool useLocal = this.colorTableMode == FrameColorTableMode.Local || (metadata.ColorTableMode == FrameColorTableMode.Local);
         int bitDepth = ColorNumerics.GetBitsNeededForColorDepth(quantized.Palette.Length);
 

--- a/src/ImageSharp/ImageFrame.cs
+++ b/src/ImageSharp/ImageFrame.cs
@@ -71,6 +71,19 @@ public abstract partial class ImageFrame : IConfigurationProvider, IDisposable
     /// <param name="disposing">Whether to dispose of managed and unmanaged objects.</param>
     protected abstract void Dispose(bool disposing);
 
+    /// <summary>
+    /// Accepts a <see cref="IImageFrameVisitor"/>.
+    /// Implemented by <see cref="ImageFrame{TPixel}"/> invoking <see cref="IImageFrameVisitor.Visit{TPixel}"/>
+    /// with the pixel type of the image.
+    /// </summary>
+    /// <param name="visitor">The visitor.</param>
+    internal abstract void Accept(IImageFrameVisitor visitor);
+
+    /// <summary>
+    /// Copies the pixel data of the image frame to a <see cref="Buffer2D{TDestinationPixel}"/> of a specific pixel type.
+    /// </summary>
+    /// <typeparam name="TDestinationPixel">The pixel type of the destination buffer.</typeparam>
+    /// <param name="destination">The buffer to copy the pixel data to.</param>
     internal abstract void CopyPixelsTo<TDestinationPixel>(Buffer2D<TDestinationPixel> destination)
         where TDestinationPixel : unmanaged, IPixel<TDestinationPixel>;
 

--- a/src/ImageSharp/ImageFrame{TPixel}.cs
+++ b/src/ImageSharp/ImageFrame{TPixel}.cs
@@ -339,6 +339,10 @@ public sealed class ImageFrame<TPixel> : ImageFrame, IPixelSource<TPixel>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ref TPixel GetPixelReference(int x, int y) => ref this.PixelBuffer[x, y];
 
+    /// <inheritdoc />
+    internal override void Accept(IImageFrameVisitor visitor)
+        => visitor.Visit(this);
+
     /// <summary>
     /// Copies the pixels to a <see cref="Buffer2D{TPixel}"/> of the same size.
     /// </summary>
@@ -346,7 +350,7 @@ public sealed class ImageFrame<TPixel> : ImageFrame, IPixelSource<TPixel>
     /// <exception cref="ArgumentException">ImageFrame{TPixel}.CopyTo(): target must be of the same size!</exception>
     internal void CopyTo(Buffer2D<TPixel> target)
     {
-        if (this.Size != target.Size())
+        if (this.Size != target.Size)
         {
             throw new ArgumentException("ImageFrame<TPixel>.CopyTo(): target must be of the same size!", nameof(target));
         }
@@ -363,8 +367,8 @@ public sealed class ImageFrame<TPixel> : ImageFrame, IPixelSource<TPixel>
     {
         Guard.NotNull(source, nameof(source));
 
-        Buffer2D<TPixel>.SwapOrCopyContent(this.PixelBuffer, source.PixelBuffer);
-        this.UpdateSize(this.PixelBuffer.Size());
+        _ = Buffer2D<TPixel>.SwapOrCopyContent(this.PixelBuffer, source.PixelBuffer);
+        this.UpdateSize(this.PixelBuffer.Size);
     }
 
     /// <summary>
@@ -475,10 +479,7 @@ public sealed class ImageFrame<TPixel> : ImageFrame, IPixelSource<TPixel>
     /// Clears the bitmap.
     /// </summary>
     /// <param name="value">The value to initialize the bitmap with.</param>
-    internal void Clear(TPixel value)
-    {
-        this.PixelBuffer.Clear(value);
-    }
+    internal void Clear(TPixel value) => this.PixelBuffer.Clear(value);
 
     [MethodImpl(InliningOptions.ShortMethod)]
     private void VerifyCoords(int x, int y)

--- a/src/ImageSharp/Image{TPixel}.cs
+++ b/src/ImageSharp/Image{TPixel}.cs
@@ -2,7 +2,6 @@
 // Licensed under the Six Labors Split License.
 
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Metadata;

--- a/src/ImageSharp/Memory/Buffer2DExtensions.cs
+++ b/src/ImageSharp/Memory/Buffer2DExtensions.cs
@@ -104,59 +104,39 @@ public static class Buffer2DExtensions
     }
 
     /// <summary>
-    /// Returns a <see cref="Rectangle"/> representing the full area of the buffer.
-    /// </summary>
-    /// <typeparam name="T">The element type</typeparam>
-    /// <param name="buffer">The <see cref="Buffer2D{T}"/></param>
-    /// <returns>The <see cref="Rectangle"/></returns>
-    internal static Rectangle FullRectangle<T>(this Buffer2D<T> buffer)
-        where T : struct
-        => new(0, 0, buffer.Width, buffer.Height);
-
-    /// <summary>
-    /// Return a <see cref="Buffer2DRegion{T}"/> to the subregion represented by 'rectangle'
+    /// Return a <see cref="Buffer2DRegion{T}"/> to the subregion represented by <paramref name="rectangle"/>.
     /// </summary>
     /// <typeparam name="T">The element type</typeparam>
     /// <param name="buffer">The <see cref="Buffer2D{T}"/></param>
     /// <param name="rectangle">The rectangle subregion</param>
     /// <returns>The <see cref="Buffer2DRegion{T}"/></returns>
-    internal static Buffer2DRegion<T> GetRegion<T>(this Buffer2D<T> buffer, Rectangle rectangle)
+    public static Buffer2DRegion<T> GetRegion<T>(this Buffer2D<T> buffer, Rectangle rectangle)
         where T : unmanaged =>
         new(buffer, rectangle);
 
-    internal static Buffer2DRegion<T> GetRegion<T>(this Buffer2D<T> buffer, int x, int y, int width, int height)
+    /// <summary>
+    /// Return a <see cref="Buffer2DRegion{T}"/> to the specified area of <paramref name="buffer"/>.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="buffer">The <see cref="Buffer2D{T}"/>.</param>
+    /// <param name="x">The X coordinate of the region.</param>
+    /// <param name="y">The Y coordinate of the region.</param>
+    /// <param name="width">The region width.</param>
+    /// <param name="height">The region height.</param>
+    /// <returns>The <see cref="Buffer2DRegion{T}"/>.</returns>
+    public static Buffer2DRegion<T> GetRegion<T>(this Buffer2D<T> buffer, int x, int y, int width, int height)
         where T : unmanaged =>
         new(buffer, new Rectangle(x, y, width, height));
 
     /// <summary>
-    /// Return a <see cref="Buffer2DRegion{T}"/> to the whole area of 'buffer'
+    /// Return a <see cref="Buffer2DRegion{T}"/> to the whole area of <paramref name="buffer"/>.
     /// </summary>
     /// <typeparam name="T">The element type</typeparam>
     /// <param name="buffer">The <see cref="Buffer2D{T}"/></param>
     /// <returns>The <see cref="Buffer2DRegion{T}"/></returns>
-    internal static Buffer2DRegion<T> GetRegion<T>(this Buffer2D<T> buffer)
+    public static Buffer2DRegion<T> GetRegion<T>(this Buffer2D<T> buffer)
         where T : unmanaged =>
         new(buffer);
-
-    /// <summary>
-    /// Returns the size of the buffer.
-    /// </summary>
-    /// <typeparam name="T">The element type</typeparam>
-    /// <param name="buffer">The <see cref="Buffer2D{T}"/></param>
-    /// <returns>The <see cref="Size{T}"/> of the buffer</returns>
-    internal static Size Size<T>(this Buffer2D<T> buffer)
-        where T : struct =>
-        new(buffer.Width, buffer.Height);
-
-    /// <summary>
-    /// Gets the bounds of the buffer.
-    /// </summary>
-    /// <typeparam name="T">The element type</typeparam>
-    /// <param name="buffer">The <see cref="Buffer2D{T}"/></param>
-    /// <returns>The <see cref="Rectangle"/></returns>
-    internal static Rectangle Bounds<T>(this Buffer2D<T> buffer)
-        where T : struct =>
-        new(0, 0, buffer.Width, buffer.Height);
 
     [Conditional("DEBUG")]
     private static void CheckColumnRegionsDoNotOverlap<T>(

--- a/src/ImageSharp/Memory/Buffer2DRegion{T}.cs
+++ b/src/ImageSharp/Memory/Buffer2DRegion{T}.cs
@@ -15,17 +15,17 @@ public readonly struct Buffer2DRegion<T>
     /// Initializes a new instance of the <see cref="Buffer2DRegion{T}"/> struct.
     /// </summary>
     /// <param name="buffer">The <see cref="Buffer2D{T}"/>.</param>
-    /// <param name="rectangle">The <see cref="Rectangle"/> defining a rectangular area within the buffer.</param>
+    /// <param name="bounds">The <see cref="Bounds"/> defining a rectangular area within the buffer.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Buffer2DRegion(Buffer2D<T> buffer, Rectangle rectangle)
+    public Buffer2DRegion(Buffer2D<T> buffer, Rectangle bounds)
     {
-        DebugGuard.MustBeGreaterThanOrEqualTo(rectangle.X, 0, nameof(rectangle));
-        DebugGuard.MustBeGreaterThanOrEqualTo(rectangle.Y, 0, nameof(rectangle));
-        DebugGuard.MustBeLessThanOrEqualTo(rectangle.Width, buffer.Width, nameof(rectangle));
-        DebugGuard.MustBeLessThanOrEqualTo(rectangle.Height, buffer.Height, nameof(rectangle));
+        DebugGuard.MustBeGreaterThanOrEqualTo(bounds.X, 0, nameof(bounds));
+        DebugGuard.MustBeGreaterThanOrEqualTo(bounds.Y, 0, nameof(bounds));
+        DebugGuard.MustBeLessThanOrEqualTo(bounds.Width, buffer.Width, nameof(bounds));
+        DebugGuard.MustBeLessThanOrEqualTo(bounds.Height, buffer.Height, nameof(bounds));
 
         this.Buffer = buffer;
-        this.Rectangle = rectangle;
+        this.Bounds = bounds;
     }
 
     /// <summary>
@@ -34,14 +34,9 @@ public readonly struct Buffer2DRegion<T>
     /// <param name="buffer">The <see cref="Buffer2D{T}"/>.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Buffer2DRegion(Buffer2D<T> buffer)
-        : this(buffer, buffer.FullRectangle())
+        : this(buffer, buffer.Bounds)
     {
     }
-
-    /// <summary>
-    /// Gets the rectangle specifying the boundaries of the area in <see cref="Buffer"/>.
-    /// </summary>
-    public Rectangle Rectangle { get; }
 
     /// <summary>
     /// Gets the <see cref="Buffer2D{T}"/> being pointed by this instance.
@@ -51,12 +46,12 @@ public readonly struct Buffer2DRegion<T>
     /// <summary>
     /// Gets the width
     /// </summary>
-    public int Width => this.Rectangle.Width;
+    public int Width => this.Bounds.Width;
 
     /// <summary>
     /// Gets the height
     /// </summary>
-    public int Height => this.Rectangle.Height;
+    public int Height => this.Bounds.Height;
 
     /// <summary>
     /// Gets the number of elements between row starts in <see cref="Buffer"/>.
@@ -66,12 +61,17 @@ public readonly struct Buffer2DRegion<T>
     /// <summary>
     /// Gets the size of the area.
     /// </summary>
-    internal Size Size => this.Rectangle.Size;
+    public Size Size => this.Bounds.Size;
+
+    /// <summary>
+    /// Gets the rectangle specifying the boundaries of the area in <see cref="Buffer"/>.
+    /// </summary>
+    public Rectangle Bounds { get; }
 
     /// <summary>
     /// Gets a value indicating whether the area refers to the entire <see cref="Buffer"/>
     /// </summary>
-    internal bool IsFullBufferArea => this.Size == this.Buffer.Size();
+    internal bool IsFullBufferArea => this.Size == this.Buffer.Size;
 
     /// <summary>
     /// Gets or sets a value at the given index.
@@ -79,7 +79,7 @@ public readonly struct Buffer2DRegion<T>
     /// <param name="x">The position inside a row</param>
     /// <param name="y">The row index</param>
     /// <returns>The reference to the value</returns>
-    internal ref T this[int x, int y] => ref this.Buffer[x + this.Rectangle.X, y + this.Rectangle.Y];
+    internal ref T this[int x, int y] => ref this.Buffer[x + this.Bounds.X, y + this.Bounds.Y];
 
     /// <summary>
     /// Gets a span to row 'y' inside this area.
@@ -89,9 +89,9 @@ public readonly struct Buffer2DRegion<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Span<T> DangerousGetRowSpan(int y)
     {
-        int yy = this.Rectangle.Y + y;
-        int xx = this.Rectangle.X;
-        int width = this.Rectangle.Width;
+        int yy = this.Bounds.Y + y;
+        int xx = this.Bounds.X;
+        int width = this.Bounds.Width;
 
         return this.Buffer.DangerousGetRowSpan(yy).Slice(xx, width);
     }
@@ -114,16 +114,16 @@ public readonly struct Buffer2DRegion<T>
     /// <summary>
     /// Returns a subregion as <see cref="Buffer2DRegion{T}"/>. (Similar to <see cref="Span{T}.Slice(int, int)"/>.)
     /// </summary>
-    /// <param name="rectangle">The <see cref="Rectangle"/> specifying the boundaries of the subregion</param>
+    /// <param name="rectangle">The <see cref="Bounds"/> specifying the boundaries of the subregion</param>
     /// <returns>The subregion</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Buffer2DRegion<T> GetSubRegion(Rectangle rectangle)
     {
-        DebugGuard.MustBeLessThanOrEqualTo(rectangle.Width, this.Rectangle.Width, nameof(rectangle));
-        DebugGuard.MustBeLessThanOrEqualTo(rectangle.Height, this.Rectangle.Height, nameof(rectangle));
+        DebugGuard.MustBeLessThanOrEqualTo(rectangle.Width, this.Bounds.Width, nameof(rectangle));
+        DebugGuard.MustBeLessThanOrEqualTo(rectangle.Height, this.Bounds.Height, nameof(rectangle));
 
-        int x = this.Rectangle.X + rectangle.X;
-        int y = this.Rectangle.Y + rectangle.Y;
+        int x = this.Bounds.X + rectangle.X;
+        int y = this.Bounds.Y + rectangle.Y;
         rectangle = new Rectangle(x, y, rectangle.Width, rectangle.Height);
         return new Buffer2DRegion<T>(this.Buffer, rectangle);
     }
@@ -135,8 +135,8 @@ public readonly struct Buffer2DRegion<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ref T GetReferenceToOrigin()
     {
-        int y = this.Rectangle.Y;
-        int x = this.Rectangle.X;
+        int y = this.Bounds.Y;
+        int x = this.Bounds.X;
         return ref this.Buffer.DangerousGetRowSpan(y)[x];
     }
 
@@ -152,7 +152,7 @@ public readonly struct Buffer2DRegion<T>
             return;
         }
 
-        for (int y = 0; y < this.Rectangle.Height; y++)
+        for (int y = 0; y < this.Bounds.Height; y++)
         {
             Span<T> row = this.DangerousGetRowSpan(y);
             row.Clear();
@@ -172,7 +172,7 @@ public readonly struct Buffer2DRegion<T>
             return;
         }
 
-        for (int y = 0; y < this.Rectangle.Height; y++)
+        for (int y = 0; y < this.Bounds.Height; y++)
         {
             Span<T> row = this.DangerousGetRowSpan(y);
             row.Fill(value);

--- a/src/ImageSharp/Memory/Buffer2D{T}.cs
+++ b/src/ImageSharp/Memory/Buffer2D{T}.cs
@@ -39,20 +39,30 @@ public sealed class Buffer2D<T> : IDisposable
         Guard.MustBeGreaterThanOrEqualTo(rowStride, width, nameof(rowStride));
 
         this.FastMemoryGroup = memoryGroup;
-        this.Width = width;
-        this.Height = height;
+        this.Size = new Size(width, height);
         this.RowStride = rowStride;
     }
 
     /// <summary>
     /// Gets the width.
     /// </summary>
-    public int Width { get; private set; }
+    public int Width => this.Size.Width;
 
     /// <summary>
     /// Gets the height.
     /// </summary>
-    public int Height { get; private set; }
+    public int Height => this.Size.Height;
+
+    /// <summary>
+    /// Gets the size of the buffer.
+    /// </summary>
+    public Size Size { get; private set; }
+
+    /// <summary>
+    /// Gets the bounds of the buffer.
+    /// </summary>
+    /// <returns>The <see cref="Rectangle"/></returns>
+    public Rectangle Bounds => new(0, 0, this.Width, this.Height);
 
     /// <summary>
     /// Gets the number of elements between row starts in the backing memory.
@@ -402,8 +412,7 @@ public sealed class Buffer2D<T> : IDisposable
             source.CopyTo(destination);
         }
 
-        (destination.Width, source.Width) = (source.Width, destination.Width);
-        (destination.Height, source.Height) = (source.Height, destination.Height);
+        (destination.Size, source.Size) = (source.Size, destination.Size);
         (destination.RowStride, source.RowStride) = (source.RowStride, destination.RowStride);
         return swapped;
     }

--- a/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resize/ResizeWorker.cs
@@ -59,7 +59,7 @@ internal sealed class ResizeWorker<TPixel> : IDisposable
     {
         this.configuration = configuration;
         this.source = source;
-        this.sourceRectangle = source.Rectangle;
+        this.sourceRectangle = source.Bounds;
         this.conversionModifiers = conversionModifiers;
         this.horizontalKernelMap = horizontalKernelMap;
         this.verticalKernelMap = verticalKernelMap;

--- a/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/SpectralJpegTests.cs
@@ -119,7 +119,7 @@ public class SpectralJpegTests
             this.Output.WriteLine($"Component{i}: [total: {total} | average: {average}]");
             averageDifference += average;
             totalDifference += total;
-            Size s = libJpegComponent.SpectralBlocks.Size();
+            Size s = libJpegComponent.SpectralBlocks.Size;
             tolerance += s.Width * s.Height;
         }
 

--- a/tests/ImageSharp.Tests/Memory/Buffer2DTests.SwapOrCopyContent.cs
+++ b/tests/ImageSharp.Tests/Memory/Buffer2DTests.SwapOrCopyContent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
 using SixLabors.ImageSharp.Memory;
@@ -15,26 +15,24 @@ public partial class Buffer2DTests
         [Fact]
         public void SwapOrCopyContent_WhenBothAllocated()
         {
-            using (Buffer2D<int> a = this.memoryAllocator.Allocate2D<int>(10, 5, AllocationOptions.Clean))
-            using (Buffer2D<int> b = this.memoryAllocator.Allocate2D<int>(3, 7, AllocationOptions.Clean))
-            {
-                a[1, 3] = 666;
-                b[1, 3] = 444;
+            using Buffer2D<int> a = this.memoryAllocator.Allocate2D<int>(10, 5, AllocationOptions.Clean);
+            using Buffer2D<int> b = this.memoryAllocator.Allocate2D<int>(3, 7, AllocationOptions.Clean);
+            a[1, 3] = 666;
+            b[1, 3] = 444;
 
-                Memory<int> aa = a.FastMemoryGroup.Single();
-                Memory<int> bb = b.FastMemoryGroup.Single();
+            Memory<int> aa = a.FastMemoryGroup.Single();
+            Memory<int> bb = b.FastMemoryGroup.Single();
 
-                Buffer2D<int>.SwapOrCopyContent(a, b);
+            Buffer2D<int>.SwapOrCopyContent(a, b);
 
-                Assert.Equal(bb, a.FastMemoryGroup.Single());
-                Assert.Equal(aa, b.FastMemoryGroup.Single());
+            Assert.Equal(bb, a.FastMemoryGroup.Single());
+            Assert.Equal(aa, b.FastMemoryGroup.Single());
 
-                Assert.Equal(new Size(3, 7), a.Size());
-                Assert.Equal(new Size(10, 5), b.Size());
+            Assert.Equal(new Size(3, 7), a.Size);
+            Assert.Equal(new Size(10, 5), b.Size);
 
-                Assert.Equal(666, b[1, 3]);
-                Assert.Equal(444, a[1, 3]);
-            }
+            Assert.Equal(666, b[1, 3]);
+            Assert.Equal(444, a[1, 3]);
         }
 
         [Fact]
@@ -171,7 +169,7 @@ public partial class Buffer2DTests
             bool swap = Buffer2D<int>.SwapOrCopyContent(dest, source);
 
             Assert.False(swap);
-            Assert.Equal(new Size(3, 2), dest.Size());
+            Assert.Equal(new Size(3, 2), dest.Size);
             Assert.Equal(6, dest[2, 1]);
         }
 
@@ -191,7 +189,7 @@ public partial class Buffer2DTests
             bool swap = Buffer2D<int>.SwapOrCopyContent(dest, source);
 
             Assert.False(swap);
-            Assert.Equal(new Size(1, 5), dest.Size());
+            Assert.Equal(new Size(1, 5), dest.Size);
             Assert.Equal(1, dest[0, 0]);
             Assert.Equal(2, dest[0, 1]);
             Assert.Equal(3, dest[0, 2]);
@@ -215,7 +213,7 @@ public partial class Buffer2DTests
             bool swap = Buffer2D<int>.SwapOrCopyContent(dest, source);
 
             Assert.False(swap);
-            Assert.Equal(new Size(2, 2), dest.Size());
+            Assert.Equal(new Size(2, 2), dest.Size);
             Assert.Equal(1, dest[0, 0]);
             Assert.Equal(2, dest[1, 0]);
             Assert.Equal(3, dest[0, 1]);

--- a/tests/ImageSharp.Tests/Memory/BufferAreaTests.cs
+++ b/tests/ImageSharp.Tests/Memory/BufferAreaTests.cs
@@ -17,7 +17,7 @@ public class BufferAreaTests
         Buffer2DRegion<int> area = new(buffer, rectangle);
 
         Assert.Equal(buffer, area.Buffer);
-        Assert.Equal(rectangle, area.Rectangle);
+        Assert.Equal(rectangle, area.Bounds);
     }
 
     private Buffer2D<int> CreateTestBuffer(int w, int h)
@@ -90,7 +90,7 @@ public class BufferAreaTests
         Rectangle expectedRect = new(10, 12, 5, 5);
 
         Assert.Equal(buffer, area1.Buffer);
-        Assert.Equal(expectedRect, area1.Rectangle);
+        Assert.Equal(expectedRect, area1.Bounds);
 
         int value00 = (12 * 100) + 10;
         Assert.Equal(value00, area1[0, 0]);
@@ -147,9 +147,9 @@ public class BufferAreaTests
         Assert.Equal(0, buffer[5, 5]);
         Assert.Equal(0, buffer[14, 14]);
 
-        for (int y = region.Rectangle.Y; y < region.Rectangle.Bottom; y++)
+        for (int y = region.Bounds.Y; y < region.Bounds.Bottom; y++)
         {
-            Span<int> span = buffer.DangerousGetRowSpan(y).Slice(region.Rectangle.X, region.Width);
+            Span<int> span = buffer.DangerousGetRowSpan(y).Slice(region.Bounds.X, region.Width);
             Assert.True(span.SequenceEqual(new int[region.Width]));
         }
     }

--- a/tests/ImageSharp.Tests/Processing/IntegralImageTests.cs
+++ b/tests/ImageSharp.Tests/Processing/IntegralImageTests.cs
@@ -76,7 +76,7 @@ public class IntegralImageTests : BaseImageOperationsExtensionTest
         Buffer2D<ulong> integralBuffer,
         Func<TPixel, ulong> getPixel)
         where TPixel : unmanaged, IPixel<TPixel>
-        => VerifySumValues(provider, integralBuffer, integralBuffer.Bounds(), getPixel);
+        => VerifySumValues(provider, integralBuffer, integralBuffer.Bounds, getPixel);
 
     private static void VerifySumValues<TPixel>(
         TestImageProvider<TPixel> provider,

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -505,7 +505,7 @@ public static class TestImageExtensions
     public static void CompareBuffers<T>(Buffer2D<T> expected, Buffer2D<T> actual)
         where T : struct, IEquatable<T>
     {
-        Assert.True(expected.Size() == actual.Size(), "Buffer sizes are not equal!");
+        Assert.True(expected.Size == actual.Size, "Buffer sizes are not equal!");
 
         for (int y = 0; y < expected.Height; y++)
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Normalizes `Size`/`Bounds` for `Buffer2D<TPixel>` to match `Image`/`ImageFrame` and exposes region extension helpers. Also adds `IImageFrameVisitor` so downstream users (Drawing) can use it to create canvas instances.


<!-- Thanks for contributing to ImageSharp! -->
