### PR TITLE
GIF: background handling & quantizer overflow fix

### DIFF
--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -990,7 +990,11 @@ internal sealed class GifDecoderCore : ImageDecoderCore
 
         byte index = this.logicalScreenDescriptor.BackgroundColorIndex;
         this.backgroundColorIndex = index;
-        this.gifMetadata.BackgroundColorIndex = index;
+        ReadOnlyMemory<Color>? globalColorTable = this.gifMetadata.GlobalColorTable;
+        if (globalColorTable.HasValue && index < globalColorTable.Value.Length)
+        {
+            this.gifMetadata.BackgroundColor = globalColorTable.Value.Span[index];
+        }
     }
 
     private unsafe struct ScratchBuffer

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -46,14 +46,6 @@ internal sealed class GifEncoderCore
     private readonly IPixelSamplingStrategy pixelSamplingStrategy;
 
     /// <summary>
-    /// The default background color of the canvas when animating.
-    /// This color may be used to fill the unused space on the canvas around the frames,
-    /// as well as the transparent pixels of the first frame.
-    /// The background color is also used when a frame disposal mode is <see cref="FrameDisposalMode.RestoreToBackground"/>.
-    /// </summary>
-    private readonly Color? backgroundColor;
-
-    /// <summary>
     /// The number of times any animation is repeated.
     /// </summary>
     private readonly ushort? repeatCount;
@@ -76,7 +68,6 @@ internal sealed class GifEncoderCore
         this.skipMetadata = encoder.SkipMetadata;
         this.colorTableMode = encoder.ColorTableMode;
         this.pixelSamplingStrategy = encoder.PixelSamplingStrategy;
-        this.backgroundColor = encoder.BackgroundColor;
         this.repeatCount = encoder.RepeatCount;
         this.transparentColorMode = encoder.TransparentColorMode;
     }
@@ -113,7 +104,17 @@ internal sealed class GifEncoderCore
         TransparentColorMode mode = this.transparentColorMode;
 
         // Create a new quantizer options instance augmenting the transparent color mode to match the encoder.
-        QuantizerOptions options = (this.encoder.Quantizer?.Options ?? new QuantizerOptions()).DeepClone(o => o.TransparentColorMode = mode);
+        QuantizerOptions options = (this.encoder.Quantizer?.Options ?? new QuantizerOptions()).DeepClone(o =>
+        {
+            o.TransparentColorMode = mode;
+
+            // Animated GIF delta frames can use one padded color-table index as transparency.
+            // Express that through MaxColors so custom quantizers receive the same budget.
+            if (image.Frames.Count > 1 && o.MaxColors == QuantizerConstants.MaxColors)
+            {
+                o.MaxColors = QuantizerConstants.MaxColors - 1;
+            }
+        });
 
         if (globalQuantizer is null)
         {
@@ -145,6 +146,11 @@ internal sealed class GifEncoderCore
         IPixelSamplingStrategy strategy = this.pixelSamplingStrategy;
 
         ImageFrame<TPixel> encodingFrame = image.Frames.RootFrame;
+
+        // This color is encoded as the logical-screen background index and is also
+        // used when de-duplicating frames that restore to the GIF background.
+        Color backgroundColor = this.encoder.BackgroundColor ?? gifMetadata.BackgroundColor ?? Color.Transparent;
+        byte backgroundIndex = 0;
         if (useGlobalTableForFirstFrame)
         {
             using IQuantizer<TPixel> firstFrameQuantizer = globalQuantizer.CreatePixelSpecificQuantizer<TPixel>(this.configuration, options);
@@ -158,6 +164,8 @@ internal sealed class GifEncoderCore
             }
 
             quantized = firstFrameQuantizer.QuantizeFrame(encodingFrame, encodingFrame.Bounds);
+            TPixel backgroundPixel = backgroundColor.ToPixel<TPixel>();
+            backgroundIndex = firstFrameQuantizer.GetQuantizedColor(backgroundPixel, out _);
         }
         else
         {
@@ -183,8 +191,6 @@ internal sealed class GifEncoderCore
             frameMetadata.HasTransparency = true;
             frameMetadata.TransparencyIndex = ClampIndex(transparencyIndex);
         }
-
-        byte backgroundIndex = GetBackgroundIndex(quantized, gifMetadata, this.backgroundColor);
 
         // Get the number of bits.
         int bitDepth = ColorNumerics.GetBitsNeededForColorDepth(quantized.Palette.Length);
@@ -222,6 +228,7 @@ internal sealed class GifEncoderCore
                     image,
                     globalQuantizer,
                     globalFrameQuantizer,
+                    backgroundColor,
                     transparencyIndex,
                     frameMetadata.DisposalMode,
                     cancellationToken);
@@ -253,6 +260,7 @@ internal sealed class GifEncoderCore
         Image<TPixel> image,
         IQuantizer globalQuantizer,
         PaletteQuantizer<TPixel> globalFrameQuantizer,
+        Color backgroundColor,
         int globalTransparencyIndex,
         FrameDisposalMode previousDisposalMode,
         CancellationToken cancellationToken)
@@ -284,6 +292,7 @@ internal sealed class GifEncoderCore
                 globalFrameQuantizer,
                 useLocal,
                 gifMetadata,
+                backgroundColor,
                 previousDisposalMode);
 
             previousFrame = currentFrame;
@@ -327,6 +336,7 @@ internal sealed class GifEncoderCore
         PaletteQuantizer<TPixel> globalFrameQuantizer,
         bool useLocal,
         GifFrameMetadata metadata,
+        Color backgroundColor,
         FrameDisposalMode previousDisposalMode)
         where TPixel : unmanaged, IPixel<TPixel>
     {
@@ -347,7 +357,7 @@ internal sealed class GifEncoderCore
             previous.Metadata.GetGifMetadata().DisposalMode;
 
         Color background = !useTransparency && disposalMode == FrameDisposalMode.RestoreToBackground
-                ? this.backgroundColor ?? Color.Transparent
+                ? backgroundColor
                 : Color.Transparent;
 
         // Deduplicate and quantize the frame capturing only required parts.
@@ -532,44 +542,6 @@ internal sealed class GifEncoderCore
         }
 
         return index;
-    }
-
-    /// <summary>
-    /// Returns the index of the background color in the palette.
-    /// </summary>
-    /// <param name="quantized">The current quantized frame.</param>
-    /// <param name="metadata">The gif metadata</param>
-    /// <param name="background">The background color to match.</param>
-    /// <typeparam name="TPixel">The pixel format.</typeparam>
-    /// <returns>The <see cref="byte"/> index of the background color.</returns>
-    private static byte GetBackgroundIndex<TPixel>(IndexedImageFrame<TPixel>? quantized, GifMetadata metadata, Color? background)
-        where TPixel : unmanaged, IPixel<TPixel>
-    {
-        int match = -1;
-        if (quantized != null)
-        {
-            if (background.HasValue)
-            {
-                TPixel backgroundPixel = background.Value.ToPixel<TPixel>();
-                ReadOnlySpan<TPixel> palette = quantized.Palette.Span;
-                for (int i = 0; i < palette.Length; i++)
-                {
-                    if (!backgroundPixel.Equals(palette[i]))
-                    {
-                        continue;
-                    }
-
-                    match = i;
-                    break;
-                }
-            }
-            else if (metadata.BackgroundColorIndex < quantized.Palette.Length)
-            {
-                match = metadata.BackgroundColorIndex;
-            }
-        }
-
-        return ClampIndex(match);
     }
 
     /// <summary>

--- a/src/ImageSharp/Formats/Gif/GifMetadata.cs
+++ b/src/ImageSharp/Formats/Gif/GifMetadata.cs
@@ -26,7 +26,7 @@ public class GifMetadata : IFormatMetadata<GifMetadata>
     {
         this.RepeatCount = other.RepeatCount;
         this.ColorTableMode = other.ColorTableMode;
-        this.BackgroundColorIndex = other.BackgroundColorIndex;
+        this.BackgroundColor = other.BackgroundColor;
 
         if (other.GlobalColorTable?.Length > 0)
         {
@@ -59,10 +59,9 @@ public class GifMetadata : IFormatMetadata<GifMetadata>
     public ReadOnlyMemory<Color>? GlobalColorTable { get; set; }
 
     /// <summary>
-    /// Gets or sets the index at the <see cref="GlobalColorTable"/> for the background color.
-    /// The background color is the color used for those pixels on the screen that are not covered by an image.
+    /// Gets or sets the background color used for pixels on the screen that are not covered by an image.
     /// </summary>
-    public byte BackgroundColorIndex { get; set; }
+    public Color? BackgroundColor { get; set; }
 
     /// <summary>
     /// Gets or sets the collection of comments about the graphics, credits, descriptions or any
@@ -101,6 +100,7 @@ public class GifMetadata : IFormatMetadata<GifMetadata>
         {
             AnimateRootFrame = true,
             ColorTableMode = this.ColorTableMode,
+            BackgroundColor = this.BackgroundColor ?? Color.Transparent,
             PixelTypeInfo = this.GetPixelTypeInfo(),
             RepeatCount = this.RepeatCount,
         };

--- a/src/ImageSharp/Processing/Processors/Quantization/HexadecatreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Quantization/HexadecatreeQuantizer{TPixel}.cs
@@ -392,11 +392,11 @@ public struct HexadecatreeQuantizer<TPixel> : IQuantizer<TPixel>
         internal struct Node
         {
             public bool Leaf;
-            public int PixelCount;
-            public int Red;
-            public int Green;
-            public int Blue;
-            public int Alpha;
+            public long PixelCount;
+            public long Red;
+            public long Green;
+            public long Blue;
+            public long Alpha;
             public short PaletteIndex;
             public short NextReducibleIndex;
             private InlineArray16<short> children;
@@ -510,12 +510,13 @@ public struct HexadecatreeQuantizer<TPixel> : IQuantizer<TPixel>
                     return;
                 }
 
-                // Now merge the (presumably reduced) children.
-                int pixelCount = 0;
-                int sumRed = 0;
-                int sumGreen = 0;
-                int sumBlue = 0;
-                int sumAlpha = 0;
+                // Allocation fallback can accumulate samples on an interior node. Seed the merge
+                // with this node's own sums so reduction preserves those samples with its children.
+                long pixelCount = this.PixelCount;
+                long sumRed = this.Red;
+                long sumGreen = this.Green;
+                long sumBlue = this.Blue;
+                long sumAlpha = this.Alpha;
                 Span<short> children = this.Children;
 
                 for (int i = 0; i < children.Length; i++)
@@ -524,7 +525,7 @@ public struct HexadecatreeQuantizer<TPixel> : IQuantizer<TPixel>
                     if (childIndex != -1)
                     {
                         ref Node child = ref tree.Nodes[childIndex];
-                        int pixels = child.PixelCount;
+                        long pixels = child.PixelCount;
                         sumRed += child.Red;
                         sumGreen += child.Green;
                         sumBlue += child.Blue;

--- a/tests/ImageSharp.Tests/Issues/Issue_396.cs
+++ b/tests/ImageSharp.Tests/Issues/Issue_396.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace SixLabors.ImageSharp.Tests.Issues;
+
+// https://github.com/SixLabors/ImageSharp.Drawing/discussions/396
+public class Issue_396
+{
+    [Theory]
+    [WithFile(TestImages.Png.Issue396Dragon, PixelTypes.Rgba32)]
+    public void GeneratesGifForInspection<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        Image<Rgba32>[] handImages =
+        [
+            Image.Load<Rgba32>(TestFile.Create(TestImages.Png.Issue396Hand1).Bytes),
+            Image.Load<Rgba32>(TestFile.Create(TestImages.Png.Issue396Hand2).Bytes)
+        ];
+
+        try
+        {
+            using Image<TPixel> inputImage = provider.GetImage();
+            using Image<Rgba32> outputImage = new(handImages[0].Width, handImages[0].Height);
+
+            const float scaleFactor = 0.6F;
+            const float squashStepFactor = 0.22F;
+
+            for (int i = 0; i < handImages.Length; i++)
+            {
+                using Image<Rgba32> frameImage = new(handImages[i].Width, handImages[i].Height);
+                float squashFactorY = 1 - (i * squashStepFactor);
+
+                frameImage.ProcessPixelRows(accessor =>
+                {
+                    Rgba32 gray = Color.Gray.ToPixel<Rgba32>();
+
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        accessor.GetRowSpan(y).Fill(gray);
+                    }
+                });
+
+                Rectangle targetRect = new(
+                    (int)((frameImage.Width - (frameImage.Width * scaleFactor)) / 2),
+                    (int)(frameImage.Height * (((1 - scaleFactor) / 2) + (scaleFactor * (1 - squashFactorY)))),
+                    (int)(frameImage.Width * scaleFactor),
+                    (int)(frameImage.Height * scaleFactor * squashFactorY));
+
+                using Image<Rgba32> dragonFrame = inputImage.CloneAs<Rgba32>();
+                dragonFrame.Mutate(context => context.Resize(targetRect.Size));
+
+                frameImage.Mutate(context =>
+                {
+                    context.DrawImage(dragonFrame, targetRect.Location, 1F);
+                    context.DrawImage(handImages[i], Point.Empty, 1F);
+                });
+
+                ImageFrame<Rgba32> outputFrame = outputImage.Frames.AddFrame(frameImage.Frames.RootFrame);
+                GifFrameMetadata gifFrameMetadata = outputFrame.Metadata.GetGifMetadata();
+                gifFrameMetadata.FrameDelay = 40;
+                gifFrameMetadata.DisposalMode = FrameDisposalMode.RestoreToBackground;
+            }
+
+            for (int i = handImages.Length - 1; i > 0; i--)
+            {
+                outputImage.Frames.AddFrame(outputImage.Frames[i]);
+            }
+
+            outputImage.Frames.RemoveFrame(0);
+            GifMetadata gifMetadata = outputImage.Metadata.GetGifMetadata();
+            gifMetadata.RepeatCount = 0;
+
+            Assert.Equal((handImages.Length * 2) - 1, outputImage.Frames.Count);
+            foreach (ImageFrame<Rgba32> frame in outputImage.Frames)
+            {
+                Assert.Equal(FrameDisposalMode.RestoreToBackground, frame.Metadata.GetGifMetadata().DisposalMode);
+            }
+
+            outputImage.DebugSaveMultiFrame(provider, "Issue396-source-frames", appendPixelTypeToFileName: false);
+            provider.Utility.SaveTestOutputFile(
+                outputImage,
+                "gif",
+                new GifEncoder(),
+                "Issue396-encoded",
+                appendPixelTypeToFileName: false,
+                appendSourceFileOrDescription: false);
+
+            // Save and decode the GIF so the encoder's optimized frame diffs can be inspected separately.
+            using MemoryStream gifStream = new();
+            outputImage.SaveAsGif(gifStream);
+            gifStream.Position = 0;
+
+            using Image<Rgba32> decodedImage = Image.Load<Rgba32>(gifStream);
+            decodedImage.DebugSaveMultiFrame(provider, "Issue396-decoded-frames", appendPixelTypeToFileName: false);
+
+            Assert.Equal(outputImage.Frames.Count, decodedImage.Frames.Count);
+        }
+        finally
+        {
+            foreach (Image<Rgba32> handImage in handImages)
+            {
+                handImage.Dispose();
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -79,6 +79,9 @@ public static class TestImages
         public const string AnimatedFrameCount = "Png/animated/issue-animated-frame-count.png";
         public const string Issue2666 = "Png/issues/Issue_2666.png";
         public const string Issue2882 = "Png/issues/Issue_2882.png";
+        public const string Issue396Dragon = "Png/issues/Issue_396_dragon.png";
+        public const string Issue396Hand1 = "Png/issues/Issue_396_hand_1.png";
+        public const string Issue396Hand2 = "Png/issues/Issue_396_hand_2.png";
 
         // Filtered test images from http://www.schaik.com/pngsuite/pngsuite_fil_png.html
         public const string Filter0 = "Png/filter0.png";

--- a/tests/Images/External/ReferenceOutput/BmpEncoderTests/Encode_8BitColor_WithHexadecatreeQuantizer_rgb32.bmp
+++ b/tests/Images/External/ReferenceOutput/BmpEncoderTests/Encode_8BitColor_WithHexadecatreeQuantizer_rgb32.bmp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a98b1ec707af066f77fad7d1a64b858d460986beb6d27682717dd5e221310fd4
+oid sha256:fff91e78a87c2b2db661609dd70af2d7a74e6a0de18924ab2b6272e12c60977d
 size 9270

--- a/tests/Images/External/ReferenceOutput/BmpEncoderTests/Encode_8BitColor_WithOctreeQuantizer_rgb32.bmp
+++ b/tests/Images/External/ReferenceOutput/BmpEncoderTests/Encode_8BitColor_WithOctreeQuantizer_rgb32.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a98b1ec707af066f77fad7d1a64b858d460986beb6d27682717dd5e221310fd4
-size 9270

--- a/tests/Images/External/ReferenceOutput/QuantizerTests/ApplyQuantization_Bike_HexadecatreeQuantizer_ErrorDither.png
+++ b/tests/Images/External/ReferenceOutput/QuantizerTests/ApplyQuantization_Bike_HexadecatreeQuantizer_ErrorDither.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b380eda5646fe97ee217ef711103001e54ee023fb8d95f7f3bbad19d886130da
-size 83702
+oid sha256:822f4ae1d8676e2231a0c938296931be42a74c0a51b4ec63fdf6dcd17d64dc7e
+size 83924

--- a/tests/Images/Input/Png/issues/Issue_396_dragon.png
+++ b/tests/Images/Input/Png/issues/Issue_396_dragon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:203aca58e0aa19cbb7ab0820ef55005af830bf4c9bfd1dd4d9967c7e1bc1d51a
+size 494160

--- a/tests/Images/Input/Png/issues/Issue_396_hand_1.png
+++ b/tests/Images/Input/Png/issues/Issue_396_hand_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ab791784ac46f9e50a63bd255f39ff8af236a922aab3510a29b473bd93bffd5
+size 16295

--- a/tests/Images/Input/Png/issues/Issue_396_hand_2.png
+++ b/tests/Images/Input/Png/issues/Issue_396_hand_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbf54bcef6730b68b18770105a15448f984aaca6910693d4e65106a526af58d8
+size 17756


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
See https://github.com/SixLabors/ImageSharp.Drawing/discussions/396

This pull request makes several significant improvements to GIF encoding and decoding, particularly around how background color is handled, quantization accuracy, and frame disposal behaviors. It also introduces a new regression test for a previously reported issue. The most important changes are grouped below:

**GIF Background Color Handling:**

* The concept of background color in `GifMetadata` has been refactored: instead of storing a palette index (`BackgroundColorIndex`), the actual `Color` value is now stored and used throughout encoding and decoding. This change ensures more accurate and flexible background color management. [[1]](diffhunk://#diff-f262ec563ad19c4d8e23ec8b42cfe9d3682141927459088eb7727edd62f29795L29-R29) [[2]](diffhunk://#diff-f262ec563ad19c4d8e23ec8b42cfe9d3682141927459088eb7727edd62f29795L62-R64) [[3]](diffhunk://#diff-133c57ab6987fbc0cae0f5447a3ab4cb617c62cd507960e4dd99219a67b2a295L993-R997) [[4]](diffhunk://#diff-f262ec563ad19c4d8e23ec8b42cfe9d3682141927459088eb7727edd62f29795R103)
* The encoder now determines the background color by first checking the encoder's setting, then falling back to the metadata's background color, and finally using transparent if neither is set. This color is then mapped to the palette for correct index assignment. [[1]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729R149-R153) [[2]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729R167-R168) [[3]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L350-R360)
* The obsolete method for determining background index (`GetBackgroundIndex`) has been removed, simplifying the code and reducing potential for errors. [[1]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L187-L188) [[2]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L537-L574)

**Quantization and Frame Encoding Enhancements:**

* The quantizer options are now adjusted for animated GIFs to reserve a color-table entry for transparency, improving color allocation for delta frames.
* The quantization logic in the `HexadecatreeQuantizer` has been updated to use `long` instead of `int` for color channel sums and pixel counts, preventing overflow and improving accuracy for large images or many samples. [[1]](diffhunk://#diff-2507c13135c8595b5c003b6c8759efa6816e620647319c069998946002fee974L395-R399) [[2]](diffhunk://#diff-2507c13135c8595b5c003b6c8759efa6816e620647319c069998946002fee974L513-R519) [[3]](diffhunk://#diff-2507c13135c8595b5c003b6c8759efa6816e620647319c069998946002fee974L527-R528)

**Codebase and API Cleanups:**

* The now-unnecessary `backgroundColor` field in `GifEncoderCore` has been removed, and related constructor and method signatures have been updated for clarity and correctness. [[1]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L48-L55) [[2]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L79) [[3]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729R263) [[4]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729R339)

**Testing Improvements:**

* A new regression test (`Issue_396`) and supporting test images have been added to ensure correct handling of animated GIFs with frame disposal to background, verifying both encoding and decoding paths. [[1]](diffhunk://#diff-718ed1ab124b6d3fd07e64cfff26d6ac26c9fe806954e5d1e9b4904c3acd724aR1-R111) [[2]](diffhunk://#diff-e03a3dfed3cced318aa98cd8d039c18dba40e090899c4639f922738d7abeaf02R82-R84) [[3]](diffhunk://#diff-8d606d1c2bf3e830f35cf840c08f0ebd8b69f7c7be28e303b18be8fa6384ef71R1-R3) [[4]](diffhunk://#diff-d7334ee0a4fea2cd7f818ad014c25cce16082f66cd1f560b2eec340d122c7dbdR1-R3) [[5]](diffhunk://#diff-9fee7ad262c08b3dac07dc8d2fe5ec89ff33f2a2b5eaf8aed3e493d533281b60R1-R3)
<!-- Thanks for contributing to ImageSharp! -->
