### PR TITLE
Validate PBM max pixel value

### DIFF
--- a/src/ImageSharp/Formats/Pbm/PbmDecoderCore.cs
+++ b/src/ImageSharp/Formats/Pbm/PbmDecoderCore.cs
@@ -155,6 +155,11 @@ internal sealed class PbmDecoderCore : ImageDecoderCore
                 ThrowPrematureEof();
             }
 
+            if (this.maxPixelValue <= 0 || this.maxPixelValue >= 65536)
+            {
+                throw new InvalidImageContentException("Invalid max pixel value.");
+            }
+
             if (this.maxPixelValue > 255)
             {
                 this.componentType = PbmComponentType.Short;

--- a/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Pbm/PbmDecoderTests.cs
@@ -123,6 +123,19 @@ public class PbmDecoderTests
             appendPixelTypeToFileName: false);
     }
 
+    [Theory]
+    [InlineData("P2")]
+    [InlineData("P3")]
+    [InlineData("P5")]
+    [InlineData("P6")]
+    public void Decode_MaxPixelValueZero_ThrowsInvalidImageContentException(string magic)
+    {
+        byte[] bytes = Encoding.ASCII.GetBytes($"{magic} 1 1 0\n0");
+        using MemoryStream stream = new(bytes);
+
+        Assert.Throws<InvalidImageContentException>(() => Image.Load<Rgba32>(stream));
+    }
+
     [Fact]
     public void PlainText_PrematureEof()
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #3130

<!-- A description of the changes proposed in the pull-request -->
This pull request adds stricter validation for the PBM image decoder to ensure that only valid max pixel values are accepted, and introduces corresponding tests to verify this behavior.

**Decoder validation improvement:**

* Added a check in `PbmDecoderCore.cs` to throw an `InvalidImageContentException` if `maxPixelValue` is less than or equal to 0 or greater than or equal to 65536, preventing invalid PBM images from being processed.

**Test coverage:**

* Added a new parameterized test in `PbmDecoderTests.cs` to verify that decoding PBM images with a max pixel value of 0 for all supported magic numbers throws an `InvalidImageContentException`.

<!-- Thanks for contributing to ImageSharp! -->
