### PR TITLE
Fix GIF transparency handling and dither

### DIFF
--- a/src/ImageSharp/Color/Color.WernerPalette.cs
+++ b/src/ImageSharp/Color/Color.WernerPalette.cs
@@ -127,6 +127,10 @@ public partial struct Color
         ParseHex("#8b7859"),
         ParseHex("#9b856b"),
         ParseHex("#766051"),
-        ParseHex("#453b32")
+        ParseHex("#453b32"),
+
+        // Werner does not define a transparent color, but we need to add one to
+        // make the palette work with the rest of the library.
+        Transparent
     ];
 }

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -361,7 +361,10 @@ internal sealed class GifEncoderCore
                 : Color.Transparent;
 
         // Deduplicate and quantize the frame capturing only required parts.
-        (bool difference, Rectangle bounds) =
+        // Pixels matching the previous frame are replaced with the transparent placeholder.
+        // When the entire frame matches there is no captured difference, but every pixel is
+        // still a placeholder, so a transparent index is always required for additional frames.
+        (_, Rectangle bounds) =
             AnimationUtilities.DeDuplicatePixels(
                 this.configuration,
                 previous,
@@ -378,7 +381,7 @@ internal sealed class GifEncoderCore
                 bounds,
                 metadata,
                 useLocal,
-                difference,
+                true,
                 transparencyIndex,
                 background);
 
@@ -403,7 +406,7 @@ internal sealed class GifEncoderCore
         Rectangle bounds,
         GifFrameMetadata metadata,
         bool useLocal,
-        bool hasDuplicates,
+        bool requiresTransparency,
         int transparencyIndex,
         Color transparentColor)
         where TPixel : unmanaged, IPixel<TPixel>
@@ -417,9 +420,11 @@ internal sealed class GifEncoderCore
                 // We can use the color data from the decoded metadata here.
                 // We avoid dithering by default to preserve the original colors.
                 ReadOnlyMemory<Color> palette = metadata.LocalColorTable.Value;
-                if (hasDuplicates && !metadata.HasTransparency)
+                if (requiresTransparency && !metadata.HasTransparency)
                 {
-                    // Duplicates were captured but the metadata does not have transparency.
+                    // The frame was de-duplicated against the previous frame, replacing matching
+                    // pixels with the transparent placeholder, but the metadata does not yet carry
+                    // a transparent index. Reserve one so those pixels encode as transparent.
                     metadata.HasTransparency = true;
 
                     if (palette.Length < 256)
@@ -480,7 +485,7 @@ internal sealed class GifEncoderCore
 
                 metadata.TransparencyIndex = ClampIndex(derivedTransparencyIndex);
 
-                if (hasDuplicates)
+                if (requiresTransparency)
                 {
                     metadata.HasTransparency = true;
                 }
@@ -492,11 +497,19 @@ internal sealed class GifEncoderCore
             // Individual frames, though using the shared palette, can use a different transparent index
             // to represent transparency.
 
-            // A difference was captured but the metadata does not have transparency.
-            if (hasDuplicates && !metadata.HasTransparency)
+            // The frame was de-duplicated against the previous frame, replacing matching pixels with
+            // the transparent placeholder. When the whole frame matches there is no captured difference,
+            // yet every pixel is still a placeholder, so we must always reserve a transparent index here;
+            // otherwise the placeholder pixels are matched to the nearest (typically darkest) palette color.
+            if (requiresTransparency && !metadata.HasTransparency)
             {
                 metadata.HasTransparency = true;
-                transparencyIndex = globalFrameQuantizer.Palette.Length;
+
+                // Normally we pad one index past the palette so the (out of range) value is treated as
+                // transparent by decoders without growing the color table. A full 256-color palette leaves
+                // no room to pad within the 8-bit index space (index 256 wraps to 0 when written and exceeds
+                // the maximum GIF bit depth), so reuse the last in-range index for transparency instead.
+                transparencyIndex = Math.Min(globalFrameQuantizer.Palette.Length, byte.MaxValue);
                 metadata.TransparencyIndex = ClampIndex(transparencyIndex);
             }
 

--- a/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs
@@ -202,6 +202,15 @@ public readonly partial struct ErrorDither : IDither, IEquatable<ErrorDither>, I
                 ref TPixel pixel = ref rowSpan[targetX];
                 Vector4 result = pixel.ToVector4();
 
+                // Do not diffuse error into fully transparent pixels. They carry no visible color
+                // (a decoder shows whatever is behind them), so perturbing them is meaningless and,
+                // for indexed transparency, nudges them off the exact transparent color so they are
+                // matched to the nearest opaque palette entry instead of being kept transparent.
+                if (result.W <= 0)
+                {
+                    continue;
+                }
+
                 result += error * coefficient;
                 pixel = TPixel.FromVector4(result);
             }

--- a/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
+++ b/src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs
@@ -182,6 +182,16 @@ public readonly partial struct OrderedDither : IDither, IEquatable<OrderedDither
         where TPixel : unmanaged, IPixel<TPixel>
     {
         Rgba32 rgba = source.ToRgba32();
+
+        // Leave fully transparent pixels untouched. They carry no visible color (a decoder shows
+        // whatever is behind them), so perturbing them is meaningless and, for indexed transparency,
+        // nudges them off the exact transparent color so they are matched to the nearest opaque
+        // palette entry instead of being kept transparent.
+        if (rgba.A == 0)
+        {
+            return source;
+        }
+
         Unsafe.SkipInit(out Rgba32 attempt);
 
         float factor = spread * this.thresholdMatrix[y % this.modulusY, x % this.modulusX] * scale;

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -7,6 +7,7 @@ using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Quantization;
 using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 
@@ -349,7 +350,7 @@ public class GifEncoderTests
 
     public static string[] Animated => TestImages.Gif.Animated;
 
-    [Theory(Skip = "Enable for visual animated testing")]
+    [Theory]//(Skip = "Enable for visual animated testing")]
     [WithFileCollection(nameof(Animated), PixelTypes.Rgba32)]
     public void Encode_Animated_VisualTest<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
@@ -429,6 +430,23 @@ public class GifEncoderTests
 
         // Save the image for visual inspection.
         provider.Utility.SaveTestOutputFile(image, "gif", new GifEncoder(), "animated");
+
+        // Now compare the debug output with the reference output.
+        // We do this because the gif encoding is lossy and encoding will lead to differences in the 10s of percent.
+        // From the unencoded image, we can see that the image is visually the same.
+        static bool Predicate(int i, int _) => i % 8 == 0; // Image has many frames, only compare a selection of them.
+        image.CompareDebugOutputToReferenceOutputMultiFrame(provider, ImageComparer.Exact, extension: "gif", predicate: Predicate);
+    }
+
+    [Theory]
+    [WithFile(TestImages.Gif.Issues.Issue3142, PixelTypes.Rgba32)]
+    public void GifEncoder_CanDecode_AndEncode_Issue3142<TPixel>(TestImageProvider<TPixel> provider)
+    where TPixel : unmanaged, IPixel<TPixel>
+    {
+        using Image<TPixel> image = provider.GetImage();
+
+        // Save the image for visual inspection.
+        provider.Utility.SaveTestOutputFile(image, "gif", new GifEncoder() { Quantizer = KnownQuantizers.Wu }, "animated");
 
         // Now compare the debug output with the reference output.
         // We do this because the gif encoding is lossy and encoding will lead to differences in the 10s of percent.

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -614,6 +614,7 @@ public static class TestImages
             public const string Issue2859_B = "Gif/issues/issue_2859_B.gif";
             public const string Issue2953 = "Gif/issues/issue_2953.gif";
             public const string Issue2980 = "Gif/issues/issue_2980.gif";
+            public const string Issue3142 = "Gif/issues/issue_3142.gif";
         }
 
         public static readonly string[] Animated =
@@ -635,7 +636,8 @@ public static class TestImages
             Issues.BadDescriptorWidth,
             Issues.Issue1530,
             Bit18RGBCube,
-            Global256NoTrans
+            Global256NoTrans,
+            Issues.Issue3142
         ];
     }
 

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/00.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/00.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba81598dc214845f18064f987a55eebdab0e53149df8fd67904733b42c760ad6
+size 7389

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/08.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/08.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba81598dc214845f18064f987a55eebdab0e53149df8fd67904733b42c760ad6
+size 7389

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/104.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/104.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6bd47e66b07bab7edf53a07631016f8334ba337243d6b8d61b0c8a3cf7f3f0d
+size 7974

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/112.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/112.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6bd47e66b07bab7edf53a07631016f8334ba337243d6b8d61b0c8a3cf7f3f0d
+size 7974

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/16.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/16.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03d4e5cdaed2def942ca8480c9e45bb3d7914c6dbe3eac2b287afc8ff815b95d
+size 8705

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/24.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/24.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ad084d64942ea1dec0c1b22a88400b47f14145d761aa22a8e7deb42b5bd9fb0
+size 13011

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/32.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/32.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:714cf4be4fc6c4164494ca1950796211577ab61cbd939f7cc53a36c3f7f742c5
+size 16457

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/40.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/40.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb04c45837b763abf2c326b3e831c5b772853d50c0bfc85fb7ac7ca62361292d
+size 16872

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/48.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/48.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb04c45837b763abf2c326b3e831c5b772853d50c0bfc85fb7ac7ca62361292d
+size 16872

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/56.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/56.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c68bad5aebb65e86e4295956b9f0bc21e181a6d8dadd9dbfbd5febf0a5ba0d8
+size 17414

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/64.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/64.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d0672248b0e45ea700aa0c484ed0e342284ce18cad1cdc233700614636bed11
+size 16556

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/72.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/72.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b12d34adf8c531c0d4ab02f7b57507a585bb1d31fb82d828c8c52732cef9f18
+size 15590

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/80.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/80.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b12d34adf8c531c0d4ab02f7b57507a585bb1d31fb82d828c8c52732cef9f18
+size 15590

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/88.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/88.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a31b9aee61fbc7d5dd5f163f2c81cb36140a05d788a7ed2d15de550c0fe13232
+size 14561

--- a/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/96.gif
+++ b/tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/96.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bc49ba55ee33a3aff5069b7a6bf45cdb429ad691f8701093ad7fe04abe25ea1
+size 12156

--- a/tests/Images/External/ReferenceOutput/PngEncoderTests/Issue2469_Quantized_Encode_Artifacts_Rgba32_issue_2469.png
+++ b/tests/Images/External/ReferenceOutput/PngEncoderTests/Issue2469_Quantized_Encode_Artifacts_Rgba32_issue_2469.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:770061fbb29cd20bc700ce3fc57e38a758c632c3e89de51f5fbee3d5d522539e
-size 912635
+oid sha256:b33a960891c6b1e9cc6ac2ddc3cf49d8f49e0c749dfa7a67db49354988b129f6
+size 935007

--- a/tests/Images/External/ReferenceOutput/PngEncoderTests/Issue2668_Quantized_Encode_Alpha_Rgba32_Issue_2668.png
+++ b/tests/Images/External/ReferenceOutput/PngEncoderTests/Issue2668_Quantized_Encode_Alpha_Rgba32_Issue_2668.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df34f8f3640b145add4f24f8003c288fe7991373b079a87b4be90842e18c82ae
-size 8236
+oid sha256:ad1630f3da7c2b997d04c75de2ac1465255c977454461f2fdc7026b3f87e11f1
+size 8232

--- a/tests/Images/Input/Gif/issues/issue_3142.gif
+++ b/tests/Images/Input/Gif/issues/issue_3142.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:982c394dbee297bb3bc5cc532827742260acb6e5aa07e1dca3f0b17e57bc3bbe
+size 386565


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #3142 

This pull request improves GIF encoding and palette handling, especially for animated images with transparency. It ensures fully transparent pixels are properly treated during dithering and quantization, fixes issues where transparent indices were not always reserved, and adds tests for a previously failing edge case (issue #3142). The changes also introduce a transparent color to the Werner palette for better compatibility.

**GIF Transparency and Palette Handling Improvements:**

* Ensured a transparent color is always present in the Werner palette to support transparency in palette-based images. (`src/ImageSharp/Color/Color.WernerPalette.cs`)
* Updated GIF encoding logic to always reserve a transparent index for additional frames when required, even if the entire frame matches the previous one, preventing placeholder pixels from being mapped to opaque colors. (`src/ImageSharp/Formats/Gif/GifEncoderCore.cs`) [[1]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L364-R367) [[2]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L381-R384) [[3]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L406-R409) [[4]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L420-R427) [[5]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L483-R488) [[6]](diffhunk://#diff-528345820a138c7f549be70e663064ff184e94a660d992c8bdea3a3eea962729L495-R512)
* Improved dithering processors to skip error diffusion for fully transparent pixels, preserving exact transparency and avoiding accidental color shifts that could break transparency in indexed images. (`src/ImageSharp/Processing/Processors/Dithering/ErrorDither.cs`, `src/ImageSharp/Processing/Processors/Dithering/OrderedDither.cs`) [[1]](diffhunk://#diff-6a627f3db6c8d00923293b1f764071ef379142f9eabc05fbc40316a73d588ed6R205-R213) [[2]](diffhunk://#diff-57a1437eb32e2904a4103e467c612038b82d44fcb5f485c3bdac74920c0c5678R185-R194)

**Testing and Regression Coverage:**

* Added a regression test and reference output for issue #3142, ensuring the encoder correctly handles animated GIFs with full transparency and placeholder frames. (`tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs`, `tests/ImageSharp.Tests/TestImages.cs`, `tests/Images/External/ReferenceOutput/GifEncoderTests/GifEncoder_CanDecode_AndEncode_Issue3142_Rgba32_issue_3142.gif/*`) [[1]](diffhunk://#diff-c1cde10cde02446d26e24c1935ecbb806b6938db81c7113b536a77f88641f941R440-R456) [[2]](diffhunk://#diff-e03a3dfed3cced318aa98cd8d039c18dba40e090899c4639f922738d7abeaf02R617) [[3]](diffhunk://#diff-e03a3dfed3cced318aa98cd8d039c18dba40e090899c4639f922738d7abeaf02L638-R640) [[4]](diffhunk://#diff-2121f8277939cd94d75312004c40ee747cc4fe54b86919c111425be2e2fcfeafR1-R3) [[5]](diffhunk://#diff-2a2bda8785ff5cbe6e32ba52f390474b2cbb9cddb7762f2fb4c618f12e318457R1-R3) [[6]](diffhunk://#diff-952ffd365946f2a6d389d24abe9ed769b1b35179798688daddf285d644dc09a6R1-R3) [[7]](diffhunk://#diff-14405cb7ae582f53357c385b0624333d7d5b234ba1be3dae38db984595339d00R1-R3) [[8]](diffhunk://#diff-20aee3c3439c29056309557105409778cfdc4619b5b50dc145a89fca74ecfe71R1-R3) [[9]](diffhunk://#diff-cd8f27c71b23dec0e0fe09b5dc6b39eb0a5013215ba6407091f1514bab17143dR1-R3) [[10]](diffhunk://#diff-3e7d516039f7dafd878af0b2444e088db0f93f26840735874bd87973f467a43eR1-R3) [[11]](diffhunk://#diff-fea69801160975cc207b487b496350a4f2621ba4a4b7b208b42827a34e34a2e3R1-R3) [[12]](diffhunk://#diff-2eb85849120d6bc8d68fa813f37298c0d47c8f2c14e7c8d3c000b7e6b6a4edfdR1-R3) [[13]](diffhunk://#diff-d857d8861a383b0bcf71931bdbab8e6f3ee601c18d8dd7495dd5e59b9d5cfbabR1-R3)

**Test Suite Improvements:**

* Enabled an animated GIF visual test for easier validation of animated encoding results. (`tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs`)
* Added missing using directive for `SixLabors.ImageSharp.Processing` to support new test cases. (`tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs`)

<!-- Thanks for contributing to ImageSharp! -->
