### PR TITLE
Fix convolution sampling for bounds smaller than the kernel radius

### DIFF
--- a/src/ImageSharp/Processing/Processors/Convolution/KernelSamplingMap.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/KernelSamplingMap.cs
@@ -104,7 +104,15 @@ internal sealed class KernelSamplingMap : IDisposable
     {
         int affectedSize = (kernelSize >> 1) * kernelSize;
         ref int spanBase = ref MemoryMarshal.GetReference(span);
-        if (affectedSize > 0)
+        if (affectedSize >= span.Length && span.Length > 0)
+        {
+            // The bounds are no larger than the kernel radius: every offset can overshoot the
+            // borders by a full sampling extent or more, which the single-pass head and tail
+            // corrections below cannot fold back into range (and for bounds strictly smaller
+            // than the radius they cannot even slice the span). Fold each offset exactly.
+            CorrectBorderExact(span, min, max, borderMode);
+        }
+        else if (affectedSize > 0)
         {
             switch (borderMode)
             {
@@ -179,5 +187,59 @@ internal sealed class KernelSamplingMap : IDisposable
                     break;
             }
         }
+    }
+
+    private static void CorrectBorderExact(Span<int> span, int min, int max, BorderWrappingMode borderMode)
+    {
+        int extent = max - min + 1;
+        switch (borderMode)
+        {
+            case BorderWrappingMode.Repeat:
+                Numerics.Clamp(span, min, max);
+                break;
+
+            case BorderWrappingMode.Mirror:
+                // Reflection about the half-sample border: ..., min+1, min | min, min+1, ...
+                int mirrorPeriod = 2 * extent;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    int offset = Modulo(span[i] - min, mirrorPeriod);
+                    span[i] = min + (offset < extent ? offset : mirrorPeriod - 1 - offset);
+                }
+
+                break;
+
+            case BorderWrappingMode.Bounce:
+                // Reflection about the border sample itself: ..., min+2, min+1 | min, min+1, ...
+                if (extent == 1)
+                {
+                    span.Fill(min);
+                    break;
+                }
+
+                int bouncePeriod = (2 * extent) - 2;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    int offset = Modulo(span[i] - min, bouncePeriod);
+                    span[i] = min + (offset < extent ? offset : bouncePeriod - offset);
+                }
+
+                break;
+
+            case BorderWrappingMode.Wrap:
+                for (int i = 0; i < span.Length; i++)
+                {
+                    span[i] = min + Modulo(span[i] - min, extent);
+                }
+
+                break;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Modulo(int value, int period)
+    {
+        int remainder = value % period;
+        return remainder < 0 ? remainder + period : remainder;
     }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/GaussianBlurTest.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/GaussianBlurTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Processors.Convolution;
 
 namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution;
 
@@ -13,4 +15,32 @@ public class GaussianBlurTest : Basic1ParameterConvolutionTests
 
     protected override void Apply(IImageProcessingContext ctx, int value, Rectangle bounds) =>
         ctx.GaussianBlur(bounds, value);
+
+    [Theory]
+    [InlineData(BorderWrappingMode.Repeat)]
+    [InlineData(BorderWrappingMode.Mirror)]
+    [InlineData(BorderWrappingMode.Bounce)]
+    [InlineData(BorderWrappingMode.Wrap)]
+    public void OnImageSmallerThanKernelRadius_LeavesSolidColorUnchanged(BorderWrappingMode mode)
+    {
+        // 8 rows against sigma 10 (61-tap kernel, radius 30). A normalized blur of a solid
+        // image must remain that color no matter how the border sampling folds.
+        Rgba32 red = new(255, 0, 0);
+        using Image<Rgba32> image = new(130, 8, red);
+        image.Mutate(x => x.GaussianBlur(image.Bounds, 10F, mode, mode));
+
+        image.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < accessor.Height; y++)
+            {
+                foreach (Rgba32 pixel in accessor.GetRowSpan(y))
+                {
+                    Assert.InRange(pixel.R, 254, 255);
+                    Assert.InRange(pixel.G, 0, 1);
+                    Assert.InRange(pixel.B, 0, 1);
+                    Assert.Equal(255, pixel.A);
+                }
+            }
+        });
+    }
 }

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/KernelSamplingMapTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/KernelSamplingMapTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.Processing.Processors.Convolution;
+
+namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution;
+
+[Trait("Category", "Processors")]
+[GroupOutput("Convolution")]
+public class KernelSamplingMapTests
+{
+    public static readonly TheoryData<BorderWrappingMode, int, int> BoundsSmallerThanKernel = new()
+    {
+        { BorderWrappingMode.Repeat, 8, 5 },
+        { BorderWrappingMode.Mirror, 8, 5 },
+        { BorderWrappingMode.Bounce, 8, 5 },
+        { BorderWrappingMode.Wrap, 8, 5 },
+        { BorderWrappingMode.Repeat, 1, 1 },
+        { BorderWrappingMode.Mirror, 1, 1 },
+        { BorderWrappingMode.Bounce, 1, 1 },
+        { BorderWrappingMode.Wrap, 1, 1 },
+        { BorderWrappingMode.Repeat, 30, 30 },
+        { BorderWrappingMode.Mirror, 30, 30 },
+        { BorderWrappingMode.Bounce, 30, 30 },
+        { BorderWrappingMode.Wrap, 30, 30 },
+    };
+
+    [Theory]
+    [MemberData(nameof(BoundsSmallerThanKernel))]
+    public void BuildSamplingOffsetMap_BoundsSmallerThanKernelRadius_OffsetsStayInBounds(BorderWrappingMode mode, int width, int height)
+    {
+        // A 61-tap kernel has radius 30, so these bounds are covered entirely by the border
+        // regions and offsets can overshoot the bounds by more than one sampling extent.
+        const int kernelSize = 61;
+        Rectangle bounds = new(100, 200, width, height);
+
+        using KernelSamplingMap map = new(Configuration.Default.MemoryAllocator);
+        map.BuildSamplingOffsetMap(kernelSize, kernelSize, bounds, mode, mode);
+
+        foreach (int x in map.GetColumnOffsetSpan())
+        {
+            Assert.InRange(x, bounds.Left, bounds.Right - 1);
+        }
+
+        foreach (int y in map.GetRowOffsetSpan())
+        {
+            Assert.InRange(y, bounds.Top, bounds.Bottom - 1);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request improves the handling of border conditions in convolution operations when the image bounds are smaller than the kernel radius. It introduces a new method to ensure all sampling offsets are correctly folded into range for all border wrapping modes, and adds comprehensive tests to verify this behavior.

### Border handling improvements

* Added the `CorrectBorderExact` method in `KernelSamplingMap.cs` to handle cases where the image bounds are smaller than the kernel radius, ensuring all offsets are folded exactly according to the selected `BorderWrappingMode`. This prevents out-of-bounds access and guarantees correct sampling for small images. [[1]](diffhunk://#diff-057df23c4e2680e9f6d06b175eefa6b48af76cf8c492952ff8166de6e42c3c24L107-R115) [[2]](diffhunk://#diff-057df23c4e2680e9f6d06b175eefa6b48af76cf8c492952ff8166de6e42c3c24R191-R244)
* Updated the logic in `CorrectBorder` to call `CorrectBorderExact` when the bounds are no larger than the kernel radius, improving reliability for edge cases.

### Testing enhancements

* Added a new test class `KernelSamplingMapTests` to verify that, for all border wrapping modes, sampling offsets stay within bounds when the image is smaller than the kernel radius.
* Added a test in `GaussianBlurTest` to ensure that applying a large-radius Gaussian blur to a solid-color image with small bounds leaves the color unchanged for all border modes, confirming correct border handling.
* Included necessary using directives in `GaussianBlurTest.cs` to support the new tests.
<!-- Thanks for contributing to ImageSharp! -->
