### PR TITLE
Fix degeneracy check for resize transforms

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/TransformUtilities.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/TransformUtilities.cs
@@ -19,7 +19,7 @@ internal static class TransformUtilities
     /// </summary>
     /// <param name="matrix">The transform matrix.</param>
     public static bool IsDegenerate(Matrix3x2 matrix)
-        => IsNaN(matrix) || IsZero(matrix.GetDeterminant());
+        => IsNaN(matrix) || matrix.GetDeterminant() == 0F;
 
     /// <summary>
     /// Returns a value that indicates whether the specified matrix is degenerate
@@ -28,11 +28,7 @@ internal static class TransformUtilities
     /// </summary>
     /// <param name="matrix">The transform matrix.</param>
     public static bool IsDegenerate(Matrix4x4 matrix)
-        => IsNaN(matrix) || IsZero(matrix.GetDeterminant());
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsZero(float a)
-        => a > -Constants.EpsilonSquared && a < Constants.EpsilonSquared;
+        => IsNaN(matrix) || matrix.GetDeterminant() == 0F;
 
     /// <summary>
     /// Returns a value that indicates whether the specified matrix contains any values

--- a/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Transforms/ResizeTests.cs
@@ -700,6 +700,20 @@ public class ResizeTests
     }
 
     [Theory]
+    [InlineData(1024)]
+    [InlineData(2048)]
+    public void Issue3156_CanResizeLargeSquareToSinglePixel(int length)
+    {
+        Rgba32 white = Color.White.ToPixel<Rgba32>();
+        using Image<Rgba32> image = new(length, length, white);
+
+        image.Mutate(x => x.Resize(1, 1));
+
+        Assert.Equal(new Size(1, 1), image.Size);
+        Assert.Equal(white, image[0, 0]);
+    }
+
+    [Theory]
     [WithTestPatternImages(100, 100, PixelTypes.Rgba32)]
     public void ResizeUpdatesSubject<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>


### PR DESCRIPTION


### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #3156 

Use exact zero determinant checks in `TransformUtilities.IsDegenerate` for `Matrix3x2` and `Matrix4x4` instead of epsilon-based near-zero detection, preventing valid transforms from being treated as degenerate during extreme downscales. Added a regression test for issue #3156 to verify resizing large square images (1024/2048) to 1x1 succeeds and preserves the expected pixel.
<!-- Thanks for contributing to ImageSharp! -->
