### PR TITLE
Add AOT compiler seeds for pixel formats and ICO, CUR, QOI codecs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -84,12 +84,15 @@
 #   treat as binary
 ###############################################################################
 *.basis             binary
+*.a                 binary
 *.dll               binary
+*.dylib             binary
 *.exe               binary
 *.pdf               binary
 *.ppt               binary
 *.pptx              binary
 *.pvr               binary
+*.so                binary
 *.snk               binary
 *.xls               binary
 *.xlsx              binary

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# GitHub Copilot Instructions
+
+Read and follow [AGENTS.md](../AGENTS.md) as the repository-wide source of coding, performance, and verification requirements. Prefer existing local patterns and repository configuration whenever generated code or suggestions are accepted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Six Labors AI Coding Guidelines
+
+These instructions apply to the entire repository. More-specific `AGENTS.md` files may add to or override them for their directory tree.
+
+## Working Practices
+
+- Inspect the relevant implementation, tests, benchmarks, project files, and nearby code before proposing or making changes. Do not infer current behavior when the source is available.
+- Make the smallest complete change that solves the requested problem. Avoid unrelated cleanup, speculative abstractions, and formatting churn.
+- Match established architecture, naming, formatting, documentation, and test patterns. Treat `.editorconfig`, analyzers, and repository build settings as authoritative.
+- Preserve public API and observable behavior unless the task explicitly requires a change. Public API documentation must describe observable behavior, not implementation details.
+- Do not use reflection against built assemblies, ad hoc assembly loading, or temporary probe projects unless explicitly requested.
+- Build .NET projects in Release configuration unless explicitly instructed otherwise.
+
+## Performance
+
+- Treat throughput, latency, memory use, and binary size as design constraints, especially in pixel-processing, drawing, parsing, encoding, and other hot paths.
+- Avoid unnecessary allocations, copies, boxing, closures, interface dispatch, repeated enumeration, and extra passes over data.
+- Reuse the repository's existing memory ownership, pooling, span, vectorization, and parallelization patterns. Do not introduce a new mechanism when an established one fits.
+- Keep hot loops simple and bounds-check-friendly. Hoist invariant work, preserve locality, and use the narrowest suitable data types without sacrificing correctness.
+- Do not trade correctness or maintainability for assumed speed. Support non-obvious optimizations with measurements or clear evidence, and add or update benchmarks when performance is the purpose of the change.
+- Consider all supported target frameworks and runtime capabilities. Do not regress fallback paths while optimizing newer runtimes.
+
+## C# Conventions
+
+- Follow the existing code around the change; local patterns take precedence over generic preferences.
+- Do not use `record` or `record struct` types.
+- Prefer established invariants over redundant guards. Validate at real external boundaries and do not add defensive checks for internally controlled states.
+- Do not extract single-use helpers merely to name a block. Extract only for genuine reuse, an established local pattern, or meaningful complexity reduction.
+- Add vertical whitespace after multi-line statements and declarations and between distinct logical stages. Never add trailing whitespace.
+- Document every method, constructor, and property, regardless of whether it is public, internal, protected, or private. Keep public API documentation limited to observable behavior; use private and internal documentation to capture the contract and intent needed to maintain the code.
+- Add inline comments throughout complex code. Explain algorithms, formulas, invariants, ownership, compatibility behavior, and performance tradeoffs at the operations and decisions they govern. Explain why the code is shaped that way rather than narrating the syntax.
+- Document SIMD code especially thoroughly. Explain the vector layout, lane meaning, widening or narrowing, masks, shuffles, constants, alignment or remainder handling, supported instruction paths, scalar equivalence, and the reason each non-obvious operation is correct.
+- Write algorithm and SIMD comments for a maintainer who is unfamiliar with the implementation. The reader should not need to reconstruct intent from external documentation, issue history, or benchmark results.
+
+## Verification
+
+- Add or update focused tests when behavior changes, following the test framework and conventions already used by the project.
+- Never hack, weaken, skip, conditionally bypass, or otherwise manipulate a test to make it pass. Fix the production defect or the genuine test defect while preserving the test's intended coverage and sensitivity.
+- Do not update golden files, reference images, snapshots, baselines, or expected-output artifacts to resolve a test failure. Treat a mismatch as evidence to investigate and correct the implementation.
+- Run the narrowest relevant formatting, test, and Release build commands, then expand verification in proportion to the risk and scope of the change.
+- Report what changed, the verification performed, and any remaining risks or unverified assumptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Instructions
+
+Read and follow [AGENTS.md](AGENTS.md) as the repository-wide source of coding, performance, and verification requirements. Apply any more-specific `AGENTS.md` or `CLAUDE.md` found below the files being changed.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# Gemini CLI Instructions
+
+Read and follow [AGENTS.md](AGENTS.md) as the repository-wide source of coding, performance, and verification requirements. Apply any more-specific `AGENTS.md` or `GEMINI.md` found below the files being changed.

--- a/src/ImageSharp/Advanced/AotCompilerTools.cs
+++ b/src/ImageSharp/Advanced/AotCompilerTools.cs
@@ -7,8 +7,10 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.Formats.Cur;
 using SixLabors.ImageSharp.Formats.Exr;
 using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.Formats.Ico;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Jpeg.Components;
 using SixLabors.ImageSharp.Formats.Jpeg.Components.Decoder;
@@ -129,6 +131,67 @@ internal static class AotCompilerTools
     }
 
     /// <summary>
+    /// Seeds the modern .NET AOT compiler with bulk pixel operations for every built-in pixel format.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// This method is used for AOT code generation only. Do not call it at runtime.
+    /// </exception>
+    [Preserve]
+    public static void SeedPixelOperations()
+    {
+        try
+        {
+            // Keep this inventory finite and explicit. ImageSharp cannot precompile consumer-defined pixel types, while
+            // these closed calls make every built-in specialization visible without retaining the much larger legacy seed graph.
+            AotCompilePixelOperations<A8>();
+            AotCompilePixelOperations<Argb32>();
+            AotCompilePixelOperations<Argb32P>();
+            AotCompilePixelOperations<Abgr32>();
+            AotCompilePixelOperations<Abgr32P>();
+            AotCompilePixelOperations<Bgr24>();
+            AotCompilePixelOperations<Bgr565>();
+            AotCompilePixelOperations<Bgra32>();
+            AotCompilePixelOperations<Bgra32P>();
+            AotCompilePixelOperations<Bgra4444>();
+            AotCompilePixelOperations<Bgra5551>();
+            AotCompilePixelOperations<Byte4>();
+            AotCompilePixelOperations<L16>();
+            AotCompilePixelOperations<L8>();
+            AotCompilePixelOperations<La16>();
+            AotCompilePixelOperations<La32>();
+            AotCompilePixelOperations<HalfSingle>();
+            AotCompilePixelOperations<HalfVector2>();
+            AotCompilePixelOperations<HalfVector4>();
+            AotCompilePixelOperations<HalfVector4P>();
+            AotCompilePixelOperations<NormalizedByte2>();
+            AotCompilePixelOperations<NormalizedByte4>();
+            AotCompilePixelOperations<NormalizedByte4P>();
+            AotCompilePixelOperations<NormalizedShort2>();
+            AotCompilePixelOperations<NormalizedShort4>();
+            AotCompilePixelOperations<Rg32>();
+            AotCompilePixelOperations<Rgb24>();
+            AotCompilePixelOperations<Rgb48>();
+            AotCompilePixelOperations<Rgb96>();
+            AotCompilePixelOperations<Rgba1010102>();
+            AotCompilePixelOperations<Rgba128>();
+            AotCompilePixelOperations<Rgba32>();
+            AotCompilePixelOperations<Rgba32P>();
+            AotCompilePixelOperations<Rgba64>();
+            AotCompilePixelOperations<RgbaHalf>();
+            AotCompilePixelOperations<RgbaHalfP>();
+            AotCompilePixelOperations<RgbaVector>();
+            AotCompilePixelOperations<Short2>();
+            AotCompilePixelOperations<Short4>();
+        }
+        catch
+        {
+            // The calls only need to exist in IL; this method must never contribute a runtime execution path.
+        }
+
+        throw new InvalidOperationException("This method is used for AOT code generation only. Do not call it at runtime.");
+    }
+
+    /// <summary>
     /// Seeds the compiler using the given pixel format.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
@@ -138,6 +201,7 @@ internal static class AotCompilerTools
     {
         // This is we actually call all the individual methods you need to seed.
         AotCompileImage<TPixel>();
+        AotCompilePixelOperations<TPixel>();
         AotCompileImageProcessingContextFactory<TPixel>();
         AotCompileImageEncoderInternals<TPixel>();
         AotCompileImageDecoderInternals<TPixel>();
@@ -156,6 +220,69 @@ internal static class AotCompilerTools
         _ = Unsafe.SizeOf<TPixel>();
 
         // TODO: Do the discovery work to figure out what works and what doesn't.
+    }
+
+    /// <summary>
+    /// Seeds every bulk operation exposed by <see cref="PixelOperations{TPixel}"/>.
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format.</typeparam>
+    [Preserve]
+    private static void AotCompilePixelOperations<TPixel>()
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        // These default arguments are never consumed. Direct calls are required so the IL contains the exact closed
+        // MethodSpecs that Mono WASM AOT can otherwise miss when following static-abstract pixel dispatch indirectly.
+        _ = PixelOperations<TPixel>.Instance;
+        PixelOperations<TPixel> operations = default;
+
+        _ = operations.GetPixelTypeInfo();
+        _ = operations.GetPixelBlender(default(GraphicsOptions));
+        _ = operations.GetPixelBlender(default, default);
+        operations.FromVector4Destructive(default, default, default);
+        operations.FromVector4Destructive(default, default, default, default);
+        operations.ToVector4(default, default, default);
+        operations.ToVector4(default, default, default, default);
+        operations.PackFromRgbPlanes(default, default, default, default);
+        operations.UnpackIntoRgbPlanes(default, default, default, default);
+
+        operations.FromArgb32Bytes(default, default, default, default);
+        operations.ToArgb32Bytes(default, default, default, default);
+
+        operations.FromAbgr32Bytes(default, default, default, default);
+        operations.ToAbgr32Bytes(default, default, default, default);
+
+        operations.FromBgr24Bytes(default, default, default, default);
+        operations.ToBgr24Bytes(default, default, default, default);
+
+        operations.FromBgra32Bytes(default, default, default, default);
+        operations.ToBgra32Bytes(default, default, default, default);
+
+        operations.FromL8Bytes(default, default, default, default);
+        operations.ToL8Bytes(default, default, default, default);
+
+        operations.FromL16Bytes(default, default, default, default);
+        operations.ToL16Bytes(default, default, default, default);
+
+        operations.FromLa16Bytes(default, default, default, default);
+        operations.ToLa16Bytes(default, default, default, default);
+
+        operations.FromLa32Bytes(default, default, default, default);
+        operations.ToLa32Bytes(default, default, default, default);
+
+        operations.FromRgb24Bytes(default, default, default, default);
+        operations.ToRgb24Bytes(default, default, default, default);
+
+        operations.FromRgba32Bytes(default, default, default, default);
+        operations.ToRgba32Bytes(default, default, default, default);
+
+        operations.FromRgb48Bytes(default, default, default, default);
+        operations.ToRgb48Bytes(default, default, default, default);
+
+        operations.FromRgba64Bytes(default, default, default, default);
+        operations.ToRgba64Bytes(default, default, default, default);
+
+        operations.FromBgra5551Bytes(default, default, default, default);
+        operations.ToBgra5551Bytes(default, default, default, default);
     }
 
     /// <summary>
@@ -229,8 +356,10 @@ internal static class AotCompilerTools
         where TPixel : unmanaged, IPixel<TPixel>
     {
         default(BmpEncoderCore).Encode<TPixel>(default, default, default);
+        default(CurEncoderCore).Encode<TPixel>(default, default, default);
         default(ExrEncoderCore).Encode<TPixel>(default, default, default);
         default(GifEncoderCore).Encode<TPixel>(default, default, default);
+        default(IcoEncoderCore).Encode<TPixel>(default, default, default);
         default(JpegEncoderCore).Encode<TPixel>(default, default, default);
         default(PbmEncoderCore).Encode<TPixel>(default, default, default);
         default(PngEncoderCore).Encode<TPixel>(default, default, default);
@@ -249,8 +378,10 @@ internal static class AotCompilerTools
         where TPixel : unmanaged, IPixel<TPixel>
     {
         default(BmpDecoderCore).Decode<TPixel>(default, default, default);
+        default(CurDecoderCore).Decode<TPixel>(default, default, default);
         default(ExrDecoderCore).Decode<TPixel>(default, default, default);
         default(GifDecoderCore).Decode<TPixel>(default, default, default);
+        default(IcoDecoderCore).Decode<TPixel>(default, default, default);
         default(JpegDecoderCore).Decode<TPixel>(default, default, default);
         default(PbmDecoderCore).Decode<TPixel>(default, default, default);
         default(PngDecoderCore).Decode<TPixel>(default, default, default);
@@ -270,11 +401,14 @@ internal static class AotCompilerTools
     {
         AotCompileImageEncoder<TPixel, WebpEncoder>();
         AotCompileImageEncoder<TPixel, BmpEncoder>();
+        AotCompileImageEncoder<TPixel, CurEncoder>();
         AotCompileImageEncoder<TPixel, ExrEncoder>();
         AotCompileImageEncoder<TPixel, GifEncoder>();
+        AotCompileImageEncoder<TPixel, IcoEncoder>();
         AotCompileImageEncoder<TPixel, JpegEncoder>();
         AotCompileImageEncoder<TPixel, PbmEncoder>();
         AotCompileImageEncoder<TPixel, PngEncoder>();
+        AotCompileImageEncoder<TPixel, QoiEncoder>();
         AotCompileImageEncoder<TPixel, TgaEncoder>();
         AotCompileImageEncoder<TPixel, TiffEncoder>();
     }
@@ -289,11 +423,14 @@ internal static class AotCompilerTools
     {
         AotCompileImageDecoder<TPixel, WebpDecoder>();
         AotCompileImageDecoder<TPixel, BmpDecoder>();
+        AotCompileImageDecoder<TPixel, CurDecoder>();
         AotCompileImageDecoder<TPixel, ExrDecoder>();
         AotCompileImageDecoder<TPixel, GifDecoder>();
+        AotCompileImageDecoder<TPixel, IcoDecoder>();
         AotCompileImageDecoder<TPixel, JpegDecoder>();
         AotCompileImageDecoder<TPixel, PbmDecoder>();
         AotCompileImageDecoder<TPixel, PngDecoder>();
+        AotCompileImageDecoder<TPixel, QoiDecoder>();
         AotCompileImageDecoder<TPixel, TgaDecoder>();
         AotCompileImageDecoder<TPixel, TiffDecoder>();
     }

--- a/src/ImageSharp/Advanced/AotCompilerTools.cs
+++ b/src/ImageSharp/Advanced/AotCompilerTools.cs
@@ -223,7 +223,7 @@ internal static class AotCompilerTools
     }
 
     /// <summary>
-    /// Seeds every bulk operation exposed by <see cref="PixelOperations{TPixel}"/>.
+    /// Seeds the selected <see cref="PixelOperations{TPixel}"/> methods required by Mono WASM AOT.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     [Preserve]
@@ -232,8 +232,7 @@ internal static class AotCompilerTools
     {
         // These default arguments are never consumed. Direct calls are required so the IL contains the exact closed
         // MethodSpecs that Mono WASM AOT can otherwise miss when following static-abstract pixel dispatch indirectly.
-        _ = PixelOperations<TPixel>.Instance;
-        PixelOperations<TPixel> operations = default;
+        PixelOperations<TPixel> operations = PixelOperations<TPixel>.Instance;
 
         _ = operations.GetPixelTypeInfo();
         _ = operations.GetPixelBlender(default(GraphicsOptions));

--- a/src/ImageSharp/Configuration.cs
+++ b/src/ImageSharp/Configuration.cs
@@ -2,6 +2,8 @@
 // Licensed under the Six Labors Split License.
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Cur;
@@ -38,6 +40,9 @@ public sealed class Configuration
     /// <summary>
     /// Initializes a new instance of the <see cref="Configuration" /> class.
     /// </summary>
+    // Every image operation requires a Configuration. Attaching the dependency to its constructors keeps the compile-only
+    // seed graph visible to modern .NET trimmers without executing that graph or adding module-initialization work.
+    [DynamicDependency(nameof(AotCompilerTools.SeedPixelOperations), typeof(AotCompilerTools))]
     public Configuration()
     {
     }
@@ -46,6 +51,8 @@ public sealed class Configuration
     /// Initializes a new instance of the <see cref="Configuration" /> class.
     /// </summary>
     /// <param name="configurationModules">A collection of configuration modules to register.</param>
+    // The default Configuration is created through this overload, while callers may use either constructor.
+    [DynamicDependency(nameof(AotCompilerTools.SeedPixelOperations), typeof(AotCompilerTools))]
     public Configuration(params IImageFormatConfigurationModule[] configurationModules)
     {
         if (configurationModules != null)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Fixes #3151 

- Add ICO, CUR, and QOI encoder/decoder seeding in `AotCompilerTools`
- Introduce `SeedPixelOperations()` to explicitly seed all built-in pixel format `PixelOperations<T>` specializations for Mono WASM AOT
- Add `[DynamicDependency]` on Configuration constructors to keep the seed graph visible to .NET trimmers
- Add AI coding guideline files (AGENTS.md, CLAUDE.md, GEMINI.md, copilot-instructions.md)
- Update .gitattributes to treat .a, .dylib, and .so as binary

<!-- Thanks for contributing to ImageSharp! -->
