### PR TITLE
Remove AntialiasThreshold from GraphicsOptions

### DIFF
--- a/src/ImageSharp/GraphicsOptions.cs
+++ b/src/ImageSharp/GraphicsOptions.cs
@@ -7,11 +7,10 @@ namespace SixLabors.ImageSharp;
 
 /// <summary>
 /// Provides configuration for controlling how graphics operations are rendered,
-/// including antialiasing, pixel blending, alpha composition, and coverage thresholding.
+/// including antialiasing, pixel blending, and alpha composition.
 /// </summary>
 public class GraphicsOptions : IDeepCloneable<GraphicsOptions>
 {
-    private float antialiasThreshold = .5F;
     private float blendPercentage = 1F;
 
     /// <summary>
@@ -25,7 +24,6 @@ public class GraphicsOptions : IDeepCloneable<GraphicsOptions>
     {
         this.AlphaCompositionMode = source.AlphaCompositionMode;
         this.Antialias = source.Antialias;
-        this.AntialiasThreshold = source.AntialiasThreshold;
         this.BlendPercentage = source.BlendPercentage;
         this.ColorBlendingMode = source.ColorBlendingMode;
     }
@@ -33,28 +31,9 @@ public class GraphicsOptions : IDeepCloneable<GraphicsOptions>
     /// <summary>
     /// Gets or sets a value indicating whether antialiasing should be applied.
     /// When <see langword="true"/>, edges are rendered with smooth sub-pixel coverage.
-    /// When <see langword="false"/>, coverage is snapped to binary (fully opaque or fully transparent)
-    /// using <see cref="AntialiasThreshold"/> as the cutoff.
     /// Defaults to <see langword="true"/>.
     /// </summary>
     public bool Antialias { get; set; } = true;
-
-    /// <summary>
-    /// Gets or sets the coverage threshold used when <see cref="Antialias"/> is <see langword="false"/>.
-    /// Pixels with antialiased coverage above this value are rendered as fully opaque;
-    /// pixels below are discarded. Valid range is 0 to 1. Lower values preserve more
-    /// thin features at small sizes. Defaults to <c>0.5F</c>.
-    /// </summary>
-    public float AntialiasThreshold
-    {
-        get => this.antialiasThreshold;
-
-        set
-        {
-            Guard.MustBeBetweenOrEqualTo(value, 0F, 1F, nameof(this.AntialiasThreshold));
-            this.antialiasThreshold = value;
-        }
-    }
 
     /// <summary>
     /// Gets or sets the blending percentage applied to the drawing operation.

--- a/src/ImageSharp/GraphicsOptions.cs
+++ b/src/ImageSharp/GraphicsOptions.cs
@@ -31,6 +31,7 @@ public class GraphicsOptions : IDeepCloneable<GraphicsOptions>
     /// <summary>
     /// Gets or sets a value indicating whether antialiasing should be applied.
     /// When <see langword="true"/>, edges are rendered with smooth sub-pixel coverage.
+    /// When <see langword="false"/>, coverage is snapped to binary (fully opaque or fully transparent).
     /// Defaults to <see langword="true"/>.
     /// </summary>
     public bool Antialias { get; set; } = true;

--- a/tests/ImageSharp.Tests/GraphicsOptionsTests.cs
+++ b/tests/ImageSharp.Tests/GraphicsOptionsTests.cs
@@ -23,14 +23,6 @@ public class GraphicsOptionsTests
     }
 
     [Fact]
-    public void DefaultGraphicsOptionsAntialiasThreshold()
-    {
-        const float expected = .5F;
-        Assert.Equal(expected, this.newGraphicsOptions.AntialiasThreshold);
-        Assert.Equal(expected, this.cloneGraphicsOptions.AntialiasThreshold);
-    }
-
-    [Fact]
     public void DefaultGraphicsOptionsBlendPercentage()
     {
         const float expected = 1F;
@@ -61,7 +53,6 @@ public class GraphicsOptionsTests
         {
             AlphaCompositionMode = PixelAlphaCompositionMode.DestAtop,
             Antialias = false,
-            AntialiasThreshold = .33F,
             BlendPercentage = .25F,
             ColorBlendingMode = PixelColorBlendingMode.HardLight,
         };
@@ -79,7 +70,6 @@ public class GraphicsOptionsTests
 
         actual.AlphaCompositionMode = PixelAlphaCompositionMode.DestAtop;
         actual.Antialias = false;
-        actual.AntialiasThreshold = .67F;
         actual.BlendPercentage = .25F;
         actual.ColorBlendingMode = PixelColorBlendingMode.HardLight;
 

--- a/tests/ImageSharp.Tests/TestUtilities/GraphicsOptionsComparer.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/GraphicsOptionsComparer.cs
@@ -8,7 +8,6 @@ public class GraphicsOptionsComparer : IEqualityComparer<GraphicsOptions>
     public bool Equals(GraphicsOptions x, GraphicsOptions y)
         => x.AlphaCompositionMode == y.AlphaCompositionMode
         && x.Antialias == y.Antialias
-        && x.AntialiasThreshold == y.AntialiasThreshold
         && x.BlendPercentage == y.BlendPercentage
         && x.ColorBlendingMode == y.ColorBlendingMode;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Drops the `AntialiasThreshold` field/property from `GraphicsOptions` and updates related XML docs to reflect the simplified antialiasing behavior. Clone logic and test coverage were adjusted accordingly, including removal of threshold assertions and comparer checks.

<!-- Thanks for contributing to ImageSharp! -->
