### PR TITLE
docs: point samples link at SixLabors.Samples.ImageSharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Support the efforts of the development of the Six Labors projects.
 ## Documentation
 
 - [Detailed documentation](https://sixlabors.github.io/docs/) for the ImageSharp API is available. This includes additional conceptual documentation to help you get started.
-- Our [Samples Repository](https://github.com/SixLabors/Samples/tree/main/ImageSharp) is also available containing buildable code samples demonstrating common activities.
+- Our [Samples Repository](https://github.com/SixLabors/Samples/tree/main/SixLabors.Samples.ImageSharp) is also available containing buildable code samples demonstrating common activities.
 
 ## Questions
 


### PR DESCRIPTION
## Problem
The README "Samples Repository" link targets `https://github.com/SixLabors/Samples/tree/main/ImageSharp`.

A GET with redirects returns 404. The Samples repo default branch now has `SixLabors.Samples.ImageSharp` instead of `ImageSharp`.

## Solution
Point the link at `https://github.com/SixLabors/Samples/tree/main/SixLabors.Samples.ImageSharp`.

## Verification
```
curl -sL -o /dev/null -w "%{http_code} %{url_effective}\n" \
  https://github.com/SixLabors/Samples/tree/main/ImageSharp
# 404

curl -sL -o /dev/null -w "%{http_code} %{url_effective}\n" \
  https://github.com/SixLabors/Samples/tree/main/SixLabors.Samples.ImageSharp
# 200
```

Checked open PRs; none update this path.
