### PR TITLE
docs: fix Samples repository path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Support the efforts of the development of the Six Labors projects.
 ## Documentation
 
 - [Detailed documentation](https://sixlabors.github.io/docs/) for the ImageSharp API is available. This includes additional conceptual documentation to help you get started.
-- Our [Samples Repository](https://github.com/SixLabors/Samples/tree/main/ImageSharp) is also available containing buildable code samples demonstrating common activities.
+- Our [Samples Repository](https://github.com/SixLabors/Samples/tree/main/SixLabors.Samples.ImageSharp) is also available containing buildable code samples demonstrating common activities.
 
 ## Questions
 


### PR DESCRIPTION
## Problem

The README samples link points at a path that no longer exists:

https://github.com/SixLabors/Samples/tree/main/ImageSharp

A GET with redirects returns 404. The samples repo now lives under `SixLabors.Samples.ImageSharp`.

## Solution

Point the README at the current samples folder.

## Verification

```
curl -sL -o /dev/null -w "%{http_code} %{url_effective}" -A "Mozilla/5.0" \
  "https://github.com/SixLabors/Samples/tree/main/ImageSharp"
# 404 https://github.com/SixLabors/Samples/tree/main/ImageSharp

curl -sL -o /dev/null -w "%{http_code} %{url_effective}" -A "Mozilla/5.0" \
  "https://github.com/SixLabors/Samples/tree/main/SixLabors.Samples.ImageSharp"
# 200 https://github.com/SixLabors/Samples/tree/main/SixLabors.Samples.ImageSharp
```
