### PR TITLE
docs: drop copied Robidoux Sharp comment from Spline

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resamplers/CubicResampler.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resamplers/CubicResampler.cs
@@ -53,10 +53,6 @@ public readonly struct CubicResampler : IResampler
     /// The function implements the spline algorithm.
     /// <see href="http://www.imagemagick.org/Usage/filter/#cubic_bc"/>
     /// </summary>
-    /// <summary>
-    /// The function implements the Robidoux Sharp algorithm.
-    /// <see href="http://www.imagemagick.org/Usage/filter/#robidoux"/>
-    /// </summary>
     public static readonly CubicResampler Spline = new(2, 1, 0);
 
     /// <summary>


### PR DESCRIPTION
## Problem
`CubicResampler.Spline` is documented twice. The second XML `<summary>` is a copy of the Robidoux Sharp comment and does not describe the spline kernel (`B=1`, `C=0`).

IntelliSense / generated docs for `Spline` would show the wrong algorithm name.

## Solution
Remove the copied Robidoux Sharp summary so `Spline` keeps only the spline documentation.

## Verification
The remaining comment matches the `Spline = new(2, 1, 0)` construction. `RobidouxSharp` still has its own summary above.

Checked open PRs; none touch this file for this comment.
