### PR TITLE
docs: update ImageMagick Usage filter links in resamplers

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resamplers/CubicResampler.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resamplers/CubicResampler.cs
@@ -10,7 +10,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms;
 /// Cubic filters contain a collection of different filters of varying B-Spline and
 /// Cardinal values. With these two values you can generate any smoothly fitting
 /// (continuious first derivative) piece-wise cubic filter.
-/// <see href="http://www.imagemagick.org/Usage/filter/#cubic_bc"/>
+/// <see href="https://usage.imagemagick.org/filter/#cubic_bc"/>
 /// <see href="https://www.cs.utexas.edu/~fussell/courses/cs384g-fall2013/lectures/mitchell/Mitchell.pdf"/>
 /// </summary>
 public readonly struct CubicResampler : IResampler
@@ -39,23 +39,23 @@ public readonly struct CubicResampler : IResampler
 
     /// <summary>
     /// The function implements the Robidoux algorithm.
-    /// <see href="http://www.imagemagick.org/Usage/filter/#robidoux"/>
+    /// <see href="https://usage.imagemagick.org/filter/#robidoux"/>
     /// </summary>
     public static readonly CubicResampler Robidoux = new(2, .37821575509399867F, .31089212245300067F);
 
     /// <summary>
     /// The function implements the Robidoux Sharp algorithm.
-    /// <see href="http://www.imagemagick.org/Usage/filter/#robidoux"/>
+    /// <see href="https://usage.imagemagick.org/filter/#robidoux"/>
     /// </summary>
     public static readonly CubicResampler RobidouxSharp = new(2, .2620145123990142F, .3689927438004929F);
 
     /// <summary>
     /// The function implements the spline algorithm.
-    /// <see href="http://www.imagemagick.org/Usage/filter/#cubic_bc"/>
+    /// <see href="https://usage.imagemagick.org/filter/#cubic_bc"/>
     /// </summary>
     /// <summary>
     /// The function implements the Robidoux Sharp algorithm.
-    /// <see href="http://www.imagemagick.org/Usage/filter/#robidoux"/>
+    /// <see href="https://usage.imagemagick.org/filter/#robidoux"/>
     /// </summary>
     public static readonly CubicResampler Spline = new(2, 1, 0);
 

--- a/src/ImageSharp/Processing/Processors/Transforms/Resamplers/WelchResampler.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resamplers/WelchResampler.cs
@@ -8,7 +8,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Transforms;
 
 /// <summary>
 /// The function implements the welch algorithm.
-/// <see href="http://www.imagemagick.org/Usage/filter/"/>
+/// <see href="https://usage.imagemagick.org/filter/"/>
 /// </summary>
 public readonly struct WelchResampler : IResampler
 {


### PR DESCRIPTION
## Problem

Cubic and Welch resampler XML docs still cite the retired ImageMagick Usage host:

http://www.imagemagick.org/Usage/filter/

GET with redirects returns 404. The same pages now live at https://usage.imagemagick.org/filter/.

## Solution

Update the `see` hrefs in `CubicResampler` and `WelchResampler` to the current Usage site, keeping the original `#cubic_bc` and `#robidoux` fragments.

## Verification

```
curl -sL -o /dev/null -w "%{http_code}" -A "Mozilla/5.0" \
  "http://www.imagemagick.org/Usage/filter/"
# 404

curl -sL -o /dev/null -w "%{http_code}" -A "Mozilla/5.0" \
  "https://usage.imagemagick.org/filter/"
# 200

curl -sL -o /dev/null -w "%{http_code}" -A "Mozilla/5.0" \
  "https://usage.imagemagick.org/filter/#cubic_bc"
# 200

curl -sL -o /dev/null -w "%{http_code}" -A "Mozilla/5.0" \
  "https://usage.imagemagick.org/filter/#robidoux"
# 200
```
