### PR TITLE
docs: fix RapidTables HSL conversion reference URL

### DIFF
--- a/tests/ImageSharp.Tests/ColorProfiles/RgbAndHslConversionTest.cs
+++ b/tests/ImageSharp.Tests/ColorProfiles/RgbAndHslConversionTest.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Tests.ColorProfiles;
 /// <remarks>
 /// Test data generated using:
 /// <see href="http://www.colorhexa.com"/>
-/// <see href="http://www.rapidtables.com/convert/color/hsl-to-rgb"/>
+/// <see href="https://www.rapidtables.com/convert/color/hsl-to-rgb.html"/>
 /// </remarks>
 [Trait("Color", "Conversion")]
 public class RgbAndHslConversionTest


### PR DESCRIPTION
## Problem

The HSL conversion test cites RapidTables without a file extension:

http://www.rapidtables.com/convert/color/hsl-to-rgb

GET with redirects returns 404. The live page is `/hsl-to-rgb.html`.

## Solution

Update the `see` href to the current RapidTables URL.

## Verification

```
curl -sL -o /dev/null -w "%{http_code} %{url_effective}" -A "Mozilla/5.0" \
  "http://www.rapidtables.com/convert/color/hsl-to-rgb"
# 404 https://www.rapidtables.com/convert/color/hsl-to-rgb

curl -sL -o /dev/null -w "%{http_code} %{url_effective}" -A "Mozilla/5.0" \
  "https://www.rapidtables.com/convert/color/hsl-to-rgb.html"
# 200 https://www.rapidtables.com/convert/color/hsl-to-rgb.html
```
