### PR TITLE
docs: remove duplicated XML doc block on CubicResampler.Spline

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/Resamplers/CubicResampler.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Resamplers/CubicResampler.cs
@@ -53,10 +53,6 @@ public readonly struct CubicResampler : IResampler
     /// The function implements the spline algorithm.
     /// <see href="http://www.imagemagick.org/Usage/filter/#cubic_bc"/>
     /// </summary>
-    /// <summary>
-    /// The function implements the Robidoux Sharp algorithm.
-    /// <see href="http://www.imagemagick.org/Usage/filter/#robidoux"/>
-    /// </summary>
     public static readonly CubicResampler Spline = new(2, 1, 0);
 
     /// <summary>


### PR DESCRIPTION
## Problem
`CubicResampler.Spline` has two consecutive `<summary>` blocks. The second one is a copy-paste leftover from `RobidouxSharp` and wrongly describes Spline as "the Robidoux Sharp algorithm".

## Solution
Remove the duplicated block so Spline keeps a single, correct summary ("The function implements the spline algorithm").

## Verification
Build-only doc comment change; no behavior change. `dotnet build` of the affected project is not affected by comment removal.
