### PR TITLE
docs: replace dead Adobe TIFF spec links with libtiff mirrors

### DIFF
--- a/src/ImageSharp/Formats/Tiff/README.md
+++ b/src/ImageSharp/Formats/Tiff/README.md
@@ -2,9 +2,9 @@
 
 ## References
 - TIFF
-  - [TIFF 6.0 Specification](http://partners.adobe.com/public/developer/en/tiff/TIFF6.pdf),(http://www.npes.org/pdf/TIFF-v6.pdf)
-  - [TIFF Supplement 1](http://partners.adobe.com/public/developer/en/tiff/TIFFPM6.pdf)
-  - [TIFF Supplement 2](http://partners.adobe.com/public/developer/en/tiff/TIFFphotoshop.pdf)
+  - [TIFF 6.0 Specification](https://download.osgeo.org/libtiff/doc/TIFF6.pdf)
+  - [TIFF Supplement 1](https://download.osgeo.org/libtiff/doc/TIFFPM6.pdf)
+  - [TIFF Supplement 2](https://download.osgeo.org/libtiff/doc/TIFFphotoshop.pdf)
   - [TIFF Supplement 3](http://chriscox.org/TIFFTN3d1.pdf)
   - [TIFF-F/FX Extension (RFC2301)](http://www.ietf.org/rfc/rfc2301.txt)
   - [TIFF/EP Extension (Wikipedia)](https://en.wikipedia.org/wiki/TIFF/EP)


### PR DESCRIPTION
## Problem
Three reference links in `src/ImageSharp/Formats/Tiff/README.md` point at retired `partners.adobe.com` URLs. Each returns GET 404:

```
curl -sL -o /dev/null -w "%{http_code}\n" http://partners.adobe.com/public/developer/en/tiff/TIFF6.pdf
# 404
curl -sL -o /dev/null -w "%{http_code}\n" http://partners.adobe.com/public/developer/en/tiff/TIFFPM6.pdf
# 404
curl -sL -o /dev/null -w "%{http_code}\n" http://partners.adobe.com/public/developer/en/tiff/TIFFphotoshop.pdf
# 404
```

The line for TIFF 6.0 also had a second bare URL appended as `(http://www.npes.org/pdf/TIFF-v6.pdf)` which was not a real markdown link.

## Solution
Point all three at the libtiff project mirrors on `download.osgeo.org`, which host the same specification PDFs:

- https://download.osgeo.org/libtiff/doc/TIFF6.pdf
- https://download.osgeo.org/libtiff/doc/TIFFPM6.pdf
- https://download.osgeo.org/libtiff/doc/TIFFphotoshop.pdf

All three verified 200 with `curl -L` GET.

## Verification
Markdown-only change. Searched open and closed PRs for prior TIFF specification link fixes and found none.
