### PR TITLE
Fix CCITT decompressor bounds checks and error handling

### DIFF
--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanTiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/ModifiedHuffmanTiffCompression.cs
@@ -53,6 +53,12 @@ internal sealed class ModifiedHuffmanTiffCompression : TiffBaseDecompressor
 
             if (bitReader.RunLength > 0)
             {
+                // A decoded run is untrusted and must fit the current row before the unchecked bit writer is used.
+                if (bitReader.RunLength > (nuint)this.Width - pixelsWritten)
+                {
+                    TiffThrowHelper.ThrowImageFormatException("CCITT compression parsing error: decoded more pixels than the image width.");
+                }
+
                 if (bitReader.IsWhiteRun)
                 {
                     BitWriterUtils.WriteBits(buffer, bitsWritten, (int)bitReader.RunLength, this.whiteValue);
@@ -85,11 +91,6 @@ internal sealed class ModifiedHuffmanTiffCompression : TiffBaseDecompressor
                 }
 
                 bitReader.StartNewRow();
-            }
-
-            if (pixelsWritten > (ulong)this.Width)
-            {
-                TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error, decoded more pixels then image width");
             }
         }
     }

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4BitReader.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4BitReader.cs
@@ -319,7 +319,7 @@ internal class T4BitReader
         {
             if (this.CurValueBitsRead > this.maxCodeLength)
             {
-                TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error: invalid code length read");
+                TiffThrowHelper.ThrowImageFormatException("CCITT compression parsing error: invalid code length read.");
             }
 
             bool isMakeupCode = this.IsMakeupCode();
@@ -401,7 +401,7 @@ internal class T4BitReader
 
             if (!this.IsEndOfScanLine)
             {
-                TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error: expected start of data marker not found");
+                TiffThrowHelper.ThrowImageFormatException("CCITT compression parsing error: expected start of data marker not found.");
             }
 
             this.Reset();

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T4TiffCompression.cs
@@ -72,7 +72,7 @@ internal sealed class T4TiffCompression : TiffBaseDecompressor
 
             if (bitReader.RunLength > 0)
             {
-                this.WritePixelRun(buffer, bitReader, bitsWritten);
+                this.WritePixelRun(buffer, bitReader, bitsWritten, pixelsWritten);
 
                 bitsWritten += (int)bitReader.RunLength;
                 pixelsWritten += bitReader.RunLength;
@@ -102,12 +102,18 @@ internal sealed class T4TiffCompression : TiffBaseDecompressor
         if (pixelsWritten > 0 && pixelsWritten < (ulong)this.width)
         {
             bitReader.ReadNextRun();
-            this.WritePixelRun(buffer, bitReader, bitsWritten);
+            this.WritePixelRun(buffer, bitReader, bitsWritten, pixelsWritten);
         }
     }
 
-    private void WritePixelRun(Span<byte> buffer, T4BitReader bitReader, nint bitsWritten)
+    private void WritePixelRun(Span<byte> buffer, T4BitReader bitReader, nint bitsWritten, nuint pixelsWritten)
     {
+        // A decoded run is untrusted and must fit the current row before the unchecked bit writer is used.
+        if (bitReader.RunLength > (nuint)this.width - pixelsWritten)
+        {
+            TiffThrowHelper.ThrowImageFormatException("CCITT compression parsing error: decoded more pixels than the image width.");
+        }
+
         if (bitReader.IsWhiteRun)
         {
             BitWriterUtils.WriteBits(buffer, bitsWritten, (int)bitReader.RunLength, this.whiteValue);

--- a/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/Decompressors/T6TiffCompression.cs
@@ -163,7 +163,7 @@ internal sealed class T6TiffCompression : TiffBaseDecompressor
                     int runLength = (int)bitReader.RunLength;
                     if (runLength > (uint)(scanline.Length - unpacked))
                     {
-                        TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error");
+                        TiffThrowHelper.ThrowImageFormatException("CCITT compression parsing error: decoded more pixels than the image width.");
                     }
 
                     scanline.Slice(unpacked, runLength).Fill(fillByte);
@@ -175,7 +175,7 @@ internal sealed class T6TiffCompression : TiffBaseDecompressor
                     runLength = (int)bitReader.RunLength;
                     if (runLength > (uint)(scanline.Length - unpacked))
                     {
-                        TiffThrowHelper.ThrowImageFormatException("ccitt compression parsing error");
+                        TiffThrowHelper.ThrowImageFormatException("CCITT compression parsing error: decoded more pixels than the image width.");
                     }
 
                     scanline.Slice(unpacked, runLength).Fill(fillByte);

--- a/src/ImageSharp/Formats/Tiff/Compression/TiffDecompressorsFactory.cs
+++ b/src/ImageSharp/Formats/Tiff/Compression/TiffDecompressorsFactory.cs
@@ -31,6 +31,10 @@ internal static class TiffDecompressorsFactory
         int tileWidth = 0,
         int tileHeight = 0)
     {
+        // Fax compression emits one decoded row at a time, so tiled images must use
+        // the tile row width that was used to size the caller's destination buffer.
+        int faxWidth = isTiled ? tileWidth : width;
+
         switch (method)
         {
             case TiffDecoderCompressionType.None:
@@ -53,15 +57,15 @@ internal static class TiffDecompressorsFactory
 
             case TiffDecoderCompressionType.T4:
                 DebugGuard.IsTrue(predictor == TiffPredictor.None, "Predictor should only be used with lzw or deflate compression");
-                return new T4TiffCompression(allocator, fillOrder, width, bitsPerPixel, faxOptions, photometricInterpretation);
+                return new T4TiffCompression(allocator, fillOrder, faxWidth, bitsPerPixel, faxOptions, photometricInterpretation);
 
             case TiffDecoderCompressionType.T6:
                 DebugGuard.IsTrue(predictor == TiffPredictor.None, "Predictor should only be used with lzw or deflate compression");
-                return new T6TiffCompression(allocator, fillOrder, width, bitsPerPixel, photometricInterpretation);
+                return new T6TiffCompression(allocator, fillOrder, faxWidth, bitsPerPixel, photometricInterpretation);
 
             case TiffDecoderCompressionType.HuffmanRle:
                 DebugGuard.IsTrue(predictor == TiffPredictor.None, "Predictor should only be used with lzw or deflate compression");
-                return new ModifiedHuffmanTiffCompression(allocator, fillOrder, width, bitsPerPixel, photometricInterpretation);
+                return new ModifiedHuffmanTiffCompression(allocator, fillOrder, faxWidth, bitsPerPixel, photometricInterpretation);
 
             case TiffDecoderCompressionType.Jpeg:
                 DebugGuard.IsTrue(predictor == TiffPredictor.None, "Predictor should only be used with lzw or deflate compression");

--- a/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
+++ b/src/ImageSharp/Formats/Tiff/TiffDecoderCore.cs
@@ -693,7 +693,7 @@ internal class TiffDecoderCore : ImageDecoderCore
                 tilesBuffers[i] = this.memoryAllocator.Allocate<byte>(uncompressedTilesSize, AllocationOptions.Clean);
             }
 
-            using TiffBaseDecompressor decompressor = this.CreateDecompressor<TPixel>(frame.Width, bitsPerPixel, frame.Metadata);
+            using TiffBaseDecompressor decompressor = this.CreateDecompressor<TPixel>(frame.Width, bitsPerPixel, frame.Metadata, true, tileWidth, tileLength);
             TiffBasePlanarColorDecoder<TPixel> colorDecoder = this.CreatePlanarColorDecoder<TPixel>(frame.Metadata);
 
             int tileIndex = 0;

--- a/tests/ImageSharp.Tests/Formats/Tiff/Compression/CcittTiffCompressionTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/Compression/CcittTiffCompressionTests.cs
@@ -17,22 +17,43 @@ public class CcittTiffCompressionTests
         "H4sICBSogmoCA3BvYy10aWZmLW1oLnRpZgDty7ENgzAQhlEfRBElNKRMnylomSIbZBkWYiTYAFs6RZkhetb7pa84r+urDKW0xa1EraUustu66L/dZ3d19+z2prz/1M0/fx/Z2zsvx2cc" +
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/+jcL3Buw0IBYAEA";
 
+    private const string TiledT4ReporterPocGzipBase64 =
+        "H4sIAAAAAAACCu3UKw7CUBCG0RkuIeC6AxQGj8TwEHWshyWxOhI2QC8Z0QWAIDnNmeQXran4xnEf64jYROQyMvo8RtYepltk++x+rXabblW7P6fZ++fZvtS+T3et/djVR8M2n/Btr1v6C/zCQbQQLUQLRAvRQrRAtBAtRAtEC9FCtEC0EC3+Mlpv/6RrkiQmAAA=";
+
     [Theory]
     [InlineData(T4PocGzipBase64)]
     [InlineData(ModifiedHuffmanPocGzipBase64)]
     public void Decode_CcittStripWithOversizedRun_ThrowsImageFormatException(string gzipBase64)
     {
-        // Keep the reporter's exact TIFF payload compressed so the regression source remains small.
-        byte[] compressed = Convert.FromBase64String(gzipBase64);
-        using MemoryStream compressedStream = new(compressed);
-        using GZipStream gzipStream = new(compressedStream, CompressionMode.Decompress);
-        using MemoryStream tiffStream = new();
-
-        gzipStream.CopyTo(tiffStream);
-        tiffStream.Position = 0;
+        using MemoryStream tiffStream = CreateTiffStream(gzipBase64);
 
         ImageFormatException exception = Assert.Throws<ImageFormatException>(() => Image.Load(tiffStream));
 
         Assert.Equal("CCITT compression parsing error: decoded more pixels than the image width.", exception.Message);
+    }
+
+    [Fact]
+    public void Decode_TiledCcittReporterSample_ThrowsImageFormatException()
+    {
+        // This is the reporter's exact tiled T4 TIFF sample, gzip-compressed only to keep the test source small.
+        using MemoryStream tiffStream = CreateTiffStream(TiledT4ReporterPocGzipBase64);
+
+        ImageFormatException exception = Assert.Throws<ImageFormatException>(() => Image.Load(tiffStream));
+
+        Assert.Equal("CCITT compression parsing error: decoded more pixels than the image width.", exception.Message);
+    }
+
+    private static MemoryStream CreateTiffStream(string gzipBase64)
+    {
+        // Keep the TIFF payloads compressed so the regression source remains small.
+        byte[] compressed = Convert.FromBase64String(gzipBase64);
+        using MemoryStream compressedStream = new(compressed);
+        using GZipStream gzipStream = new(compressedStream, CompressionMode.Decompress);
+        MemoryStream tiffStream = new();
+
+        gzipStream.CopyTo(tiffStream);
+        tiffStream.Position = 0;
+
+        return tiffStream;
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Tiff/Compression/CcittTiffCompressionTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Tiff/Compression/CcittTiffCompressionTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.IO.Compression;
+using SixLabors.ImageSharp.Formats;
+
+namespace SixLabors.ImageSharp.Tests.Formats.Tiff.Compression;
+
+[Trait("Format", "Tiff")]
+public class CcittTiffCompressionTests
+{
+    private const string T4PocGzipBase64 =
+        "H4sICBOogmoCA3BvYy10aWZmLXQ0LnRpZgDty7ENwjAQhlFfjKKUoYGSPlPQZopskGVYiJFgA2zpFGUG9Kz3S19xXtelTKX0xaVEq2dbZPcNUY+u2bVtzO7vmvd72+3095792vJyfsQH" +
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgH33fP9Zj5xoBYAEA";
+
+    private const string ModifiedHuffmanPocGzipBase64 =
+        "H4sICBSogmoCA3BvYy10aWZmLW1oLnRpZgDty7ENgzAQhlEfRBElNKRMnylomSIbZBkWYiTYAFs6RZkhetb7pa84r+urDKW0xa1EraUustu66L/dZ3d19+z2prz/1M0/fx/Z2zsvx2cc" +
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/+jcL3Buw0IBYAEA";
+
+    [Theory]
+    [InlineData(T4PocGzipBase64)]
+    [InlineData(ModifiedHuffmanPocGzipBase64)]
+    public void Decode_CcittStripWithOversizedRun_ThrowsImageFormatException(string gzipBase64)
+    {
+        // Keep the reporter's exact TIFF payload compressed so the regression source remains small.
+        byte[] compressed = Convert.FromBase64String(gzipBase64);
+        using MemoryStream compressedStream = new(compressed);
+        using GZipStream gzipStream = new(compressedStream, CompressionMode.Decompress);
+        using MemoryStream tiffStream = new();
+
+        gzipStream.CopyTo(tiffStream);
+        tiffStream.Position = 0;
+
+        ImageFormatException exception = Assert.Throws<ImageFormatException>(() => Image.Load(tiffStream));
+
+        Assert.Equal("CCITT compression parsing error: decoded more pixels than the image width.", exception.Message);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request strengthens the handling of CCITT (fax) TIFF decompression by adding strict validation to prevent writing more pixels than the image width, especially in tiled images. It also introduces targeted regression tests to ensure these checks work as intended. The changes improve both the robustness and reliability of TIFF decoding.

**TIFF CCITT Decompression Robustness:**

* Added checks in `ModifiedHuffmanTiffCompression`, `T4TiffCompression`, and `T6TiffCompression` to throw an `ImageFormatException` if a decoded run exceeds the image row width, preventing buffer overruns and ensuring data integrity. [[1]](diffhunk://#diff-4523e3feaf5e39d9170e8bde6d6004dc2a29bb0711537de9c521878fc9ec62bfR56-R61) [[2]](diffhunk://#diff-d72fe0c4d2ff84ccd807d88a1594e0bee9da926ea0b8ee675d2f9bc9b7c9d5dfL75-R75) [[3]](diffhunk://#diff-d72fe0c4d2ff84ccd807d88a1594e0bee9da926ea0b8ee675d2f9bc9b7c9d5dfL105-R116) [[4]](diffhunk://#diff-ad721f6f40473ce1cf187898d4a1792c8977e691f6b3b54a4e1440784e1dcd6bL166-R166) [[5]](diffhunk://#diff-ad721f6f40473ce1cf187898d4a1792c8977e691f6b3b54a4e1440784e1dcd6bL178-R178)
* Updated error messages for consistency and clarity in `T4BitReader` methods. [[1]](diffhunk://#diff-446e4e2c1dbd219ac1aa34ecc8bfb408bd548b752aee0b55cb9c22212f94b6d9L322-R322) [[2]](diffhunk://#diff-446e4e2c1dbd219ac1aa34ecc8bfb408bd548b752aee0b55cb9c22212f94b6d9L404-R404)

**Tiled TIFF Support Improvements:**

* Modified the TIFF decompressor factory and decoder to correctly handle tiled images by passing the tile width to fax decompressors, ensuring proper row width validation during decompression. [[1]](diffhunk://#diff-2f7a64be3cc3a44bfd2e3d82dcff6e1bb62100ff5a86b1499bb785c7c66975e1R34-R37) [[2]](diffhunk://#diff-2f7a64be3cc3a44bfd2e3d82dcff6e1bb62100ff5a86b1499bb785c7c66975e1L56-R68) [[3]](diffhunk://#diff-7aee87e7eb3fd59490713053c0420b1f47f02dfdd583fddc81322bfc9dcae344L696-R696)

**Testing and Regression Coverage:**

* Added new regression tests in `CcittTiffCompressionTests.cs` to verify that oversized runs in both strip-based and tiled CCITT TIFF images throw the correct `ImageFormatException`. These tests use compressed TIFF samples to keep the test codebase small and efficient.
<!-- Thanks for contributing to ImageSharp! -->
